### PR TITLE
trim empty objects to allow correct validation of optional objects with mandatory fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ yarn.lock
 
 # IDE
 .vscode
+.idea
 
 # Code coverage
 coverage

--- a/src/utils.js
+++ b/src/utils.js
@@ -844,3 +844,34 @@ export function rangeSpec(schema) {
   }
   return spec;
 }
+
+function trimObject(object) {
+  return Object.entries(object).reduce((acc, [key, value]) => {
+    const trimmed = trimEmptyValues(value);
+    if (trimmed) {
+      if (!acc) {
+        acc = {};
+      }
+      acc[key] = trimmed;
+    }
+    return acc;
+  }, undefined);
+}
+
+function trimArray(array) {
+  return array.reduce((acc, value) => {
+    const trimmed = trimEmptyValues(value);
+    if (trimmed) {
+      acc.push(trimmed);
+    }
+    return acc;
+  }, []);
+}
+
+export function trimEmptyValues(value) {
+  return Array.isArray(value)
+    ? trimArray(value)
+    : typeof value === "object"
+    ? trimObject(value)
+    : value;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -848,7 +848,7 @@ export function rangeSpec(schema) {
 function trimObject(object) {
   return Object.entries(object).reduce((acc, [key, value]) => {
     const trimmed = trimEmptyValues(value);
-    if (trimmed) {
+    if (trimmed || trimmed === false) {
       if (!acc) {
         acc = {};
       }
@@ -861,7 +861,7 @@ function trimObject(object) {
 function trimArray(array) {
   return array.reduce((acc, value) => {
     const trimmed = trimEmptyValues(value);
-    if (trimmed) {
+    if (trimmed || trimmed === false) {
       acc.push(trimmed);
     }
     return acc;

--- a/src/validate.js
+++ b/src/validate.js
@@ -5,7 +5,7 @@ import { deepEquals } from "./utils";
 
 let formerMetaSchema = null;
 
-import { isObject, mergeObjects } from "./utils";
+import { isObject, mergeObjects, trimEmptyValues } from "./utils";
 
 function createAjvInstance() {
   const ajv = new Ajv({
@@ -182,7 +182,9 @@ export default function validateFormData(
 
   let validationError = null;
   try {
-    ajv.validate(schema, formData);
+    // 675 - deal with optional objects with required values
+    const trimmedData = trimEmptyValues(formData);
+    ajv.validate(schema, trimmedData);
   } catch (err) {
     validationError = err;
   }
@@ -248,7 +250,9 @@ export default function validateFormData(
  */
 export function isValid(schema, data) {
   try {
-    return ajv.validate(schema, data);
+    // 675 - deal with optional objects with required values
+    const trimmedData = trimEmptyValues(data);
+    return ajv.validate(schema, trimmedData);
   } catch (e) {
     return false;
   }

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1518,6 +1518,11 @@ describe("utils", () => {
       const expected = { a: "value", b: 3 };
       expect(trimEmptyValues(input)).to.eql(expected);
     });
+    it("flat populated object with boolean values", () => {
+      const input = { a: true, b: false };
+      const expected = { a: true, b: false };
+      expect(trimEmptyValues(input)).to.eql(expected);
+    });
     it("flat partially populated object", () => {
       const input = { a: "value", b: undefined };
       const expected = { a: "value" };
@@ -1564,6 +1569,7 @@ describe("utils", () => {
             c32: {
               c321: undefined,
               c322: undefined,
+              c323: false,
             },
             c33: {
               c331: "nested value",
@@ -1577,6 +1583,9 @@ describe("utils", () => {
         c: {
           c2: "nested value",
           c3: {
+            c32: {
+              c323: false,
+            },
             c33: {
               c331: "nested value",
             },
@@ -1607,6 +1616,7 @@ describe("utils", () => {
             c32: {
               c321: undefined,
               c322: undefined,
+              c323: false,
             },
             c33: {
               c331: "nested value",
@@ -1621,6 +1631,9 @@ describe("utils", () => {
           c1: [],
           c2: "nested value",
           c3: {
+            c32: {
+              c323: false,
+            },
             c33: {
               c331: "nested value",
               c332: [{ b: "value" }],

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -18,6 +18,7 @@ import {
   toDateString,
   toIdSchema,
   guessType,
+  trimEmptyValues,
 } from "../src/utils";
 
 describe("utils", () => {
@@ -1503,6 +1504,131 @@ describe("utils", () => {
       for (const test of cases) {
         expect(getSchemaType(test.schema)).eql(test.expected);
       }
+    });
+  });
+
+  describe("trimEmptyValues", () => {
+    it("empty object", () => {
+      const input = {};
+      const expected = undefined;
+      expect(trimEmptyValues(input)).to.eql(expected);
+    });
+    it("flat populated object", () => {
+      const input = { a: "value", b: 3 };
+      const expected = { a: "value", b: 3 };
+      expect(trimEmptyValues(input)).to.eql(expected);
+    });
+    it("flat partially populated object", () => {
+      const input = { a: "value", b: undefined };
+      const expected = { a: "value" };
+      expect(trimEmptyValues(input)).to.eql(expected);
+    });
+    it("flat unpopulated object", () => {
+      const input = { a: undefined, b: undefined };
+      const expected = undefined;
+      expect(trimEmptyValues(input)).to.eql(expected);
+    });
+    it("nested populated object", () => {
+      const input = { a: "value", b: 3, c: { c1: "nested value" } };
+      const expected = { a: "value", b: 3, c: { c1: "nested value" } };
+      expect(trimEmptyValues(input)).to.eql(expected);
+    });
+    it("nested partially populated object", () => {
+      const input = { a: "value", b: undefined, c: { c1: "nested value" } };
+      const expected = { a: "value", c: { c1: "nested value" } };
+      expect(trimEmptyValues(input)).to.eql(expected);
+    });
+    it("unpopulated nested object", () => {
+      const input = { a: "value", b: 3, c: { c1: undefined } };
+      const expected = { a: "value", b: 3 };
+      expect(trimEmptyValues(input)).to.eql(expected);
+    });
+    it("partially populated nested object", () => {
+      const input = {
+        a: "value",
+        b: 3,
+        c: { c1: undefined, c2: "nested value" },
+      };
+      const expected = { a: "value", b: 3, c: { c2: "nested value" } };
+      expect(trimEmptyValues(input)).to.eql(expected);
+    });
+    it("partially populated deeply nested object", () => {
+      const input = {
+        a: "value",
+        b: undefined,
+        c: {
+          c1: undefined,
+          c2: "nested value",
+          c3: {
+            c31: undefined,
+            c32: {
+              c321: undefined,
+              c322: undefined,
+            },
+            c33: {
+              c331: "nested value",
+              c332: undefined,
+            },
+          },
+        },
+      };
+      const expected = {
+        a: "value",
+        c: {
+          c2: "nested value",
+          c3: {
+            c33: {
+              c331: "nested value",
+            },
+          },
+        },
+      };
+      expect(trimEmptyValues(input)).to.eql(expected);
+    });
+    it("empty array is kept", () => {
+      const input = { a: [] };
+      const expected = { a: [] };
+      expect(trimEmptyValues(input)).to.eql(expected);
+    });
+    it("populated array is kept", () => {
+      const input = { a: [{ b: "value" }] };
+      const expected = { a: [{ b: "value" }] };
+      expect(trimEmptyValues(input)).to.eql(expected);
+    });
+    it("partially populated deeply nested object with arrays", () => {
+      const input = {
+        a: "value",
+        b: undefined,
+        c: {
+          c1: [],
+          c2: "nested value",
+          c3: {
+            c31: undefined,
+            c32: {
+              c321: undefined,
+              c322: undefined,
+            },
+            c33: {
+              c331: "nested value",
+              c332: [{ a: undefined, b: { c: undefined } }, { b: "value" }],
+            },
+          },
+        },
+      };
+      const expected = {
+        a: "value",
+        c: {
+          c1: [],
+          c2: "nested value",
+          c3: {
+            c33: {
+              c331: "nested value",
+              c332: [{ b: "value" }],
+            },
+          },
+        },
+      };
+      expect(trimEmptyValues(input)).to.eql(expected);
     });
   });
 });


### PR DESCRIPTION
### Reasons for making this change

**NOT FOR MERGE YET!**
Test failures remain - see discussion below.

This PR offers a potential solution for the issue of allowing optional objects with required fields to pass validation when none of their values are defined.

The approach is similar to that discussed in [Issue 675](https://github.com/mozilla-services/react-jsonschema-form/issues/675) and proposed, then withdrawn, in [PR 682](https://github.com/mozilla-services/react-jsonschema-form/pull/682).

Prior to validation, a clone of formData is generated where all objects with no defined values are removed (note: empty arrays are **not** removed).

This works nicely - **but changes the semantics of the errors**. Primarily 'is a required property' errors become 'should be object'.  Currently I have **not**  changed the tests so as to display that.

I have raised this PR to essentially ask whether this approach could be used and, if so, to seek advice on what to about the changed errors (I note the conversation [here](https://github.com/mozilla-services/react-jsonschema-form/pull/682#issuecomment-326076044)).

If this is related to existing tickets, include links to them as well:
https://github.com/mozilla-services/react-jsonschema-form/issues/675
https://github.com/mozilla-services/react-jsonschema-form/pull/682

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X ] **I'm adding or updating code**
  - [ X] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [X ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
