### PR TITLE
More error information

### DIFF
--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -125,6 +125,13 @@ if (process.env.NODE_ENV !== "production") {
     children: PropTypes.node.isRequired,
     errors: PropTypes.element,
     rawErrors: PropTypes.arrayOf(PropTypes.string),
+    errorInfos: PropTypes.arrayOf(
+      PropTypes.shape({
+        message: PropTypes.string,
+        name: PropTypes.string,
+        params: PropTypes.object,
+      })
+    ),
     help: PropTypes.element,
     rawHelp: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     description: PropTypes.element,
@@ -190,7 +197,7 @@ function SchemaFieldRender(props) {
     displayLabel = false;
   }
 
-  const { __errors, ...fieldErrorSchema } = errorSchema;
+  const { __errors, __errorInfos, ...fieldErrorSchema } = errorSchema;
 
   // See #439: uiSchema: Don't pass consumed class names to child components
   const field = (
@@ -215,6 +222,7 @@ function SchemaFieldRender(props) {
     props.schema.description ||
     schema.description;
   const errors = __errors;
+  const errorInfos = __errorInfos;
   const help = uiSchema["ui:help"];
   const hidden = uiSchema["ui:widget"] === "hidden";
   const classNames = [
@@ -240,6 +248,7 @@ function SchemaFieldRender(props) {
     rawHelp: typeof help === "string" ? help : undefined,
     errors: <ErrorList errors={errors} />,
     rawErrors: errors,
+    errorInfos,
     id,
     label,
     hidden,

--- a/src/validate.js
+++ b/src/validate.js
@@ -27,8 +27,8 @@ function toErrorSchema(errors) {
   // {
   //   level1: {
   //     level2: {
-  //       2: {level3: {errors: ["err a", "err b"]}},
-  //       4: {level3: {errors: ["err b"]}},
+  //       2: {level3: {__errors: ["err a", "err b"]}},
+  //       4: {level3: {__errors: ["err b"]}},
   //     }
   //   }
   // };
@@ -88,7 +88,7 @@ function createErrorHandler(formData) {
   const handler = {
     // We store the list of errors for this node in a property named __errors
     // to avoid name collision with a possible sub schema field named
-    // "errors" (see `utils.toErrorSchema`).
+    // "errors" (see `toErrorSchema`).
     __errors: [],
     addError(message) {
       this.__errors.push(message);

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -807,6 +807,13 @@ describe("Form", () => {
 
           expect(comp.state.errorSchema).eql({
             __errors: ["should NOT be shorter than 8 characters"],
+            __errorInfos: [
+              {
+                message: "should NOT be shorter than 8 characters",
+                name: "minLength",
+                params: { limit: 8 },
+              },
+            ],
           });
         });
 
@@ -876,6 +883,15 @@ describe("Form", () => {
 
         expect(comp.state.errorSchema).eql({
           __errors: ["should NOT be shorter than 8 characters"],
+          __errorInfos: [
+            {
+              message: "should NOT be shorter than 8 characters",
+              name: "minLength",
+              params: {
+                limit: 8,
+              },
+            },
+          ],
         });
       });
 
@@ -915,6 +931,13 @@ describe("Form", () => {
 
         expect(comp.state.errorSchema).eql({
           __errors: ["should NOT be shorter than 8 characters"],
+          __errorInfos: [
+            {
+              message: "should NOT be shorter than 8 characters",
+              name: "minLength",
+              params: { limit: 8 },
+            },
+          ],
         });
       });
 
@@ -945,6 +968,18 @@ describe("Form", () => {
           __errors: [
             "should NOT be shorter than 8 characters",
             'should match pattern "d+"',
+          ],
+          __errorInfos: [
+            {
+              message: "should NOT be shorter than 8 characters",
+              name: "minLength",
+              params: { limit: 8 },
+            },
+            {
+              message: 'should match pattern "d+"',
+              name: "pattern",
+              params: { pattern: "d+" },
+            },
           ],
         });
       });
@@ -995,6 +1030,13 @@ describe("Form", () => {
           level1: {
             level2: {
               __errors: ["should NOT be shorter than 8 characters"],
+              __errorInfos: [
+                {
+                  message: "should NOT be shorter than 8 characters",
+                  name: "minLength",
+                  params: { limit: 8 },
+                },
+              ],
             },
           },
         });
@@ -1032,7 +1074,16 @@ describe("Form", () => {
         const { comp } = createFormComponent(formProps);
 
         expect(comp.state.errorSchema).eql({
-          1: { __errors: ["should NOT be shorter than 4 characters"] },
+          1: {
+            __errors: ["should NOT be shorter than 4 characters"],
+            __errorInfos: [
+              {
+                message: "should NOT be shorter than 4 characters",
+                name: "minLength",
+                params: { limit: 4 },
+              },
+            ],
+          },
         });
       });
 
@@ -1084,8 +1135,26 @@ describe("Form", () => {
 
         expect(comp.state.errorSchema).eql({
           level1: {
-            1: { __errors: ["should NOT be shorter than 4 characters"] },
-            3: { __errors: ["should NOT be shorter than 4 characters"] },
+            1: {
+              __errors: ["should NOT be shorter than 4 characters"],
+              __errorInfos: [
+                {
+                  message: "should NOT be shorter than 4 characters",
+                  name: "minLength",
+                  params: { limit: 4 },
+                },
+              ],
+            },
+            3: {
+              __errors: ["should NOT be shorter than 4 characters"],
+              __errorInfos: [
+                {
+                  message: "should NOT be shorter than 4 characters",
+                  name: "minLength",
+                  params: { limit: 4 },
+                },
+              ],
+            },
           },
         });
       });
@@ -1134,10 +1203,28 @@ describe("Form", () => {
         expect(comp.state.errorSchema).eql({
           outer: {
             0: {
-              1: { __errors: ["should NOT be shorter than 4 characters"] },
+              1: {
+                __errors: ["should NOT be shorter than 4 characters"],
+                __errorInfos: [
+                  {
+                    message: "should NOT be shorter than 4 characters",
+                    name: "minLength",
+                    params: { limit: 4 },
+                  },
+                ],
+              },
             },
             1: {
-              0: { __errors: ["should NOT be shorter than 4 characters"] },
+              0: {
+                __errors: ["should NOT be shorter than 4 characters"],
+                __errorInfos: [
+                  {
+                    message: "should NOT be shorter than 4 characters",
+                    name: "minLength",
+                    params: { limit: 4 },
+                  },
+                ],
+              },
             },
           },
         });
@@ -1187,6 +1274,13 @@ describe("Form", () => {
           1: {
             foo: {
               __errors: ["should NOT be shorter than 4 characters"],
+              __errorInfos: [
+                {
+                  message: "should NOT be shorter than 4 characters",
+                  name: "minLength",
+                  params: { limit: 4 },
+                },
+              ],
             },
           },
         });

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -274,6 +274,7 @@ describe("Validation", () => {
 
         expect(comp.state.errorSchema).eql({
           __errors: ["Invalid"],
+          __errorInfos: [{ message: "Invalid", name: "custom", params: {} }],
         });
       });
 
@@ -356,13 +357,29 @@ describe("Validation", () => {
 
         expect(comp.state.errorSchema).eql({
           __errors: [],
+          __errorInfos: [],
           pass1: {
             __errors: [],
+            __errorInfos: [],
           },
           pass2: {
             __errors: [
               "should NOT be shorter than 3 characters",
               "Passwords don't match",
+            ],
+            __errorInfos: [
+              {
+                message: "should NOT be shorter than 3 characters",
+                name: "minLength",
+                params: {
+                  limit: 3,
+                },
+              },
+              {
+                message: "Passwords don't match",
+                name: "custom",
+                params: {},
+              },
             ],
           },
         });
@@ -405,22 +422,35 @@ describe("Validation", () => {
           0: {
             pass1: {
               __errors: [],
+              __errorInfos: [],
             },
             pass2: {
               __errors: ["Passwords don't match"],
+              __errorInfos: [
+                {
+                  name: "custom",
+                  message: "Passwords don't match",
+                  params: {},
+                },
+              ],
             },
             __errors: [],
+            __errorInfos: [],
           },
           1: {
             pass1: {
               __errors: [],
+              __errorInfos: [],
             },
             pass2: {
               __errors: [],
+              __errorInfos: [],
             },
             __errors: [],
+            __errorInfos: [],
           },
           __errors: [],
+          __errorInfos: [],
         });
       });
 
@@ -449,10 +479,13 @@ describe("Validation", () => {
         comp.componentWillReceiveProps({ formData });
 
         expect(comp.state.errorSchema).eql({
-          0: { __errors: [] },
-          1: { __errors: [] },
-          2: { __errors: [] },
+          0: { __errors: [], __errorInfos: [] },
+          1: { __errors: [], __errorInfos: [] },
+          2: { __errors: [], __errorInfos: [] },
           __errors: ["Forbidden value: bbb"],
+          __errorInfos: [
+            { message: "Forbidden value: bbb", name: "custom", params: {} },
+          ],
         });
       });
     });


### PR DESCRIPTION
### Reasons for making this change

In issue #730 I describe my use case for having access to having more information concerning the
errors generated by the system. By the time they reach SchemaField we only have a list of strings, but I'd like to determine whether I'm dealing with a ``required`` error for instance. ajv generates more information, in particular the name of the error and params that went into the construction of the error message itself.

I think having the error name available in the SchemaField template would be useful as a simpler alternative to transformErrors as a way to inject custom error messages.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

This branch isn't complete yet according to the checklist, but I'd like to get some feedback first.

I maintain a new field, __errorInfos in the error schema. This field is redundant with __errors. I could instead reuse __errors to store the error information. I would prefer to do this, but it would break a semi-public API, in the sense that people may have overridden SchemaFieldRender and expect ``__errors`` to be a list of strings, instead of a list of objects. If it's okay to break this internal API, I'm happy to rewrite things.

I've adjusted addError to add an error info object as well, with the name "custom" and no parameters. It would be nicer if we expanded the addError API with additional optional ``name`` and ``params`` arguments, so that the developer creating custom validation errors can control exactly what error gets created.

A consequence of this is that the error names and params generated by ajv become part of the public API of this project. We need to refer to this information in the documentation. While ajv error params are described here: https://github.com/epoberezkin/ajv#error-parameters

I think ajv error names may be simply the validation keywords defined by json-schema:

http://json-schema.org/latest/json-schema-validation.html#rfc.section.6

but I'm not 100% sure of this.
