### PR TITLE
Introduce Form autoComplete attribute and deprecate autocomplete

### DIFF
--- a/docs/form-customization.md
+++ b/docs/form-customization.md
@@ -728,7 +728,7 @@ The `Form` component supports the following html attributes:
   method="post"
   target="_blank"
   action="/users/list"
-  autocomplete="off"
+  autoComplete="off"
   enctype="multipart/form-data"
   acceptcharset="ISO-8859-1" />
 ```

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -333,11 +333,6 @@ export default class Form extends Component {
       console.warn(
         "Using autocomplete property of Form is deprecated, use autoComplete instead."
       );
-      if (currentAutoComplete) {
-        console.warn(
-          "Both autocomplete and autoComplete properties of Form are set, autoComplete will be used."
-        );
-      }
     }
     const autoComplete = currentAutoComplete
       ? currentAutoComplete

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -316,7 +316,8 @@ export default class Form extends Component {
       method,
       target,
       action,
-      autocomplete,
+      autocomplete: deprecatedAutocomplete,
+      autoComplete: currentAutoComplete,
       enctype,
       acceptcharset,
       noHtml5Validate,
@@ -328,6 +329,19 @@ export default class Form extends Component {
     const registry = this.getRegistry();
     const _SchemaField = registry.fields.SchemaField;
     const FormTag = tagName ? tagName : "form";
+    if (deprecatedAutocomplete) {
+      console.warn(
+        "Using autocomplete property of Form is deprecated, use autoComplete instead."
+      );
+      if (currentAutoComplete) {
+        console.warn(
+          "Both autocomplete and autoComplete properties of Form are set, autoComplete will be used."
+        );
+      }
+    }
+    const autoComplete = currentAutoComplete
+      ? currentAutoComplete
+      : deprecatedAutocomplete;
 
     return (
       <FormTag
@@ -337,7 +351,7 @@ export default class Form extends Component {
         method={method}
         target={target}
         action={action}
-        autoComplete={autocomplete}
+        autoComplete={autoComplete}
         encType={enctype}
         acceptCharset={acceptcharset}
         noValidate={noHtml5Validate}
@@ -400,6 +414,7 @@ if (process.env.NODE_ENV !== "production") {
     target: PropTypes.string,
     action: PropTypes.string,
     autocomplete: PropTypes.string,
+    autoComplete: PropTypes.string,
     enctype: PropTypes.string,
     acceptcharset: PropTypes.string,
     noValidate: PropTypes.bool,

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -2138,6 +2138,7 @@ describeRepeated("Form common", createFormComponent => {
   describe("Deprecated autocomplete attribute", () => {
     it("should set attr autocomplete of form", () => {
       const formProps = {
+        schema: {},
         autocomplete: "off",
       };
       const node = createFormComponent(formProps).node;
@@ -2145,7 +2146,9 @@ describeRepeated("Form common", createFormComponent => {
     });
 
     it("should log deprecation warning when it is used", () => {
+      sandbox.stub(console, "warn");
       createFormComponent({
+        schema: {},
         autocomplete: "off",
       });
       expect(
@@ -2155,20 +2158,9 @@ describeRepeated("Form common", createFormComponent => {
       ).to.be.true;
     });
 
-    it("should log warning when autocomplete is used along with autoComplete", () => {
-      createFormComponent({
-        autocomplete: "off",
-        autoComplete: "off",
-      });
-      expect(
-        console.warn.calledWithMatch(
-          /Both autocomplete and autoComplete properties of Form are set/
-        )
-      ).to.be.true;
-    });
-
     it("should use autoComplete value if both autocomplete and autoComplete are used", () => {
       const formProps = {
+        schema: {},
         autocomplete: "off",
         autoComplete: "on",
       };

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -2082,7 +2082,7 @@ describeRepeated("Form common", createFormComponent => {
       method: "post",
       target: "_blank",
       action: "/users/list",
-      autocomplete: "off",
+      autoComplete: "off",
       enctype: "multipart/form-data",
       acceptcharset: "ISO-8859-1",
       noHtml5Validate: true,
@@ -2118,8 +2118,8 @@ describeRepeated("Form common", createFormComponent => {
       expect(node.getAttribute("action")).eql(formProps.action);
     });
 
-    it("should set attr autoComplete of form", () => {
-      expect(node.getAttribute("autocomplete")).eql(formProps.autocomplete);
+    it("should set attr autocomplete of form", () => {
+      expect(node.getAttribute("autocomplete")).eql(formProps.autoComplete);
     });
 
     it("should set attr enctype of form", () => {
@@ -2132,6 +2132,48 @@ describeRepeated("Form common", createFormComponent => {
 
     it("should set attr novalidate of form", () => {
       expect(node.getAttribute("novalidate")).not.to.be.null;
+    });
+  });
+
+  describe("Deprecated autocomplete attribute", () => {
+    it("should set attr autocomplete of form", () => {
+      const formProps = {
+        autocomplete: "off",
+      };
+      const node = createFormComponent(formProps).node;
+      expect(node.getAttribute("autocomplete")).eql(formProps.autocomplete);
+    });
+
+    it("should log deprecation warning when it is used", () => {
+      createFormComponent({
+        autocomplete: "off",
+      });
+      expect(
+        console.warn.calledWithMatch(
+          /Using autocomplete property of Form is deprecated/
+        )
+      ).to.be.true;
+    });
+
+    it("should log warning when autocomplete is used along with autoComplete", () => {
+      createFormComponent({
+        autocomplete: "off",
+        autoComplete: "off",
+      });
+      expect(
+        console.warn.calledWithMatch(
+          /Both autocomplete and autoComplete properties of Form are set/
+        )
+      ).to.be.true;
+    });
+
+    it("should use autoComplete value if both autocomplete and autoComplete are used", () => {
+      const formProps = {
+        autocomplete: "off",
+        autoComplete: "on",
+      };
+      const node = createFormComponent(formProps).node;
+      expect(node.getAttribute("autocomplete")).eql(formProps.autoComplete);
     });
   });
 


### PR DESCRIPTION
### Reasons for making this change

We should rename the `autocomplete` attribute on `<Form>` to `autoComplete`. This is because that's how React does it on the actual `<form>` element, so it will be a more familiar attribute name for React developers.

If this is related to existing tickets, include links to them as well.
fixes #1156

### Checklist

* [X] **I'm updating documentation**
  - [X] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests
  - [X] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
