### PR TITLE
Rewrite mergeSchemas to fix schema dependencies merging

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -775,8 +775,9 @@ export function mergeSchemas(obj1, obj2) {
     if (obj1 && obj1.hasOwnProperty(key) && isObject(right)) {
       acc[key] = mergeSchemas(left, right);
     } else if (
-      (getSchemaType(obj1 || {}) === "object" ||
-        getSchemaType(obj2 || {}) === "object") &&
+      obj1 &&
+      obj2 &&
+      (getSchemaType(obj1) === "object" || getSchemaType(obj2) === "object") &&
       key === "required" &&
       Array.isArray(left) &&
       Array.isArray(right)

--- a/src/utils.js
+++ b/src/utils.js
@@ -67,6 +67,7 @@ export function getDefaultRegistry() {
   };
 }
 
+/* Gets the type of a given schema. */
 export function getSchemaType(schema) {
   let { type } = schema;
 
@@ -774,6 +775,8 @@ export function mergeSchemas(obj1, obj2) {
     if (obj1 && obj1.hasOwnProperty(key) && isObject(right)) {
       acc[key] = mergeSchemas(left, right);
     } else if (
+      (getSchemaType(obj1 || {}) === "object" ||
+        getSchemaType(obj2 || {}) === "object") &&
       key === "required" &&
       Array.isArray(left) &&
       Array.isArray(right)

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,7 @@ import React from "react";
 import * as ReactIs from "react-is";
 import fill from "core-js/library/fn/array/fill";
 import validateFormData, { isValid } from "./validate";
+import { union } from "lodash";
 
 export const ADDITIONAL_PROPERTY_FLAG = "__additional_property";
 
@@ -763,7 +764,8 @@ function withExactlyOneSubschema(
 // Recursively merge deeply nested schemas.
 // The difference between mergeSchemas and mergeObjects
 // is that mergeSchemas only concats arrays for
-// values under the "required" keyword.
+// values under the "required" keyword, and when it does,
+// it doesn't include duplicate values.
 export function mergeSchemas(obj1, obj2) {
   var acc = Object.assign({}, obj1); // Prevent mutation of source object.
   return Object.keys(obj2).reduce((acc, key) => {
@@ -776,7 +778,9 @@ export function mergeSchemas(obj1, obj2) {
       Array.isArray(left) &&
       Array.isArray(right)
     ) {
-      acc[key] = left.concat(right);
+      // Don't include duplicate values when merging
+      // "required" fields.
+      acc[key] = union(left, right);
     } else {
       acc[key] = right;
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -760,8 +760,28 @@ function withExactlyOneSubschema(
   );
 }
 
-function mergeSchemas(schema1, schema2) {
-  return mergeObjects(schema1, schema2, true);
+// Recursively merge deeply nested schemas.
+// The difference between mergeSchemas and mergeObjects
+// is that mergeSchemas only concats arrays for
+// values under the "required" keyword.
+export function mergeSchemas(obj1, obj2) {
+  var acc = Object.assign({}, obj1); // Prevent mutation of source object.
+  return Object.keys(obj2).reduce((acc, key) => {
+    const left = obj1 ? obj1[key] : {},
+      right = obj2[key];
+    if (obj1 && obj1.hasOwnProperty(key) && isObject(right)) {
+      acc[key] = mergeSchemas(left, right);
+    } else if (
+      key === "required" &&
+      Array.isArray(left) &&
+      Array.isArray(right)
+    ) {
+      acc[key] = left.concat(right);
+    } else {
+      acc[key] = right;
+    }
+    return acc;
+  }, acc);
 }
 
 function isArguments(object) {

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -2291,7 +2291,44 @@ describeRepeated("Form common", createFormComponent => {
     });
   });
 
-  describe("Dependency defaults", () => {
+  describe("Dependencies", () => {
+    it("should not give a validation error by duplicating enum values in dependencies", () => {
+      const schema = {
+        title: "A registration form",
+        description: "A simple form example.",
+        type: "object",
+        properties: {
+          type1: {
+            type: "string",
+            title: "Type 1",
+            enum: ["FOO", "BAR", "BAZ"],
+          },
+          type2: {
+            type: "string",
+            title: "Type 2",
+            enum: ["GREEN", "BLUE", "RED"],
+          },
+        },
+        dependencies: {
+          type1: {
+            properties: {
+              type1: {
+                enum: ["FOO"],
+              },
+              type2: {
+                enum: ["GREEN"],
+              },
+            },
+          },
+        },
+      };
+      const formData = {
+        type1: "FOO",
+      };
+      const { node, comp } = createFormComponent({ schema, formData });
+      Simulate.submit(node);
+      expect(comp.state.errors).to.have.length.of(0);
+    });
     it("should show dependency defaults for uncontrolled components", () => {
       const schema = {
         type: "object",

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1144,6 +1144,13 @@ describe("utils", () => {
 
         expect(mergeSchemas(obj1, obj2)).eql({ a: { required: [1, 2] } });
       });
+
+      it("should not include duplicate values when concatting arrays under 'required' keyword", () => {
+        const obj1 = { required: [1] };
+        const obj2 = { required: [1] };
+
+        expect(mergeSchemas(obj1, obj2)).eql({ required: [1] });
+      });
     });
   });
 
@@ -1409,13 +1416,14 @@ describe("utils", () => {
               required: ["a", "b"],
             });
           });
-          it("should not concat enum properties", () => {
+          it("should not concat enum properties, but should concat 'required' properties", () => {
             const schema = {
               type: "object",
               properties: {
                 a: { type: "string", enum: ["FOO", "BAR", "BAZ"] },
                 b: { type: "string", enum: ["GREEN", "BLUE", "RED"] },
               },
+              required: ["a"],
               dependencies: {
                 a: {
                   properties: {

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1132,24 +1132,36 @@ describe("utils", () => {
       });
 
       it("should concat arrays under 'required' keyword", () => {
-        const obj1 = { required: [1] };
-        const obj2 = { required: [2] };
+        const obj1 = { type: "object", required: [1] };
+        const obj2 = { type: "object", required: [2] };
 
-        expect(mergeSchemas(obj1, obj2)).eql({ required: [1, 2] });
+        expect(mergeSchemas(obj1, obj2)).eql({
+          type: "object",
+          required: [1, 2],
+        });
       });
 
       it("should concat nested arrays under 'required' keyword", () => {
-        const obj1 = { a: { required: [1] } };
-        const obj2 = { a: { required: [2] } };
+        const obj1 = { a: { type: "object", required: [1] } };
+        const obj2 = { a: { type: "object", required: [2] } };
 
-        expect(mergeSchemas(obj1, obj2)).eql({ a: { required: [1, 2] } });
+        expect(mergeSchemas(obj1, obj2)).eql({
+          a: { type: "object", required: [1, 2] },
+        });
       });
 
       it("should not include duplicate values when concatting arrays under 'required' keyword", () => {
-        const obj1 = { required: [1] };
-        const obj2 = { required: [1] };
+        const obj1 = { type: "object", required: [1] };
+        const obj2 = { type: "object", required: [1] };
 
-        expect(mergeSchemas(obj1, obj2)).eql({ required: [1] });
+        expect(mergeSchemas(obj1, obj2)).eql({ type: "object", required: [1] });
+      });
+
+      it("should not concat arrays under 'required' keyword that are not under an object type", () => {
+        const obj1 = { required: [1] };
+        const obj2 = { required: [2] };
+
+        expect(mergeSchemas(obj1, obj2)).eql({ required: [2] });
       });
     });
   });

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1141,6 +1141,16 @@ describe("utils", () => {
         });
       });
 
+      it("should concat arrays under 'required' keyword when one of the schemas is an object type", () => {
+        const obj1 = { type: "object", required: [1] };
+        const obj2 = { required: [2] };
+
+        expect(mergeSchemas(obj1, obj2)).eql({
+          type: "object",
+          required: [1, 2],
+        });
+      });
+
       it("should concat nested arrays under 'required' keyword", () => {
         const obj1 = { a: { type: "object", required: [1] } };
         const obj2 = { a: { type: "object", required: [2] } };

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -23,6 +23,7 @@ import {
   toIdSchema,
   toPathSchema,
   guessType,
+  mergeSchemas,
 } from "../src/utils";
 
 describe("utils", () => {
@@ -1058,6 +1059,94 @@ describe("utils", () => {
     });
   });
 
+  describe("mergeSchemas()", () => {
+    it("should't mutate the provided objects", () => {
+      const obj1 = { a: 1 };
+      mergeSchemas(obj1, { b: 2 });
+      expect(obj1).eql({ a: 1 });
+    });
+
+    it("should merge two one-level deep objects", () => {
+      expect(mergeSchemas({ a: 1 }, { b: 2 })).eql({ a: 1, b: 2 });
+    });
+
+    it("should override the first object with the values from the second", () => {
+      expect(mergeSchemas({ a: 1 }, { a: 2 })).eql({ a: 2 });
+    });
+
+    it("should override non-existing values of the first object with the values from the second", () => {
+      expect(mergeSchemas({ a: { b: undefined } }, { a: { b: { c: 1 } } })).eql(
+        { a: { b: { c: 1 } } }
+      );
+    });
+
+    it("should recursively merge deeply nested objects", () => {
+      const obj1 = {
+        a: 1,
+        b: {
+          c: 3,
+          d: [1, 2, 3],
+          e: { f: { g: 1 } },
+        },
+        c: 2,
+      };
+      const obj2 = {
+        a: 1,
+        b: {
+          d: [3, 2, 1],
+          e: { f: { h: 2 } },
+          g: 1,
+        },
+        c: 3,
+      };
+      const expected = {
+        a: 1,
+        b: {
+          c: 3,
+          d: [3, 2, 1],
+          e: { f: { g: 1, h: 2 } },
+          g: 1,
+        },
+        c: 3,
+      };
+      expect(mergeSchemas(obj1, obj2)).eql(expected);
+    });
+
+    it("should recursively merge File objects", () => {
+      const file = new File(["test"], "test.txt");
+      const obj1 = {
+        a: {},
+      };
+      const obj2 = {
+        a: file,
+      };
+      expect(mergeSchemas(obj1, obj2).a).instanceOf(File);
+    });
+
+    describe("arrays", () => {
+      it("should not concat arrays", () => {
+        const obj1 = { a: [1] };
+        const obj2 = { a: [2] };
+
+        expect(mergeSchemas(obj1, obj2)).eql({ a: [2] });
+      });
+
+      it("should concat arrays under 'required' keyword", () => {
+        const obj1 = { required: [1] };
+        const obj2 = { required: [2] };
+
+        expect(mergeSchemas(obj1, obj2)).eql({ required: [1, 2] });
+      });
+
+      it("should concat nested arrays under 'required' keyword", () => {
+        const obj1 = { a: { required: [1] } };
+        const obj2 = { a: { required: [2] } };
+
+        expect(mergeSchemas(obj1, obj2)).eql({ a: { required: [1, 2] } });
+      });
+    });
+  });
+
   describe("retrieveSchema()", () => {
     it("should 'resolve' a schema which contains definitions", () => {
       const schema = { $ref: "#/definitions/address" };
@@ -1316,6 +1405,34 @@ describe("utils", () => {
               properties: {
                 a: { type: "string" },
                 b: { type: "integer" },
+              },
+              required: ["a", "b"],
+            });
+          });
+          it("should not concat enum properties", () => {
+            const schema = {
+              type: "object",
+              properties: {
+                a: { type: "string", enum: ["FOO", "BAR", "BAZ"] },
+                b: { type: "string", enum: ["GREEN", "BLUE", "RED"] },
+              },
+              dependencies: {
+                a: {
+                  properties: {
+                    a: { enum: ["FOO"] },
+                    b: { enum: ["BLUE"] },
+                  },
+                  required: ["a", "b"],
+                },
+              },
+            };
+            const definitions = {};
+            const formData = { a: "FOO" };
+            expect(retrieveSchema(schema, definitions, formData)).eql({
+              type: "object",
+              properties: {
+                a: { type: "string", enum: ["FOO"] },
+                b: { type: "string", enum: ["BLUE"] },
               },
               required: ["a", "b"],
             });


### PR DESCRIPTION
### Reasons for making this change

Fixes #998. This makes sure that when dependencies are merged with the main schema, only arrays under the key `required` are merged. Other arrays are overwritten.

With this PR, `mergeSchemas` uses lodash's `union` operator to merge required arrays, so that the arrays do not have duplicate values when merged.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
