### PR TITLE
Resolves  from definitions, detects circular references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1395,6 +1395,98 @@ This library partially supports [inline schema definition dereferencing]( http:/
 }
 ```
 
+The library partially supports `$id` for any object placed within the `definitions` property. A property within the form can refer to a definition using a `$id` field like this:
+
+```json
+{
+  "title": "A registration form",
+    "description": "A simple form example.",
+    "type": "object",
+    "required": [
+      "firstName",
+    "lastName"
+    ],
+    "definitions": {
+      "firstName": {
+        "$id": "#firstName",
+        "type": "string",
+        "title": "First name"
+      },
+      "lastName": {
+        "$id": "#lastName",
+        "type": "string",
+        "title": "Last name"
+      },
+      "age": {
+        "$id": "#age",
+        "type": "integer",
+        "title": "Age"
+      },
+      "bio": {
+        "$id": "#bio",
+        "type": "string",
+        "title": "Bio"
+      },
+      "password": {
+        "$id": "#password",
+        "type": "string",
+        "title": "Password",
+        "minLength": 3
+      }
+    },
+    "properties": {
+      "firstName": {
+        "$ref": "#firstName"
+      },
+      "lastName": {
+        "$ref": "#lastName"
+      },
+      "age": {
+        "$ref": "#age"
+      },
+      "bio": {
+        "$ref": "#bio"
+      },
+      "password": {
+        "$ref": "#password"
+      }
+    }
+}
+```
+
+Sometimes normalizing a deep nested schema can result in a subschema which is accessed by a reference and has references of its own. Such references will be followed unless the subschema refers to itself or has a circular reference between two items, then the form will throw an Error due to the malformed schema.
+
+Self referencing schema:
+
+```json
+{
+  "definitions": {
+    "object": {
+      "$id": "#object",
+      "$ref": "#object"
+    }
+  }
+}
+```
+
+Circular reference within the schema:
+
+```json
+{
+  "definitions": {
+    "object1": {
+      "$id": "#object1",
+        "$ref": "#object2"
+    },
+
+    "object2": {
+        "$id": "#object2",
+        "$ref": "#object1"
+    }
+  }
+}
+```
+
 *(Sample schema courtesy of the [Space Telescope Science Institute](http://spacetelescope.github.io/understanding-json-schema/structuring.html))*
 
 Note that it only supports local definition referencing, we do not plan on fetching foreign schemas over HTTP anytime soon. Basically, you can only reference a definition from the very schema object defining it.

--- a/README.md
+++ b/README.md
@@ -1395,6 +1395,8 @@ This library partially supports [inline schema definition dereferencing]( http:/
 }
 ```
 
+*(Sample schema courtesy of the [Space Telescope Science Institute](http://spacetelescope.github.io/understanding-json-schema/structuring.html))*
+
 The library partially supports `$id` for any object placed within the `definitions` property. A property within the form can refer to a definition using a `$id` field like this:
 
 ```json
@@ -1404,7 +1406,7 @@ The library partially supports `$id` for any object placed within the `definitio
     "type": "object",
     "required": [
       "firstName",
-    "lastName"
+      "lastName"
     ],
     "definitions": {
       "firstName": {
@@ -1454,7 +1456,7 @@ The library partially supports `$id` for any object placed within the `definitio
 }
 ```
 
-Sometimes normalizing a deep nested schema can result in a subschema which is accessed by a reference and has references of its own. Such references will be followed unless the subschema refers to itself or has a circular reference between two items, then the form will throw an Error due to the malformed schema.
+Subschemas can reference other subschemas, which can reference other subschemas and so on. This chain of references will be followed, but if it appears to be infinite or circular, an error will be thrown.
 
 Self referencing schema:
 
@@ -1487,7 +1489,6 @@ Circular reference within the schema:
 }
 ```
 
-*(Sample schema courtesy of the [Space Telescope Science Institute](http://spacetelescope.github.io/understanding-json-schema/structuring.html))*
 
 Note that it only supports local definition referencing, we do not plan on fetching foreign schemas over HTTP anytime soon. Basically, you can only reference a definition from the very schema object defining it.
 


### PR DESCRIPTION
### Reasons for making this change

Adding support for `$id` within `definitions` when data is normalized using `normalizr` which requires an `id` attribute of some sort to aid it. The data is only one level deep within the `definitions` which is provided as the key to the  `schema.Entity` defined there as mentioned in https://github.com/mozilla-services/react-jsonschema-form/issues/594

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests
  - [X] I've updated docs if needed
  - [X] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
