### PR TITLE
Remove setState util call in Form.onChange

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -140,7 +140,10 @@ export default class Form extends Component {
       };
     }
 
-    this.setState(state, () => this.props.onChange && this.props.onChange(state) );
+    this.setState(
+      state,
+      () => this.props.onChange && this.props.onChange(state)
+    );
   };
 
   onBlur = (...args) => {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -140,8 +140,8 @@ export default class Form extends Component {
       };
     }
 
-    this.props.onChange && this.props.onChange(state);
     this.setState(state);
+    this.props.onChange && this.props.onChange(state);
   };
 
   onBlur = (...args) => {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -140,8 +140,7 @@ export default class Form extends Component {
       };
     }
 
-    this.setState(state);
-    this.props.onChange && this.props.onChange(state);
+    this.setState(state, () => this.props.onChange && this.props.onChange(state) );
   };
 
   onBlur = (...args) => {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -139,11 +139,9 @@ export default class Form extends Component {
         errors: toErrorList(newErrorSchema),
       };
     }
-    setState(this, state, () => {
-      if (this.props.onChange) {
-        this.props.onChange(this.state);
-      }
-    });
+
+    this.props.onChange && this.props.onChange(state);
+    this.setState(state);
   };
 
   onBlur = (...args) => {


### PR DESCRIPTION
### Reasons for making this change

Remove the util setState call from Form.onChange because it sets the state too early or something? Hard to describe, I came upon this fix (for #1281) after trying a bunch of things like using a leaner `componentDidUpdate` and removing `shouldComponentUpdate` (so it uses the default React Component function which always returns true) instead of the existing `componentWillReceiveProps` and `shouldComponentUpdate`. Note that removing `componentWillReceiveProps` breaks a lot of existing tests because for some reason they rely on `componentWillReceiveProps` (not sure why tests call that function directly, but I'm just a little more used to Jest than the raw 'react-addons-test-utils' library), so that's not an option anyway.

I'm not sure how to add tests for the bug I'm trying to fix, so feel free to edit this PR.

If this is related to existing tickets, include links to them as well.
#1281 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [X] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
