### PR TITLE
Add errorSchema to onError prop callback.

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -128,7 +128,7 @@ export default class Form extends Component {
       if (Object.keys(errors).length > 0) {
         setState(this, { errors, errorSchema }, () => {
           if (this.props.onError) {
-            this.props.onError(errors);
+            this.props.onError(errors, errorSchema);
           } else {
             console.error("Form validation failed", errors);
           }


### PR DESCRIPTION
Any qualms about exposing the `errorSchema` structure to a wrapping component in the `onError` method?

### Reasons for making this change

I'm using CSS-in-JS and looking to access the structured information in errorSchema. The flat structure of the errors array (currently passed back in `onError`) is good for printing out errors, but the names are missing then nested structure of the `errorSchema`.

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

^^ Before I do these things, I'm hoping to get an initial 👍 / 👎
