### PR TITLE
Issue-906 input autocomplete

### DIFF
--- a/docs/form-customization.md
+++ b/docs/form-customization.md
@@ -2,7 +2,7 @@
 
 ### The `uiSchema` object
 
-JSONSchema is limited for describing how a given data type should be rendered as a form input component. That's why this lib introduces the concept of *UI schema*.
+JSONSchema is limited for describing how a given data type should be rendered as a form input component. That's why this lib introduces the concept of _UI schema_.
 
 A UI schema is basically an object literal providing information on **how** the form should be rendered, while the JSON schema tells **what**.
 
@@ -15,7 +15,7 @@ const schema = {
     foo: {
       type: "object",
       properties: {
-        bar: {type: "string"}
+        bar: { type: "string" }
       }
     },
     baz: {
@@ -24,19 +24,19 @@ const schema = {
         type: "object",
         properties: {
           description: {
-            "type": "string"
+            type: "string"
           }
         }
       }
     }
   }
-}
+};
 
 const uiSchema = {
   foo: {
     bar: {
       "ui:widget": "textarea"
-    },
+    }
   },
   baz: {
     // note the "items" for an array
@@ -46,50 +46,49 @@ const uiSchema = {
       }
     }
   }
-}
+};
 
-render((
-  <Form schema={schema}
-        uiSchema={uiSchema} />
-), document.getElementById("app"));
+render(
+  <Form schema={schema} uiSchema={uiSchema} />,
+  document.getElementById("app")
+);
 ```
 
 ### Alternative widgets
 
-The uiSchema `ui:widget` property tells the form which UI widget should be used to render a field. 
+The uiSchema `ui:widget` property tells the form which UI widget should be used to render a field.
 
 Example:
 
 ```jsx
