### PR TITLE
Don't crash when schema property is a non-object - show an error instead

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -152,12 +152,13 @@ export function hasWidget(schema, widget, registeredWidgets = {}) {
 }
 
 function computeDefaults(
-  schema,
+  _schema,
   parentDefaults,
   definitions,
   rawFormData = {},
   includeUndefinedValues = false
 ) {
+  let schema = isObject(_schema) ? _schema : {};
   const formData = isObject(rawFormData) ? rawFormData : {};
   // Compute the defaults recursively: give highest priority to deepest nodes.
   let defaults = parentDefaults;
@@ -655,6 +656,9 @@ function resolveReference(schema, definitions, formData) {
 }
 
 export function retrieveSchema(schema, definitions = {}, formData = {}) {
+  if (!isObject(schema)) {
+    return {};
+  }
   let resolvedSchema = resolveSchema(schema, definitions, formData);
   if ("allOf" in schema) {
     try {
@@ -971,7 +975,7 @@ export function toIdSchema(
     const field = schema.properties[name];
     const fieldId = idSchema.$id + "_" + name;
     idSchema[name] = toIdSchema(
-      field,
+      isObject(field) ? field : {},
       fieldId,
       definitions,
       // It's possible that formData is not an object -- this can happen if an

--- a/packages/core/test/Form_test.js
+++ b/packages/core/test/Form_test.js
@@ -51,6 +51,35 @@ describeRepeated("Form common", createFormComponent => {
       const node = findDOMNode(comp);
       expect(node.querySelectorAll("button[type=submit]")).to.have.length.of(2);
     });
+
+    it("should render errors if schema is't object", () => {
+      const props = {
+        schema: {
+          type: "object",
+          title: "object",
+          properties: {
+            firstName: "some mame",
+            address: {
+              $ref: "#/definitions/address",
+            },
+          },
+          definitions: {
+            address: {
+              street: "some street",
+            },
+          },
+        },
+      };
+      const comp = renderIntoDocument(
+        <Form {...props}>
+          <button type="submit">Submit</button>
+        </Form>
+      );
+      const node = findDOMNode(comp);
+      expect(node.querySelector(".unsupported-field").textContent).to.contain(
+        "Unknown field type undefined"
+      );
+    });
   });
 
   describe("on component creation", () => {

--- a/packages/core/test/Form_test.js
+++ b/packages/core/test/Form_test.js
@@ -52,7 +52,7 @@ describeRepeated("Form common", createFormComponent => {
       expect(node.querySelectorAll("button[type=submit]")).to.have.length.of(2);
     });
 
-    it("should render errors if schema is't object", () => {
+    it("should render errors if schema isn't object", () => {
       const props = {
         schema: {
           type: "object",


### PR DESCRIPTION
### Reasons for making this change

`TypeError: Cannot use 'in' operator to search for` if properties are simple type (not object)

To reproduce on https://rjsf-team.github.io/react-jsonschema-form/ use following schema (where `firstName` property is empty string)

```json
{
  "title": "A registration form",
  "description": "A simple form example.",
  "type": "object",
  "required": [
    "firstName"
  ],
  "properties": {
    "firstName": "" 
  }
}
```
 
Related to:
- https://github.com/rjsf-team/react-jsonschema-form/issues/1188#issuecomment-466647714
- https://github.com/rjsf-team/react-jsonschema-form/issues/866

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
