### PR TITLE
Overridable DescriptionField in BooleanField

### DIFF
--- a/packages/core/src/components/fields/BooleanField.js
+++ b/packages/core/src/components/fields/BooleanField.js
@@ -26,7 +26,7 @@ function BooleanField(props) {
     rawErrors,
   } = props;
   const { title } = schema;
-  const { widgets, formContext } = registry;
+  const { widgets, formContext, fields } = registry;
   const { widget = "checkbox", ...options } = getUiOptions(uiSchema);
   const Widget = getWidget(schema, widget, widgets);
 
@@ -67,6 +67,7 @@ function BooleanField(props) {
       formContext={formContext}
       autofocus={autofocus}
       rawErrors={rawErrors}
+      DescriptionField={fields.DescriptionField}
     />
   );
 }

--- a/packages/core/src/components/widgets/CheckboxWidget.js
+++ b/packages/core/src/components/widgets/CheckboxWidget.js
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import DescriptionField from "../fields/DescriptionField.js";
 
 // Check to see if a schema specifies that a value must be true
 function schemaRequiresTrueValue(schema) {
@@ -43,6 +42,7 @@ function CheckboxWidget(props) {
     onBlur,
     onFocus,
     onChange,
+    DescriptionField,
   } = props;
 
   // Because an unchecked checkbox will cause html5 validation to fail, only add

--- a/packages/core/test/BooleanField_test.js
+++ b/packages/core/test/BooleanField_test.js
@@ -184,6 +184,23 @@ describe("BooleanField", () => {
     expect(description.textContent).eql("my description");
   });
 
+  it("should render the description using provided description field", () => {
+    const { node } = createFormComponent({
+      schema: {
+        type: "boolean",
+        description: "my description",
+      },
+      fields: {
+        DescriptionField: ({ description }) => (
+          <div className="field-description">{description} overridden</div>
+        ),
+      },
+    });
+
+    const description = node.querySelector(".field-description");
+    expect(description.textContent).eql("my description overridden");
+  });
+
   it("should assign a default value", () => {
     const { node } = createFormComponent({
       schema: {


### PR DESCRIPTION
### Reasons for making this change

When supplying the fields-object in Form's props, the normal behavior is to override the fields globally. For example, 
`<Form fields={{DescriptionField: ()=><div>overriden</div>}}/>`
will cause all descriptions to show "overriden". Except for BooleanField, which always uses the built-in implementation of DescriptionField. This commit causes the BooleanField to use the overridden Description, if supplied.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
