### PR TITLE
Refactor idSchema related code

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -40,7 +40,6 @@ export default class Form extends Component {
     const mustValidate = edit && !props.noValidate && liveValidate;
     const { definitions } = schema;
     const formData = getDefaultFormState(schema, props.formData, definitions);
-    const retrievedSchema = retrieveSchema(schema, definitions, formData);
 
     const { errors, errorSchema } = mustValidate
       ? this.validate(formData, schema)
@@ -49,11 +48,10 @@ export default class Form extends Component {
           errorSchema: state.errorSchema || {},
         };
     const idSchema = toIdSchema(
-      retrievedSchema,
-      uiSchema["ui:rootFieldId"],
+      schema,
+      uiSchema["ui:rootFieldId"] || props.idPrefix,
       definitions,
-      formData,
-      props.idPrefix
+      formData
     );
     return {
       schema,
@@ -102,7 +100,17 @@ export default class Form extends Component {
 
   onChange = (formData, newErrorSchema) => {
     const mustValidate = !this.props.noValidate && this.props.liveValidate;
-    let state = { formData };
+    const { schema, uiSchema } = this.state;
+    const { definitions } = schema;
+    let state = {
+      formData,
+      idSchema: toIdSchema(
+        schema,
+        uiSchema["ui:rootFieldId"] || this.props.idPrefix,
+        definitions,
+        formData
+      ),
+    };
     if (mustValidate) {
       const { errors, errorSchema } = this.validate(formData);
       state = { ...state, errors, errorSchema };

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -12,7 +12,6 @@ import {
   allowAdditionalItems,
   optionsList,
   retrieveSchema,
-  toIdSchema,
   getDefaultRegistry,
 } from "../../utils";
 
@@ -368,7 +367,6 @@ class ArrayField extends Component {
       registry = getDefaultRegistry(),
       onBlur,
       onFocus,
-      idPrefix,
       rawErrors,
     } = this.props;
     const title = schema.title === undefined ? name : schema.title;
@@ -380,14 +378,7 @@ class ArrayField extends Component {
       items: formData.map((item, index) => {
         const itemSchema = retrieveSchema(schema.items, definitions, item);
         const itemErrorSchema = errorSchema ? errorSchema[index] : undefined;
-        const itemIdPrefix = idSchema.$id + "_" + index;
-        const itemIdSchema = toIdSchema(
-          itemSchema,
-          itemIdPrefix,
-          definitions,
-          item,
-          idPrefix
-        );
+        const itemIdSchema = idSchema[index];
         return this.renderArrayFieldItem({
           index,
           canMoveUp: index > 0,
@@ -510,7 +501,6 @@ class ArrayField extends Component {
       uiSchema,
       formData,
       errorSchema,
-      idPrefix,
       idSchema,
       name,
       required,
@@ -551,14 +541,7 @@ class ArrayField extends Component {
         const itemSchema = additional
           ? retrieveSchema(schema.additionalItems, definitions, item)
           : itemSchemas[index];
-        const itemIdPrefix = idSchema.$id + "_" + index;
-        const itemIdSchema = toIdSchema(
-          itemSchema,
-          itemIdPrefix,
-          definitions,
-          item,
-          idPrefix
-        );
+        const itemIdSchema = idSchema[index];
         const itemUiSchema = additional
           ? uiSchema.additionalItems || {}
           : Array.isArray(uiSchema.items)
@@ -592,7 +575,7 @@ class ArrayField extends Component {
       rawErrors,
     };
 
-    // Check if a custom template template was passed in
+    // check if a custom template template was passed in
     const Template = ArrayFieldTemplate || DefaultFixedArrayFieldTemplate;
     return <Template {...arrayProps} />;
   }

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -4,9 +4,7 @@ import PropTypes from "prop-types";
 import {
   isMultiSelect,
   retrieveSchema,
-  toIdSchema,
   getDefaultRegistry,
-  mergeObjects,
   getUiOptions,
   isFilesArray,
   deepEquals,
@@ -155,7 +153,6 @@ function SchemaFieldRender(props) {
     uiSchema,
     formData,
     errorSchema,
-    idPrefix,
     name,
     required,
     registry = getDefaultRegistry(),
@@ -168,10 +165,6 @@ function SchemaFieldRender(props) {
   } = registry;
   let idSchema = props.idSchema;
   const schema = retrieveSchema(props.schema, definitions, formData);
-  idSchema = mergeObjects(
-    toIdSchema(schema, null, definitions, formData, idPrefix),
-    idSchema
-  );
   const FieldComponent = getFieldComponent(schema, uiSchema, idSchema, fields);
   const { DescriptionField } = fields;
   const disabled = Boolean(props.disabled || uiSchema["ui:disabled"]);
@@ -206,7 +199,6 @@ function SchemaFieldRender(props) {
   const field = (
     <FieldComponent
       {...props}
-      idSchema={idSchema}
       schema={schema}
       uiSchema={{ ...uiSchema, classNames: undefined }}
       disabled={disabled}

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1027,9 +1027,15 @@ describe("utils", () => {
         },
       };
 
-      expect(toIdSchema(schema)).eql({
+      expect(
+        toIdSchema(schema, undefined, undefined, [
+          { foo: "foo 0" },
+          { foo: "foo 1" },
+        ])
+      ).eql({
         $id: "root",
-        foo: { $id: "root_foo" },
+        0: { $id: "root_0", foo: { $id: "root_0_foo" } },
+        1: { $id: "root_1", foo: { $id: "root_1_foo" } },
       });
     });
 
@@ -1068,13 +1074,11 @@ describe("utils", () => {
         $ref: "#/definitions/testdef",
       };
 
-      expect(toIdSchema(schema, undefined, schema.definitions, {}, "rjsf")).eql(
-        {
-          $id: "rjsf",
-          foo: { $id: "rjsf_foo" },
-          bar: { $id: "rjsf_bar" },
-        }
-      );
+      expect(toIdSchema(schema, "rjsf", schema.definitions, {})).eql({
+        $id: "rjsf",
+        foo: { $id: "rjsf_foo" },
+        bar: { $id: "rjsf_bar" },
+      });
     });
   });
 


### PR DESCRIPTION
### Reasons for making this change

Simply refactoring, no functionality change.
The reasons is to generate a well formed idSchema at the root instead of re-generate it everytime in the children components.
Also with this change, users can customize idSchema easier.

_**!!!This change might potentially break custom array schema components rely on idSchema.!!!**_

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests
  - [X] I've updated docs if needed
  - [X] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
