### PR TITLE
fix: test suite running one test

### DIFF
--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1104,7 +1104,7 @@ describe("utils", () => {
       });
     });
 
-    it.only("should 'resolve' and stub out a schema which contains an `additionalProperties` with a type and definition", () => {
+    it("should 'resolve' and stub out a schema which contains an `additionalProperties` with a type and definition", () => {
       const schema = {
         type: "string",
         additionalProperties: {


### PR DESCRIPTION
### Reasons for making this change

Noticed the test suite wasn't running all the tests due to a `it.only(..)` statement introduced in [here](https://github.com/mozilla-services/react-jsonschema-form/compare/642ad5699ffe...d2112d3988c5#diff-0de170772e45d2602c103dd916607787R1107) in #1402 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
