### PR TITLE
Add propertyNames enum and pattern validation (fixes #1250)

### DIFF
--- a/playground/samples/index.js
+++ b/playground/samples/index.js
@@ -20,6 +20,7 @@ import alternatives from "./alternatives";
 import propertyDependencies from "./propertyDependencies";
 import schemaDependencies from "./schemaDependencies";
 import additionalProperties from "./additionalProperties";
+import propertyNames from "./propertyNames";
 import nullable from "./nullable";
 import nullField from "./null";
 
@@ -44,6 +45,7 @@ export const samples = {
   "Property dependencies": propertyDependencies,
   "Schema dependencies": schemaDependencies,
   "Additional Properties": additionalProperties,
+  "Property Names": propertyNames,
   "Any Of": anyOf,
   "One Of": oneOf,
   "Null fields": nullField,

--- a/playground/samples/propertyNames.js
+++ b/playground/samples/propertyNames.js
@@ -1,0 +1,36 @@
+export default {
+  schema: {
+    title: "A customizable form",
+    description: "A simple form with property names validation example.",
+    type: "object",
+    required: ["patternValidation", "enumValidation"],
+    properties: {
+      enumValidation: {
+        type: "object",
+        title: "Property names dropdown",
+        additionalProperties: true,
+        propertyNames: {
+          enum: ["prop1", "prop2"],
+        },
+      },
+      patternValidation: {
+        type: "object",
+        title: "Only digits as property names",
+        additionalProperties: true,
+        propertyNames: {
+          type: "string",
+          pattern: "^\\d*$",
+        },
+      },
+    },
+  },
+  formData: {
+    patternValidation: {
+      123: "One two three",
+    },
+    enumValidation: {
+      prop1: "valid property name from enum",
+      invalidProp: "invalid property name from enum",
+    },
+  },
+};

--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -265,6 +265,7 @@ class ObjectField extends Component {
                   ? uiSchema.additionalProperties
                   : uiSchema[name]
               }
+              propertyNamesSchema={schema.propertyNames}
               errorSchema={errorSchema[name]}
               idSchema={idSchema[name]}
               idPrefix={idPrefix}

--- a/src/components/fields/SchemaField.js
+++ b/src/components/fields/SchemaField.js
@@ -72,17 +72,38 @@ function Label(props) {
   );
 }
 
-function LabelInput(props) {
-  const { id, label, onChange } = props;
-  return (
-    <input
-      className="form-control"
-      type="text"
-      id={id}
-      onBlur={event => onChange(event.target.value)}
-      defaultValue={label}
-    />
-  );
+class LabelInput extends React.Component {
+  constructor(props) {
+    super();
+    this.state = {
+      value: props.label,
+    };
+  }
+  render() {
+    const { id, label, onChange, schema, registry } = this.props;
+
+    if (!schema) {
+      return (
+        <input
+          className="form-control"
+          type="text"
+          id={id}
+          onBlur={event => onChange(event.target.value)}
+          defaultValue={label}
+        />
+      );
+    }
+
+    return (
+      <SchemaField
+        schema={schema}
+        formData={this.state.value}
+        registry={registry}
+        onChange={value => this.setState({ value })}
+        onBlur={(id, value) => onChange(value)}
+      />
+    );
+  }
 }
 
 function Help(props) {
@@ -183,6 +204,7 @@ function WrapIfAdditional(props) {
     readonly,
     required,
     schema,
+    propertyNamesSchema,
   } = props;
   const keyLabel = `${label} Key`; // i18n ?
   const additional = schema.hasOwnProperty(ADDITIONAL_PROPERTY_FLAG);
@@ -199,7 +221,8 @@ function WrapIfAdditional(props) {
             <Label label={keyLabel} required={required} id={`${id}-key`} />
             <LabelInput
               label={label}
-              required={required}
+              schema={propertyNamesSchema}
+              registry={props.registry}
               id={`${id}-key`}
               onChange={onKeyChange}
             />
@@ -236,6 +259,7 @@ function SchemaFieldRender(props) {
     required,
     registry = getDefaultRegistry(),
     wasPropertyKeyModified = false,
+    propertyNamesSchema,
   } = props;
   const { definitions, fields, formContext } = registry;
   const FieldTemplate =
@@ -350,6 +374,8 @@ function SchemaFieldRender(props) {
     fields,
     schema,
     uiSchema,
+    propertyNamesSchema,
+    registry,
   };
 
   const _AnyOfField = registry.fields.AnyOfField;
@@ -434,6 +460,7 @@ if (process.env.NODE_ENV !== "production") {
     schema: PropTypes.object.isRequired,
     uiSchema: PropTypes.object,
     idSchema: PropTypes.object,
+    propertyNamesSchema: PropTypes.object,
     formData: PropTypes.any,
     errorSchema: PropTypes.object,
     registry: types.registry.isRequired,

--- a/test/SchemaField_test.js
+++ b/test/SchemaField_test.js
@@ -210,6 +210,36 @@ describe("SchemaField", () => {
     });
   });
 
+  describe("additional properties", () => {
+    const schema = {
+      type: "object",
+      additionalProperties: true,
+    };
+
+    it("should render text input for object key if schema has additional properties", () => {
+      const { node } = createFormComponent({ schema });
+      Simulate.click(node.querySelector(".glyphicon-plus"));
+
+      expect(node.querySelectorAll("input[value='newKey']")).to.have.length.of(
+        1
+      );
+    });
+
+    it("should render SchemaField as input for object key if schema has propertyNames schema", () => {
+      const schemaWithPropertyNames = {
+        ...schema,
+        propertyNames: {
+          type: "string",
+          enum: ["1", "2"],
+        },
+      };
+      const { node } = createFormComponent({ schema: schemaWithPropertyNames });
+      Simulate.click(node.querySelector(".glyphicon-plus"));
+
+      expect(node.querySelectorAll("select")).to.have.length.of(1);
+    });
+  });
+
   describe("description support", () => {
     const schema = {
       type: "object",


### PR DESCRIPTION
### Reasons for making this change

JSON Schema Draft 6 allows to validate propertyNames, I added this feature
Also fixes #1250 

If this is related to existing tickets, include links to them as well.

### Checklist

* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
