### PR TITLE
Potential fix for DateTime Widget #878

### DIFF
--- a/src/components/widgets/DateTimeWidget.js
+++ b/src/components/widgets/DateTimeWidget.js
@@ -23,7 +23,16 @@ export function utcToLocal(jsonDate) {
   const ss = pad(date.getSeconds(), 2);
   const SSS = pad(date.getMilliseconds(), 3);
 
-  return `${yyyy}-${MM}-${dd}T${hh}:${mm}:${ss}.${SSS}`;
+  // Users can specify precision using step attribute otherwise (some) browsers automatically trim off when 0
+  // and this value difference breaks the cursor position from ambiguity in the change diff
+  // For example if an existing value is set and user focuses into the year field and types 1957, they
+  // go from 0001 and inbetween the 1 and the 9 the field renders current value in a format browser changes and
+  // so react sees the values as diff and resets cursor resulting in 0009 and then 0005 instead of the intended 1957.
+  return SSS === "000"
+    ? ss === "00"
+      ? `${yyyy}-${MM}-${dd}T${hh}:${mm}`
+      : `${yyyy}-${MM}-${dd}T${hh}:${mm}:${ss}`
+    : `${yyyy}-${MM}-${dd}T${hh}:${mm}:${ss}.${SSS}`;
 }
 
 export function localToUTC(dateString) {


### PR DESCRIPTION
Eagerly truncating optional seconds/milliseconds when ambiguous to improve behavior in browsers when editing a DateTime widget populated with data

### Reasons for making this change

https://github.com/mozilla-services/react-jsonschema-form/issues/878 exists and is eerily similar to a problem I encountered while working on https://github.com/mozilla-services/react-jsonschema-form/pull/894. I recreated locally and the fix worked.

I say potential because this workaround may have side effects in other browsers that don't eagerly truncate the seconds/milliseconds when they are potentially optional.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
