### PR TITLE
support AltDateWidget.js to bootstrap 4

### DIFF
--- a/packages/core/src/components/widgets/AltDateWidget.js
+++ b/packages/core/src/components/widgets/AltDateWidget.js
@@ -137,7 +137,7 @@ class AltDateWidget extends Component {
     return (
       <ul className="list-inline">
         {this.dateElementProps.map((elemProps, i) => (
-          <li key={i}>
+          <li class="list-inline-item" key={i}>
             <DateElement
               rootId={id}
               select={this.onChange}
@@ -153,7 +153,7 @@ class AltDateWidget extends Component {
         {(options.hideNowButton !== "undefined"
           ? !options.hideNowButton
           : true) && (
-          <li>
+          <li class="list-inline-item">
             <a href="#" className="btn btn-info btn-now" onClick={this.setNow}>
               Now
             </a>
@@ -162,7 +162,7 @@ class AltDateWidget extends Component {
         {(options.hideClearButton !== "undefined"
           ? !options.hideClearButton
           : true) && (
-          <li>
+          <li class="list-inline-item">
             <a
               href="#"
               className="btn btn-warning btn-clear"


### PR DESCRIPTION
https://getbootstrap.com/docs/4.3/migration/#typography

> .list-inline now requires that its children list items have the new .list-inline-item class applied to them.

### Reasons for making this change

alt-date & alt-datetime does not work with bootstrap4.

If this is related to existing tickets, include links to them as well.

#1455 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
