### PR TITLE
Added Time input Widget as new String format

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,8 @@ The built-in string field also supports the JSONSchema `format` property, and wi
 - `data-url`: By default, an `input[type=file]` element is used; in case the string is part of an array, multiple files will be handled automatically (see [File widgets](#file-widgets)).
 - `date`: By default, an `input[type=date]` element is used;
 - `date-time`: By default, an `input[type=datetime-local]` element is used.
+- `time`: By default, an `input[type=time]` element is used.
+
 
 ![](http://i.imgur.com/xqu6Lcp.png)
 

--- a/playground/app.js
+++ b/playground/app.js
@@ -380,7 +380,9 @@ class App extends Component {
 
   onShare = () => {
     const { formData, schema, uiSchema } = this.state;
-    const { location: { origin, pathname } } = document;
+    const {
+      location: { origin, pathname },
+    } = document;
     try {
       const hash = btoa(JSON.stringify({ formData, schema, uiSchema }));
       this.setState({ shareURL: `${origin}${pathname}#${hash}` });

--- a/playground/samples/date.js
+++ b/playground/samples/date.js
@@ -17,6 +17,15 @@ module.exports = {
             type: "string",
             format: "date",
           },
+          time: {
+            type: "string",
+            format: "time",
+          },
+          time_with_step: {
+            title: "Time with Step attribute",
+            type: "string",
+            format: "time",
+          },
         },
       },
       alternative: {
@@ -37,6 +46,13 @@ module.exports = {
     },
   },
   uiSchema: {
+    native: {
+      time_with_step: {
+        "ui:options": {
+          step: 1,
+        },
+      },
+    },
     alternative: {
       "alt-datetime": {
         "ui:widget": "alt-datetime",

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -607,7 +607,9 @@ class ArrayField extends Component {
       uiSchema,
       registry = getDefaultRegistry(),
     } = this.props;
-    const { fields: { SchemaField } } = registry;
+    const {
+      fields: { SchemaField },
+    } = registry;
     const { orderable, removable } = {
       orderable: true,
       removable: true,

--- a/src/components/widgets/ColorWidget.js
+++ b/src/components/widgets/ColorWidget.js
@@ -2,7 +2,13 @@ import React from "react";
 import PropTypes from "prop-types";
 
 function ColorWidget(props) {
-  const { disabled, readonly, registry: { widgets: { BaseInput } } } = props;
+  const {
+    disabled,
+    readonly,
+    registry: {
+      widgets: { BaseInput },
+    },
+  } = props;
   return <BaseInput type="color" {...props} disabled={disabled || readonly} />;
 }
 

--- a/src/components/widgets/DateTimeWidget.js
+++ b/src/components/widgets/DateTimeWidget.js
@@ -33,7 +33,13 @@ export function localToUTC(dateString) {
 }
 
 function DateTimeWidget(props) {
-  const { value, onChange, registry: { widgets: { BaseInput } } } = props;
+  const {
+    value,
+    onChange,
+    registry: {
+      widgets: { BaseInput },
+    },
+  } = props;
   return (
     <BaseInput
       type="datetime-local"

--- a/src/components/widgets/DateWidget.js
+++ b/src/components/widgets/DateWidget.js
@@ -2,7 +2,12 @@ import React from "react";
 import PropTypes from "prop-types";
 
 function DateWidget(props) {
-  const { onChange, registry: { widgets: { BaseInput } } } = props;
+  const {
+    onChange,
+    registry: {
+      widgets: { BaseInput },
+    },
+  } = props;
   return (
     <BaseInput
       type="date"

--- a/src/components/widgets/RangeWidget.js
+++ b/src/components/widgets/RangeWidget.js
@@ -4,7 +4,13 @@ import PropTypes from "prop-types";
 import { rangeSpec } from "../../utils";
 
 function RangeWidget(props) {
-  const { schema, value, registry: { widgets: { BaseInput } } } = props;
+  const {
+    schema,
+    value,
+    registry: {
+      widgets: { BaseInput },
+    },
+  } = props;
   return (
     <div className="field-range-wrapper">
       <BaseInput type="range" {...props} {...rangeSpec(schema)} />

--- a/src/components/widgets/TimeWidget.js
+++ b/src/components/widgets/TimeWidget.js
@@ -1,0 +1,109 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { pad } from "../../utils";
+
+export const isHHMMFormat = /^(?:2[0-3]|[01]?[0-9]):[0-5][0-9]$/;
+export const is24HourFormatWithMilli = /^(?:2[0-3]|[01]?[0-9]):[0-5][0-9](?::[0-5][0-9](?:.[0-9][0-9][0-9])?)?$/;
+
+/**
+ * Convert stored form RFC3339 format HH:MM:SS into format suitable for input in typical browsers (HH:MM).
+ *
+ * Ideal world could hand as-is, but for browsers that do not support input="time" we can do the formatting for them.
+ *
+ * @param jsonDate
+ * @returns {string}
+ */
+export function sanitizeValueForBrowserInput(jsonDate) {
+  if (!jsonDate) {
+    return "";
+  }
+
+  // If we do not understand we should either bail or maintain value
+  // Unsure of proper avenue we are maintaining value in hopes to do least harm incase of data mismatch..
+  // Validator should catch it as should browser. Alternative deletes their data and enforce valid values.
+  if (!jsonDate.match(is24HourFormatWithMilli)) {
+    return jsonDate;
+  }
+
+  // https://tools.ietf.org/html/rfc3339
+
+  // https://html.spec.whatwg.org/multipage/input.html#time-state-(type=time)
+  // The algorithm to convert a string to a Date object, given a string input, is as follows: If parsing a time from
+  // input results in an error, then return an error; otherwise, return a new Date object representing the parsed
+  // time in UTC on 1970-01-01.
+
+  const date = new Date("1970-01-01T" + jsonDate);
+
+  const hh = pad(date.getHours(), 2);
+  const mm = pad(date.getMinutes(), 2);
+  const ss = pad(date.getSeconds(), 2);
+  const SSS = pad(date.getMilliseconds(), 3);
+
+  // Users can specify precision using step attribute otherwise (some) browsers automatically trim off when 0
+  // and this value difference breaks the cursor position from ambiguity in the change diff
+  // For example if existing value is 1:10 and want 1:15 then when typing "1" and "5" into minutes section
+  // state will quickly go to 1:10:00.000 and when diffed with "1:10" will accept next keypress as 1:05 instead of
+  // the intended 1:15
+  return SSS === "000"
+    ? ss === "00" ? `${hh}:${mm}` : `${hh}:${mm}:${ss}`
+    : `${hh}:${mm}:${ss}.${SSS}`;
+}
+
+/**
+ * Convert HH:MM to HH:MM:SS.SSS
+ *
+ * Use of ajv and [RFC3339](https://tools.ietf.org/html/rfc3339) means we need the seconds to be present
+ * for valid "time" format but browsers tend to prefer HH:MM without :SS which ajv will fail.
+ *
+ * https://html.spec.whatwg.org/multipage/input.html#time-state-(type=time) describes the algorithm for parsing
+ * string to Date object as using the given time on date 1970-01-01, so this function uses this that approach.
+ *
+ * @param time Time string from input.
+ * @returns {string}
+ */
+export function ensureSecondsArePresentInTimeFormat(time) {
+  if (!time) {
+    return "";
+  }
+
+  // if (!time.match(isHHMMFormat)) {
+  //   return time;
+  // }
+
+  const timeVers = new Date("1970-01-01T" + time);
+  return (
+    pad(timeVers.getHours(), 2) +
+    ":" +
+    pad(timeVers.getMinutes(), 2) +
+    ":" +
+    pad(timeVers.getSeconds(), 2) +
+    "." +
+    (timeVers.getMilliseconds() / 1000).toFixed(3).slice(2, 5)
+  );
+}
+
+function TimeWidget(props) {
+  const {
+    value,
+    onChange,
+    registry: { widgets: { BaseInput } },
+    options: { step },
+  } = props;
+  return (
+    <BaseInput
+      type="time"
+      {...props}
+      value={sanitizeValueForBrowserInput(value)}
+      onChange={value => onChange(ensureSecondsArePresentInTimeFormat(value))}
+      step={step ? step : null}
+    />
+  );
+}
+
+if (process.env.NODE_ENV !== "production") {
+  TimeWidget.propTypes = {
+    value: PropTypes.string,
+  };
+}
+
+export default TimeWidget;

--- a/src/components/widgets/TimeWidget.js
+++ b/src/components/widgets/TimeWidget.js
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { pad } from "../../utils";
 
-export const isHHMMFormat = /^(?:2[0-3]|[01]?[0-9]):[0-5][0-9]$/;
 export const is24HourFormatWithMilli = /^(?:2[0-3]|[01]?[0-9]):[0-5][0-9](?::[0-5][0-9](?:.[0-9][0-9][0-9])?)?$/;
 
 /**
@@ -65,10 +64,6 @@ export function ensureSecondsArePresentInTimeFormat(time) {
   if (!time) {
     return "";
   }
-
-  // if (!time.match(isHHMMFormat)) {
-  //   return time;
-  // }
 
   const timeVers = new Date("1970-01-01T" + time);
   return (

--- a/src/components/widgets/TimeWidget.js
+++ b/src/components/widgets/TimeWidget.js
@@ -44,7 +44,9 @@ export function sanitizeValueForBrowserInput(jsonDate) {
   // state will quickly go to 1:10:00.000 and when diffed with "1:10" will accept next keypress as 1:05 instead of
   // the intended 1:15
   return SSS === "000"
-    ? ss === "00" ? `${hh}:${mm}` : `${hh}:${mm}:${ss}`
+    ? ss === "00"
+      ? `${hh}:${mm}`
+      : `${hh}:${mm}:${ss}`
     : `${hh}:${mm}:${ss}.${SSS}`;
 }
 
@@ -81,7 +83,9 @@ function TimeWidget(props) {
   const {
     value,
     onChange,
-    registry: { widgets: { BaseInput } },
+    registry: {
+      widgets: { BaseInput },
+    },
     options: { step },
   } = props;
   return (

--- a/src/components/widgets/UpDownWidget.js
+++ b/src/components/widgets/UpDownWidget.js
@@ -4,7 +4,11 @@ import PropTypes from "prop-types";
 import { rangeSpec } from "../../utils";
 
 function UpDownWidget(props) {
-  const { registry: { widgets: { BaseInput } } } = props;
+  const {
+    registry: {
+      widgets: { BaseInput },
+    },
+  } = props;
   return <BaseInput type="number" {...props} {...rangeSpec(props.schema)} />;
 }
 

--- a/src/components/widgets/index.js
+++ b/src/components/widgets/index.js
@@ -6,6 +6,7 @@ import CheckboxesWidget from "./CheckboxesWidget";
 import ColorWidget from "./ColorWidget";
 import DateWidget from "./DateWidget";
 import DateTimeWidget from "./DateTimeWidget";
+import TimeWidget from "./TimeWidget";
 import EmailWidget from "./EmailWidget";
 import FileWidget from "./FileWidget";
 import HiddenWidget from "./HiddenWidget";
@@ -28,6 +29,7 @@ export default {
   TextWidget,
   DateWidget,
   DateTimeWidget,
+  TimeWidget,
   AltDateWidget,
   AltDateTimeWidget,
   EmailWidget,

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,6 +27,7 @@ const widgetMap = {
     "date-time": "DateTimeWidget",
     "alt-date": "AltDateWidget",
     "alt-datetime": "AltDateTimeWidget",
+    time: "TimeWidget",
     color: "ColorWidget",
     file: "FileWidget",
   },

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -508,6 +508,135 @@ describe("StringField", () => {
     });
   });
 
+  describe("TimeWidget", () => {
+    it("should render a time field", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "string",
+          format: "time",
+        },
+      });
+
+      expect(node.querySelectorAll(".field [type=time]")).to.have.length.of(1);
+    });
+
+    it("should assign a default value", () => {
+      const datetime = "04:30";
+      const { comp, node } = createFormComponent({
+        schema: {
+          type: "string",
+          format: "time",
+          default: datetime,
+        },
+      });
+
+      expect(comp.state.formData).eql(datetime);
+      expect(node.querySelector("[type=time]").value).eql(datetime);
+    });
+
+    it("should reflect the change into the dom", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "string",
+          format: "time",
+        },
+      });
+
+      const newTime = "13:36:10.123";
+
+      Simulate.change(node.querySelector("[type=time]"), {
+        target: { value: newTime },
+      });
+
+      expect(node.querySelector("[type=time]").value).eql("13:36:10.123");
+    });
+
+    it("should pass step along", () => {
+      const { node } = createFormComponent({
+        uiSchema: {
+          "ui:options": {
+            step: 0.1,
+          },
+        },
+        schema: {
+          type: "string",
+          format: "time",
+        },
+      });
+
+      expect(node.querySelector("[type=time]").getAttribute("step")).eql("0.1");
+    });
+
+    it("should fill field with data", () => {
+      const datetime = "04:20";
+      const { comp, node } = createFormComponent({
+        schema: {
+          type: "string",
+          format: "time",
+        },
+        formData: datetime,
+      });
+
+      expect(comp.state.formData).eql(datetime);
+      expect(node.querySelector("[type=time]").value).eql(datetime);
+    });
+
+    it("should render the widget with the expected id", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "string",
+          format: "time",
+        },
+      });
+
+      expect(node.querySelector("[type=time]").id).eql("root");
+    });
+
+    it("should reject an invalid entered datetime", () => {
+      const { comp, node } = createFormComponent({
+        schema: {
+          type: "string",
+          format: "time",
+        },
+        liveValidate: true,
+      });
+
+      Simulate.change(node.querySelector("[type=time]"), {
+        target: { value: "invalid" },
+      });
+
+      expect(comp.state.errors).to.have.length.of(1);
+    });
+
+    it("should render customized TimeWidget", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "string",
+          format: "time",
+        },
+        widgets: {
+          TimeWidget: CustomWidget,
+        },
+      });
+
+      expect(node.querySelector("#custom")).to.exist;
+    });
+
+    it("should allow overriding of BaseInput", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "string",
+          format: "time",
+        },
+        widgets: {
+          BaseInput: CustomWidget,
+        },
+      });
+
+      expect(node.querySelector("#custom")).to.exist;
+    });
+  });
+
   describe("DateWidget", () => {
     const uiSchema = { "ui:widget": "date" };
 

--- a/test/time_regexp_test.js
+++ b/test/time_regexp_test.js
@@ -1,0 +1,30 @@
+import { expect } from "chai";
+import {
+  isHHMMFormat,
+  is24HourFormatWithMilli,
+} from "../src/components/widgets/TimeWidget";
+
+describe("Time Regular Expression Tests", () => {
+  describe("isHHMMFormat", () => {
+    it("should not render if next props are equivalent", () => {
+      expect(isHHMMFormat.test("2018-01-01T08:00:00.000Z:")).eql(false);
+      expect(isHHMMFormat.test("14:")).eql(false);
+      expect(isHHMMFormat.test("invalid")).eql(false);
+      expect(isHHMMFormat.test("14:35")).eql(true);
+      expect(isHHMMFormat.test("14:35:13")).eql(false);
+      expect(isHHMMFormat.test("14:35:13.123")).eql(false);
+    });
+  });
+  describe("is24HourFormatWithMilli", () => {
+    it("should not render if next props are equivalent", () => {
+      expect(is24HourFormatWithMilli.test("2018-01-01T08:00:00.000Z:")).eql(
+        false
+      );
+      expect(is24HourFormatWithMilli.test("14:")).eql(false);
+      expect(is24HourFormatWithMilli.test("invalid")).eql(false);
+      expect(is24HourFormatWithMilli.test("14:35")).eql(true);
+      expect(is24HourFormatWithMilli.test("14:35:13")).eql(true);
+      expect(is24HourFormatWithMilli.test("14:35:13.123")).eql(true);
+    });
+  });
+});

--- a/test/time_regexp_test.js
+++ b/test/time_regexp_test.js
@@ -1,20 +1,7 @@
 import { expect } from "chai";
-import {
-  isHHMMFormat,
-  is24HourFormatWithMilli,
-} from "../src/components/widgets/TimeWidget";
+import { is24HourFormatWithMilli } from "../src/components/widgets/TimeWidget";
 
 describe("Time Regular Expression Tests", () => {
-  describe("isHHMMFormat", () => {
-    it("should not render if next props are equivalent", () => {
-      expect(isHHMMFormat.test("2018-01-01T08:00:00.000Z:")).eql(false);
-      expect(isHHMMFormat.test("14:")).eql(false);
-      expect(isHHMMFormat.test("invalid")).eql(false);
-      expect(isHHMMFormat.test("14:35")).eql(true);
-      expect(isHHMMFormat.test("14:35:13")).eql(false);
-      expect(isHHMMFormat.test("14:35:13.123")).eql(false);
-    });
-  });
   describe("is24HourFormatWithMilli", () => {
     it("should not render if next props are equivalent", () => {
       expect(is24HourFormatWithMilli.test("2018-01-01T08:00:00.000Z:")).eql(

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -632,6 +632,16 @@ describe("uiSchema", () => {
         );
       });
 
+      it("should focus on time input", () => {
+        shouldFocus(
+          {
+            type: "string",
+            format: "time",
+          },
+          { "ui:autofocus": true }
+        );
+      });
+
       it("should focus on alt-date input", () => {
         shouldFocus(
           {
@@ -1993,6 +2003,17 @@ describe("uiSchema", () => {
         );
       });
 
+      it("should disable a time widget", () => {
+        shouldBeDisabled(
+          "input[type=time]",
+          {
+            type: "string",
+            format: "time",
+          },
+          { "ui:disabled": true }
+        );
+      });
+
       it("should disable an alternative date widget", () => {
         const { node } = createFormComponent({
           schema: {
@@ -2265,6 +2286,17 @@ describe("uiSchema", () => {
           {
             type: "string",
             format: "date-time",
+          },
+          { "ui:readonly": true }
+        );
+      });
+
+      it("should mark as readonly a time widget", () => {
+        shouldBeReadonly(
+          "input[type=time]",
+          {
+            type: "string",
+            format: "time",
           },
           { "ui:readonly": true }
         );


### PR DESCRIPTION
### Reasons for making this change

react-jsonschema-form supports date and date-time String formats but not time itself while the underlying JSON parser used, ajv, supports the time format.

If this is related to existing tickets, include links to them as well.

This relates to https://github.com/mozilla-services/react-jsonschema-form/issues/878 in that the problem sounds like what I ran into and solved for in Chrome and noted solution at https://github.com/r4j4h/react-jsonschema-form/commit/0a39e3c8568263ac099e38b88c54a393f3a317e8#diff-b936f552ddd7fd586fc97f5b3ac7975cR42. I recreated locally and will try the same solution and push up another PR if it works to solve it.

This relates to https://github.com/mozilla-services/react-jsonschema-form/issues/496 as it punts on time zones. I thought I read something that confirmed time inputs adhere to `partial-time` from [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6) but I can't find it now so maybe it is `full-time` - we can fix that now or in a subsequent PR as desired.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
