### PR TITLE
Allow choosing a seperate widget for MultiSelect rather than just Select

### DIFF
--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -433,7 +433,10 @@ class ArrayField extends Component {
     const { widgets, definitions, formContext } = registry;
     const itemsSchema = retrieveSchema(schema.items, definitions, formData);
     const enumOptions = optionsList(itemsSchema);
-    const { widget = "select", ...options } = {
+    const selectWidget = widgets.hasOwnProperty("MultiSelectWidget")
+      ? "multiselect"
+      : "select";
+    const { widget = selectWidget, ...options } = {
       ...getUiOptions(uiSchema),
       enumOptions,
     };

--- a/src/components/widgets/index.js
+++ b/src/components/widgets/index.js
@@ -38,5 +38,4 @@ export default {
   FileWidget,
   CheckboxWidget,
   CheckboxesWidget,
-  MultiSelectWidget: SelectWidget,
 };

--- a/src/components/widgets/index.js
+++ b/src/components/widgets/index.js
@@ -38,4 +38,5 @@ export default {
   FileWidget,
   CheckboxWidget,
   CheckboxesWidget,
+  MultiSelectWidget: SelectWidget,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -49,7 +49,8 @@ const widgetMap = {
     hidden: "HiddenWidget",
   },
   array: {
-    select: "MultiSelectWidget",
+    multiselect: "MultiSelectWidget",
+    select: "SelectWidget",
     checkboxes: "CheckboxesWidget",
     files: "FileWidget",
     hidden: "HiddenWidget",

--- a/src/utils.js
+++ b/src/utils.js
@@ -49,7 +49,7 @@ const widgetMap = {
     hidden: "HiddenWidget",
   },
   array: {
-    select: "SelectWidget",
+    select: "MultiSelectWidget",
     checkboxes: "CheckboxesWidget",
     files: "FileWidget",
     hidden: "HiddenWidget",

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -750,6 +750,23 @@ describe("ArrayField", () => {
         const { node } = createFormComponent({
           schema,
           widgets: {
+            SelectWidget: CustomComponent,
+          },
+          formData: ["foo", "foo"],
+          liveValidate: true,
+        });
+
+        const matches = node.querySelectorAll("#custom");
+        expect(matches).to.have.length.of(1);
+        expect(matches[0].textContent).to.eql(
+          "should NOT have duplicate items (items ## 0 and 1 are identical)"
+        );
+      });
+
+      it("should pass rawErrors down to custom widgets", () => {
+        const { node } = createFormComponent({
+          schema,
+          widgets: {
             MultiSelectWidget: CustomComponent,
           },
           formData: ["foo", "foo"],

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -750,7 +750,7 @@ describe("ArrayField", () => {
         const { node } = createFormComponent({
           schema,
           widgets: {
-            SelectWidget: CustomComponent,
+            MultiSelectWidget: CustomComponent,
           },
           formData: ["foo", "foo"],
           liveValidate: true,

--- a/test/FormContext_test.js
+++ b/test/FormContext_test.js
@@ -129,6 +129,25 @@ describe("FormContext", () => {
   });
 
   it("should be passed to multiselect", () => {
+    const widgets = { SelectWidget: CustomComponent };
+    const { node } = createFormComponent({
+      schema: {
+        type: "array",
+        items: {
+          type: "string",
+          enum: ["foo"],
+          enumNames: ["bar"],
+        },
+        uniqueItems: true,
+      },
+      widgets,
+      formContext,
+    });
+
+    expect(node.querySelector("#" + formContext.foo)).to.exist;
+  });
+
+  it("should be passed to multiselect", () => {
     const widgets = { MultiSelectWidget: CustomComponent };
     const { node } = createFormComponent({
       schema: {

--- a/test/FormContext_test.js
+++ b/test/FormContext_test.js
@@ -129,7 +129,7 @@ describe("FormContext", () => {
   });
 
   it("should be passed to multiselect", () => {
-    const widgets = { SelectWidget: CustomComponent };
+    const widgets = { MultiSelectWidget: CustomComponent };
     const { node } = createFormComponent({
       schema: {
         type: "array",


### PR DESCRIPTION
### Reasons for making this change

Allows you to override just the MultiSelectWidget without overriding SelectWidget. Use-case is that you would like to render all your multi-choice arrays as checkboxes rather than a multiselect without having to provide an UiSchema for each of your values.

i.e. 
const widgets = { MultiSelectWidget: CheckBoxesWidget };

Fixes https://github.com/mozilla-services/react-jsonschema-form/issues/1193

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [X] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
