### PR TITLE
Fix oneOf/anyOf nested defaults

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -199,10 +199,10 @@ function computeDefaults(
     );
   } else if ("oneOf" in schema) {
     schema =
-      schema.oneOf[getMatchingOption(undefined, schema.oneOf, definitions)];
+      schema.oneOf[getMatchingOption(formData, schema.oneOf, definitions)];
   } else if ("anyOf" in schema) {
     schema =
-      schema.anyOf[getMatchingOption(undefined, schema.anyOf, definitions)];
+      schema.anyOf[getMatchingOption(formData, schema.anyOf, definitions)];
   }
 
   // Not defaults defined for this node, fallback to generic typed ones.

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -1150,6 +1150,55 @@ describe("utils", () => {
         };
         expect(getDefaultFormState(schema, formData)).to.eql(result);
       });
+
+      it("shouldn't add in default objects to formData", () => {
+        const schema = {
+          type: "object",
+          oneOf: [
+            {
+              properties: {
+                first: {
+                  type: "object",
+                  properties: {
+                    shared: {
+                      type: "string",
+                    },
+                  },
+                  default: {
+                    shared: "first",
+                  },
+                },
+              },
+            },
+            {
+              properties: {
+                second: {
+                  type: "object",
+                  properties: {
+                    shared: {
+                      type: "string",
+                    },
+                  },
+                  default: {
+                    shared: "first",
+                  },
+                },
+              },
+            },
+          ],
+        };
+        const formData = {
+          second: {
+            shared: "second",
+          },
+        };
+        const result = {
+          second: {
+            shared: "second",
+          },
+        };
+        expect(getDefaultFormState(schema, formData)).to.eql(result);
+      });
     });
   });
 


### PR DESCRIPTION
### Reasons for making this change

Somewhat related to (but does not fully address): #1558 

There is a cheeky bug whereby nested defaults in oneOf/anyOf remain in the `formData` when the option is changed. See [playground example](https://rjsf-team.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6eyJxMSI6eyJsb3JlbSI6Im9wdGlvbiAxIn19LCJzY2hlbWEiOnsidHlwZSI6Im9iamVjdCIsIm9uZU9mIjpbeyJwcm9wZXJ0aWVzIjp7InExIjp7InR5cGUiOiJvYmplY3QiLCJwcm9wZXJ0aWVzIjp7ImxvcmVtIjp7InR5cGUiOiJzdHJpbmcifX0sImRlZmF1bHQiOnsibG9yZW0iOiJvcHRpb24gMSJ9fX0sInJlcXVpcmVkIjpbInExIl19LHsicHJvcGVydGllcyI6eyJxMiI6eyJ0eXBlIjoib2JqZWN0IiwicHJvcGVydGllcyI6eyJsb3JlbSI6eyJ0eXBlIjoic3RyaW5nIn19LCJkZWZhdWx0Ijp7ImxvcmVtIjoib3B0aW9uIDIifX19LCJyZXF1aXJlZCI6WyJxMiJdfV19LCJ1aVNjaGVtYSI6e30sImxpdmVTZXR0aW5ncyI6eyJ2YWxpZGF0ZSI6dHJ1ZSwiZGlzYWJsZSI6ZmFsc2UsIm9taXRFeHRyYURhdGEiOmZhbHNlLCJsaXZlT21pdCI6ZmFsc2V9fQ==). Select "Option 2" and watch how there is stale data in `formData`.

However, note that there are still some issues when options to omit data are selected. This needs to be investigated further as it goes deeper into the logic of several utility functions.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
