### PR TITLE
Support for "examples" keyword

### DIFF
--- a/packages/core/playground/samples/examples.js
+++ b/packages/core/playground/samples/examples.js
@@ -7,7 +7,7 @@ module.exports = {
       browser: {
         type: "string",
         title: "Browser",
-        examples: ["Firefox", "Chrome", "Opera", "Vivaldi", "Safari"]
+        examples: ["Firefox", "Chrome", "Opera", "Vivaldi", "Safari"],
       },
     },
   },

--- a/packages/core/playground/samples/examples.js
+++ b/packages/core/playground/samples/examples.js
@@ -1,0 +1,14 @@
+module.exports = {
+  schema: {
+    title: "Examples",
+    description: "A text field with example values.",
+    type: "object",
+    properties: {
+      browser: {
+        type: "string",
+        title: "Browser",
+        examples: ["Firefox", "Chrome", "Opera", "Vivaldi", "Safari"]
+      },
+    },
+  },
+};

--- a/packages/core/playground/samples/index.js
+++ b/packages/core/playground/samples/index.js
@@ -9,6 +9,7 @@ import ordering from "./ordering";
 import references from "./references";
 import custom from "./custom";
 import errors from "./errors";
+import examples from "./examples";
 import large from "./large";
 import date from "./date";
 import validation from "./validation";
@@ -35,6 +36,7 @@ export const samples = {
   References: references,
   Custom: custom,
   Errors: errors,
+  Examples: examples,
   Large: large,
   "Date & time": date,
   Validation: validation,

--- a/packages/core/src/components/widgets/BaseInput.js
+++ b/packages/core/src/components/widgets/BaseInput.js
@@ -61,7 +61,7 @@ function BaseInput(props) {
     return props.onChange(value === "" ? options.emptyValue : value);
   };
 
-  return (
+  return [
     <input
       className="form-control"
       readOnly={readonly}
@@ -69,11 +69,19 @@ function BaseInput(props) {
       autoFocus={autofocus}
       value={value == null ? "" : value}
       {...inputProps}
+      list={schema.examples ? `examples_${inputProps.id}` : null}
       onChange={_onChange}
       onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}
       onFocus={onFocus && (event => onFocus(inputProps.id, event.target.value))}
-    />
-  );
+    />,
+    schema.examples ? (
+      <datalist id={`examples_${inputProps.id}`}>
+        {schema.examples.concat([]).map(example => (
+          <option key={example} value={example} />
+        ))}
+      </datalist>
+    ) : null,
+  ];
 }
 
 BaseInput.defaultProps = {

--- a/packages/core/src/components/widgets/BaseInput.js
+++ b/packages/core/src/components/widgets/BaseInput.js
@@ -76,11 +76,13 @@ function BaseInput(props) {
     />,
     schema.examples ? (
       <datalist id={`examples_${inputProps.id}`}>
-        {schema.examples
-          .concat(schema.default ? [schema.default] : [])
-          .map(example => (
-            <option key={example} value={example} />
-          ))}
+        {[
+          ...new Set(
+            schema.examples.concat(schema.default ? [schema.default] : [])
+          ),
+        ].map(example => (
+          <option key={example} value={example} />
+        ))}
       </datalist>
     ) : null,
   ];

--- a/packages/core/src/components/widgets/BaseInput.js
+++ b/packages/core/src/components/widgets/BaseInput.js
@@ -76,9 +76,11 @@ function BaseInput(props) {
     />,
     schema.examples ? (
       <datalist id={`examples_${inputProps.id}`}>
-        {schema.examples.concat([]).map(example => (
-          <option key={example} value={example} />
-        ))}
+        {schema.examples
+          .concat(schema.default ? [schema.default] : [])
+          .map(example => (
+            <option key={example} value={example} />
+          ))}
       </datalist>
     ) : null,
   ];

--- a/packages/core/test/StringField_test.js
+++ b/packages/core/test/StringField_test.js
@@ -63,6 +63,9 @@ describe("StringField", () => {
       });
 
       expect(node.querySelector(".field input").value).eql("plop");
+      expect(
+        node.querySelectorAll(".field datalist > option")
+      ).to.have.length.of(0);
     });
 
     it("should render a string field with examples", () => {

--- a/packages/core/test/StringField_test.js
+++ b/packages/core/test/StringField_test.js
@@ -65,6 +65,57 @@ describe("StringField", () => {
       expect(node.querySelector(".field input").value).eql("plop");
     });
 
+    it("should render a string field with examples", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "string",
+          examples: ["Firefox", "Chrome", "Vivaldi"],
+        },
+      });
+
+      expect(
+        node.querySelectorAll(".field datalist > option")
+      ).to.have.length.of(3);
+      const datalistId = node.querySelector(".field datalist").id;
+      expect(node.querySelector(".field input").getAttribute("list")).eql(
+        datalistId
+      );
+    });
+
+    it("should render a string with examples that includes the default value", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "string",
+          default: "Firefox",
+          examples: ["Chrome", "Vivaldi"],
+        },
+      });
+      expect(
+        node.querySelectorAll(".field datalist > option")
+      ).to.have.length.of(3);
+      const datalistId = node.querySelector(".field datalist").id;
+      expect(node.querySelector(".field input").getAttribute("list")).eql(
+        datalistId
+      );
+    });
+
+    it("should render a string with examples that overlaps with the default value", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "string",
+          default: "Firefox",
+          examples: ["Firefox", "Chrome", "Vivaldi"],
+        },
+      });
+      expect(
+        node.querySelectorAll(".field datalist > option")
+      ).to.have.length.of(3);
+      const datalistId = node.querySelector(".field datalist").id;
+      expect(node.querySelector(".field input").getAttribute("list")).eql(
+        datalistId
+      );
+    });
+
     it("should default state value to undefined", () => {
       const { comp } = createFormComponent({
         schema: { type: "string" },


### PR DESCRIPTION
### Reasons for making this change

The [examples](https://json-schema.org/understanding-json-schema/reference/generic.html) keyword is not currently supported, as noted in [issue 632](https://github.com/rjsf-team/react-jsonschema-form/issues/632). This pull requests adds support for this using the [HTML datalist tag](https://www.w3schools.com/tags/tag_datalist.asp).

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
