### PR TITLE
Corrected defaulting & non-required empty property handling

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -37,12 +37,7 @@ export default class Form extends Component {
     const liveValidate = props.liveValidate || this.props.liveValidate;
     const mustValidate = edit && !props.noValidate && liveValidate;
     const { definitions } = schema;
-    const formData = getDefaultFormState(
-      schema,
-      props.formData,
-      definitions,
-      true
-    );
+    const formData = getDefaultFormState(schema, props.formData, definitions);
     const { errors, errorSchema } = mustValidate
       ? this.validate(formData, schema)
       : {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -37,7 +37,12 @@ export default class Form extends Component {
     const liveValidate = props.liveValidate || this.props.liveValidate;
     const mustValidate = edit && !props.noValidate && liveValidate;
     const { definitions } = schema;
-    const formData = getDefaultFormState(schema, props.formData, definitions);
+    const formData = getDefaultFormState(
+      schema,
+      props.formData,
+      definitions,
+      true
+    );
     const { errors, errorSchema } = mustValidate
       ? this.validate(formData, schema)
       : {

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -12,6 +12,7 @@ import {
   retrieveSchema,
   toIdSchema,
   getDefaultRegistry,
+  cleanUpNonRequiredArray,
 } from "../../utils";
 
 function ArrayFieldTitle({ TitleField, idSchema, title, required }) {
@@ -220,7 +221,6 @@ class ArrayField extends Component {
   };
 
   onDropIndexClick = index => {
-    console.log("DROP INDEX");
     return event => {
       if (event) {
         event.preventDefault();
@@ -231,11 +231,7 @@ class ArrayField extends Component {
       // if field isn't required and doesn't contain any entries
       // remove the whole property from formData to guarantee correct validation
       if (!required) {
-        formData = formData.filter(item => {
-          return item !== null && item !== undefined;
-        });
-
-        formData = formData.length ? formData : undefined;
+        formData = cleanUpNonRequiredArray(formData);
       }
       // refs #195: revalidate to ensure properly reindexing errors
 

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -592,7 +592,7 @@ if (process.env.NODE_ENV !== "production") {
     errorSchema: PropTypes.object,
     onChange: PropTypes.func.isRequired,
     onBlur: PropTypes.func,
-    //formData: PropTypes.array,
+    formData: PropTypes.array,
     required: PropTypes.bool,
     disabled: PropTypes.bool,
     readonly: PropTypes.bool,

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -26,9 +26,34 @@ class ObjectField extends Component {
 
   onPropertyChange = name => {
     return (value, options) => {
-      const newFormData = { ...this.props.formData, [name]: value };
+      const newFormData = this.getCleanFormDataFromValues({
+        ...this.props.formData,
+        [name]: value,
+      });
       this.props.onChange(newFormData, options);
     };
+  };
+
+  getCleanFormDataFromValues = values => {
+    const { required } = this.props;
+
+    if (required) {
+      return values;
+    }
+
+    const cleanValues = [];
+
+    for (let key in values) {
+      if (values.hasOwnProperty(key) && typeof values[key] !== "undefined") {
+        cleanValues.push(values[key]);
+      }
+    }
+
+    if (!cleanValues.length) {
+      values = undefined;
+    }
+
+    return values;
   };
 
   render() {

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -4,6 +4,7 @@ import {
   orderProperties,
   retrieveSchema,
   getDefaultRegistry,
+  cleanUpNonRequiredObject,
 } from "../../utils";
 
 class ObjectField extends Component {
@@ -26,34 +27,16 @@ class ObjectField extends Component {
 
   onPropertyChange = name => {
     return (value, options) => {
-      const newFormData = this.getCleanFormDataFromValues({
-        ...this.props.formData,
-        [name]: value,
-      });
+      const { required } = this.props;
+
+      let newFormData = { ...this.props.formData, [name]: value };
+
+      if (!required) {
+        newFormData = cleanUpNonRequiredObject(newFormData);
+      }
+
       this.props.onChange(newFormData, options);
     };
-  };
-
-  getCleanFormDataFromValues = values => {
-    const { required } = this.props;
-
-    if (required) {
-      return values;
-    }
-
-    const cleanValues = [];
-
-    for (let key in values) {
-      if (values.hasOwnProperty(key) && typeof values[key] !== "undefined") {
-        cleanValues.push(values[key]);
-      }
-    }
-
-    if (!cleanValues.length) {
-      values = undefined;
-    }
-
-    return values;
   };
 
   render() {

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -330,7 +330,40 @@ describe("ArrayField", () => {
       expect(inputs[3].id).eql("root_foo_1_baz");
     });
 
-    it("should render enough inputs with proper defaults to match minItems in schema when no formData is set", () => {
+    it("should render enough inputs with proper defaults when required to match minItems in schema when no formData is set", () => {
+      const complexSchema = {
+        type: "object",
+        definitions: {
+          Thing: {
+            type: "object",
+            properties: {
+              name: {
+                type: "string",
+                default: "Default name",
+              },
+            },
+          },
+        },
+        properties: {
+          foo: {
+            type: "array",
+            minItems: 2,
+            items: {
+              $ref: "#/definitions/Thing",
+            },
+          },
+        },
+        required: ["foo"],
+      };
+      let form = createFormComponent({ schema: complexSchema, formData: {} });
+      let inputs = form.node.querySelectorAll("input[type=text]");
+      console.log(0, inputs[0].value);
+      console.log(1, inputs[1].value);
+      expect(inputs[0].value).eql("Default name");
+      expect(inputs[1].value).eql("Default name");
+    });
+
+    it("should not render inputs with defaults when not required to match minItems in schema when no formData is set", () => {
       const complexSchema = {
         type: "object",
         definitions: {
@@ -356,8 +389,7 @@ describe("ArrayField", () => {
       };
       let form = createFormComponent({ schema: complexSchema, formData: {} });
       let inputs = form.node.querySelectorAll("input[type=text]");
-      expect(inputs[0].value).eql("Default name");
-      expect(inputs[1].value).eql("Default name");
+      expect(inputs.length).eql(0);
     });
 
     it("should honor given formData, even when it does not meet ths minItems-requirement", () => {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -43,7 +43,7 @@ describe("utils", () => {
         ).to.eql({ string: "foo" });
       });
 
-      it("should recursively map schema object default to form state", () => {
+      it("should recursively map schema object default to form state if required", () => {
         expect(
           getDefaultFormState({
             type: "object",
@@ -58,6 +58,7 @@ describe("utils", () => {
                 },
               },
             },
+            required: ["object"],
           })
         ).to.eql({ object: { string: "foo" } });
       });
@@ -77,6 +78,40 @@ describe("utils", () => {
             },
           })
         ).to.eql({ array: ["foo", "bar"] });
+      });
+
+      it("should map schema array to undefined when no data and no defaults provided", () => {
+        expect(
+          getDefaultFormState({
+            type: "object",
+            properties: {
+              array: {
+                type: "array",
+                items: {
+                  type: "string",
+                },
+              },
+            },
+          })
+        ).to.eql({ array: undefined });
+      });
+
+      it("should map schema to undefined when not required and every property is undefined data and no defaults provided", () => {
+        expect(
+          getDefaultFormState({
+            type: "object",
+            properties: {
+              object: {
+                type: "object",
+                properties: {
+                  string: {
+                    type: "string",
+                  },
+                },
+              },
+            },
+          })
+        ).to.eql({ object: undefined });
       });
 
       it("should recursively map schema array default to form state", () => {
@@ -161,7 +196,7 @@ describe("utils", () => {
         });
       });
 
-      it("should use parent defaults for ArrayFields", () => {
+      it("should use parent defaults for ArrayFields if required", () => {
         const schema = {
           type: "object",
           properties: {


### PR DESCRIPTION
### Reasons for making this change

In the current version imho the defaulting is broken:

* When having a non required array property minItems will be set though. Behavior should be: When required, minItems will be applied, when not required and no defaults are set, minItems should not be applied

The value handling imho also is broken for non required fields:

* When having defined an object which is not required but has required properties, the following should apply:

  * When one of the object's property is set the invariant rules shall apply
  * When no property of the object is set the whole object should be undefined since it is not required because otherwise an empty object is left in formData and the invariant rules will be applied which causes an incorrect validation error  

* When deleting the last item of a non required array, the following should apply:
  * When the last element of a non required array is removed, the whole array should be set to undefined, otherwise the array is left empty in formData and eventual invariants like minItems would be applied and cause validation errors although they should not in this case

If this is related to existing tickets, include links to them as well.

#465 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
