### PR TITLE
Allow customization of 'Now' and 'Clear' buttons in alt-date widget

### DIFF
--- a/packages/core/docs/form-customization.md
+++ b/packages/core/docs/form-customization.md
@@ -56,7 +56,7 @@ render((
 
 ### Alternative widgets
 
-The uiSchema `ui:widget` property tells the form which UI widget should be used to render a field. 
+The uiSchema `ui:widget` property tells the form which UI widget should be used to render a field.
 
 Example:
 
@@ -112,7 +112,7 @@ Please note that, even though they are standardized, `datetime-local` and `date`
 
 ![](https://i.imgur.com/VF5tY60.png)
 
-You can customize the list of years displayed in the `year` dropdown by providing a ``yearsRange`` property to ``ui:options`` in your uiSchema. Its also possible to remove the `Now` and `Clear` buttons with the `hideNowButton` and `hideClearButton` options.
+You can customize the list of years displayed in the `year` dropdown by providing a `yearsRange` property to `ui:options` in your uiSchema. The labels and placeholders are customizable using the `labels` and `placeholder` options. It's also possible to remove the `Now` and `Clear` buttons with the `hideNowButton` and `hideClearButton` options.
 
 ```jsx
 uiSchema: {
@@ -121,6 +121,18 @@ uiSchema: {
       "ui:widget": "alt-datetime",
       "ui:options": {
         yearsRange: [1980, 2030],
+        placeholders: {
+          year: "year",
+          month: "month",
+          day: "day",
+          hour: "hour",
+          minute: "minute",
+          second: "second",
+        },
+        labels: {
+          clear: "Clear",
+          now: "Now",
+        },
         hideNowButton: true,
         hideClearButton: true,
       },
@@ -735,7 +747,7 @@ The `Form` component supports the following html attributes:
 
 ### Disabling a form
 
-It's possible to disable the whole form by setting the `disabled` prop. The `disabled` prop is then forwarded down to each field of the form. 
+It's possible to disable the whole form by setting the `disabled` prop. The `disabled` prop is then forwarded down to each field of the form.
 
 ```jsx
 <Form
@@ -743,7 +755,7 @@ It's possible to disable the whole form by setting the `disabled` prop. The `dis
   schema={} />
 ```
 
-If you just want to disable some of the fields, see the [`ui:disabled`](#disabled-fields) parameter in the `uiSchema` directive. 
+If you just want to disable some of the fields, see the [`ui:disabled`](#disabled-fields) parameter in the `uiSchema` directive.
 
 
 ### Changing the tag name

--- a/packages/core/docs/form-customization.md
+++ b/packages/core/docs/form-customization.md
@@ -115,7 +115,7 @@ Please note that, even though they are standardized, `datetime-local` and `date`
 You can customize the list of years displayed in the `year` dropdown by providing a `yearsRange` property to `ui:options` in your uiSchema. The labels and placeholders are customizable using the `labels` and `placeholder` options. It's also possible to remove the `Now` and `Clear` buttons with the `hideNowButton` and `hideClearButton` options.
 
 ```jsx
-uiSchema: {
+const uiSchema = {
   a_date: {
     "alt-datetime": {
       "ui:widget": "alt-datetime",

--- a/packages/core/playground/samples/date.js
+++ b/packages/core/playground/samples/date.js
@@ -41,6 +41,18 @@ module.exports = {
       "alt-datetime": {
         "ui:widget": "alt-datetime",
         "ui:options": {
+          placeholders: {
+            year: "Jahr",
+            month: "Monat",
+            day: "Tag",
+            hour: "Stunde",
+            minute: "Minute",
+            second: "Sekunde",
+          },
+          labels: {
+            clear: "Zurücksetzen",
+            now: "Jetzt",
+          },
           yearsRange: [1980, 2030],
         },
       },

--- a/packages/core/src/components/widgets/AltDateWidget.js
+++ b/packages/core/src/components/widgets/AltDateWidget.js
@@ -48,6 +48,20 @@ function DateElement(props) {
   );
 }
 
+const defaultLabels = {
+  now: "Now",
+  clear: "Clear",
+};
+
+const defaultPlaceholders = {
+  year: "year",
+  month: "month",
+  day: "day",
+  hour: "hour",
+  minute: "minute",
+  second: "second",
+};
+
 class AltDateWidget extends Component {
   static defaultProps = {
     time: false,
@@ -56,18 +70,8 @@ class AltDateWidget extends Component {
     autofocus: false,
     options: {
       yearsRange: [1900, new Date().getFullYear() + 2],
-      labels: {
-        now: "Now",
-        clear: "Clear",
-      },
-      placeholders: {
-        year: "year",
-        month: "month",
-        day: "day",
-        hour: "hour",
-        minute: "minute",
-        second: "second",
-      },
+      labels: defaultLabels,
+      placeholders: defaultPlaceholders,
     },
   };
 
@@ -124,19 +128,19 @@ class AltDateWidget extends Component {
     const data = [
       {
         type: "year",
-        placeholder: placeholders.year,
+        placeholder: placeholders.year || defaultPlaceholders.year,
         range: options.yearsRange,
         value: year,
       },
       {
         type: "month",
-        placeholder: placeholders.month,
+        placeholder: placeholders.month || defaultPlaceholders.month,
         range: [1, 12],
         value: month,
       },
       {
         type: "day",
-        placeholder: placeholders.day,
+        placeholder: placeholders.day || defaultPlaceholders.day,
         range: [1, 31],
         value: day,
       },
@@ -145,19 +149,19 @@ class AltDateWidget extends Component {
       data.push(
         {
           type: "hour",
-          placeholder: placeholders.hour,
+          placeholder: placeholders.hour || defaultPlaceholders.hour,
           range: [0, 23],
           value: hour,
         },
         {
           type: "minute",
-          placeholder: placeholders.minute,
+          placeholder: placeholders.minute || defaultPlaceholders.minute,
           range: [0, 59],
           value: minute,
         },
         {
           type: "second",
-          placeholder: placeholders.second,
+          placeholder: placeholders.second || defaultPlaceholders.second,
           range: [0, 59],
           value: second,
         }
@@ -197,7 +201,7 @@ class AltDateWidget extends Component {
           : true) && (
           <li>
             <a href="#" className="btn btn-info btn-now" onClick={this.setNow}>
-              {labels.now}
+              {labels.now || defaultLabels.now}
             </a>
           </li>
         )}
@@ -209,7 +213,7 @@ class AltDateWidget extends Component {
               href="#"
               className="btn btn-warning btn-clear"
               onClick={this.clear}>
-              {labels.clear}
+              {labels.clear || defaultLabels.clear}
             </a>
           </li>
         )}

--- a/packages/core/src/components/widgets/AltDateWidget.js
+++ b/packages/core/src/components/widgets/AltDateWidget.js
@@ -55,6 +55,8 @@ class AltDateWidget extends Component {
     autofocus: false,
     options: {
       yearsRange: [1900, new Date().getFullYear() + 2],
+      now: "Now",
+      clear: "Clear",
     },
   };
 
@@ -155,7 +157,7 @@ class AltDateWidget extends Component {
           : true) && (
           <li>
             <a href="#" className="btn btn-info btn-now" onClick={this.setNow}>
-              Now
+              {options.now}
             </a>
           </li>
         )}
@@ -167,7 +169,7 @@ class AltDateWidget extends Component {
               href="#"
               className="btn btn-warning btn-clear"
               onClick={this.clear}>
-              Clear
+              {options.clear}
             </a>
           </li>
         )}

--- a/packages/core/src/components/widgets/AltDateWidget.js
+++ b/packages/core/src/components/widgets/AltDateWidget.js
@@ -57,6 +57,12 @@ class AltDateWidget extends Component {
       yearsRange: [1900, new Date().getFullYear() + 2],
       now: "Now",
       clear: "Clear",
+      year: "year",
+      month: "month",
+      day: "day",
+      hour: "hour",
+      minute: "minute",
+      second: "second",
     },
   };
 
@@ -109,18 +115,18 @@ class AltDateWidget extends Component {
     const { year, month, day, hour, minute, second } = this.state;
     const data = [
       {
-        type: "year",
+        type: options.year,
         range: options.yearsRange,
         value: year,
       },
-      { type: "month", range: [1, 12], value: month },
-      { type: "day", range: [1, 31], value: day },
+      { type: options.month, range: [1, 12], value: month },
+      { type: options.day, range: [1, 31], value: day },
     ];
     if (time) {
       data.push(
-        { type: "hour", range: [0, 23], value: hour },
-        { type: "minute", range: [0, 59], value: minute },
-        { type: "second", range: [0, 59], value: second }
+        { type: options.hour, range: [0, 23], value: hour },
+        { type: options.minute, range: [0, 59], value: minute },
+        { type: options.second, range: [0, 59], value: second }
       );
     }
     return data;

--- a/packages/core/src/components/widgets/AltDateWidget.js
+++ b/packages/core/src/components/widgets/AltDateWidget.js
@@ -56,14 +56,18 @@ class AltDateWidget extends Component {
     autofocus: false,
     options: {
       yearsRange: [1900, new Date().getFullYear() + 2],
-      now: "Now",
-      clear: "Clear",
-      year: "year",
-      month: "month",
-      day: "day",
-      hour: "hour",
-      minute: "minute",
-      second: "second",
+      labels: {
+        now: "Now",
+        clear: "Clear",
+      },
+      placeholders: {
+        year: "year",
+        month: "month",
+        day: "day",
+        hour: "hour",
+        minute: "minute",
+        second: "second",
+      },
     },
   };
 
@@ -112,40 +116,48 @@ class AltDateWidget extends Component {
   };
 
   get dateElementProps() {
-    const { time, options } = this.props;
+    const {
+      time,
+      options: { placeholders, ...options },
+    } = this.props;
     const { year, month, day, hour, minute, second } = this.state;
     const data = [
       {
         type: "year",
-        placeholder: options.year,
+        placeholder: placeholders.year,
         range: options.yearsRange,
         value: year,
       },
       {
         type: "month",
-        placeholder: options.month,
+        placeholder: placeholders.month,
         range: [1, 12],
         value: month,
       },
-      { type: "day", placeholder: options.day, range: [1, 31], value: day },
+      {
+        type: "day",
+        placeholder: placeholders.day,
+        range: [1, 31],
+        value: day,
+      },
     ];
     if (time) {
       data.push(
         {
           type: "hour",
-          placeholder: options.hour,
+          placeholder: placeholders.hour,
           range: [0, 23],
           value: hour,
         },
         {
           type: "minute",
-          placeholder: options.minute,
+          placeholder: placeholders.minute,
           range: [0, 59],
           value: minute,
         },
         {
           type: "second",
-          placeholder: options.second,
+          placeholder: placeholders.second,
           range: [0, 59],
           value: second,
         }
@@ -162,7 +174,7 @@ class AltDateWidget extends Component {
       autofocus,
       registry,
       onBlur,
-      options,
+      options: { labels, ...options },
     } = this.props;
     return (
       <ul className="list-inline">
@@ -185,7 +197,7 @@ class AltDateWidget extends Component {
           : true) && (
           <li>
             <a href="#" className="btn btn-info btn-now" onClick={this.setNow}>
-              {options.now}
+              {labels.now}
             </a>
           </li>
         )}
@@ -197,7 +209,7 @@ class AltDateWidget extends Component {
               href="#"
               className="btn btn-warning btn-clear"
               onClick={this.clear}>
-              {options.clear}
+              {labels.clear}
             </a>
           </li>
         )}

--- a/packages/core/src/components/widgets/AltDateWidget.js
+++ b/packages/core/src/components/widgets/AltDateWidget.js
@@ -18,6 +18,7 @@ function readyForChange(state) {
 function DateElement(props) {
   const {
     type,
+    placeholder,
     range,
     value,
     select,
@@ -36,7 +37,7 @@ function DateElement(props) {
       id={id}
       className="form-control"
       options={{ enumOptions: rangeOptions(range[0], range[1]) }}
-      placeholder={type}
+      placeholder={placeholder}
       value={value}
       disabled={disabled}
       readonly={readonly}
@@ -115,18 +116,39 @@ class AltDateWidget extends Component {
     const { year, month, day, hour, minute, second } = this.state;
     const data = [
       {
-        type: options.year,
+        type: "year",
+        placeholder: options.year,
         range: options.yearsRange,
         value: year,
       },
-      { type: options.month, range: [1, 12], value: month },
-      { type: options.day, range: [1, 31], value: day },
+      {
+        type: "month",
+        placeholder: options.month,
+        range: [1, 12],
+        value: month,
+      },
+      { type: "day", placeholder: options.day, range: [1, 31], value: day },
     ];
     if (time) {
       data.push(
-        { type: options.hour, range: [0, 23], value: hour },
-        { type: options.minute, range: [0, 59], value: minute },
-        { type: options.second, range: [0, 59], value: second }
+        {
+          type: "hour",
+          placeholder: options.hour,
+          range: [0, 23],
+          value: hour,
+        },
+        {
+          type: "minute",
+          placeholder: options.minute,
+          range: [0, 59],
+          value: minute,
+        },
+        {
+          type: "second",
+          placeholder: options.second,
+          range: [0, 59],
+          value: second,
+        }
       );
     }
     return data;

--- a/packages/core/test/StringField_test.js
+++ b/packages/core/test/StringField_test.js
@@ -960,6 +960,42 @@ describe("StringField", () => {
       ]);
     });
 
+    it("should use the provided placeholders in dropdowns", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "string",
+          format: "date-time",
+        },
+        uiSchema: {
+          ...uiSchema,
+          "ui:options": {
+            placeholders: {
+              year: "jaro",
+              month: "monato",
+              day: "tago",
+              hour: "horo",
+              minute: "minuto",
+              second: "sekundo",
+            },
+          },
+        },
+      });
+
+      const placeholders = [].map.call(
+        node.querySelectorAll("select option:first-child"),
+        node => node.textContent
+      );
+
+      expect(placeholders).eql([
+        "jaro",
+        "monato",
+        "tago",
+        "horo",
+        "minuto",
+        "sekundo",
+      ]);
+    });
+
     describe("Action buttons", () => {
       it("should render action buttons", () => {
         const { node } = createFormComponent({
@@ -1007,6 +1043,30 @@ describe("StringField", () => {
         Simulate.click(node.querySelector("a.btn-clear"));
 
         expect(comp.state.formData).eql(undefined);
+      });
+
+      it("should use provided labels for action buttons", () => {
+        const { node } = createFormComponent({
+          schema: {
+            type: "string",
+            format: "date-time",
+          },
+          uiSchema: {
+            ...uiSchema,
+            "ui:options": {
+              labels: {
+                now: "nun",
+                clear: "malplenigi",
+              },
+            },
+          },
+        });
+
+        const buttonLabels = [].map.call(
+          node.querySelectorAll("a.btn"),
+          x => x.textContent
+        );
+        expect(buttonLabels).eql(["nun", "malplenigi"]);
       });
     });
 
@@ -1204,6 +1264,32 @@ describe("StringField", () => {
       ]);
     });
 
+    it("should use the provided placeholders in dropdowns", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "string",
+          format: "date-time",
+        },
+        uiSchema: {
+          ...uiSchema,
+          "ui:options": {
+            placeholders: {
+              year: "jaro",
+              month: "monato",
+              day: "tago",
+            },
+          },
+        },
+      });
+
+      const placeholders = [].map.call(
+        node.querySelectorAll("select option:first-child"),
+        node => node.textContent
+      );
+
+      expect(placeholders).eql(["jaro", "monato", "tago"]);
+    });
+
     it("should accept a valid date", () => {
       const { comp } = createFormComponent({
         schema: {
@@ -1267,6 +1353,30 @@ describe("StringField", () => {
         Simulate.click(node.querySelector("a.btn-clear"));
 
         expect(comp.state.formData).eql(undefined);
+      });
+
+      it("should use provided labels for action buttons", () => {
+        const { node } = createFormComponent({
+          schema: {
+            type: "string",
+            format: "date",
+          },
+          uiSchema: {
+            ...uiSchema,
+            "ui:options": {
+              labels: {
+                now: "nun",
+                clear: "malplenigi",
+              },
+            },
+          },
+        });
+
+        const buttonLabels = [].map.call(
+          node.querySelectorAll("a.btn"),
+          x => x.textContent
+        );
+        expect(buttonLabels).eql(["nun", "malplenigi"]);
       });
     });
 

--- a/packages/core/test/StringField_test.js
+++ b/packages/core/test/StringField_test.js
@@ -996,6 +996,39 @@ describe("StringField", () => {
       ]);
     });
 
+    it("should use default placeholders as fallback", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "string",
+          format: "date-time",
+        },
+        uiSchema: {
+          ...uiSchema,
+          "ui:options": {
+            placeholders: {
+              year: "YYYY",
+              month: "MM",
+              day: "DD",
+            },
+          },
+        },
+      });
+
+      const placeholders = [].map.call(
+        node.querySelectorAll("select option:first-child"),
+        node => node.textContent
+      );
+
+      expect(placeholders).eql([
+        "YYYY",
+        "MM",
+        "DD",
+        "hour",
+        "minute",
+        "second",
+      ]);
+    });
+
     describe("Action buttons", () => {
       it("should render action buttons", () => {
         const { node } = createFormComponent({
@@ -1068,6 +1101,29 @@ describe("StringField", () => {
         );
         expect(buttonLabels).eql(["nun", "malplenigi"]);
       });
+    });
+
+    it("should use default labels as fallback", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "string",
+          format: "date-time",
+        },
+        uiSchema: {
+          ...uiSchema,
+          "ui:options": {
+            labels: {
+              clear: "Reset",
+            },
+          },
+        },
+      });
+
+      const buttonLabels = [].map.call(
+        node.querySelectorAll("a.btn"),
+        x => x.textContent
+      );
+      expect(buttonLabels).eql(["Now", "Reset"]);
     });
 
     it("should render customized AltDateWidget", () => {


### PR DESCRIPTION
### Reasons for making this change

The *Now* and *Clear* buttons on the `alt-date` widget are static. This adds support for customization via `ui:options`.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
