### PR TITLE
Add x-enumNames support

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -369,7 +369,9 @@ export function allowAdditionalItems(schema) {
 export function optionsList(schema) {
   if (schema.enum) {
     return schema.enum.map((value, i) => {
-      const label = (schema.enumNames && schema.enumNames[i]) || String(value);
+      const label = (schema.enumNames && schema.enumNames[i]) || 
+                    (schema["x-enumNames"] && schema["x-enumNames"][i]) || 
+                    String(value);
       return { label, value };
     });
   } else {


### PR DESCRIPTION
First: Thanks for this awesome project, works like a charm...

### Reasons for making this change

Add support for the x-enumNames property which has the same semantics as enumNames but uses the x- prefix to declare it as a custom/extension property. I'm maintaining the NJsonSchema C# library which generates these properties from .NET enums. See https://github.com/RSuter/NJsonSchema/wiki/Enums

I think it makes sense to support this scenario because this prefix is required/defined in the JSON Schema spec. It seems that the proposal for the property enumNames has been rejected in favor of const (see below). 

**Alternatives**

There are also const enums: https://github.com/json-schema-org/json-schema-spec/issues/67#issuecomment-300235090

Spec for const: https://github.com/json-schema-org/json-schema-spec/issues/58

### Checklist

* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated docs if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
