### PR TITLE
Allow errorSchema to be passed into a form

### DIFF
--- a/playground/app.js
+++ b/playground/app.js
@@ -314,12 +314,19 @@ class App extends Component {
   constructor(props) {
     super(props);
     // initialize state with Simple data sample
-    const { schema, uiSchema, formData, validate } = samples.Simple;
+    const {
+      schema,
+      uiSchema,
+      formData,
+      errorSchema,
+      validate,
+    } = samples.Simple;
     this.state = {
       form: false,
       schema,
       uiSchema,
       formData,
+      errorSchema,
       validate,
       editor: "default",
       theme: "default",
@@ -365,6 +372,9 @@ class App extends Component {
 
   onFormDataEdited = formData => this.setState({ formData, shareURL: null });
 
+  onErrorSchemaEdited = errorSchema =>
+    this.setState({ errorSchema, shareURL: null });
+
   onThemeSelected = (theme, { stylesheet, editor }) => {
     this.setState({ theme, editor: editor ? editor : "default" });
     setImmediate(() => {
@@ -375,14 +385,19 @@ class App extends Component {
 
   setLiveValidate = ({ formData }) => this.setState({ liveValidate: formData });
 
-  onFormDataChange = ({ formData }) =>
-    this.setState({ formData, shareURL: null });
+  onFormDataChange = ({ formData, errorSchema }) =>
+    this.setState({ formData, errorSchema, shareURL: null });
+
+  onErrorSchemaChange = errorSchema =>
+    this.setState({ errorSchema, shareURL: null });
 
   onShare = () => {
-    const { formData, schema, uiSchema } = this.state;
+    const { formData, schema, uiSchema, errorSchema } = this.state;
     const { location: { origin, pathname } } = document;
     try {
-      const hash = btoa(JSON.stringify({ formData, schema, uiSchema }));
+      const hash = btoa(
+        JSON.stringify({ formData, schema, uiSchema, errorSchema })
+      );
       this.setState({ shareURL: `${origin}${pathname}#${hash}` });
     } catch (err) {
       this.setState({ shareURL: null });
@@ -394,6 +409,7 @@ class App extends Component {
       schema,
       uiSchema,
       formData,
+      errorSchema,
       liveValidate,
       validate,
       theme,
@@ -449,6 +465,16 @@ class App extends Component {
               />
             </div>
           </div>
+          <div className="row">
+            <div className="col">
+              <Editor
+                title="errorSchema"
+                theme={editor}
+                code={toJson(errorSchema)}
+                onChange={this.onErrorSchemaEdited}
+              />
+            </div>
+          </div>
         </div>
         <div className="col-sm-5">
           {this.state.form && (
@@ -459,7 +485,9 @@ class App extends Component {
               schema={schema}
               uiSchema={uiSchema}
               formData={formData}
+              errorSchema={errorSchema}
               onChange={this.onFormDataChange}
+              onValidate={this.onErrorSchemaChange}
               onSubmit={({ formData }) =>
                 console.log("submitted formData", formData)
               }

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -45,8 +45,10 @@ export default class Form extends Component {
     const { errors, errorSchema } = mustValidate
       ? this.validate(formData, schema)
       : {
-          errors: state.errors || [],
-          errorSchema: state.errorSchema || {},
+          errors: props.errorSchema
+            ? toErrorList(props.errorSchema)
+            : state.errors || [],
+          errorSchema: props.errorSchema || state.errorSchema || {},
         };
     const idSchema = toIdSchema(
       retrievedSchema,
@@ -72,12 +74,18 @@ export default class Form extends Component {
 
   validate(formData, schema) {
     const { validate, transformErrors } = this.props;
-    return validateFormData(
+    const { errors, errorSchema } = validateFormData(
       formData,
       schema || this.props.schema,
       validate,
       transformErrors
     );
+
+    if (this.props.onValidate) {
+      this.props.onValidate(errorSchema);
+    }
+
+    return { errors, errorSchema };
   }
 
   renderErrors() {
@@ -232,6 +240,7 @@ if (process.env.NODE_ENV !== "production") {
   Form.propTypes = {
     schema: PropTypes.object.isRequired,
     uiSchema: PropTypes.object,
+    errorSchema: PropTypes.object,
     formData: PropTypes.any,
     widgets: PropTypes.objectOf(
       PropTypes.oneOfType([PropTypes.func, PropTypes.object])
@@ -243,6 +252,7 @@ if (process.env.NODE_ENV !== "production") {
     ErrorList: PropTypes.func,
     onChange: PropTypes.func,
     onError: PropTypes.func,
+    onValidate: PropTypes.func,
     showErrorList: PropTypes.bool,
     onSubmit: PropTypes.func,
     id: PropTypes.string,

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -50,6 +50,11 @@ export default class Form extends Component {
             : state.errors || [],
           errorSchema: props.errorSchema || state.errorSchema || {},
         };
+
+    if (mustValidate && props.onValidate) {
+      props.onValidate(errorSchema);
+    }
+
     const idSchema = toIdSchema(
       retrievedSchema,
       uiSchema["ui:rootFieldId"],
@@ -76,18 +81,12 @@ export default class Form extends Component {
     const { validate, transformErrors } = this.props;
     const { definitions } = this.getRegistry();
     const resolvedSchema = retrieveSchema(schema, definitions, formData);
-    const { errors, errorSchema } = validateFormData(
+    return validateFormData(
       formData,
       resolvedSchema,
       validate,
       transformErrors
     );
-
-    if (this.props.onValidate) {
-      this.props.onValidate(errorSchema);
-    }
-
-    return { errors, errorSchema };
   }
 
   renderErrors() {
@@ -147,6 +146,9 @@ export default class Form extends Component {
       const { errors, errorSchema } = this.validate(this.state.formData);
       if (Object.keys(errors).length > 0) {
         setState(this, { errors, errorSchema }, () => {
+          if (this.props.onValidate) {
+            this.props.onValidate(errorSchema);
+          }
           if (this.props.onError) {
             this.props.onError(errors);
           } else {


### PR DESCRIPTION
### Reasons for making this change
Fixes #155. Users should be able to control the `errorSchema` externally. For instance, if you receive errors from a server, you should be able to inject those errors into the form.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature