### PR TITLE
Add documentation example for dynamically hiding widgets

### DIFF
--- a/docs/form-customization.md
+++ b/docs/form-customization.md
@@ -56,7 +56,7 @@ render((
 
 ### Alternative widgets
 
-The uiSchema `ui:widget` property tells the form which UI widget should be used to render a field. 
+The uiSchema `ui:widget` property tells the form which UI widget should be used to render a field.
 
 Example:
 
@@ -186,164 +186,7 @@ Notes:
 
 ##### Filtering forms dynamically with hidden widgets
 
-Filtering large forms can be accomplished by taking a search string and dynamically constructing a `uiSchema` object based on it, using code like the following:
-
-```js
-const schema = {
-  type: 'object',
-  properties: {
-    foo: {
-      type: 'object',
-      properties: {
-        bar: {type: 'string'},
-      },
-    },
-    baz: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          description: {
-            type: 'string',
-          },
-        },
-      },
-    },
-  },
-};
-
-const objectContainsMatchingChildren = (object, stringToSearchFor) => {
-  const arrayToSearchFor = stringToSearchFor.split(',');
-
-  if (typeof object === 'object') {
-    return Object.keys(object).map(element => {
-      if (
-        typeof element === 'string' &&
-        arrayToSearchFor
-          .map(substringToSearchFor =>
-            element
-              .toLowerCase()
-              .includes(substringToSearchFor.toLowerCase().trim())
-          )
-          .includes(true)
-      ) {
-        return true;
-      }
-      if (typeof object[element] === 'object') {
-        return objectContainsMatchingChildren(
-          object[element],
-          stringToSearchFor
-        ).includes(true);
-      }
-      return false;
-    });
-  }
-  return false;
-};
-
-const applyFilterToObject = (object, searchString) => {
-  const arrayToSearchFor = searchString.split(',');
-
-  let objectCopy = {};
-
-  Object.keys(object).forEach(key => {
-    if (typeof object[key] === 'object') {
-      if (Array.isArray(object[key])) {
-        objectCopy[key] = {};
-      } else if (
-        typeof key === 'string' &&
-        arrayToSearchFor
-          .map(substringToSearchFor =>
-            key
-              .toLowerCase()
-              .includes(substringToSearchFor.toLowerCase().trim())
-          )
-          .includes(true)
-      ) {
-        objectCopy[key] = {};
-      } else if (
-        !objectContainsMatchingChildren(object[key], searchString).includes(
-          true
-        )
-      ) {
-        objectCopy[key] = {'ui:widget': 'hidden'};
-      } else if (key === 'properties') {
-        if (
-          objectContainsMatchingChildren(object[key], searchString).includes(
-            true
-          )
-        ) {
-          // console.log(
-          //   `Properties key "${key}" contains matching children.`
-          // );
-        }
-        objectCopy = objectContainsMatchingChildren(
-          object[key],
-          searchString
-        ).includes(true)
-          ? {
-              ...objectCopy[key],
-              ...applyFilterToObject(object[key], searchString),
-            }
-          : {
-              'ui:widget': 'hidden',
-            };
-      } else if (key === 'items') {
-        // console.log(`Entered 'items' part of tree with key "${key}".`);
-        if (
-          objectContainsMatchingChildren(object[key], searchString).includes(
-            true
-          )
-        ) {
-          // console.log(`Item key "${key}" contains matching children.`);
-        }
-        objectCopy[key] = objectContainsMatchingChildren(
-          object[key],
-          searchString
-        ).includes(true)
-          ? {
-              ...objectCopy[key],
-              ...applyFilterToObject(object[key], searchString),
-            }
-          : {
-              'ui:widget': 'hidden',
-            };
-      } else {
-        const elementContainsChildObjects = Object.keys(object[key])
-          .map(element => typeof object[key][element] === 'object')
-          .includes(true);
-
-        objectCopy[key] = elementContainsChildObjects
-          ? {...applyFilterToObject(object[key], searchString)}
-          : {'ui:widget': 'hidden'};
-      }
-    } else {
-      // console.log(`Rejecting key "${key}"...`);
-      objectCopy[key] = {'ui:widget': 'hidden'};
-    }
-  });
-
-  return objectCopy;
-};
-
-const uiSchema = applyFilterToObject(schema.properties, 'bar, description');
-
-console.log(uiSchema);
-
-// {
-//   "foo": {
-//     "bar": {}
-//   },
-//   "baz": {
-//     "type": {
-//       "ui:widget": "hidden"
-//     },
-//     "items": {
-//       "description": {}
-//     }
-//   }
-// }
-```
+Filtering large forms can be accomplished by taking a search string and dynamically constructing a `uiSchema` object based on it. See [this Code Sandbox](https://codesandbox.io/s/examplereactjsonschemaformfilter-wikn6) for an example implementation.
 
 #### File widgets
 
@@ -874,7 +717,7 @@ The `Form` component supports the following html attributes:
 
 ### Disabling a form
 
-It's possible to disable the whole form by setting the `disabled` prop. The `disabled` prop is then forwarded down to each field of the form. 
+It's possible to disable the whole form by setting the `disabled` prop. The `disabled` prop is then forwarded down to each field of the form.
 
 ```jsx
 <Form
@@ -882,4 +725,4 @@ It's possible to disable the whole form by setting the `disabled` prop. The `dis
   schema={} />
 ```
 
-If you just want to disable some of the fields, see the [`ui:disabled`](#disabled-fields) parameter in the `uiSchema` directive. 
+If you just want to disable some of the fields, see the [`ui:disabled`](#disabled-fields) parameter in the `uiSchema` directive.

--- a/docs/index.md
+++ b/docs/index.md
@@ -292,6 +292,8 @@ A: Probably not. We use Bootstrap v3 and it works fine for our needs. We would l
 
 A: There's no specific built-in way to do this, but you can write your own FieldTemplate that supports hiding/showing fields according to user input. See the "tips and tricks" section above for one example implementation. See also: [#268](https://github.com/mozilla-services/react-jsonschema-form/issues/268), [#304](https://github.com/mozilla-services/react-jsonschema-form/pull/304), [#598](https://github.com/mozilla-services/react-jsonschema-form/issues/598), [#920](https://github.com/mozilla-services/react-jsonschema-form/issues/920).
 
+For filtering fields using a search box, see [this example implementation](https://codesandbox.io/s/examplereactjsonschemaformfilter-wikn6).
+
 ## License
 
 Apache 2


### PR DESCRIPTION
First, thank you *very much* for your work on this project! I'm grateful for the work that's gone into the project to date.

### Reasons for making this change

This PR updates the "Hidden Widget" documentation to include an example for dynamically hiding / filtering aspects of large forms. This new documentation would answer #598. The change I've proposed does not illustrate using a search box and the component's React state, but could be expanded to.

Is this a change that you think would be useful for others in the community to have available as an example?

### Checklist

* [X] **I'm updating documentation**
  - [X] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature