### PR TITLE
Bug/add nofill option

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,26 @@ const schema = {
 };
 ```
 
+When `minItems` is used with an array of objects it will cause the form data to be filled with at least as many objects as its value. To override this behavior, and to not prefill an array with default objects, you can use the `noFill` property and define a custom `default` for the array. This can be useful if you want to validate that an array is not empty without filling it with empty versions of the object.
+
+Example:
+
+```js
+const schema = {
+  type: "array",
+  minItems: 2,
+  title: "An object list",
+  default: [],
+  noFill: true,
+  items: {
+    type: "object",
+    properties: {
+      id: {type: "string"}
+    },
+  }
+};
+```
+
 By default, checkboxes are stacked. If you prefer them inline, set the `inline` property to `true`:
 
 ```js

--- a/src/utils.js
+++ b/src/utils.js
@@ -150,6 +150,9 @@ function computeDefaults(schema, parentDefaults, definitions = {}) {
 
     case "array":
       if (schema.minItems) {
+        if (schema.default && schema.noFill === true) {
+          return schema.default;
+        }
         if (!isMultiSelect(schema, definitions)) {
           const defaultsLength = defaults ? defaults.length : 0;
           if (schema.minItems > defaultsLength) {

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -490,6 +490,28 @@ describe("ArrayField", () => {
       expect(inputs[3].value).to.eql("");
     });
 
+    it("should render only the default when noFill is true, even when the default is less than minItems", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          turtles: {
+            type: "array",
+            minItems: 4,
+            default: ["Raphael", "Michaelangelo"],
+            noFill: true,
+            items: {
+              type: "string",
+            },
+          },
+        },
+      };
+      const { node } = createFormComponent({ schema });
+      const inputs = node.querySelectorAll("input[type=text]");
+      expect(inputs.length).to.eql(2);
+      expect(inputs[0].value).to.eql("Raphael");
+      expect(inputs[1].value).to.eql("Michaelangelo");
+    });
+
     it("should render enough input to match minItems, populating the first with default values, and the rest with the item default", () => {
       const schema = {
         type: "object",


### PR DESCRIPTION
### Reasons for making this change

Fixes #1026 

I am not exactly sure if this breaks some kind of json schema spec, but this seemed like the best way to fix this issue while still maintaining backwards compatibility.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've checked the rendering of the Markdown text I've added
  - [ ] If I'm adding a new section, I've updated the Table of Content
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated docs if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
