### PR TITLE
Fix - additionalProperties' type-guessing

### DIFF
--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -90,7 +90,7 @@ class ObjectField extends Component {
         // fields which are "mandated" by the schema, these fields can
         // be set to undefined by clicking a "delete field" button, so
         // set empty values to the empty string.
-        if (typeof value == "boolean") {
+        if (typeof value === "boolean") {
           value = false;
         } else {
           value = "";

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -90,7 +90,11 @@ class ObjectField extends Component {
         // fields which are "mandated" by the schema, these fields can
         // be set to undefined by clicking a "delete field" button, so
         // set empty values to the empty string.
-        value = "";
+        if (typeof value == "boolean") {
+          value = false;
+        } else {
+          value = "";
+        }
       }
       const newFormData = { ...this.props.formData, [name]: value };
       this.props.onChange(

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -92,7 +92,7 @@ class ObjectField extends Component {
         // set empty values to the empty string.
         if (typeof value === "boolean") {
           value = false;
-        } else {
+        } else if (value === "" || value === undefined) {
           value = "";
         }
       }


### PR DESCRIPTION
Fixes #1412 

Hey @epicfaace 

This patch seems to fix the problem locally. Is this okay or this patch will create problems somewhere else?

Also, should I change this [comment](https://github.com/mozilla-services/react-jsonschema-form/blob/310b8a5309bd55fd1c3e1533c93b3ce135b03dda/src/components/fields/ObjectField.js#L92) here to something like

```set empty values to false```

Thanks! 