### PR TITLE
Add extraErrors prop for async validation

### DIFF
--- a/docs/advanced-customization.md
+++ b/docs/advanced-customization.md
@@ -247,6 +247,50 @@ The following props are passed to `ErrorList`
 - `uiSchema`: The uiSchema that was passed to `Form`.
 - `formContext`: The `formContext` object that you passed to Form.
 
+
+### Async Errors
+
+Handling async errors is an important part of many applications. Support for this is added in the form of the `errorSchema` prop.
+
+For example, a request could be made to some backend when the user submits the form. If that request fails, the errors returned by the backend should be formatted like in the following example.
+
+```jsx
+const schema = {
+  type: "object",
+  properties: {
+    foo: {
+      type: "string",
+    },
+    candy: {
+      type: "object",
+      properties: {
+        bar: {
+          type: "string
+        }
+      }
+    },
+  },
+},
+
+const errorSchema = {
+  foo: {
+    __errors: ["some error that got added as a prop"],
+  },
+  candy: {
+    bar: {
+    __errors: ["some error that got added as a prop"],
+    }
+  }
+}
+
+render((
+  <Form schema={schema}
+        errorSchema={errorSchema} />,
+), document.getElementById("app"));
+```
+
+An important note is that these errors are 'display only' and will not block the user from submitting the form again.
+
 ### Id prefix
 
 To avoid collisions with existing ids in the DOM, it is possible to change the prefix used for ids (the default is `root`).

--- a/docs/advanced-customization.md
+++ b/docs/advanced-customization.md
@@ -270,7 +270,7 @@ const schema = {
       }
     },
   },
