### PR TITLE
Inject defaults in arrays

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -196,6 +196,31 @@ This component follows [JSON Schema](http://json-schema.org/documentation.html) 
 
 * `"additionalProperties":false` produces incorrect schemas when used with [schema dependencies](#schema-dependencies). This library does not remove extra properties, which causes validation to fail. It is recommended to avoid setting `"additionalProperties":false` when you use schema dependencies. See [#848](https://github.com/mozilla-services/react-jsonschema-form/issues/848) [#902](https://github.com/mozilla-services/react-jsonschema-form/issues/902) [#992](https://github.com/mozilla-services/react-jsonschema-form/issues/992)
 
+## Handling of schema defaults
+
+This library automatically fills default values defined the [JSON Schema](http://json-schema.org/documentation.html) as initial values in your form. This also works for complex structures in the schema. If a field has a default defined, it should always appear as default value in form. This also works when using [schema dependencies](#schema-dependencies).
+
+Since there is a complex interaction between any supplied original form data and any injected defaults, this library tries to do the injection in a way which keeps the original intention of the original form data.
+
+Check out the defaults example on the [live playground](https://mozilla-services.github.io/react-jsonschema-form/) to see this in action.
+
+### Merging of defaults into the form data
+
+There are three different cases which need to be considered for the merging. Objects, arrays and scalar values. This library always deeply merges any defaults with the existing form data for objects.
+
+This are the rules which are used when injecting the defaults: 
+
+- When the is a scalar in the form data, nothing is changed. 
+- When the value is `undefined` in the form data, the default is created in the form data.
+- When the value is an object in the form data, the defaults are deeply merged into the form data, using the rules defined here for the deep merge.
+- Then the value is an array in the form data, defaults are only injected in existing array items. No new array items will be created, even if the schema has minItems or additional items defined.
+
+### Merging of defaults within the schema
+
+In the schema itself, defaults of parent elements are propagated into children. So when you have a schema which defines a deeply nested object as default, these defaults will be applied to children of the current node. This also merges objects defined at different levels together with the "deeper" not having precedence. If the parent node defines properties, which are not defined in the child, they will be merged so that the default for the child will be the merged defaults of parent and child.
+
+For arrays this is not the case. Defining an array, when a parent also defines an array, will be overwritten. This is only true when arrays are used in the same level, for objects within these arrays, they will be deeply merged again.
+
 ## Tips and tricks
 
  - Custom field template: <https://jsfiddle.net/hdp1kgn6/1/>

--- a/playground/samples/defaults.js
+++ b/playground/samples/defaults.js
@@ -1,0 +1,70 @@
+module.exports = {
+  schema: {
+    title: "Schema default properties",
+    type: "object",
+    properties: {
+      valuesInFormData: {
+        title: "Values in form data",
+        $ref: "#/definitions/defaultsExample",
+      },
+      noValuesInFormData: {
+        title: "No values in form data",
+        $ref: "#/definitions/defaultsExample",
+      },
+    },
+    definitions: {
+      defaultsExample: {
+        type: "object",
+        properties: {
+          scalar: {
+            title: "Scalar",
+            type: "string",
+            default: "scalar default",
+          },
+          array: {
+            title: "Array",
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                nested: {
+                  title: "Nested array",
+                  type: "string",
+                  default: "nested array default",
+                },
+              },
+            },
+          },
+          object: {
+            title: "Object",
+            type: "object",
+            properties: {
+              nested: {
+                title: "Nested object",
+                type: "string",
+                default: "nested object default",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  uiSchema: {},
+  formData: {
+    valuesInFormData: {
+      scalar: "value",
+      array: [
+        {
+          nested: "nested array value",
+        },
+      ],
+      object: {
+        nested: "nested object value",
+      },
+    },
+    noValuesInFormData: {
+      array: [{}, {}],
+    },
+  },
+};

--- a/playground/samples/index.js
+++ b/playground/samples/index.js
@@ -22,6 +22,7 @@ import schemaDependencies from "./schemaDependencies";
 import additionalProperties from "./additionalProperties";
 import nullable from "./nullable";
 import nullField from "./null";
+import defaults from "./defaults";
 
 export const samples = {
   Simple: simple,
@@ -48,4 +49,5 @@ export const samples = {
   "One Of": oneOf,
   "Null fields": nullField,
   Nullable: nullable,
+  Defaults: defaults,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -181,10 +181,10 @@ function computeDefaults(
       includeUndefinedValues
     );
   } else if (isFixedItems(schema)) {
-    defaults = schema.items.map(itemSchema =>
+    defaults = schema.items.map((itemSchema, idx) =>
       computeDefaults(
         itemSchema,
-        undefined,
+        Array.isArray(parentDefaults) ? parentDefaults[idx] : undefined,
         definitions,
         formData,
         includeUndefinedValues
@@ -223,6 +223,17 @@ function computeDefaults(
       }, {});
 
     case "array":
+      // inject defaults into existing array defaults
+      if (Array.isArray(defaults)) {
+        defaults = defaults.map((item, idx) => {
+          return computeDefaults(
+            schema.items[idx] || schema.additionalItems || {},
+            item,
+            definitions
+          );
+        });
+      }
+
       // deeply inject defaults into already existing form data
       if (Array.isArray(rawFormData)) {
         defaults = rawFormData.map((array, idx) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -299,7 +299,6 @@ export function getDefaultFormState(
  * - scalars are overwritten/set by form data
  */
 export function mergeDefaultsWithFormData(defaults, formData) {
-  // Recursively merge deeply nested objects.
   if (Array.isArray(formData)) {
     const leftArray = Array.isArray(defaults) ? defaults : [];
     return formData.map((value, idx) => {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -373,7 +373,7 @@ describe("utils", () => {
         });
       });
 
-      it("should merge schema array item defaults from sam item for overlapping default definitions", () => {
+      it("should merge schema array item defaults from the same item for overlapping default definitions", () => {
         const schema = {
           type: "object",
           properties: {


### PR DESCRIPTION
### Reasons for making this change

When using dependencies in array items, defaults are now injected.
This adjusts injecting arrays into the form data from defaults to be
in line with the previous behaviour. So the defaults are injected when
there is either no value defined in the form data or when an array is
already set in the form data, injects only into existing entries.
This makes sure that we don't change any existing behaviour by creating
array entries where we did not create them before.

For example for following schema:
```
{
  "type": "array",
  "minItems": 2,
  "items": {
    "title": "asd",
    "type": "object",
    "properties": {
      "item": {
        "type": "string",
        "default": "foo"
      }
    }
  }
}
```
and following form data:
```
[{}]
```

The result will be (note how it did not full up the array to min items)
``` 
[{ "item": "foo" }]
``` 

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
