### PR TITLE
Use setTimeout instead of setImmediate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jsonschema-form",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/playground/app.js
+++ b/playground/app.js
@@ -122,7 +122,7 @@ class GeoPosition extends Component {
   onChange(name) {
     return event => {
       this.setState({ [name]: parseFloat(event.target.value) });
-      setImmediate(() => this.props.onChange(this.state));
+      setTimeout(() => this.props.onChange(this.state), 0);
     };
   }
 
@@ -231,7 +231,7 @@ class Selector extends Component {
     return event => {
       event.preventDefault();
       this.setState({ current: label });
-      setImmediate(() => this.props.onSelected(samples[label]));
+      setTimeout(() => this.props.onSelected(samples[label]), 0);
     };
   };
 
@@ -372,10 +372,10 @@ class App extends Component {
 
   onThemeSelected = (theme, { stylesheet, editor }) => {
     this.setState({ theme, editor: editor ? editor : "default" });
-    setImmediate(() => {
+    setTimeout(() => {
       // Side effect!
       document.getElementById("theme").setAttribute("href", stylesheet);
-    });
+    }, 0);
   };
 
   setLiveSettings = ({ formData }) => this.setState({ liveSettings: formData });

--- a/src/utils.js
+++ b/src/utils.js
@@ -962,7 +962,7 @@ export function setState(instance, state, callback) {
     instance.setState(state, callback);
   } else {
     instance.setState(state);
-    setImmediate(callback);
+    setTimeout(callback, 0);
   }
 }
 

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -1183,7 +1183,7 @@ describe("ArrayField", () => {
         },
       });
 
-      return new Promise(setImmediate).then(() =>
+      return new Promise(resolve => setTimeout(resolve, 0)).then(() =>
         expect(comp.state.formData).eql([
           "data:text/plain;name=file1.txt;base64,x=",
           "data:text/plain;name=file2.txt;base64,x=",

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -1609,7 +1609,7 @@ describe("StringField", () => {
         },
       });
 
-      return new Promise(setImmediate).then(() =>
+      return new Promise(resolve => setTimeout(resolve, 0)).then(() =>
         expect(comp.state.formData).eql(
           "data:text/plain;name=file1.txt;base64,x="
         )
@@ -1640,7 +1640,7 @@ describe("StringField", () => {
         },
       });
 
-      return new Promise(setImmediate).then(() =>
+      return new Promise(resolve => setTimeout(resolve, 0)).then(() =>
         expect(comp.state.formData).eql(
           "data:text/plain;name=" + uriEncodedValue + ";base64,x="
         )

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1104,7 +1104,7 @@ describe("utils", () => {
       });
     });
 
-    it.only("should 'resolve' and stub out a schema which contains an `additionalProperties` with a type and definition", () => {
+    it("should 'resolve' and stub out a schema which contains an `additionalProperties` with a type and definition", () => {
       const schema = {
         type: "string",
         additionalProperties: {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -15,7 +15,7 @@ module.exports = {
     new MonacoWebpackPlugin({
       languages: ['json']
     }),
-    new MiniCssExtractPlugin({filename: "styles.css", allChunks: true}),
+    new MiniCssExtractPlugin({ filename: "styles.css", allChunks: true }),
     new webpack.DefinePlugin({
       "process.env": {
         NODE_ENV: JSON.stringify("production"),


### PR DESCRIPTION
### Reasons for making this change

At one place in the library code, we use setImmediate. 
However this function is not standard : 

> This method is not expected to become standard, and is only implemented by recent builds of Internet Explorer and Node.js 0.10+. It meets resistance both from Gecko (Firefox) and Webkit (Google/Apple).
[Source](https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate)

Since it is not standard, the setImmediate is transformed by babel to : `var _setImmediate2 = _interopRequireDefault(require("@babel/runtime-corejs2/core-js/set-immediate"));` which adds a lot of unneeded code to the build.

In my application tests, we use react-json-schema-form and are mocking the time with lolex, however, this "polyfil" by babel seems to not react to lolex.

setTimeout(function, 0) has the same behavior, it brakes no tests.

It would be great to release a patch version with those changes :-)

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
