### PR TITLE
fix: Update anyOf schema to correctly update items in an array

### DIFF
--- a/src/components/fields/MultiSchemaField.js
+++ b/src/components/fields/MultiSchemaField.js
@@ -8,6 +8,7 @@ import {
   retrieveSchema,
   getDefaultFormState,
   getMatchingOption,
+  deepEquals,
 } from "../../utils";
 
 class AnyOfField extends Component {
@@ -21,17 +22,24 @@ class AnyOfField extends Component {
     };
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    const matchingOption = this.getMatchingOption(
-      nextProps.formData,
-      nextProps.options
-    );
+  componentDidUpdate(prevProps, prevState) {
+    if (
+      !deepEquals(this.props.formData, prevProps.formData) &&
+      this.props.idSchema.$id === prevProps.idSchema.$id
+    ) {
+      const matchingOption = this.getMatchingOption(
+        this.props.formData,
+        this.props.options
+      );
 
-    if (matchingOption === this.state.selectedOption) {
-      return;
+      if (!prevState || matchingOption === this.state.selectedOption) {
+        return;
+      }
+
+      this.setState({
+        selectedOption: matchingOption,
+      });
     }
-
-    this.setState({ selectedOption: matchingOption });
   }
 
   getMatchingOption(formData, options) {

--- a/test/anyOf_test.js
+++ b/test/anyOf_test.js
@@ -663,6 +663,59 @@ describe("anyOf", () => {
       expect(node.querySelectorAll("input#root_foo")).to.have.length.of(1);
     });
 
+    it("should not change the selected option when switching order of items for anyOf inside array items", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          items: {
+            type: "array",
+            items: {
+              type: "object",
+              anyOf: [
+                {
+                  properties: {
+                    foo: {
+                      type: "string",
+                    },
+                  },
+                },
+                {
+                  properties: {
+                    bar: {
+                      type: "string",
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const { node } = createFormComponent({
+        schema,
+        formData: {
+          items: [
+            {},
+            {
+              bar: "defaultbar",
+            },
+          ],
+        },
+      });
+
+      let selects = node.querySelectorAll("select");
+      expect(selects[0].value).eql("0");
+      expect(selects[1].value).eql("1");
+
+      const moveUpBtns = node.querySelectorAll(".array-item-move-up");
+      Simulate.click(moveUpBtns[1]);
+
+      selects = node.querySelectorAll("select");
+      expect(selects[0].value).eql("1");
+      expect(selects[1].value).eql("0");
+    });
+
     it("should correctly render mixed types for anyOf inside array items", () => {
       const schema = {
         type: "object",


### PR DESCRIPTION
### Reasons for making this change

componentWillReceiveProps is no longer recommended by React after updating to React 16 as it has some design flaws. Instead, I've updated to a componentDidUpdate that will change after formData changes specifically. I've added a test to demonstrate the bug that was causing an update twice and selectedOption to become out of sync when moving indices in an array using anyOf.

If this is related to existing tickets, include links to them as well.

fixes first issue in #1486 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
