### PR TITLE
use __id instead of $id to avoid collision

### DIFF
--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -23,7 +23,7 @@ function ArrayFieldTitle({ TitleField, idSchema, title, required }) {
   if (!title) {
     return null;
   }
-  const id = `${idSchema.$id}__title`;
+  const id = `${idSchema.__id}__title`;
   return <TitleField id={id} title={title} required={required} />;
 }
 
@@ -31,7 +31,7 @@ function ArrayFieldDescription({ DescriptionField, idSchema, description }) {
   if (!description) {
     return null;
   }
-  const id = `${idSchema.$id}__description`;
+  const id = `${idSchema.__id}__description`;
   return <DescriptionField id={id} description={description} />;
 }
 
@@ -101,9 +101,9 @@ function DefaultArrayItem(props) {
 
 function DefaultFixedArrayFieldTemplate(props) {
   return (
-    <fieldset className={props.className} id={props.idSchema.$id}>
+    <fieldset className={props.className} id={props.idSchema.__id}>
       <ArrayFieldTitle
-        key={`array-field-title-${props.idSchema.$id}`}
+        key={`array-field-title-${props.idSchema.__id}`}
         TitleField={props.TitleField}
         idSchema={props.idSchema}
         title={props.uiSchema["ui:title"] || props.title}
@@ -113,14 +113,14 @@ function DefaultFixedArrayFieldTemplate(props) {
       {(props.uiSchema["ui:description"] || props.schema.description) && (
         <div
           className="field-description"
-          key={`field-description-${props.idSchema.$id}`}>
+          key={`field-description-${props.idSchema.__id}`}>
           {props.uiSchema["ui:description"] || props.schema.description}
         </div>
       )}
 
       <div
         className="row array-item-list"
-        key={`array-item-list-${props.idSchema.$id}`}>
+        key={`array-item-list-${props.idSchema.__id}`}>
         {props.items && props.items.map(DefaultArrayItem)}
       </div>
 
@@ -137,9 +137,9 @@ function DefaultFixedArrayFieldTemplate(props) {
 
 function DefaultNormalArrayFieldTemplate(props) {
   return (
-    <fieldset className={props.className} id={props.idSchema.$id}>
+    <fieldset className={props.className} id={props.idSchema.__id}>
       <ArrayFieldTitle
-        key={`array-field-title-${props.idSchema.$id}`}
+        key={`array-field-title-${props.idSchema.__id}`}
         TitleField={props.TitleField}
         idSchema={props.idSchema}
         title={props.uiSchema["ui:title"] || props.title}
@@ -148,7 +148,7 @@ function DefaultNormalArrayFieldTemplate(props) {
 
       {(props.uiSchema["ui:description"] || props.schema.description) && (
         <ArrayFieldDescription
-          key={`array-field-description-${props.idSchema.$id}`}
+          key={`array-field-description-${props.idSchema.__id}`}
           DescriptionField={props.DescriptionField}
           idSchema={props.idSchema}
           description={
@@ -159,7 +159,7 @@ function DefaultNormalArrayFieldTemplate(props) {
 
       <div
         className="row array-item-list"
-        key={`array-item-list-${props.idSchema.$id}`}>
+        key={`array-item-list-${props.idSchema.__id}`}>
         {props.items && props.items.map(p => DefaultArrayItem(p))}
       </div>
 
@@ -370,7 +370,7 @@ class ArrayField extends Component {
       items: formData.map((item, index) => {
         const itemSchema = retrieveSchema(schema.items, definitions, item);
         const itemErrorSchema = errorSchema ? errorSchema[index] : undefined;
-        const itemIdPrefix = idSchema.$id + "_" + index;
+        const itemIdPrefix = idSchema.__id + "_" + index;
         const itemIdSchema = toIdSchema(
           itemSchema,
           itemIdPrefix,
@@ -438,7 +438,7 @@ class ArrayField extends Component {
     const Widget = getWidget(schema, widget, widgets);
     return (
       <Widget
-        id={idSchema && idSchema.$id}
+        id={idSchema && idSchema.__id}
         multiple
         onChange={this.onSelectChange}
         onBlur={onBlur}
@@ -477,7 +477,7 @@ class ArrayField extends Component {
     return (
       <Widget
         options={options}
-        id={idSchema && idSchema.$id}
+        id={idSchema && idSchema.__id}
         multiple
         onChange={this.onSelectChange}
         onBlur={onBlur}
@@ -541,7 +541,7 @@ class ArrayField extends Component {
         const itemSchema = additional
           ? retrieveSchema(schema.additionalItems, definitions, item)
           : itemSchemas[index];
-        const itemIdPrefix = idSchema.$id + "_" + index;
+        const itemIdPrefix = idSchema.__id + "_" + index;
         const itemIdSchema = toIdSchema(
           itemSchema,
           itemIdPrefix,

--- a/src/components/fields/BooleanField.js
+++ b/src/components/fields/BooleanField.js
@@ -54,7 +54,7 @@ function BooleanField(props) {
     <Widget
       options={{ ...options, enumOptions }}
       schema={schema}
-      id={idSchema && idSchema.$id}
+      id={idSchema && idSchema.__id}
       onChange={onChange}
       onFocus={onFocus}
       onBlur={onBlur}

--- a/src/components/fields/MultiSchemaField.js
+++ b/src/components/fields/MultiSchemaField.js
@@ -161,7 +161,7 @@ class AnyOfField extends Component {
             className="form-control"
             onChange={this.onOptionChange}
             value={selectedOption}
-            id={`${idSchema.$id}_anyof_select`}>
+            id={`${idSchema.__id}_anyof_select`}>
             {options.map((option, index) => {
               return (
                 <option key={index} value={index}>

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -30,10 +30,10 @@ function DefaultObjectFieldTemplate(props) {
 
   const { TitleField, DescriptionField } = props;
   return (
-    <fieldset id={props.idSchema.$id}>
+    <fieldset id={props.idSchema.__id}>
       {(props.uiSchema["ui:title"] || props.title) && (
         <TitleField
-          id={`${props.idSchema.$id}__title`}
+          id={`${props.idSchema.__id}__title`}
           title={props.title || props.uiSchema["ui:title"]}
           required={props.required}
           formContext={props.formContext}
@@ -41,7 +41,7 @@ function DefaultObjectFieldTemplate(props) {
       )}
       {props.description && (
         <DescriptionField
-          id={`${props.idSchema.$id}__description`}
+          id={`${props.idSchema.__id}__description`}
           description={props.description}
           formContext={props.formContext}
         />

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -292,7 +292,7 @@ function SchemaFieldRender(props) {
   );
 
   const { type } = schema;
-  const id = idSchema.$id;
+  const id = idSchema.__id;
   const label =
     uiSchema["ui:title"] || props.schema.title || schema.title || name;
   const description =

--- a/src/components/fields/StringField.js
+++ b/src/components/fields/StringField.js
@@ -38,7 +38,7 @@ function StringField(props) {
     <Widget
       options={{ ...options, enumOptions }}
       schema={schema}
-      id={idSchema && idSchema.$id}
+      id={idSchema && idSchema.__id}
       label={title === undefined ? name : title}
       value={formData}
       onChange={onChange}

--- a/src/components/fields/UnsupportedField.js
+++ b/src/components/fields/UnsupportedField.js
@@ -6,9 +6,9 @@ function UnsupportedField({ schema, idSchema, reason }) {
     <div className="unsupported-field">
       <p>
         Unsupported field schema
-        {idSchema && idSchema.$id && (
+        {idSchema && idSchema.__id && (
           <span>
-            {" for"} field <code>{idSchema.$id}</code>
+            {" for"} field <code>{idSchema.__id}</code>
           </span>
         )}
         {reason && <em>: {reason}</em>}.

--- a/src/utils.js
+++ b/src/utils.js
@@ -725,7 +725,7 @@ export function toIdSchema(
   idPrefix = "root"
 ) {
   const idSchema = {
-    $id: id || idPrefix,
+    __id: id || idPrefix,
   };
   if ("$ref" in schema || "dependencies" in schema) {
     const _schema = retrieveSchema(schema, definitions, formData);
@@ -739,7 +739,7 @@ export function toIdSchema(
   }
   for (const name in schema.properties || {}) {
     const field = schema.properties[name];
-    const fieldId = idSchema.$id + "_" + name;
+    const fieldId = idSchema.__id + "_" + name;
     idSchema[name] = toIdSchema(
       field,
       fieldId,

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -1848,7 +1848,7 @@ describe("Form", () => {
         },
         formData: { a: "int" },
       });
-      expect(comp.state.idSchema).eql({ $id: "root", a: { $id: "root_a" } });
+      expect(comp.state.idSchema).eql({ __id: "root", a: { __id: "root_a" } });
     });
 
     it("should update idSchema based on truthy value", () => {
@@ -1883,9 +1883,9 @@ describe("Form", () => {
         formData: { a: "bool" },
       });
       expect(comp.state.idSchema).eql({
-        $id: "root",
-        a: { $id: "root_a" },
-        b: { $id: "root_b" },
+        __id: "root",
+        a: { __id: "root_a" },
+        b: { __id: "root_b" },
       });
     });
   });

--- a/test/performance_test.js
+++ b/test/performance_test.js
@@ -63,7 +63,7 @@ describe("Rendering performance optimizations", () => {
       const fields = scryRenderedComponentsWithType(comp, SchemaField).reduce(
         (fields, fieldComp) => {
           sandbox.stub(fieldComp, "render").returns(<div />);
-          fields[fieldComp.props.idSchema.$id] = fieldComp;
+          fields[fieldComp.props.idSchema.__id] = fieldComp;
           return fields;
         }
       );
@@ -88,7 +88,7 @@ describe("Rendering performance optimizations", () => {
       const fields = scryRenderedComponentsWithType(comp, SchemaField).reduce(
         (fields, fieldComp) => {
           sandbox.stub(fieldComp, "render").returns(<div />);
-          fields[fieldComp.props.idSchema.$id] = fieldComp;
+          fields[fieldComp.props.idSchema.__id] = fieldComp;
           return fields;
         }
       );
@@ -112,7 +112,7 @@ describe("Rendering performance optimizations", () => {
         foo: { type: "string" },
       },
     };
-    const idSchema = { $id: "root", foo: { $id: "root_plop" } };
+    const idSchema = { __id: "root", foo: { __id: "root_plop" } };
 
     it("should not render if next props are equivalent", () => {
       const props = {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1078,7 +1078,7 @@ describe("utils", () => {
     it("should return an idSchema for root field", () => {
       const schema = { type: "string" };
 
-      expect(toIdSchema(schema)).eql({ $id: "root" });
+      expect(toIdSchema(schema)).eql({ __id: "root" });
     });
 
     it("should return an idSchema for nested objects", () => {
@@ -1095,10 +1095,10 @@ describe("utils", () => {
       };
 
       expect(toIdSchema(schema)).eql({
-        $id: "root",
+        __id: "root",
         level1: {
-          $id: "root_level1",
-          level2: { $id: "root_level1_level2" },
+          __id: "root_level1",
+          level2: { __id: "root_level1_level2" },
         },
       });
     });
@@ -1125,16 +1125,16 @@ describe("utils", () => {
       };
 
       expect(toIdSchema(schema)).eql({
-        $id: "root",
+        __id: "root",
         level1a: {
-          $id: "root_level1a",
-          level1a2a: { $id: "root_level1a_level1a2a" },
-          level1a2b: { $id: "root_level1a_level1a2b" },
+          __id: "root_level1a",
+          level1a2a: { __id: "root_level1a_level1a2a" },
+          level1a2b: { __id: "root_level1a_level1a2b" },
         },
         level1b: {
-          $id: "root_level1b",
-          level1b2a: { $id: "root_level1b_level1b2a" },
-          level1b2b: { $id: "root_level1b_level1b2b" },
+          __id: "root_level1b",
+          level1b2a: { __id: "root_level1b_level1b2a" },
+          level1b2b: { __id: "root_level1b_level1b2b" },
         },
       });
     });
@@ -1155,10 +1155,10 @@ describe("utils", () => {
         },
       };
       expect(toIdSchema(schema)).eql({
-        $id: "root",
+        __id: "root",
         metadata: {
-          $id: "root_metadata",
-          id: { $id: "root_metadata_id" },
+          __id: "root_metadata",
+          id: { __id: "root_metadata_id" },
         },
       });
     });
@@ -1175,8 +1175,8 @@ describe("utils", () => {
       };
 
       expect(toIdSchema(schema)).eql({
-        $id: "root",
-        foo: { $id: "root_foo" },
+        __id: "root",
+        foo: { __id: "root_foo" },
       });
     });
 
@@ -1195,9 +1195,9 @@ describe("utils", () => {
       };
 
       expect(toIdSchema(schema, undefined, schema.definitions)).eql({
-        $id: "root",
-        foo: { $id: "root_foo" },
-        bar: { $id: "root_bar" },
+        __id: "root",
+        foo: { __id: "root_foo" },
+        bar: { __id: "root_bar" },
       });
     });
 
@@ -1220,9 +1220,9 @@ describe("utils", () => {
       };
 
       expect(toIdSchema(schema, undefined, schema.definitions, formData)).eql({
-        $id: "root",
-        foo: { $id: "root_foo" },
-        bar: { $id: "root_bar" },
+        __id: "root",
+        foo: { __id: "root_foo" },
+        bar: { __id: "root_bar" },
       });
     });
 
@@ -1252,11 +1252,11 @@ describe("utils", () => {
       };
 
       expect(toIdSchema(schema, undefined, schema.definitions, formData)).eql({
-        $id: "root",
+        __id: "root",
         obj: {
-          $id: "root_obj",
-          foo: { $id: "root_obj_foo" },
-          bar: { $id: "root_obj_bar" },
+          __id: "root_obj",
+          foo: { __id: "root_obj_foo" },
+          bar: { __id: "root_obj_bar" },
         },
       });
     });
@@ -1279,8 +1279,8 @@ describe("utils", () => {
       const formData = {};
 
       expect(toIdSchema(schema, undefined, schema.definitions, formData)).eql({
-        $id: "root",
-        foo: { $id: "root_foo" },
+        __id: "root",
+        foo: { __id: "root_foo" },
       });
     });
 
@@ -1300,9 +1300,9 @@ describe("utils", () => {
 
       expect(toIdSchema(schema, undefined, schema.definitions, {}, "rjsf")).eql(
         {
-          $id: "rjsf",
-          foo: { $id: "rjsf_foo" },
-          bar: { $id: "rjsf_bar" },
+          __id: "rjsf",
+          foo: { __id: "rjsf_foo" },
+          bar: { __id: "rjsf_bar" },
         }
       );
     });
@@ -1319,9 +1319,9 @@ describe("utils", () => {
       const result = toIdSchema(schema, null, {}, formData, "rjsf");
 
       expect(result).eql({
-        $id: "rjsf",
-        foo: { $id: "rjsf_foo" },
-        bar: { $id: "rjsf_bar" },
+        __id: "rjsf",
+        foo: { __id: "rjsf_foo" },
+        bar: { __id: "rjsf_bar" },
       });
     });
   });


### PR DESCRIPTION
### Reasons for making this change

it is possible to have a property named `$id` which causes issues when creating id's.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
