### PR TITLE
Added `alt-time` Time input Widget as new String format

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Please note that while standardized, `datetime-local` and `date` input elements 
 
 - `alt-datetime`: Six `select` elements are used to select the year, the month, the day, the hour, the minute and the second;
 - `alt-date`: Three `select` elements are used to select the year, month and the day.
+- `alt-time`: Two `select` elements are used to select the hour and minutes.
 
 ![](http://i.imgur.com/VF5tY60.png)
 

--- a/playground/samples/date.js
+++ b/playground/samples/date.js
@@ -32,6 +32,10 @@ module.exports = {
             type: "string",
             format: "date",
           },
+          "alt-time": {
+            type: "string",
+            format: "time",
+          },
         },
       },
     },
@@ -49,6 +53,9 @@ module.exports = {
         "ui:options": {
           yearsRange: [1980, 2030],
         },
+      },
+      "alt-time": {
+        "ui:widget": "alt-time",
       },
     },
   },

--- a/src/components/widgets/AltTimeWidget.js
+++ b/src/components/widgets/AltTimeWidget.js
@@ -1,0 +1,205 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+
+import {
+  shouldRender,
+  parseDateString as _parseDateString,
+  toDateString as _toDateString,
+  pad,
+} from "../../utils";
+
+function parseTimeString(dateString) {
+  if (dateString) {
+    dateString = "1970-01-01T" + dateString + "Z";
+  }
+  let result = _parseDateString(dateString, true);
+  if (result) {
+    delete result.year;
+    delete result.month;
+    delete result.day;
+  }
+  return result;
+}
+
+function toTimeString(dataObj) {
+  let tArgs = { ...dataObj };
+  tArgs.year = 1970;
+  tArgs.month = 1;
+  tArgs.day = 1;
+  let result = _toDateString(tArgs);
+  return fromDateStringToTime(result);
+}
+
+/**
+ *
+ * @param dateString
+ * @returns {*}
+ */
+function fromDateStringToTime(dateString) {
+  if (dateString) {
+    if (dateString.length >= 23) {
+      return dateString.slice(11, 23);
+    } else if (dateString.length === 19) {
+      return dateString.slice(11, 19);
+    }
+  }
+  console.warn(dateString + " is an unknown date format.");
+  return dateString;
+}
+
+function rangeOptions(start, stop) {
+  let options = [];
+  for (let i = start; i <= stop; i++) {
+    options.push({ value: i, label: pad(i, 2) });
+  }
+  return options;
+}
+
+function readyForChange(state) {
+  return Object.keys(state).every(key => state[key] !== -1);
+}
+
+function DateElement(props) {
+  const {
+    type,
+    range,
+    value,
+    select,
+    rootId,
+    disabled,
+    readonly,
+    autofocus,
+    registry,
+    onBlur,
+  } = props;
+  const id = rootId + "_" + type;
+  const { SelectWidget } = registry.widgets;
+  return (
+    <SelectWidget
+      schema={{ type: "integer" }}
+      id={id}
+      className="form-control"
+      options={{ enumOptions: rangeOptions(range[0], range[1]) }}
+      placeholder={type}
+      value={value}
+      disabled={disabled}
+      readonly={readonly}
+      autofocus={autofocus}
+      onChange={value => select(type, value)}
+      onBlur={onBlur}
+    />
+  );
+}
+
+class AltTimeWidget extends Component {
+  static defaultProps = {
+    disabled: false,
+    readonly: false,
+    autofocus: false,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = parseTimeString(props.value);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState(parseTimeString(nextProps.value));
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return shouldRender(this, nextProps, nextState);
+  }
+
+  onChange = (property, value) => {
+    this.setState(
+      { [property]: typeof value === "undefined" ? -1 : value },
+      () => {
+        // Only propagate to parent state if we have a complete date{time}
+        if (readyForChange(this.state)) {
+          this.props.onChange(toTimeString(this.state));
+        }
+      }
+    );
+  };
+
+  setNow = event => {
+    event.preventDefault();
+    const { disabled, readonly, onChange } = this.props;
+    if (disabled || readonly) {
+      return;
+    }
+    const nowDateObj = _parseDateString(new Date().toJSON());
+    this.setState(nowDateObj, () => onChange(toTimeString(this.state)));
+  };
+
+  clear = event => {
+    event.preventDefault();
+    const { disabled, readonly, onChange } = this.props;
+    if (disabled || readonly) {
+      return;
+    }
+    this.setState(parseTimeString(""), () => onChange(undefined));
+  };
+
+  get dateElementProps() {
+    const { hour, minute, second } = this.state;
+    const data = [
+      { type: "hour", range: [0, 23], value: hour },
+      { type: "minute", range: [0, 59], value: minute },
+      { type: "second", range: [0, 59], value: second },
+    ];
+    return data;
+  }
+
+  render() {
+    const { id, disabled, readonly, autofocus, registry, onBlur } = this.props;
+    return (
+      <ul className="list-inline">
+        {this.dateElementProps.map((elemProps, i) => (
+          <li key={i}>
+            <DateElement
+              rootId={id}
+              select={this.onChange}
+              {...elemProps}
+              disabled={disabled}
+              readonly={readonly}
+              registry={registry}
+              onBlur={onBlur}
+              autofocus={autofocus && i === 0}
+            />
+          </li>
+        ))}
+        <li>
+          <a href="#" className="btn btn-info btn-now" onClick={this.setNow}>
+            Now
+          </a>
+        </li>
+        <li>
+          <a
+            href="#"
+            className="btn btn-warning btn-clear"
+            onClick={this.clear}>
+            Clear
+          </a>
+        </li>
+      </ul>
+    );
+  }
+}
+console.log("abc");
+if (process.env.NODE_ENV !== "production") {
+  AltTimeWidget.propTypes = {
+    schema: PropTypes.object.isRequired,
+    id: PropTypes.string.isRequired,
+    value: PropTypes.string,
+    required: PropTypes.bool,
+    disabled: PropTypes.bool,
+    readonly: PropTypes.bool,
+    autofocus: PropTypes.bool,
+    onChange: PropTypes.func,
+    onBlur: PropTypes.func,
+  };
+}
+
+export default AltTimeWidget;