-},
+}
 
 const errorSchema = {
   foo: {

--- a/docs/advanced-customization.md
+++ b/docs/advanced-customization.md
@@ -265,7 +265,7 @@ const schema = {
       type: "object",
       properties: {
         bar: {
-          type: "string
+          type: "string",
         }
       }
     },

--- a/docs/advanced-customization.md
+++ b/docs/advanced-customization.md
@@ -272,7 +272,7 @@ const schema = {
   },
 }
 
-const errorSchema = {
+const extraErrors = {
   foo: {
     __errors: ["some error that got added as a prop"],
   },
@@ -285,7 +285,7 @@ const errorSchema = {
 
 render((
   <Form schema={schema}
-        errorSchema={errorSchema} />,
+        extraErrors={extraErrors} />,
 ), document.getElementById("app"));
 ```
 

--- a/playground/app.js
+++ b/playground/app.js
@@ -370,6 +370,9 @@ class App extends Component {
 
   onFormDataEdited = formData => this.setState({ formData, shareURL: null });
 
+  onErrorSchemaEdited = errorSchema =>
+    this.setState({ errorSchema, shareURL: null });
+
   onThemeSelected = (theme, { stylesheet, editor }) => {
     this.setState({ theme, editor: editor ? editor : "default" });
     setImmediate(() => {
@@ -384,13 +387,25 @@ class App extends Component {
     this.setState({ formData, shareURL: null });
 
   onShare = () => {
-    const { formData, schema, uiSchema, liveSettings } = this.state;
+    const {
+      formData,
+      schema,
+      uiSchema,
+      liveSettings,
+      errorSchema,
+    } = this.state;
     const {
       location: { origin, pathname },
     } = document;
     try {
       const hash = btoa(
-        JSON.stringify({ formData, schema, uiSchema, liveSettings })
+        JSON.stringify({
+          formData,
+          schema,
+          uiSchema,
+          liveSettings,
+          errorSchema,
+        })
       );
       this.setState({ shareURL: `${origin}${pathname}#${hash}` });
     } catch (err) {
@@ -403,6 +418,7 @@ class App extends Component {
       schema,
       uiSchema,
       formData,
+      errorSchema,
       liveSettings,
       validate,
       theme,
@@ -458,6 +474,16 @@ class App extends Component {
               />
             </div>
           </div>
+          <div className="row">
+            <div className="col">
+              <Editor
+                title="errorSchema"
+                theme={editor}
+                code={toJson(errorSchema || {})}
+                onChange={this.onErrorSchemaEdited}
+              />
+            </div>
+          </div>
         </div>
         <div className="col-sm-5">
           {this.state.form && (
@@ -471,6 +497,7 @@ class App extends Component {
               schema={schema}
               uiSchema={uiSchema}
               formData={formData}
+              errorSchema={errorSchema}
               onChange={this.onFormDataChange}
               onSubmit={({ formData }, e) => {
                 console.log("submitted formData", formData);

--- a/playground/app.js
+++ b/playground/app.js
@@ -348,7 +348,7 @@ class App extends Component {
 
   load = data => {
     // Reset the ArrayFieldTemplate whenever you load new data
-    const { ArrayFieldTemplate, ObjectFieldTemplate, errorSchema } = data;
+    const { ArrayFieldTemplate, ObjectFieldTemplate, extraErrors } = data;
     // uiSchema is missing on some examples. Provide a default to
     // clear the field in all cases.
     const { uiSchema = {} } = data;
@@ -360,7 +360,7 @@ class App extends Component {
         ArrayFieldTemplate,
         ObjectFieldTemplate,
         uiSchema,
-        errorSchema,
+        extraErrors,
       })
     );
   };
@@ -371,8 +371,8 @@ class App extends Component {
 
   onFormDataEdited = formData => this.setState({ formData, shareURL: null });
 
-  onErrorSchemaEdited = errorSchema =>
-    this.setState({ errorSchema, shareURL: null });
+  onExtraErrorsEdited = extraErrors =>
+    this.setState({ extraErrors, shareURL: null });
 
   onThemeSelected = (theme, { stylesheet, editor }) => {
     this.setState({ theme, editor: editor ? editor : "default" });
@@ -419,7 +419,7 @@ class App extends Component {
       schema,
       uiSchema,
       formData,
-      errorSchema,
+      extraErrors,
       liveSettings,
       validate,
       theme,
@@ -475,14 +475,14 @@ class App extends Component {
               />
             </div>
           </div>
-          {errorSchema && (
+          {extraErrors && (
             <div className="row">
               <div className="col">
                 <Editor
-                  title="errorSchema"
+                  title="extraErrors"
                   theme={editor}
-                  code={toJson(errorSchema || {})}
-                  onChange={this.onErrorSchemaEdited}
+                  code={toJson(extraErrors || {})}
+                  onChange={this.onExtraErrorsEdited}
                 />
               </div>
             </div>
@@ -500,7 +500,7 @@ class App extends Component {
               schema={schema}
               uiSchema={uiSchema}
               formData={formData}
-              errorSchema={errorSchema}
+              extraErrors={extraErrors}
               onChange={this.onFormDataChange}
               onSubmit={({ formData }, e) => {
                 console.log("submitted formData", formData);

--- a/playground/app.js
+++ b/playground/app.js
@@ -348,7 +348,7 @@ class App extends Component {
 
   load = data => {
     // Reset the ArrayFieldTemplate whenever you load new data
-    const { ArrayFieldTemplate, ObjectFieldTemplate } = data;
+    const { ArrayFieldTemplate, ObjectFieldTemplate, errorSchema } = data;
     // uiSchema is missing on some examples. Provide a default to
     // clear the field in all cases.
     const { uiSchema = {} } = data;
@@ -360,6 +360,7 @@ class App extends Component {
         ArrayFieldTemplate,
         ObjectFieldTemplate,
         uiSchema,
+        errorSchema,
       })
     );
   };
@@ -474,16 +475,18 @@ class App extends Component {
               />
             </div>
           </div>
-          <div className="row">
-            <div className="col">
-              <Editor
-                title="errorSchema"
-                theme={editor}
-                code={toJson(errorSchema || {})}
-                onChange={this.onErrorSchemaEdited}
-              />
+          {errorSchema && (
+            <div className="row">
+              <div className="col">
+                <Editor
+                  title="errorSchema"
+                  theme={editor}
+                  code={toJson(errorSchema || {})}
+                  onChange={this.onErrorSchemaEdited}
+                />
+              </div>
             </div>
-          </div>
+          )}
         </div>
         <div className="col-sm-5">
           {this.state.form && (

--- a/playground/samples/errorSchema.js
+++ b/playground/samples/errorSchema.js
@@ -1,0 +1,74 @@
+module.exports = {
+  schema: {
+    title: "A registration form",
+    description: "A simple form example.",
+    type: "object",
+    required: ["firstName", "lastName"],
+    properties: {
+      firstName: {
+        type: "string",
+        title: "First name",
+        default: "Chuck",
+      },
+      lastName: {
+        type: "string",
+        title: "Last name",
+      },
+      age: {
+        type: "integer",
+        title: "Age",
+      },
+      bio: {
+        type: "string",
+        title: "Bio",
+      },
+      password: {
+        type: "string",
+        title: "Password",
+        minLength: 3,
+      },
+      telephone: {
+        type: "string",
+        title: "Telephone",
+        minLength: 10,
+      },
+    },
+  },
+  uiSchema: {
+    firstName: {
+      "ui:autofocus": true,
+      "ui:emptyValue": "",
+    },
+    age: {
+      "ui:widget": "updown",
+      "ui:title": "Age of person",
+      "ui:description": "(earthian year)",
+    },
+    bio: {
+      "ui:widget": "textarea",
+    },
+    password: {
+      "ui:widget": "password",
+      "ui:help": "Hint: Make it strong!",
+    },
+    date: {
+      "ui:widget": "alt-datetime",
+    },
+    telephone: {
+      "ui:options": {
+        inputType: "tel",
+      },
+    },
+  },
+  formData: {
+    lastName: "Norris",
+    age: 75,
+    bio: "Roundhouse kicking asses since 1940",
+    password: "noneed",
+  },
+  errorSchema: {
+    firstName: {
+      __errors: ["some error that got added as a prop"],
+    },
+  },
+};

--- a/playground/samples/errorSchema.js
+++ b/playground/samples/errorSchema.js
@@ -66,7 +66,7 @@ module.exports = {
     bio: "Roundhouse kicking asses since 1940",
     password: "noneed",
   },
-  errorSchema: {
+  extraErrors: {
     firstName: {
       __errors: ["some error that got added as a prop"],
     },

--- a/playground/samples/index.js
+++ b/playground/samples/index.js
@@ -22,6 +22,7 @@ import schemaDependencies from "./schemaDependencies";
 import additionalProperties from "./additionalProperties";
 import nullable from "./nullable";
 import nullField from "./null";
+import errorSchema from "./errorSchema";
 
 export const samples = {
   Simple: simple,
@@ -48,4 +49,5 @@ export const samples = {
   "One Of": oneOf,
   "Null fields": nullField,
   Nullable: nullable,
+  ErrorSchema: errorSchema,
 };

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -73,8 +73,8 @@ export default class Form extends Component {
           errors: state.errors || [],
           errorSchema: state.errorSchema || {},
         };
-    if (props.errorSchema) {
-      errorSchema = mergeObjects(errorSchema, props.errorSchema);
+    if (props.extraErrors) {
+      errorSchema = mergeObjects(errorSchema, props.extraErrors);
       errors = toErrorList(errorSchema);
     }
     const idSchema = toIdSchema(
@@ -207,14 +207,14 @@ export default class Form extends Component {
 
     if (mustValidate) {
       let { errors, errorSchema } = this.validate(newFormData);
-      if (this.props.errorSchema) {
-        errorSchema = mergeObjects(errorSchema, this.props.errorSchema);
+      if (this.props.extraErrors) {
+        errorSchema = mergeObjects(errorSchema, this.props.extraErrors);
         errors = toErrorList(errorSchema);
       }
       state = { formData: newFormData, errors, errorSchema };
     } else if (!this.props.noValidate && newErrorSchema) {
-      const errorSchema = this.props.errorSchema
-        ? mergeObjects(newErrorSchema, this.props.errorSchema)
+      const errorSchema = this.props.extraErrors
+        ? mergeObjects(newErrorSchema, this.props.extraErrors)
         : newErrorSchema;
       state = {
         formData: newFormData,
@@ -271,8 +271,8 @@ export default class Form extends Component {
     if (!this.props.noValidate) {
       let { errors, errorSchema } = this.validate(newFormData);
       if (Object.keys(errors).length > 0) {
-        if (this.props.errorSchema) {
-          errorSchema = mergeObjects(errorSchema, this.props.errorSchema);
+        if (this.props.extraErrors) {
+          errorSchema = mergeObjects(errorSchema, this.props.extraErrors);
           errors = toErrorList(errorSchema);
         }
         setState(this, { errors, errorSchema }, () => {
@@ -288,8 +288,8 @@ export default class Form extends Component {
 
     let errorSchema;
     let errors;
-    if (this.props.errorSchema) {
-      errorSchema = this.props.errorSchema;
+    if (this.props.extraErrors) {
+      errorSchema = this.props.extraErrors;
       errors = toErrorList(errorSchema);
     } else {
       errorSchema = {};
@@ -438,6 +438,6 @@ if (process.env.NODE_ENV !== "production") {
     customFormats: PropTypes.object,
     additionalMetaSchemas: PropTypes.arrayOf(PropTypes.object),
     omitExtraData: PropTypes.bool,
-    errorSchema: PropTypes.object,
+    extraErrors: PropTypes.object,
   };
 }

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -206,13 +206,20 @@ export default class Form extends Component {
     }
 
     if (mustValidate) {
-      const { errors, errorSchema } = this.validate(newFormData);
+      let { errors, errorSchema } = this.validate(newFormData);
+      if (this.props.errorSchema) {
+        errorSchema = mergeObjects(errorSchema, this.props.errorSchema);
+        errors = toErrorList(errorSchema);
+      }
       state = { formData: newFormData, errors, errorSchema };
     } else if (!this.props.noValidate && newErrorSchema) {
+      const errorSchema = this.props.errorSchema
+        ? mergeObjects(newErrorSchema, this.props.errorSchema)
+        : newErrorSchema;
       state = {
         formData: newFormData,
-        errorSchema: newErrorSchema,
-        errors: toErrorList(newErrorSchema),
+        errorSchema: errorSchema,
+        errors: toErrorList(errorSchema),
       };
     }
     setState(this, state, () => {

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -2779,4 +2779,40 @@ describe("Form omitExtraData and liveOmit", () => {
 
     expect(comp.state.formData).eql({ foo: "foobar" });
   });
+
+  describe("Async errors", () => {
+    it("should render the async errors", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: {
+            type: "string",
+          },
+          candy: {
+            type: "object",
+            properties: {
+              bar: {
+                type: "string",
+              },
+            },
+          },
+        },
+      };
+
+      const errorSchema = {
+        foo: {
+          __errors: ["some error that got added as a prop"],
+        },
+        candy: {
+          bar: {
+            __errors: ["some other error that got added as a prop"],
+          },
+        },
+      };
+
+      const { node } = createFormComponent({ schema, errorSchema });
+
+      expect(node.querySelectorAll(".error-detail li")).to.have.length.of(2);
+    });
+  });
 });

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -2810,5 +2810,25 @@ describe("Form omitExtraData and liveOmit", () => {
 
       expect(node.querySelectorAll(".error-detail li")).to.have.length.of(2);
     });
+
+    it("should not block form submission", () => {
+      const onSubmit = sinon.spy();
+      const schema = {
+        type: "object",
+        properties: {
+          foo: { type: "string" },
+        },
+      };
+
+      const errorSchema = {
+        foo: {
+          __errors: ["some error that got added as a prop"],
+        },
+      };
+
+      const { node } = createFormComponent({ schema, errorSchema, onSubmit });
+      Simulate.submit(node);
+      sinon.assert.calledOnce(onSubmit);
+    });
   });
 });

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -2785,15 +2785,11 @@ describe("Form omitExtraData and liveOmit", () => {
       const schema = {
         type: "object",
         properties: {
-          foo: {
-            type: "string",
-          },
+          foo: { type: "string" },
           candy: {
             type: "object",
             properties: {
-              bar: {
-                type: "string",
-              },
+              bar: { type: "string" },
             },
           },
         },

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -2795,7 +2795,7 @@ describe("Form omitExtraData and liveOmit", () => {
         },
       };
 
-      const errorSchema = {
+      const extraErrors = {
         foo: {
           __errors: ["some error that got added as a prop"],
         },
@@ -2806,7 +2806,7 @@ describe("Form omitExtraData and liveOmit", () => {
         },
       };
 
-      const { node } = createFormComponent({ schema, errorSchema });
+      const { node } = createFormComponent({ schema, extraErrors });
 
       expect(node.querySelectorAll(".error-detail li")).to.have.length.of(2);
     });
@@ -2820,13 +2820,13 @@ describe("Form omitExtraData and liveOmit", () => {
         },
       };
 
-      const errorSchema = {
+      const extraErrors = {
         foo: {
           __errors: ["some error that got added as a prop"],
         },
       };
 
-      const { node } = createFormComponent({ schema, errorSchema, onSubmit });
+      const { node } = createFormComponent({ schema, extraErrors, onSubmit });
       Simulate.submit(node);
       sinon.assert.calledOnce(onSubmit);
     });


### PR DESCRIPTION
### Reasons for making this change

Another attempt at async validation. I've previously attempted this in #1383 but got stuck on some stuff. I've now more closely followed the changes made in #874 so i could allow the form to be submitted even when async errors are present.

Fixes #1389

The main difference between this PR and #874 is that instead of being completely in control of the errorSchema, the provided errorSchema is merged with the generated errorSchema. I did this because I saw no use case in being able to edit the generated errorSchema and merging makes it easier for the developer.

If you like these changes i'll try to make some tests and update the documentation.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
