### PR TITLE
chore: remove node version < 8 from ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 language:
 - node_js
 node_js:
-- "6"
-- "7"
 - "8"
 - "9"
 - "10"


### PR DESCRIPTION
### Reasons for making this change

From discussion in #1454, removing node versions less than 8 due to no longer support.
