### PR TITLE
✨ Add support for a custom style in uiSchema

### DIFF
--- a/docs/advanced-customization.md
+++ b/docs/advanced-customization.md
@@ -17,9 +17,9 @@ A field template is basically a React stateless component being passed field-rel
 
 ```jsx
 function CustomFieldTemplate(props) {
-  const {id, classNames, label, help, required, description, errors, children} = props;
+  const {id, classNames, style, label, help, required, description, errors, children} = props;
   return (
-    <div className={classNames}>
+    <div className={classNames} style={style}>
       <label htmlFor={id}>{label}{required ? "*" : null}</label>
       {description}
       {children}
@@ -41,6 +41,7 @@ The following props are passed to a custom field template component:
 
 - `id`: The id of the field in the hierarchy. You can use it to render a label targeting the wrapped widget.
 - `classNames`: A string containing the base Bootstrap CSS classes, merged with any [custom ones](#custom-css-class-names) defined in your uiSchema.
+- `style`: An object of styles
 - `label`: The computed label for this field, as a string.
 - `description`: A component instance rendering the field description, if one is defined (this will use any [custom `DescriptionField`](#custom-descriptions) defined).
 - `rawDescription`: A string containing any `ui:description` uiSchema directive defined.

--- a/docs/form-customization.md
+++ b/docs/form-customization.md
@@ -336,7 +336,32 @@ const uiSchema = {
 Will result in:
 
 ```html
-<div class="field field-string task-title foo-bar" >
+<div class="field field-string task-title foo-bar">
+  <label>
+    <span>Title*</span>
+    <input value="My task" required="" type="text">
+  </label>
+</div>
+```
+
+### Custom styles
+
+The uiSchema object accepts a `style` property for each field of the schema:
+
+```jsx
+const uiSchema = {
+  title: {
+    style: {
+      color: "orange"
+    }
+  }
+};
+```
+
+Will result in:
+
+```html
+<div class="field field-string" style="color: orange">
   <label>
     <span>Title*</span>
     <input value="My task" required="" type="text">

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -148,6 +148,7 @@ if (process.env.NODE_ENV !== "production") {
   DefaultTemplate.propTypes = {
     id: PropTypes.string,
     classNames: PropTypes.string,
+    style: PropTypes.object,
     label: PropTypes.string,
     children: PropTypes.node.isRequired,
     errors: PropTypes.element,
@@ -176,6 +177,7 @@ function WrapIfAdditional(props) {
   const {
     id,
     classNames,
+    style,
     disabled,
     label,
     onKeyChange,
@@ -188,11 +190,15 @@ function WrapIfAdditional(props) {
   const additional = schema.hasOwnProperty(ADDITIONAL_PROPERTY_FLAG);
 
   if (!additional) {
-    return <div className={classNames}>{props.children}</div>;
+    return (
+      <div className={classNames} style={style}>
+        {props.children}
+      </div>
+    );
   }
 
   return (
-    <div className={classNames}>
+    <div className={classNames} style={style}>
       <div className="row">
         <div className="col-xs-5 form-additional">
           <div className="form-group">
@@ -282,7 +288,7 @@ function SchemaFieldRender(props) {
       {...props}
       idSchema={idSchema}
       schema={schema}
-      uiSchema={{ ...uiSchema, classNames: undefined }}
+      uiSchema={{ ...uiSchema, classNames: undefined, style: undefined }}
       disabled={disabled}
       readonly={readonly}
       autofocus={autofocus}
@@ -336,6 +342,7 @@ function SchemaFieldRender(props) {
     readonly,
     displayLabel,
     classNames,
+    style: uiSchema.style,
     formContext,
     fields,
     schema,

--- a/test/SchemaField_test.js
+++ b/test/SchemaField_test.js
@@ -176,6 +176,35 @@ describe("SchemaField", () => {
 
       expect(node.querySelectorAll(".foo")).to.have.length.of(1);
     });
+
+    it("should not pass style to child component", () => {
+      const CustomSchemaField = function(props) {
+        return (
+          <SchemaField
+            {...props}
+            uiSchema={{ ...props.uiSchema, "ui:field": undefined }}
+            name="field"
+          />
+        );
+      };
+
+      const schema = {
+        type: "string",
+      };
+      const uiSchema = {
+        "ui:rootFieldId": "myform",
+        "ui:field": "customSchemaField",
+        classNames: "foo",
+        style: {
+          paddingRight: "1.5em",
+        },
+      };
+      const fields = { customSchemaField: CustomSchemaField };
+
+      const { node } = createFormComponent({ schema, uiSchema, fields });
+
+      expect(node.querySelectorAll("[style*='1.5em']")).to.have.length.of(1);
+    });
   });
 
   describe("label support", () => {

--- a/test/uiSchema_test.js
+++ b/test/uiSchema_test.js
@@ -48,6 +48,43 @@ describe("uiSchema", () => {
     });
   });
 
+  describe("custom style", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        foo: {
+          type: "string",
+        },
+        bar: {
+          type: "string",
+        },
+      },
+    };
+
+    const uiSchema = {
+      foo: {
+        style: {
+          paddingRight: "1em",
+        },
+      },
+      bar: {
+        style: {
+          paddingLeft: "1.5em",
+          color: "orange",
+        },
+      },
+    };
+
+    it("should apply custom styles to target widgets", () => {
+      const { node } = createFormComponent({ schema, uiSchema });
+      const [foo, bar] = node.querySelectorAll(".field-string");
+
+      expect(foo.style.paddingRight).eql("1em");
+      expect(bar.style.paddingLeft).eql("1.5em");
+      expect(bar.style.color).eql("orange");
+    });
+  });
+
   describe("custom widget", () => {
     describe("root widget", () => {
       const schema = {


### PR DESCRIPTION
### Reasons for making this change

More flexibility to use inline styles. Handles https://github.com/mozilla-services/react-jsonschema-form/issues/1200 

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
