### PR TITLE
[WIP] feat(errorList): *naive* add links to fields in error in the Error section

### DIFF
--- a/src/components/ErrorList.js
+++ b/src/components/ErrorList.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 
-export default function ErrorList({errors}) {
+export default function ErrorList({errors, idSchema}) {
   return (
     <div className="panel panel-danger errors">
       <div className="panel-heading">
@@ -9,10 +9,13 @@ export default function ErrorList({errors}) {
       </div>
       <ul className="list-group">{
         errors.map((error, i) => {
+          const fieldId = idSchema[error.argument].$id;
           return (
-            <li key={i} className="list-group-item text-danger">{
-              error.stack
-            }</li>
+            <li key={i} className="list-group-item text-danger">
+              <a href={`#${fieldId}`}>{
+              	error.stack
+              }</a>
+            </li>
           );
         })
       }</ul>

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -66,11 +66,11 @@ export default class Form extends Component {
   }
 
   renderErrors() {
-    const {status, errors} = this.state;
+    const {status, errors, idSchema} = this.state;
     const {showErrorList} = this.props;
 
     if (status !== "editing" && errors.length && showErrorList != false) {
-      return <ErrorList errors={errors}/>;
+      return <ErrorList errors={errors} idSchema={idSchema} />;
     }
     return null;
   }

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -91,7 +91,7 @@ function DefaultTemplate(props) {
   }
 
   return (
-    <div className={classNames}>
+    <div id={id} className={classNames}>
       {displayLabel ? <Label label={label} required={required} id={id}/> : null}
       {displayLabel && description ? description : null}
       {children}


### PR DESCRIPTION
### Reasons for making this change

https://github.com/mozilla-services/react-jsonschema-form/issues/86#issuecomment-284218618

*This Pull Request is WIP.*

This is a naive implementation of the Issue. I assume this is the sort of fix you meant by [it should be trivial](https://github.com/mozilla-services/react-jsonschema-form/issues/86#issue-143018959)?

Can I get some feedback on the following before I continue:
* I believe that scroll to links should work without hash anchors for the case where people are using Hash Routing
* Is this along the lines of the implementation that you had in mind?
* Should this behaviour be configurable? 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
