### PR TITLE
Proof of concept async validation

### DIFF
--- a/playground/samples/validation.js
+++ b/playground/samples/validation.js
@@ -1,8 +1,12 @@
 function validate({ pass1, pass2 }, errors) {
-  if (pass1 !== pass2) {
-    errors.pass2.addError("Passwords don't match.");
-  }
-  return errors;
+  return new Promise(resolve => {
+    setTimeout(() => {
+      if (pass1 !== pass2) {
+        errors.pass2.addError("Passwords don't match.");
+      }
+      resolve(errors);
+    }, 1000);
+  });
 }
 
 function transformErrors(errors) {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -116,8 +116,9 @@ export default class Form extends Component {
     let state = { formData };
     if (mustValidate) {
       this.validate(formData).then(setStateAndBackPropagate);
+    } else {
+      setStateAndBackPropagate(state);
     }
-    setStateAndBackPropagate(state);
   };
 
   onBlur = (...args) => {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -105,7 +105,7 @@ export default class Form extends Component {
   onChange = (formData, options = { validate: false }) => {
     const setStateAndBackPropagate = state => {
       setState(this, state, () => {
-        if (this.props.onChange) {
+        if (state.formData && this.props.onChange) {
           this.props.onChange(this.state);
         }
       });
@@ -116,9 +116,8 @@ export default class Form extends Component {
     let state = { formData };
     if (mustValidate) {
       this.validate(formData).then(setStateAndBackPropagate);
-    } else {
-      setStateAndBackPropagate(state);
     }
+    setStateAndBackPropagate(state);
   };
 
   onBlur = (...args) => {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -39,27 +39,36 @@ export default class Form extends Component {
     const mustValidate = edit && !props.noValidate && liveValidate;
     const { definitions } = schema;
     const formData = getDefaultFormState(schema, props.formData, definitions);
-    const { errors, errorSchema } = mustValidate
-      ? this.validate(formData, schema)
-      : {
-          errors: state.errors || [],
-          errorSchema: state.errorSchema || {},
-        };
     const idSchema = toIdSchema(
       schema,
       uiSchema["ui:rootFieldId"],
       definitions,
       formData
     );
-    return {
+
+    const nextState = {
       schema,
       uiSchema,
       idSchema,
       formData,
       edit,
-      errors,
-      errorSchema,
     };
+
+    if (mustValidate) {
+      // XXX: We use this.propsForPromise as a hack to cancel the Promise.
+      // If the props that the Promise is using don't match the very latest
+      // props, it shouldn't execute.
+      this.propsForPromise = props;
+      this.validate(formData, schema).then(state => {
+        this.propsForPromise === props && this.setState(state);
+        this.setState(state);
+      });
+    } else {
+      nextState.errors = state.errors || [];
+      nextState.errorsSchema = state.errorSchema || {};
+    }
+
+    return nextState;
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -80,7 +89,7 @@ export default class Form extends Component {
     const { errors, errorSchema, schema, uiSchema } = this.state;
     const { ErrorList, showErrorList, formContext } = this.props;
 
-    if (errors.length && showErrorList != false) {
+    if (errors && errors.length && showErrorList != false) {
       return (
         <ErrorList
           errors={errors}
@@ -95,18 +104,21 @@ export default class Form extends Component {
   }
 
   onChange = (formData, options = { validate: false }) => {
+    const setStateAndBackPropagate = state => {
+      setState(this, state, () => {
+        if (this.props.onChange) {
+          this.props.onChange(this.state);
+        }
+      });
+    };
+
     const mustValidate =
       !this.props.noValidate && (this.props.liveValidate || options.validate);
     let state = { formData };
     if (mustValidate) {
-      const { errors, errorSchema } = this.validate(formData);
-      state = { ...state, errors, errorSchema };
+      this.validate(formData).then(setStateAndBackPropagate);
     }
-    setState(this, state, () => {
-      if (this.props.onChange) {
-        this.props.onChange(this.state);
-      }
-    });
+    setStateAndBackPropagate(state);
   };
 
   onBlur = (...args) => {
@@ -124,24 +136,29 @@ export default class Form extends Component {
   onSubmit = event => {
     event.preventDefault();
 
-    if (!this.props.noValidate) {
-      const { errors, errorSchema } = this.validate(this.state.formData);
-      if (Object.keys(errors).length > 0) {
-        setState(this, { errors, errorSchema }, () => {
-          if (this.props.onError) {
-            this.props.onError(errors);
+    const onValidationOK = () => {
+      if (this.props.onSubmit) {
+        this.props.onSubmit({ ...this.state, status: "submitted" });
+      }
+      this.setState({ errors: [], errorSchema: {} });
+    };
+
+    this.props.noValidate
+      ? onValidationOK()
+      : this.validate(this.state.formData).then(({ errors, errorSchema }) => {
+          if (Object.keys(errors).length > 0) {
+            setState(this, { errors, errorSchema }, () => {
+              if (this.props.onError) {
+                this.props.onError(errors);
+              } else {
+                console.error("Form validation failed", errors);
+              }
+            });
+            return;
           } else {
-            console.error("Form validation failed", errors);
+            onValidationOK();
           }
         });
-        return;
-      }
-    }
-
-    if (this.props.onSubmit) {
-      this.props.onSubmit({ ...this.state, status: "submitted" });
-    }
-    this.setState({ errors: [], errorSchema: {} });
   };
 
   getRegistry() {

--- a/test/ObjectFieldTemplate_test.js
+++ b/test/ObjectFieldTemplate_test.js
@@ -30,7 +30,7 @@ describe("ObjectFieldTemplate", () => {
           <TitleField title={title} />
           <DescriptionField description={description} />
           <div>
-            {properties.map(({ content, index }) => (
+            {properties.map(({ content }, index) => (
               <div key={index} className="property">
                 {content}
               </div>


### PR DESCRIPTION
### Reasons for making this change

Async validation is probably one of the most desired features that RJSF is missing. There's been at least one very good attempt at this: #401. I suspect that the PR is abandoned, so I wrote this quick implementation to push this feature forward.

I needed this feature NOW, so I wrote it and didn't fix the tests yet, because I hope that #401 would provide this feature instead (not very likely, I think)., as it is way more polished and though out.

EDIT: You can see it in action at the "Validation" tab on the playground and entering non-matching passwords.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