-const uiSchema =  {
+const uiSchema = {
   done: {
     "ui:widget": "radio" // could also be "select"
   }
 };
 
-render((
-  <Form schema={schema}
-        uiSchema={uiSchema}
-        formData={formData} />
-), document.getElementById("app"));
+render(
+  <Form schema={schema} uiSchema={uiSchema} formData={formData} />,
+  document.getElementById("app")
+);
 ```
 
 Here's a list of supported alternative widgets for different JSONSchema data types:
 
 #### For `boolean` fields
 
-  * `radio`: a radio button group with `true` and `false` as selectable values;
-  * `select`: a select box with `true` and `false` as options;
-  * by default, a checkbox is used
+- `radio`: a radio button group with `true` and `false` as selectable values;
+- `select`: a select box with `true` and `false` as options;
+- by default, a checkbox is used
 
 > Note: To set the labels for a boolean field, instead of using `true` and `false` you can set `enumNames` in your schema. Note that `enumNames` belongs in your `schema`, not the `uiSchema`, and the order is always `[true, false]`.
 
 #### For `string` fields
 
-  * `textarea`: a `textarea` element is used;
-  * `password`: an `input[type=password]` element is used;
-  * `color`: an `input[type=color]` element is used;
-  * by default, a regular `input[type=text]` element is used.
+- `textarea`: a `textarea` element is used;
+- `password`: an `input[type=password]` element is used;
+- `color`: an `input[type=color]` element is used;
+- by default, a regular `input[type=text]` element is used.
 
 ##### String formats
 
@@ -112,7 +111,7 @@ Please note that, even though they are standardized, `datetime-local` and `date`
 
 ![](https://i.imgur.com/VF5tY60.png)
 
-You can customize the list of years displayed in the `year` dropdown by providing a ``yearsRange`` property to ``ui:options`` in your uiSchema. Its also possible to remove the `Now` and `Clear` buttons with the `hideNowButton` and `hideClearButton` options.
+You can customize the list of years displayed in the `year` dropdown by providing a `yearsRange` property to `ui:options` in your uiSchema. Its also possible to remove the `Now` and `Clear` buttons with the `hideNowButton` and `hideClearButton` options.
 
 ```jsx
 uiSchema: {
@@ -131,10 +130,10 @@ uiSchema: {
 
 #### For `number` and `integer` fields
 
-  * `updown`: an `input[type=number]` updown selector;
-  * `range`: an `input[type=range]` slider;
-  * `radio`: a radio button group with enum values. This can only be used when `enum` values are specified for this input.
-  * By default, a regular `input[type=text]` element is used.
+- `updown`: an `input[type=number]` updown selector;
+- `range`: an `input[type=range]` slider;
+- `radio`: a radio button group with enum values. This can only be used when `enum` values are specified for this input.
+- By default, a regular `input[type=text]` element is used.
 
 > Note: If JSONSchema's `minimum`, `maximum` and `multipleOf` values are defined, the `min`, `max` and `step` input attributes values will take those values.
 
@@ -156,19 +155,19 @@ It's possible to use a hidden widget for a field by setting its `ui:widget` uiSc
 const schema = {
   type: "object",
   properties: {
-    foo: {type: "boolean"}
+    foo: { type: "boolean" }
   }
 };
 
 const uiSchema = {
-  foo: {"ui:widget": "hidden"}
+  foo: { "ui:widget": "hidden" }
 };
 ```
 
 Notes:
 
- - Hiding widgets is only supported for `boolean`, `string`, `number` and `integer` schema types;
- - A hidden widget takes its value from the `formData` prop.
+- Hiding widgets is only supported for `boolean`, `string`, `number` and `integer` schema types;
+- A hidden widget takes its value from the `formData` prop.
 
 #### File widgets
 
@@ -177,21 +176,23 @@ This library supports a limited form of `input[type=file]` widgets, in the sense
 There are two ways to use file widgets.
 
 1. By declaring a `string` json schema type along a `data-url` [format](#string-formats):
+
 ```js
 const schema = {
   type: "string",
-  format: "data-url",
+  format: "data-url"
 };
 ```
 
 2. By specifying a `ui:widget` field uiSchema directive as `file`:
+
 ```js
 const schema = {
-  type: "string",
+  type: "string"
 };
 
 const uiSchema = {
-  "ui:widget": "file",
+  "ui:widget": "file"
 };
 ```
 
@@ -204,7 +205,7 @@ const schema = {
   type: "array",
   items: {
     type: "string",
-    format: "data-url",
+    format: "data-url"
   }
 };
 ```
@@ -225,8 +226,8 @@ Since the order of object properties in Javascript and JSON is not guaranteed, t
 const schema = {
   type: "object",
   properties: {
-    foo: {type: "string"},
-    bar: {type: "string"}
+    foo: { type: "string" },
+    bar: { type: "string" }
   }
 };
 
@@ -234,10 +235,10 @@ const uiSchema = {
   "ui:order": ["bar", "foo"]
 };
 
-render((
-  <Form schema={schema}
-        uiSchema={uiSchema} />
-), document.getElementById("app"));
+render(
+  <Form schema={schema} uiSchema={uiSchema} />,
+  document.getElementById("app")
+);
 ```
 
 If a guaranteed fixed order is only important for some fields, you can insert a wildcard `"*"` item in your `ui:order` definition. All fields that are not referenced explicitly anywhere in the list will be rendered at that point:
@@ -254,10 +255,10 @@ You can define `additionalProperties` by setting its value to a schema object, s
 
 ```js
 const schema = {
-  "type": "object",
-  "properties": {"type": "string"},
-  "additionalProperties": {"type": "number"}
-}
+  type: "object",
+  properties: { type: "string" },
+  additionalProperties: { type: "number" }
+};
 ```
 
 In this way, an add button for new properties is shown by default. The UX for editing properties whose names are user-defined is still experimental.
@@ -270,7 +271,7 @@ You can turn support for `additionalProperties` off with the `expandable` option
 
 ```jsx
 const uiSchema = {
-  "ui:options":  {
+  "ui:options": {
     expandable: false
   }
 };
@@ -291,7 +292,7 @@ const schema = {
 };
 
 const uiSchema = {
-  "ui:options":  {
+  "ui:options": {
     orderable: false
   }
 };
@@ -303,7 +304,7 @@ If either `items` or `additionalItems` contains a schema object, an add button f
 
 ```jsx
 const uiSchema = {
-  "ui:options":  {
+  "ui:options": {
     addable: false
   }
 };
@@ -315,7 +316,7 @@ A remove button is shown by default for an item if `items` contains a schema obj
 
 ```jsx
 const uiSchema = {
-  "ui:options":  {
+  "ui:options": {
     removable: false
   }
 };
@@ -336,10 +337,9 @@ const uiSchema = {
 Will result in:
 
 ```html
-<div class="field field-string task-title foo-bar" >
+<div class="field field-string task-title foo-bar">
   <label>
-    <span>Title*</span>
-    <input value="My task" required="" type="text">
+    <span>Title*</span> <input value="My task" required="" type="text" />
   </label>
 </div>
 ```
@@ -374,28 +374,22 @@ JSON Schema has an alternative approach to enumerations; react-jsonschema-form s
 
 ```js
 const schema = {
-  "type": "number",
-  "anyOf": [
+  type: "number",
+  anyOf: [
     {
-      "type": "number",
-      "title": "one",
-      "enum": [
-        1
-      ]
+      type: "number",
+      title: "one",
+      enum: [1]
     },
     {
-      "type": "number",
-      "title": "two",
-      "enum": [
-        2
-      ]
+      type: "number",
+      title: "two",
+      enum: [2]
     },
     {
-      "type": "number",
-      "title": "three",
-      "enum": [
-        3
-      ]
+      type: "number",
+      title: "three",
+      enum: [3]
     }
   ]
 };
@@ -415,15 +409,15 @@ This also works for radio buttons:
 
 ```js
 const schema = {
-  "type": "boolean",
-  "oneOf": [
+  type: "boolean",
+  oneOf: [
     {
-      "const": true,
-      "title": "Yes"
+      const: true,
+      title: "Yes"
     },
     {
-      "const": false,
-      "title": "No"
+      const: false,
+      title: "No"
     }
   ]
 };
@@ -440,14 +434,18 @@ This will be rendered as follows:
   <div class="radio">
     <label>
       <span>
-        <input type="radio" name="0.005549338200675935" value="true"><span>Enable</span>
+        <input type="radio" name="0.005549338200675935" value="true" /><span
+          >Enable</span
+        >
       </span>
     </label>
   </div>
   <div class="radio">
     <label>
       <span>
-        <input type="radio" name="0.005549338200675935" value="false"><span>Disable</span>
+        <input type="radio" name="0.005549338200675935" value="false" /><span
+          >Disable</span
+        >
       </span>
     </label>
   </div>
@@ -463,12 +461,12 @@ To disable an option, use the `enumDisabled` property in uiSchema.
 ```js
 const schema = {
   type: "string",
-  enum: ["one", "two", "three"],
+  enum: ["one", "two", "three"]
 };
 
-const uiSchema={
-  "ui:enumDisabled": ['two'],
-}
+const uiSchema = {
+  "ui:enumDisabled": ["two"]
+};
 ```
 
 This will be rendered using a select box as follows:
@@ -493,7 +491,7 @@ const schema = {
   title: "A multiple-choice list",
   items: {
     type: "string",
-    enum: ["foo", "bar", "fuzz", "qux"],
+    enum: ["foo", "bar", "fuzz", "qux"]
   },
   uniqueItems: true
 };
@@ -518,7 +516,7 @@ const schema = {
   title: "A multiple-choice list",
   items: {
     type: "string",
-    enum: ["foo", "bar", "fuzz", "qux"],
+    enum: ["foo", "bar", "fuzz", "qux"]
   },
   uniqueItems: true
 };
@@ -554,14 +552,15 @@ So all widgets will have an id prefixed with `myform`.
 You can provide custom buttons to your form via the `Form` component's `children`. Otherwise a default submit button will be rendered.
 
 ```jsx
-render((
+render(
   <Form schema={schema}>
     <div>
       <button type="submit">Submit</button>
       <button type="button">Cancel</button>
     </div>
-  </Form>
-), document.getElementById("app"));
+  </Form>,
+  document.getElementById("app")
+);
 ```
 
 > **Warning:** There needs to be a button or an input with `type="submit"` to trigger the form submission (and then the form validation).
@@ -571,7 +570,7 @@ render((
 Sometimes it's convenient to add text next to a field to guide the end user filling it. This is the purpose of the `ui:help` uiSchema directive:
 
 ```js
-const schema = {type: "string"};
+const schema = { type: "string" };
 const uiSchema = {
   "ui:widget": "password",
   "ui:help": "Hint: Make it strong!"
@@ -587,7 +586,7 @@ Help texts work for any kind of field at any level, and will always be rendered 
 Sometimes it's convenient to change a field's title. this is the purpose of the `ui:title` uiSchema directive:
 
 ```js
-const schema = {type: "string"};
+const schema = { type: "string" };
 const uiSchema = {
   "ui:widget": "password",
   "ui:title": "Your password"
@@ -599,7 +598,7 @@ const uiSchema = {
 Sometimes it's convenient to change the description of a field. This is the purpose of the `ui:description` uiSchema directive:
 
 ```js
-const schema = {type: "string"};
+const schema = { type: "string" };
 const uiSchema = {
   "ui:widget": "password",
   "ui:description": "The best password"
@@ -611,25 +610,38 @@ const uiSchema = {
 If you want to automatically focus on a text input or textarea input, set the `ui:autofocus` uiSchema directive to `true`.
 
 ```js
-const schema = {type: "string"};
+const schema = { type: "string" };
 const uiSchema = {
   "ui:widget": "textarea",
   "ui:autofocus": true
-}
+};
 ```
+
+### Autocomplete
+
+If you want to assign autocomplete form form contact details, such as `firstname`, `middlename` or `phone-number`.
+
+```js
+const schema = { type: "string" };
+const uiSchema = {
+  "ui:autocomplete": "given-name"
+};
+```
+
+> [Google Developers Web AutoComplete Attributes](https://developers.google.com/web/fundamentals/design-and-ux/input/forms/#recommended_input_name_and_autocomplete_attribute_values)
 
 ### Textarea `rows` option
 
 You can set the initial height of a textarea widget by specifying `rows` option.
 
 ```js
-const schema = {type: "string"};
+const schema = { type: "string" };
 const uiSchema = {
   "ui:widget": "textarea",
   "ui:options": {
     rows: 15
   }
-}
+};
 ```
 
 ### Placeholders
@@ -637,7 +649,7 @@ const uiSchema = {
 You can add placeholder text to an input by using the `ui:placeholder` uiSchema directive:
 
 ```jsx
-const schema = {type: "string", format: "uri"};
+const schema = { type: "string", format: "uri" };
 const uiSchema = {
   "ui:placeholder": "http://"
 };
@@ -648,7 +660,7 @@ const uiSchema = {
 Fields using `enum` can also use `ui:placeholder`. The value will be used as the text for the empty option in the select widget.
 
 ```jsx
-const schema = {type: "string", enum: ["First", "Second"]};
+const schema = { type: "string", enum: ["First", "Second"] };
 const uiSchema = {
   "ui:placeholder": "Choose an option"
 };
@@ -659,7 +671,7 @@ const uiSchema = {
 Field labels are rendered by default. Labels may be omitted by setting the `label` option to `false` in the `ui:options` uiSchema directive.
 
 ```jsx
-const schema = {type: "string"};
+const schema = { type: "string" };
 const uiSchema = {
   "ui:options": {
     label: false
@@ -672,10 +684,10 @@ const uiSchema = {
 To change the input type (for example, `tel` or `email`) you can specify the `inputType` in the `ui:options` uiSchema directive.
 
 ```jsx
-const schema = {type: "string"};
+const schema = { type: "string" };
 const uiSchema = {
   "ui:options": {
-    inputType: 'tel'
+    inputType: "tel"
   }
 };
 ```
@@ -694,12 +706,13 @@ The `Form` component supports the following html attributes:
   action="/users/list"
   autocomplete="off"
   enctype="multipart/form-data"
-  acceptcharset="ISO-8859-1" />
+  acceptcharset="ISO-8859-1"
+/>
 ```
 
 ### Disabling a form
 
-It's possible to disable the whole form by setting the `disabled` prop. The `disabled` prop is then forwarded down to each field of the form. 
+It's possible to disable the whole form by setting the `disabled` prop. The `disabled` prop is then forwarded down to each field of the form.
 
 ```jsx
 <Form
@@ -707,4 +720,4 @@ It's possible to disable the whole form by setting the `disabled` prop. The `dis
   schema={} />
 ```
 
-If you just want to disable some of the fields, see the [`ui:disabled`](#disabled-fields) parameter in the `uiSchema` directive. 
+If you just want to disable some of the fields, see the [`ui:disabled`](#disabled-fields) parameter in the `uiSchema` directive.

--- a/playground/samples/simple.js
+++ b/playground/samples/simple.js
@@ -39,6 +39,10 @@ module.exports = {
       "ui:autofocus": true,
       "ui:emptyValue": "",
     },
+    lastName: {
+      "ui:emptyValue": "",
+      "ui:autocomplete": "given-name", // try family-name
+    },
     age: {
       "ui:widget": "updown",
       "ui:title": "Age of person",
@@ -61,7 +65,6 @@ module.exports = {
     },
   },
   formData: {
-    lastName: "Norris",
     age: 75,
     bio: "Roundhouse kicking asses since 1940",
     password: "noneed",

--- a/src/components/widgets/BaseInput.js
+++ b/src/components/widgets/BaseInput.js
@@ -42,7 +42,11 @@ function BaseInput(props) {
       inputProps.type = "text";
     }
   }
-
+  // If ui:autocomplete passed
+  // https://developers.google.com/web/fundamentals/design-and-ux/input/forms/#recommended_input_name_and_autocomplete_attribute_values
+  if (options.autocomplete) {
+    inputProps.autoComplete = options.autocomplete;
+  }
   // If multipleOf is defined, use this as the step value. This mainly improves
   // the experience for keyboard users (who can use the up/down KB arrows).
   if (schema.multipleOf) {


### PR DESCRIPTION
### Autocomplete support for input

Whatever autocomplete passed for text type `ui:autocomplete` as per the [Google Web Doc](https://developers.google.com/web/fundamentals/design-and-ux/input/forms/#recommended_input_name_and_autocomplete_attribute_values) value will be filled for that input field. 

[Issue 906](https://github.com/mozilla-services/react-jsonschema-form/issues/906)
### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
