### PR TITLE
Use index for value in SelectWidget

### DIFF
--- a/packages/core/playground/samples/enumObjects.js
+++ b/packages/core/playground/samples/enumObjects.js
@@ -1,0 +1,47 @@
+module.exports = {
+  schema: {
+    definitions: {
+      locations: {
+        enumNames: ["New York", "Amsterdam", "Hong Kong"],
+        enum: [
+          {
+            name: "New York",
+            lat: 40,
+            lon: 74,
+          },
+          {
+            name: "Amsterdam",
+            lat: 52,
+            lon: 5,
+          },
+          {
+            name: "Hong Kong",
+            lat: 22,
+            lon: 114,
+          },
+        ],
+      },
+    },
+    type: "object",
+    properties: {
+      location: {
+        title: "Location",
+        $ref: "#/definitions/locations",
+      },
+      multiSelect: {
+        type: "array",
+        uniqueItems: true,
+        items: {
+          $ref: "#/definitions/locations",
+        },
+      },
+    },
+  },
+  formData: {
+    location: {
+      name: "Amsterdam",
+      lat: 52,
+      lon: 5,
+    },
+  },
+};

--- a/packages/core/src/components/widgets/SelectWidget.js
+++ b/packages/core/src/components/widgets/SelectWidget.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import _findIndex from "lodash/findIndex";
-import _indexOf from "lodash/indexOf";
+import _isEqual from "lodash/isEqual";
 
 function getValue(event, enumOptions, multiple) {
   if (event.target.value === "") {
@@ -15,6 +14,34 @@ function getValue(event, enumOptions, multiple) {
   } else {
     return enumOptions[event.target.value].value;
   }
+}
+
+function getOneSelected(value, enumOptions) {
+  if (typeof value === "undefined") {
+    return "";
+  }
+
+  for (const i in enumOptions) {
+    if (_isEqual(enumOptions[i].value, value)) {
+      return i;
+    }
+  }
+  return "";
+}
+
+function getMultipleSelected(values, enumOptions) {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  let selected = [];
+  for (const i in enumOptions) {
+    for (const value of values) {
+      if (_isEqual(enumOptions[i].value, value)) {
+        selected.push(i);
+      }
+    }
+  }
+  return selected;
 }
 
 function SelectWidget(props) {
@@ -34,20 +61,15 @@ function SelectWidget(props) {
     placeholder,
   } = props;
   const { enumOptions, enumDisabled } = options;
-  const emptyValue = multiple ? [] : "";
-  const find = typeof value === "object" ? _findIndex : _indexOf;
-  const selectedIndices =
-    typeof value === "undefined"
-      ? emptyValue
-      : multiple
-      ? value.map(value => find(enumOptions.map(el => el.value), value))
-      : find(enumOptions.map(el => el.value), value);
+  const selected = multiple
+    ? getMultipleSelected(value, enumOptions)
+    : getOneSelected(value, enumOptions);
   return (
     <select
       id={id}
       multiple={multiple}
       className="form-control"
-      value={selectedIndices}
+      value={selected}
       required={required}
       disabled={disabled || readonly}
       autoFocus={autofocus}

--- a/packages/core/src/components/widgets/SelectWidget.js
+++ b/packages/core/src/components/widgets/SelectWidget.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-// import _isEqual from "lodash/isEqual";
 import _findIndex from "lodash/findIndex";
+import _indexOf from "lodash/indexOf";
 
 function getValue(event, enumOptions, multiple) {
   if (event.target.value === "") {
@@ -35,12 +35,13 @@ function SelectWidget(props) {
   } = props;
   const { enumOptions, enumDisabled } = options;
   const emptyValue = multiple ? [] : "";
+  const find = typeof value === "object" ? _findIndex : _indexOf;
   const selectedIndices =
     typeof value === "undefined"
       ? emptyValue
       : multiple
-      ? value.map(value => _findIndex(enumOptions.map(el => el.value), value))
-      : _findIndex(enumOptions.map(el => el.value), value);
+      ? value.map(value => find(enumOptions.map(el => el.value), value))
+      : find(enumOptions.map(el => el.value), value);
   return (
     <select
       id={id}

--- a/packages/core/src/components/widgets/SelectWidget.js
+++ b/packages/core/src/components/widgets/SelectWidget.js
@@ -1,48 +1,19 @@
 import React from "react";
 import PropTypes from "prop-types";
+// import _isEqual from "lodash/isEqual";
+import _findIndex from "lodash/findIndex";
 
-import { asNumber, guessType } from "../../utils";
-
-const nums = new Set(["number", "integer"]);
-
-/**
- * This is a silly limitation in the DOM where option change event values are
- * always retrieved as strings.
- */
-function processValue(schema, value) {
-  // "enum" is a reserved word, so only "type" and "items" can be destructured
-  const { type, items } = schema;
-  if (value === "") {
+function getValue(event, enumOptions, multiple) {
+  if (event.target.value === "") {
     return undefined;
-  } else if (type === "array" && items && nums.has(items.type)) {
-    return value.map(asNumber);
-  } else if (type === "boolean") {
-    return value === "true";
-  } else if (type === "number") {
-    return asNumber(value);
   }
-
-  // If type is undefined, but an enum is present, try and infer the type from
-  // the enum values
-  if (schema.enum) {
-    if (schema.enum.every(x => guessType(x) === "number")) {
-      return asNumber(value);
-    } else if (schema.enum.every(x => guessType(x) === "boolean")) {
-      return value === "true";
-    }
-  }
-
-  return value;
-}
-
-function getValue(event, multiple) {
   if (multiple) {
     return [].slice
       .call(event.target.options)
       .filter(o => o.selected)
-      .map(o => o.value);
+      .map(o => enumOptions[o.value].value);
   } else {
-    return event.target.value;
+    return enumOptions[event.target.value].value;
   }
 }
 
@@ -64,32 +35,35 @@ function SelectWidget(props) {
   } = props;
   const { enumOptions, enumDisabled } = options;
   const emptyValue = multiple ? [] : "";
+  const selectedIndices =
+    typeof value === "undefined"
+      ? emptyValue
+      : multiple
+      ? value.map(value => _findIndex(enumOptions.map(el => el.value), value))
+      : _findIndex(enumOptions.map(el => el.value), value);
   return (
     <select
       id={id}
       multiple={multiple}
       className="form-control"
-      value={typeof value === "undefined" ? emptyValue : value}
+      value={selectedIndices}
       required={required}
       disabled={disabled || readonly}
       autoFocus={autofocus}
       onBlur={
         onBlur &&
         (event => {
-          const newValue = getValue(event, multiple);
-          onBlur(id, processValue(schema, newValue));
+          onBlur(id, getValue(event, enumOptions, multiple));
         })
       }
       onFocus={
         onFocus &&
         (event => {
-          const newValue = getValue(event, multiple);
-          onFocus(id, processValue(schema, newValue));
+          onFocus(id, getValue(event, enumOptions, multiple));
         })
       }
       onChange={event => {
-        const newValue = getValue(event, multiple);
-        onChange(processValue(schema, newValue));
+        onChange(getValue(event, enumOptions, multiple));
       }}>
       {!multiple && schema.default === undefined && (
         <option value="">{placeholder}</option>
@@ -97,7 +71,7 @@ function SelectWidget(props) {
       {enumOptions.map(({ value, label }, i) => {
         const disabled = enumDisabled && enumDisabled.indexOf(value) != -1;
         return (
-          <option key={i} value={value} disabled={disabled}>
+          <option key={i} value={i} disabled={disabled}>
             {label}
           </option>
         );

--- a/packages/playground/src/samples/index.js
+++ b/packages/playground/src/samples/index.js
@@ -2,6 +2,7 @@ import arrays from "./arrays";
 import anyOf from "./anyOf";
 import oneOf from "./oneOf";
 import allOf from "./allOf";
+import enumObjects from "./enumObjects";
 import nested from "./nested";
 import numbers from "./numbers";
 import simple from "./simple";
@@ -52,6 +53,7 @@ export const samples = {
   "Any Of": anyOf,
   "One Of": oneOf,
   "All Of": allOf,
+  "Enumerated objects": enumObjects,
   "Null fields": nullField,
   Nullable: nullable,
   ErrorSchema: errorSchema,


### PR DESCRIPTION
This PR changes the way options are selected in the SelectWidget by using the options array  index instead of a serializing the selected value to the DOM (cast to string). This allows removal of a lot of hacky code to guess type of deserialized values, and also allows for selecting complete objects via a dropdown, addressing #1494.

I've added a playground example. I haven't looked at fixing the tests yet as  would like feedback on the approach first.
