### PR TITLE
fix: update arrays correctly when changing index

### DIFF
--- a/src/components/fields/ArrayField.js
+++ b/src/components/fields/ArrayField.js
@@ -750,6 +750,7 @@ class ArrayField extends Component {
     return {
       children: (
         <SchemaField
+          index={index}
           schema={itemSchema}
           uiSchema={itemUiSchema}
           formData={itemData}

--- a/test/ArrayField_test.js
+++ b/test/ArrayField_test.js
@@ -616,6 +616,23 @@ describe("ArrayField", () => {
       expect(inputs[0].value).eql("bar");
     });
 
+    it("should delete item from list and correct indices", () => {
+      const { node } = createFormComponent({
+        schema,
+        formData: ["foo", "bar", "baz"],
+      });
+      const deleteBtns = node.querySelectorAll(".array-item-remove");
+
+      Simulate.click(deleteBtns[0]);
+
+      const inputs = node.querySelectorAll(".field-string input[type=text]");
+
+      Simulate.change(inputs[0], { target: { value: "fuzz" } });
+      expect(inputs).to.have.length.of(2);
+      expect(inputs[0].value).eql("fuzz");
+      expect(inputs[1].value).eql("baz");
+    });
+
     it("should retain row keys/ids of remaining rows when a row is removed", () => {
       const { node } = createFormComponent({
         schema,


### PR DESCRIPTION
### Reasons for making this change
SchemaField needs to be updated when items are removed or repositioned in the array with the correct indices. If the index is not passed down from ArrayField, shouldComponentRender in SchemaField returns false as it detects nothing has changed for the array children.

[Please describe them here]
fixes #1479 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
