### PR TITLE
Prevent multiple times rendering when formData change

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -26,7 +26,7 @@ export default class Form extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState(this.getStateFromProps(nextProps));
+    this.state = {...this.state, ...this.getStateFromProps(nextProps)};
   }
 
   getStateFromProps(props) {
@@ -82,11 +82,18 @@ export default class Form extends Component {
       const {errors, errorSchema} = this.validate(formData);
       state = {...state, errors, errorSchema};
     }
-    setState(this, state, () => {
+
+    if ("formData" in this.props) {
       if (this.props.onChange) {
-        this.props.onChange(this.state);
+        this.props.onChange(state);
       }
-    });
+    } else {
+      setState(this, state, () => {
+        if (this.props.onChange) {
+          this.props.onChange(this.state);
+        }
+      });
+    }
   };
 
   onBlur = (...args) => {


### PR DESCRIPTION
### Reasons for making this change

~~In [react livecycle](https://facebook.github.io/react/docs/react-component.html#updating), "render" function will be called after "componentWillReceiveProps". So, calling "setState" in it will cause multiple times rendering.~~
Also, calling "setState" in "onChange" function may potentially cause multiple times rendering because parent may try to update the form after receiving new formData.

This update fix #482 and the blinking ErrorList.

Since this update will break a lot of test cases, I would like to have some feedback before updating the test cases.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
