### PR TITLE
add  property to path schema to decide whether we should add a path to field names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-jsonschema-form",
-  "version": "1.7.0",
+  "name": "@vidyvideni/react-jsonschema-form",
+  "version": "1.7.2",
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
     "build:lib": "rimraf lib && cross-env NODE_ENV=production babel -d lib/ src/",

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import _pick from "lodash/pick";
-import _get from "lodash/get";
 
 import { default as DefaultErrorList } from "./ErrorList";
 import {
@@ -142,7 +141,7 @@ export default class Form extends Component {
     return _pick(formData, fields);
   };
 
-  getFieldNames = (pathSchema, formData) => {
+  getFieldNames = pathSchema => {
     const getAllPaths = (_obj, acc = [], paths = []) => {
       Object.keys(_obj).forEach(key => {
         if (typeof _obj[key] === "object") {
@@ -158,8 +157,7 @@ export default class Form extends Component {
           }
         } else if (key === "$name") {
           paths.forEach(path => {
-            const formValue = _get(formData, path);
-            if (typeof formValue !== "object") {
+            if (!_obj["$hasChildren"]) {
               acc.push(path);
             }
           });
@@ -183,10 +181,7 @@ export default class Form extends Component {
     if (this.props.omitExtraData === true && this.props.liveOmit === true) {
       const newState = this.getStateFromProps(this.props, formData);
 
-      const fieldNames = this.getFieldNames(
-        newState.pathSchema,
-        newState.formData
-      );
+      const fieldNames = this.getFieldNames(newState.pathSchema);
 
       newFormData = this.getUsedFormData(formData, fieldNames);
       state = {
@@ -235,7 +230,7 @@ export default class Form extends Component {
     const { pathSchema } = this.state;
 
     if (this.props.omitExtraData === true) {
-      const fieldNames = this.getFieldNames(pathSchema, this.state.formData);
+      const fieldNames = this.getFieldNames(pathSchema);
       newFormData = this.getUsedFormData(this.state.formData, fieldNames);
     }
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -170,12 +170,17 @@ export default class Form extends Component {
   };
 
   onChange = (formData, newErrorSchema) => {
+    let state = {};
     if (isObject(formData) || Array.isArray(formData)) {
       const newState = this.getStateFromProps(this.props, formData);
       formData = newState.formData;
+
+      state = {
+        formData,
+        pathSchema: newState.pathSchema,
+      };
     }
     const mustValidate = !this.props.noValidate && this.props.liveValidate;
-    let state = { formData };
     let newFormData = formData;
 
     if (this.props.omitExtraData === true && this.props.liveOmit === true) {
@@ -185,6 +190,7 @@ export default class Form extends Component {
 
       newFormData = this.getUsedFormData(formData, fieldNames);
       state = {
+        pathSchema: newState.pathSchema,
         formData: newFormData,
       };
     }

--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -281,12 +281,12 @@ class ArrayField extends Component {
       item: this._getNewFormDataRow(),
     };
     const newKeyedFormData = [...this.state.keyedFormData, newKeyedFormDataRow];
+    onChange(keyedToPlainFormData(newKeyedFormData));
 
     this.setState(
       {
         keyedFormData: newKeyedFormData,
-      },
-      () => onChange(keyedToPlainFormData(newKeyedFormData))
+      }
     );
   };
 
@@ -302,12 +302,12 @@ class ArrayField extends Component {
       };
       let newKeyedFormData = [...this.state.keyedFormData];
       newKeyedFormData.splice(index, 0, newKeyedFormDataRow);
+      onChange(keyedToPlainFormData(newKeyedFormData));
 
       this.setState(
         {
           keyedFormData: newKeyedFormData,
-        },
-        () => onChange(keyedToPlainFormData(newKeyedFormData))
+        }
       );
     };
   };
@@ -334,11 +334,11 @@ class ArrayField extends Component {
         }
       }
       const newKeyedFormData = keyedFormData.filter((_, i) => i !== index);
+      onChange(keyedToPlainFormData(newKeyedFormData), newErrorSchema);
       this.setState(
         {
           keyedFormData: newKeyedFormData,
-        },
-        () => onChange(keyedToPlainFormData(newKeyedFormData), newErrorSchema)
+        }
       );
     };
   };
@@ -377,11 +377,12 @@ class ArrayField extends Component {
         return _newKeyedFormData;
       }
       const newKeyedFormData = reOrderArray();
+      onChange(keyedToPlainFormData(newKeyedFormData), newErrorSchema);
+
       this.setState(
         {
           keyedFormData: newKeyedFormData,
-        },
-        () => onChange(keyedToPlainFormData(newKeyedFormData), newErrorSchema)
+        }
       );
     };
   };

--- a/src/utils.js
+++ b/src/utils.js
@@ -910,6 +910,7 @@ export function toPathSchema(schema, name = "", definitions, formData = {}) {
       // array item has just been added, but not populated with data yet
       (formData || {})[property]
     );
+    pathSchema["$hasChildren"] = true;
   }
   return pathSchema;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,7 @@ import React from "react";
 import * as ReactIs from "react-is";
 import fill from "core-js/library/fn/array/fill";
 import validateFormData, { isValid } from "./validate";
+import isPlainObject from "lodash/isPlainObject";
 
 export const ADDITIONAL_PROPERTY_FLAG = "__additional_property";
 
@@ -881,14 +882,19 @@ export function toPathSchema(schema, name = "", definitions, formData = {}) {
   }
   if ("items" in schema) {
     const retVal = {};
+    const setItemPathSchema = (element, index) => {
+      retVal[`${index}`] = toPathSchema(
+        schema.items,
+        `${name}.${index}`,
+        definitions,
+        element
+      );
+    };
     if (Array.isArray(formData) && formData.length > 0) {
-      formData.forEach((element, index) => {
-        retVal[`${index}`] = toPathSchema(
-          schema.items,
-          `${name}.${index}`,
-          definitions,
-          element
-        );
+      formData.forEach(setItemPathSchema);
+    } else if (isPlainObject(formData)) {
+      Object.keys(formData).forEach(name => {
+        setItemPathSchema(formData[name], name);
       });
     }
     return retVal;

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -983,11 +983,14 @@ describe("Form", () => {
 
       const pathSchema = {
         $name: "",
+        $hasChildren: true,
         level1: {
           $name: "level1",
+          $hasChildren: true,
           level2: { $name: "level1.level2" },
           anotherThing: {
             $name: "level1.anotherThing",
+            $hasChildren: true,
             anotherThingNested: {
               $name: "level1.anotherThing.anotherThingNested",
             },
@@ -1039,9 +1042,11 @@ describe("Form", () => {
 
       const pathSchema = {
         $name: "",
+        $hasChildren: true,
         address_list: {
           "0": {
             $name: "address_list.0",
+            $hasChildren: true,
             city: {
               $name: "address_list.0.city",
             },
@@ -1054,6 +1059,7 @@ describe("Form", () => {
           },
           "1": {
             $name: "address_list.1",
+            $hasChildren: true,
             city: {
               $name: "address_list.1.city",
             },

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1955,8 +1955,10 @@ describe("utils", () => {
 
       expect(toPathSchema(schema)).eql({
         $name: "",
+        $hasChildren: true,
         level1: {
           $name: "level1",
+          $hasChildren: true,
           level2: { $name: "level1.level2" },
         },
       });
@@ -2008,9 +2010,11 @@ describe("utils", () => {
 
       expect(toPathSchema(schema, "", schema.definitions, formData)).eql({
         $name: "",
+        $hasChildren: true,
         list: {
           "0": {
             $name: "list.0",
+            $hasChildren: true,
             a: {
               $name: "list.0.a",
             },
@@ -2023,6 +2027,7 @@ describe("utils", () => {
           },
           "1": {
             $name: "list.1",
+            $hasChildren: true,
             a: {
               $name: "list.1.a",
             },
@@ -2032,6 +2037,7 @@ describe("utils", () => {
           },
           "2": {
             $name: "list.2",
+            $hasChildren: true,
             a: {
               $name: "list.2.a",
             },
@@ -2081,8 +2087,10 @@ describe("utils", () => {
 
       expect(toPathSchema(schema, "", schema.definitions, formData)).eql({
         $name: "",
+        $hasChildren: true,
         billing_address: {
           $name: "billing_address",
+          $hasChildren: true,
           city: {
             $name: "billing_address.city",
           },
@@ -2144,9 +2152,11 @@ describe("utils", () => {
 
       expect(toPathSchema(schema, "", schema.definitions, formData)).eql({
         $name: "",
+        $hasChildren: true,
         address_list: {
           "0": {
             $name: "address_list.0",
+            $hasChildren: true,
             city: {
               $name: "address_list.0.city",
             },
@@ -2159,6 +2169,7 @@ describe("utils", () => {
           },
           "1": {
             $name: "address_list.1",
+            $hasChildren: true,
             city: {
               $name: "address_list.1.city",
             },
@@ -2361,6 +2372,7 @@ describe("utils", () => {
 
       expect(toPathSchema(schema, "", schema.definitions, formData)).eql({
         $name: "",
+        $hasChildren: true,
         defaultsAndMinItems: {
           "0": {
             $name: "defaultsAndMinItems.0",
@@ -2406,6 +2418,7 @@ describe("utils", () => {
         listOfObjects: {
           "0": {
             $name: "listOfObjects.0",
+            $hasChildren: true,
             id: {
               $name: "listOfObjects.0.id",
             },
@@ -2415,6 +2428,7 @@ describe("utils", () => {
           },
           "1": {
             $name: "listOfObjects.1",
+            $hasChildren: true,
             id: {
               $name: "listOfObjects.1.id",
             },
@@ -2424,6 +2438,7 @@ describe("utils", () => {
           },
           "2": {
             $name: "listOfObjects.2",
+            $hasChildren: true,
             id: {
               $name: "listOfObjects.2.id",
             },
@@ -2443,18 +2458,21 @@ describe("utils", () => {
         minItemsList: {
           "0": {
             $name: "minItemsList.0",
+            $hasChildren: true,
             name: {
               $name: "minItemsList.0.name",
             },
           },
           "1": {
             $name: "minItemsList.1",
+            $hasChildren: true,
             name: {
               $name: "minItemsList.1.name",
             },
           },
           "2": {
             $name: "minItemsList.2",
+            $hasChildren: true,
             name: {
               $name: "minItemsList.2.name",
             },

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -2527,6 +2527,96 @@ describe("utils", () => {
         },
       });
     });
+
+    it("should return a pathSchema for none indexed form data for array types", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          listOfStrings: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
+          listOfObjects: {
+            type: "array",
+            title: "List of objects",
+            items: {
+              type: "object",
+              title: "Object in list",
+              properties: {
+                name: {
+                  type: "string",
+                  default: "Default name",
+                },
+                id: {
+                  type: "number",
+                  default: "an id",
+                },
+              },
+            },
+          },
+        },
+      };
+
+      //let server control keys for array type.
+      const formData = {
+        listOfStrings: {
+          a: "foo",
+          b: "bar",
+        },
+        listOfObjects: {
+          "123": { name: "name1", id: 123 },
+          "1234": { name: "name2", id: 1234 },
+          "12345": { id: 12345 },
+        },
+      };
+
+      expect(toPathSchema(schema, "", null, formData)).eql({
+        $name: "",
+        $hasChildren: true,
+        listOfStrings: {
+          a: {
+            $name: "listOfStrings.a",
+          },
+          b: {
+            $name: "listOfStrings.b",
+          },
+        },
+        listOfObjects: {
+          "123": {
+            $name: "listOfObjects.123",
+            $hasChildren: true,
+            id: {
+              $name: "listOfObjects.123.id",
+            },
+            name: {
+              $name: "listOfObjects.123.name",
+            },
+          },
+          "1234": {
+            $name: "listOfObjects.1234",
+            $hasChildren: true,
+            id: {
+              $name: "listOfObjects.1234.id",
+            },
+            name: {
+              $name: "listOfObjects.1234.name",
+            },
+          },
+          "12345": {
+            $name: "listOfObjects.12345",
+            $hasChildren: true,
+            id: {
+              $name: "listOfObjects.12345.id",
+            },
+            name: {
+              $name: "listOfObjects.12345.name",
+            },
+          },
+        },
+      });
+    });
   });
 
   describe("parseDateString()", () => {

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -16,7 +16,8 @@ module.exports = {
   },
   plugins: [
     new MonacoWebpackPlugin({
-      languages: ['json']
+      languages: ['json'],
+      features: ['!gotoSymbol'],
     }),
     new webpack.HotModuleReplacementPlugin(),
   ],

--- a/webpack.config.dist.js
+++ b/webpack.config.dist.js
@@ -16,7 +16,8 @@ module.exports = {
   },
   plugins: [
     new MonacoWebpackPlugin({
-      languages: ['json']
+      languages: ['json'],
+      features: ['!gotoSymbol'],
     }),
     new webpack.DefinePlugin({
       "process.env": {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -13,7 +13,8 @@ module.exports = {
   },
   plugins: [
     new MonacoWebpackPlugin({
-      languages: ['json']
+      languages: ['json'],
+      features: ['!gotoSymbol'],
     }),
     new MiniCssExtractPlugin({filename: "styles.css", allChunks: true}),
     new webpack.DefinePlugin({


### PR DESCRIPTION
Add  property to path schema to decide whether we should add a path to field names instead of form data type check.

### Reasons for making this change

this PR doesn't break anything, but allow us to customize object field completely.

Please look [issue 1404](https://github.com/mozilla-services/react-jsonschema-form/issues/1404)

### Changes

1. now no need pass formData to getFieldNames method anymore
2. path schema will have $hasChildren property
3. allow server to control the field name of array type.

### Checklist

* [x] test is fixed
 