### PR TITLE
Fix onAddClick required event parameter

### DIFF
--- a/docs/advanced-customization.md
+++ b/docs/advanced-customization.md
@@ -120,7 +120,7 @@ The following props are passed to each `ArrayFieldTemplate`:
 - `disabled`: A boolean value stating if the array is disabled.
 - `idSchema`: Object
 - `items`: An array of objects representing the items in the array. Each of the items represent a child with properties described below.
-- `onAddClick: (event) => void`: A function that adds a new item to the array.
+- `onAddClick: ([event]) => void`: A function that adds a new item to the array. The "event" object is optional as it is already accessible via lexical scope.
 - `readonly`: A boolean value stating if the array is read-only.
 - `required`: A boolean value stating if the array is required.
 - `schema`: The schema object for this array.

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -262,7 +262,7 @@ class ArrayField extends Component {
     return addable;
   }
 
-  onAddClick = event => {
+  onAddClick = (event = event) => {
     event.preventDefault();
     const { schema, registry = getDefaultRegistry(), onChange } = this.props;
     const { definitions } = registry;


### PR DESCRIPTION
Now it is optional. 

### Reasons for making this change

Passing the event object for onAddClick should not be mandatory. Without a fix, the event listener will throw an error. The event object is already available via lexical scope.

https://github.com/mozilla-services/react-jsonschema-form/issues/1314

### Checklist

* [Y ] **I'm updating documentation**
  - [ Y] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [Y ] **I'm adding or updating code**
  - [Y] I've added and/or updated tests
  - [Y] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [N] **I'm adding a new feature**
  - [NA ] I've updated the playground with an example use of the feature