--- a/src/components/widgets/AltTimeWidget.js
+++ b/src/components/widgets/AltTimeWidget.js
@@ -187,7 +187,7 @@ class AltTimeWidget extends Component {
     );
   }
 }
-console.log("abc");
+
 if (process.env.NODE_ENV !== "production") {
   AltTimeWidget.propTypes = {
     schema: PropTypes.object.isRequired,

--- a/src/components/widgets/index.js
+++ b/src/components/widgets/index.js
@@ -1,5 +1,6 @@
 import AltDateWidget from "./AltDateWidget";
 import AltDateTimeWidget from "./AltDateTimeWidget";
+import AltTimeWidget from "./AltTimeWidget";
 import BaseInput from "./BaseInput";
 import CheckboxWidget from "./CheckboxWidget";
 import CheckboxesWidget from "./CheckboxesWidget";
@@ -30,6 +31,7 @@ export default {
   DateTimeWidget,
   AltDateWidget,
   AltDateTimeWidget,
+  AltTimeWidget,
   EmailWidget,
   URLWidget,
   TextareaWidget,

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,6 +27,7 @@ const widgetMap = {
     "date-time": "DateTimeWidget",
     "alt-date": "AltDateWidget",
     "alt-datetime": "AltDateTimeWidget",
+    "alt-time": "AltTimeWidget",
     color: "ColorWidget",
     file: "FileWidget",
   },

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -1219,7 +1219,7 @@ describe("StringField", () => {
     });
 
     it("should fill field with data", () => {
-      const datetime = '03:04:05.000';
+      const datetime = "03:04:05.000";
       const { comp } = createFormComponent({
         schema: {
           type: "string",

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -687,6 +687,20 @@ describe("uiSchema", () => {
           "select"
         );
       });
+
+      it("should focus on alt-time input", () => {
+        shouldFocus(
+          {
+            type: "string",
+            format: "time",
+          },
+          {
+            "ui:widget": "alt-time",
+            "ui:autofocus": true,
+          },
+          "select"
+        );
+      });
     });
 
     describe("array", () => {
@@ -2062,6 +2076,25 @@ describe("uiSchema", () => {
         );
         expect(disabled).eql([true, true, true, true, true, true]);
       });
+
+      it("should disable an alternative time widget", () => {
+        const { node } = createFormComponent({
+          schema: {
+            type: "string",
+            format: "time",
+          },
+          uiSchema: {
+            "ui:disabled": true,
+            "ui:widget": "alt-time",
+          },
+        });
+
+        const disabled = [].map.call(
+          node.querySelectorAll("select"),
+          node => node.disabled
+        );
+        expect(disabled).eql([true, true, true]);
+      });
     });
   });
 
@@ -2340,6 +2373,24 @@ describe("uiSchema", () => {
           node.hasAttribute("disabled")
         );
         expect(readonly).eql([true, true, true, true, true, true]);
+      });
+
+      it("should mark readonly as disabled on an alternative time widget", () => {
+        const { node } = createFormComponent({
+          schema: {
+            type: "string",
+            format: "time",
+          },
+          uiSchema: {
+            "ui:readonly": true,
+            "ui:widget": "alt-time",
+          },
+        });
+
+        const readonly = [].map.call(node.querySelectorAll("select"), node =>
+          node.hasAttribute("disabled")
+        );
+        expect(readonly).eql([true, true, true]);
       });
     });
   });


### PR DESCRIPTION
### Reasons for making this change

react-jsonschema-form supports date and date-time String formats but not time itself while the underlying JSON parser used, ajv, supports the time format.

This adds a more browser-safe time input option through the already existing `alt` widget family.

#894 is an approach towards a "browser native" time input, while this is the more accessible drop down version.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
