### PR TITLE
Add initial support for if/then/else and not

### DIFF
--- a/README.md
+++ b/README.md
@@ -1749,9 +1749,6 @@ JSON Schema Draft 7 introduces support for `if`/`then`/`else as a more procedura
     }
   },
   "if": {
-    "required": [
-      "referrer"
-    ],
     "properties": {
       "referrer": {
         "const": "Other (please specify)"

--- a/README.md
+++ b/README.md
@@ -1737,35 +1737,37 @@ JSON Schema Draft 7 introduces support for `if`/`then`/`else as a more procedura
 {
   "type": "object",
   "properties": {
-    "referrer": {
-      "title": "How did you hear about us?",
+    "ownsCar": {
+      "title": "Do you own a car?",
       "type": "string",
       "enum": [
-        "Friends",
-        "Family",
-        "Internet",
-        "Other (please specify)"
+        "Yes",
+        "No"
       ]
     }
   },
   "if": {
+    "required": [
+      "ownsCar"
+    ],
     "properties": {
-      "referrer": {
-        "const": "Other (please specify)"
+      "ownsCar": {
+        "const": "Yes"
       }
     }
   },
   "then": {
     "properties": {
-      "referrerOther": {
-        "title": "Other",
-        "type": "string"
+      "carColor": {
+        "title": "What color is your car?",
+        "type": "string",
+        "default": "#ff0000"
       }
     }
   },
   "else": {
     "properties": {
-      "referrerOther": {
+      "carColor": {
         "not": {}
       }
     }
@@ -1775,11 +1777,11 @@ JSON Schema Draft 7 introduces support for `if`/`then`/`else as a more procedura
 
 If the form data validates against the `if` schema then the `then` schema is merged into the form schema and rendered. An `else` schema can optionally be specified to be applied if the form data does not validate against the `if` schema.
 
-In the above example the `else` schema causes any previous input for `reffererOther` to be deleted when not applicable. Ommiting `"not": {}` would retain the value. See [not](#not) for more details.
+In the above example the `else` schema causes any previous input for `carColor` to be deleted when not applicable. Ommiting `"not": {}` would retain the value. See [not](#not) for more details.
 
 ## `not`
 
-Limited support is currently provided for the  `not` keyword. In some cases you may wish for form data to be deleted, this can be specified using `"not": {}`.
+Limited support is currently provided for the  `not` keyword. In some cases you may wish for form data to be deleted, this can be specified using `"not": {}`. See [`if`/`then`/`else`](#ifthenelse) for an example.
 
 ## JSON Schema supporting status
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ A [live playground](https://mozilla-services.github.io/react-jsonschema-form/) i
   - [Schema dependencies](#schema-dependencies)
      - [Conditional](#conditional)
      - [Dynamic](#dynamic)
+  - [`if`/`then`/`else`](#ifthenelse)
+  - [`not`](#not)
   - [JSON Schema supporting status](#json-schema-supporting-status)
   - [Tips and tricks](#tips-and-tricks)
   - [Contributing](#contributing)
@@ -1726,6 +1728,61 @@ In this example the user is prompted with different follow-up questions dynamica
 Note that this is quite far from complete `oneOf` support!
 
 In these examples, the "Do you have any pets?" question is validated against the corresponding property in each schema in the `oneOf` array. If exactly one matches, the rest of that schema is merged with the existing schema.
+
+## `if`/`then`/`else`
+
+JSON Schema Draft 7 introduces support for `if`/`then`/`else as a more procedural-like alternative to schema dependencies:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "referrer": {
+      "title": "How did you hear about us?",
+      "type": "string",
+      "enum": [
+        "Friends",
+        "Family",
+        "Internet",
+        "Other (please specify)"
+      ]
+    }
+  },
+  "if": {
+    "required": [
+      "referrer"
+    ],
+    "properties": {
+      "referrer": {
+        "const": "Other (please specify)"
+      }
+    }
+  },
+  "then": {
+    "properties": {
+      "referrerOther": {
+        "title": "Other",
+        "type": "string"
+      }
+    }
+  },
+  "else": {
+    "properties": {
+      "referrerOther": {
+        "not": {}
+      }
+    }
+  }
+}
+```
+
+If the form data validates against the `if` schema then the `then` schema is merged into the form schema and rendered. An `else` schema can optionally be specified to be applied if the form data does not validate against the `if` schema.
+
+In the above example the `else` schema causes any previous input for `reffererOther` to be deleted when not applicable. Ommiting `"not": {}` would retain the value. See [not](#not) for more details.
+
+## `not`
+
+Limited support is currently provided for the  `not` keyword. In some cases you may wish for form data to be deleted, this can be specified using `"not": {}`.
 
 ## JSON Schema supporting status
 

--- a/README.md
+++ b/README.md
@@ -1747,14 +1747,14 @@ JSON Schema Draft 7 introduces support for `if`/`then`/`else` as a more procedur
     }
   },
   "if": {
-    "required": [
-      "ownsCar"
-    ],
     "properties": {
       "ownsCar": {
         "const": "Yes"
       }
-    }
+    },
+    "required": [
+      "ownsCar"
+    ]
   },
   "then": {
     "properties": {

--- a/README.md
+++ b/README.md
@@ -1731,7 +1731,7 @@ In these examples, the "Do you have any pets?" question is validated against the
 
 ## `if`/`then`/`else`
 
-JSON Schema Draft 7 introduces support for `if`/`then`/`else as a more procedural-like alternative to schema dependencies:
+JSON Schema Draft 7 introduces support for `if`/`then`/`else` as a more procedural-like alternative to schema dependencies:
 
 ```json
 {

--- a/playground/samples/conditional.js
+++ b/playground/samples/conditional.js
@@ -2,18 +2,31 @@ module.exports = {
   schema: {
     type: "object",
     properties: {
-      referrer: {
-        title: "How did you hear about us?",
+      ownsCar: {
+        title: "Do you own a car?",
         type: "string",
-        enum: ["Friends", "Family", "Internet", "Other (please specify)"],
+        enum: ["Yes", "No"],
       },
     },
     if: {
-      properties: { referrer: { const: "Other (please specify)" } },
+      required: ["ownsCar"],
+      properties: { ownsCar: { const: "Yes" } },
     },
-    then: { properties: { referrerOther: { title: "Other", type: "string" } } },
-    else: { properties: { referrerOther: { not: {} } } },
+    then: {
+      properties: {
+        carColor: {
+          title: "What color is your car?",
+          type: "string",
+          default: "#ff0000",
+        },
+      },
+    },
+    else: { properties: { carColor: { not: {} } } },
   },
-  uiSchema: {},
+  uiSchema: {
+    carColor: {
+      "ui:widget": "color",
+    },
+  },
   formData: {},
 };

--- a/playground/samples/conditional.js
+++ b/playground/samples/conditional.js
@@ -9,8 +9,7 @@ module.exports = {
       },
     },
     if: {
-      required: ["referrer"],
-      properties: { referrer: { enum: ["Other (please specify)"] } },
+      properties: { referrer: { const: "Other (please specify)" } },
     },
     then: { properties: { referrerOther: { title: "Other", type: "string" } } },
     else: { properties: { referrerOther: { not: {} } } },

--- a/playground/samples/conditional.js
+++ b/playground/samples/conditional.js
@@ -9,8 +9,8 @@ module.exports = {
       },
     },
     if: {
-      required: ["ownsCar"],
       properties: { ownsCar: { const: "Yes" } },
+      required: ["ownsCar"],
     },
     then: {
       properties: {

--- a/playground/samples/conditional.js
+++ b/playground/samples/conditional.js
@@ -1,0 +1,20 @@
+module.exports = {
+  schema: {
+    type: "object",
+    properties: {
+      referrer: {
+        title: "How did you hear about us?",
+        type: "string",
+        enum: ["Friends", "Family", "Internet", "Other (please specify)"],
+      },
+    },
+    if: {
+      required: ["referrer"],
+      properties: { referrer: { enum: ["Other (please specify)"] } },
+    },
+    then: { properties: { referrerOther: { title: "Other", type: "string" } } },
+    else: { properties: { referrerOther: { not: {} } } },
+  },
+  uiSchema: {},
+  formData: {},
+};

--- a/playground/samples/index.js
+++ b/playground/samples/index.js
@@ -17,6 +17,7 @@ import customObject from "./customObject";
 import alternatives from "./alternatives";
 import propertyDependencies from "./propertyDependencies";
 import schemaDependencies from "./schemaDependencies";
+import conditional from "./conditional";
 
 export const samples = {
   Simple: simple,
@@ -38,4 +39,5 @@ export const samples = {
   Alternatives: alternatives,
   "Property dependencies": propertyDependencies,
   "Schema dependencies": schemaDependencies,
+  Conditional: conditional,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -431,7 +431,7 @@ export function retrieveSchema(schema, definitions = {}, formData = {}) {
       const { errors } = validateFormData(formData, ifSchema);
       // If the form data validates then use the `then` schema; otherwise the `else` schema
       const conditionalSchema = errors.length === 0 ? thenSchema : elseSchema;
-      // Merge the conditional schema (or and empty schema if undefined) with the remaining schema
+      // Merge the conditional schema (or an empty schema if undefined) with the remaining schema
       const updatedSchema = mergeSchemas(
         remainingSchema,
         conditionalSchema || {}

--- a/src/utils.js
+++ b/src/utils.js
@@ -419,6 +419,7 @@ export function retrieveSchema(schema, definitions = {}, formData = {}) {
     const resolvedSchema = resolveDependencies(schema, definitions, formData);
     return retrieveSchema(resolvedSchema, definitions, formData);
   } else if (schema.if || schema.then || schema.else) {
+    // Extract if/then/else and capture the remaining schema to be returned
     const {
       if: ifSchema,
       then: thenSchema,
@@ -426,13 +427,22 @@ export function retrieveSchema(schema, definitions = {}, formData = {}) {
       ...remainingSchema
     } = schema;
     if (isObject(ifSchema)) {
+      // The `if` schema is defined and is an object, validate against it
       const { errors } = validateFormData(formData, ifSchema);
+      // If the form data validates then use the `then` schema; otherwise the `else` schema
+      const conditionalSchema = errors.length === 0 ? thenSchema : elseSchema;
+      // Merge the conditional schema (or and empty schema if undefined) with the remaining schema
       const updatedSchema = mergeSchemas(
         remainingSchema,
-        errors.length === 0 ? thenSchema || {} : elseSchema || {}
+        conditionalSchema || {}
       );
       return retrieveSchema(updatedSchema, definitions, formData);
     } else {
+      // Use the remaining schema without merging anything with it
+      // Note that the remaining schema no longer contains any `then` or `else` schemas
+      // This is important so that and `if` schema that gets merged into the schema
+      // from a schema dependency or another if/then/else does not trigger an
+      // orphaned `then` or `else` schema.
       return retrieveSchema(remainingSchema, definitions, formData);
     }
   } else {
@@ -440,7 +450,9 @@ export function retrieveSchema(schema, definitions = {}, formData = {}) {
     // deep clone the schema before possibly mutating it
     schema = JSON.parse(JSON.stringify(schema));
     if (schema.type === "object" && isObject(schema.properties)) {
-      // delete any properties in the formData if their schemas are not: {} and remove not from the property schema
+      // delete any properties in the formData if their schemas contain
+      // `"not": {}` and remove `not` from any property schemas so that no
+      // attempts are made to render them
       for (const propertyKey of Object.keys(schema.properties)) {
         const propertySchema = schema.properties[propertyKey];
         if (deepEquals(propertySchema.not, {})) {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -845,6 +845,118 @@ describe("utils", () => {
         });
       });
     });
+
+    describe("if/then/else", () => {
+      describe("true", () => {
+        it("should merge `then` schema properties", () => {
+          const schema = {
+            type: "object",
+            properties: {
+              a: { type: "integer" },
+            },
+            if: {
+              properties: {
+                a: {
+                  minimum: 100,
+                },
+              },
+            },
+            then: {
+              required: ["a"],
+            },
+          };
+          const formData = { a: 100 };
+          expect(retrieveSchema(schema, {}, formData)).eql({
+            type: "object",
+            properties: {
+              a: { type: "integer" },
+            },
+            required: ["a"],
+          });
+        });
+        it("should not merge `else` schema properties", () => {
+          const schema = {
+            type: "object",
+            properties: {
+              a: { type: "integer" },
+            },
+            if: {
+              properties: {
+                a: {
+                  minimum: 100,
+                },
+              },
+            },
+            else: {
+              required: ["a"],
+            },
+          };
+          const formData = { a: 100 };
+          expect(retrieveSchema(schema, {}, formData)).eql({
+            type: "object",
+            properties: {
+              a: { type: "integer" },
+            },
+          });
+        });
+      });
+      describe("false", () => {
+        it("should merge `else` schema properties", () => {
+          const schema = {
+            type: "object",
+            properties: {
+              a: { type: "integer" },
+            },
+            if: {
+              properties: {
+                a: {
+                  minimum: 100,
+                },
+              },
+            },
+            then: {
+              multipleOf: 3,
+            },
+            else: {
+              required: ["a"],
+            },
+          };
+          const formData = { a: 99 };
+          expect(retrieveSchema(schema, {}, formData)).eql({
+            type: "object",
+            properties: {
+              a: { type: "integer" },
+            },
+            required: ["a"],
+          });
+        });
+        it("should not merge `then` schema properties", () => {
+          const schema = {
+            type: "object",
+            properties: {
+              a: { type: "integer" },
+            },
+            if: {
+              properties: {
+                a: {
+                  minimum: 100,
+                },
+              },
+            },
+            then: {
+              required: ["a"],
+            },
+          };
+          const formData = { a: 99 };
+          expect(retrieveSchema(schema, {}, formData)).eql({
+            type: "object",
+            properties: {
+              a: { type: "integer" },
+            },
+          });
+        });
+      });
+    });
   });
 
   describe("shouldRender", () => {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -957,6 +957,29 @@ describe("utils", () => {
         });
       });
     });
+
+    describe("not", () => {
+      describe("{}", () => {
+        it("should remove data", () => {
+          const schema = {
+            type: "object",
+            properties: {
+              a: { type: "integer" },
+              b: { type: "integer", not: {} },
+            },
+          };
+          const formData = { a: 42, b: 12 };
+          expect(retrieveSchema(schema, {}, formData)).eql({
+            type: "object",
+            properties: {
+              a: { type: "integer" },
+              b: { type: "integer" },
+            },
+          });
+          expect(formData).eql({ a: 42 });
+        });
+      });
+    });
   });
 
   describe("shouldRender", () => {


### PR DESCRIPTION
- if/then/else follows Draft 7 keyword definitions
- for special cases where you want to delete form data
  (e.g. based on some condition) `"not": {}` can be used
  to specify that nothing is allowed for a property.

### Reasons for making this change

Schema dependencies don't allow triggering conditional schema on the absence of some property and can sometimes be difficult to understand with their declarative nature (e.g. when using `oneOf`).

Add support for Draft 7's `if`/`then`/`else` makes it possible to define conditional schema attributes using any schema.

This also leads to cases where some input data should only be allowed and persisted in the form data when applicable and be removed when not applicable. As such, this change also includes very basic/limited support for the `not` keyword to specify that any associated value with a property key should be deleted via `"not": {}` (see examples and README for details).

Closes #885.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [x] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
