### PR TITLE
Add minRemovable to ui:options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A [live playground](https://mozilla-services.github.io/react-jsonschema-form/) i
         - [orderable option](#orderable-option)
         - [addable option](#addable-option)
         - [removable option](#removable-option)
+        - [minRemovable option](#minremovable-option)
      - [Custom CSS class names](#custom-css-class-names)
      - [Custom labels for enum fields](#custom-labels-for-enum-fields)
      - [Disabled enum fields](#disabled-attribute-for-enum-fields)
@@ -508,6 +509,18 @@ A remove button is shown by default for an item if `items` contains a schema obj
 const uiSchema = {
   "ui:options":  {
     removable: false
+  }
+};
+```
+
+#### `minRemovable` option
+
+A remove button is shown by default even when the number of items is less than or equal to `minItems`. You can turn this off with the `minRemovable` option in `uiSchema`:
+
+```jsx
+const uiSchema = {
+  "ui:options":  {
+    minRemovable: false
   }
 };
 ```

--- a/playground/samples/arrays.js
+++ b/playground/samples/arrays.js
@@ -139,6 +139,11 @@ module.exports = {
         "ui:widget": "updown",
       },
     },
+    minItemsList: {
+      "ui:options": {
+        minRemovable: false,
+      },
+    },
     unorderable: {
       "ui:options": {
         orderable: false,

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -335,6 +335,7 @@ class ArrayField extends Component {
     const { ArrayFieldTemplate, definitions, fields } = registry;
     const { TitleField, DescriptionField } = fields;
     const itemsSchema = retrieveSchema(schema.items, definitions);
+    const { minRemovable } = { minRemovable: true, ...uiSchema["ui:options"] };
     const arrayProps = {
       canAdd: this.canAddItem(formData),
       items: formData.map((item, index) => {
@@ -349,6 +350,7 @@ class ArrayField extends Component {
         );
         return this.renderArrayFieldItem({
           index,
+          canRemove: minRemovable || formData.length > schema.minItems,
           canMoveUp: index > 0,
           canMoveDown: index < formData.length - 1,
           itemSchema: itemSchema,
@@ -491,6 +493,8 @@ class ArrayField extends Component {
       items = items.concat(new Array(itemSchemas.length - items.length));
     }
 
+    const { minRemovable } = { minRemovable: true, ...uiSchema["ui:options"] };
+
     // These are the props passed into the render function
     const arrayProps = {
       canAdd: this.canAddItem(items) && additionalSchema,
@@ -519,7 +523,8 @@ class ArrayField extends Component {
 
         return this.renderArrayFieldItem({
           index,
-          canRemove: additional,
+          canRemove:
+            additional && (minRemovable || formData.length > schema.minItems),
           canMoveUp: index >= itemSchemas.length + 1,
           canMoveDown: additional && index < items.length - 1,
           itemSchema,

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -296,6 +296,34 @@ describe("ArrayField", () => {
       expect(dropBtn).to.be.null;
     });
 
+    it("should not show remove button if minRemovable is false and items length is not greater than minItems", () => {
+      const { node } = createFormComponent({
+        schema: {
+          ...schema,
+          minItems: 2,
+        },
+        formData: ["foo", "bar"],
+        uiSchema: { "ui:options": { minRemovable: false } },
+      });
+      const dropBtn = node.querySelector(".array-item-remove");
+
+      expect(dropBtn).to.be.null;
+    });
+
+    it("should show remove button if minRemovable is false and items length is greater than minItems", () => {
+      const { node } = createFormComponent({
+        schema: {
+          ...schema,
+          minItems: 1,
+        },
+        formData: ["foo", "bar"],
+        uiSchema: { "ui:options": { minRemovable: false } },
+      });
+      const dropBtn = node.querySelector(".array-item-remove");
+
+      expect(dropBtn).to.not.be.null;
+    });
+
     it("should force revalidation when a field is removed", () => {
       // refs #195
       const { node } = createFormComponent({


### PR DESCRIPTION
### Reasons for making this change

Sometimes I'd like to prevent the users from removing array items when they've only entered `minItems` worth of items.

This implements #635.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [x] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
