### PR TITLE
Maintain json schema error properties when using custom validation

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -252,10 +252,8 @@ export default function validateFormData(
   const errorHandler = customValidate(formData, createErrorHandler(formData));
   const userErrorSchema = unwrapErrorHandler(errorHandler);
   const newErrorSchema = mergeObjects(errorSchema, userErrorSchema, true);
-  // XXX: The errors list produced is not fully compliant with the format
-  // exposed by the jsonschema lib, which contains full field paths and other
-  // properties.
-  const newErrors = toErrorList(newErrorSchema);
+  // Append the custom errors to the current error list.
+  const newErrors = [].concat(errors, toErrorList(userErrorSchema));
 
   return {
     errors: newErrors,

--- a/src/validate.js
+++ b/src/validate.js
@@ -80,13 +80,16 @@ function toErrorSchema(errors) {
   }, {});
 }
 
-export function toErrorList(errorSchema, fieldName = "root") {
-  // XXX: We should transform fieldName as a full field path string.
+export function toErrorList(errorSchema, fieldPath = []) {
+  const fieldName =
+    fieldPath.length > 0 ? fieldPath[fieldPath.length - 1] : "root";
+
   let errorList = [];
   if ("__errors" in errorSchema) {
     errorList = errorList.concat(
       errorSchema.__errors.map(stack => {
         return {
+          property: "." + fieldPath.join("."),
           stack: `${fieldName}: ${stack}`,
         };
       })
@@ -94,7 +97,7 @@ export function toErrorList(errorSchema, fieldName = "root") {
   }
   return Object.keys(errorSchema).reduce((acc, key) => {
     if (key !== "__errors") {
-      acc = acc.concat(toErrorList(errorSchema[key], key));
+      acc = acc.concat(toErrorList(errorSchema[key], [...fieldPath, key]));
     }
     return acc;
   }, errorList);

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -220,7 +220,7 @@ describe("Validation", () => {
       });
     });
 
-    describe.only("Custom validate function", () => {
+    describe("Custom validate function", () => {
       let errors, errorSchema;
 
       const schema = {
@@ -248,7 +248,10 @@ describe("Validation", () => {
 
       it("should return an error list", () => {
         expect(errors).to.have.length.of(2);
-        expect(errors[0].message).eql("test");
+
+        expect(errors[0].property).eql(".numberWithMinimum");
+        expect(errors[0].message).eql("should be >= 5");
+
         expect(errors[1].stack).eql("pass2: passwords don't match.");
       });
 
@@ -256,8 +259,8 @@ describe("Validation", () => {
         expect(errorSchema.pass2.__errors).to.have.length.of(1);
         expect(errorSchema.pass2.__errors[0]).eql("passwords don't match.");
 
-        expect(errorSchema.numberWithMinimum._errors).to.have.length.of(1);
-        expect(errorSchema.numberWithMinimum._errors[0]).eql("test");
+        expect(errorSchema.numberWithMinimum.__errors).to.have.length.of(1);
+        expect(errorSchema.numberWithMinimum.__errors[0]).eql("should be >= 5");
       });
     });
 

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -252,6 +252,7 @@ describe("Validation", () => {
         expect(errors[0].property).eql(".numberWithMinimum");
         expect(errors[0].message).eql("should be >= 5");
 
+        expect(errors[1].property).eql(".pass2");
         expect(errors[1].stack).eql("pass2: passwords don't match.");
       });
 
@@ -343,11 +344,11 @@ describe("Validation", () => {
           },
         })
       ).eql([
-        { stack: "root: err1" },
-        { stack: "root: err2" },
-        { stack: "b: err3" },
-        { stack: "b: err4" },
-        { stack: "c: err5" },
+        { property: ".", stack: "root: err1" },
+        { property: ".", stack: "root: err2" },
+        { property: ".a.b", stack: "b: err3" },
+        { property: ".a.b", stack: "b: err4" },
+        { property: ".c", stack: "c: err5" },
       ]);
     });
   });

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -220,7 +220,7 @@ describe("Validation", () => {
       });
     });
 
-    describe("Custom validate function", () => {
+    describe.only("Custom validate function", () => {
       let errors, errorSchema;
 
       const schema = {
@@ -229,6 +229,7 @@ describe("Validation", () => {
         properties: {
           pass1: { type: "string" },
           pass2: { type: "string" },
+          numberWithMinimum: { type: "number", minimum: 5 },
         },
       };
 
@@ -239,20 +240,24 @@ describe("Validation", () => {
           }
           return errors;
         };
-        const formData = { pass1: "a", pass2: "b" };
+        const formData = { pass1: "a", pass2: "b", numberWithMinimum: 2 };
         const result = validateFormData(formData, schema, validate);
         errors = result.errors;
         errorSchema = result.errorSchema;
       });
 
       it("should return an error list", () => {
-        expect(errors).to.have.length.of(1);
-        expect(errors[0].stack).eql("pass2: passwords don't match.");
+        expect(errors).to.have.length.of(2);
+        expect(errors[0].message).eql("test");
+        expect(errors[1].stack).eql("pass2: passwords don't match.");
       });
 
       it("should return an errorSchema", () => {
         expect(errorSchema.pass2.__errors).to.have.length.of(1);
         expect(errorSchema.pass2.__errors[0]).eql("passwords don't match.");
+
+        expect(errorSchema.numberWithMinimum._errors).to.have.length.of(1);
+        expect(errorSchema.numberWithMinimum._errors[0]).eql("test");
       });
     });
 


### PR DESCRIPTION
This is a fix for 1.x.  After it lands, I will cherry-pick to 2.x and adjust as nescessary.

### Reasons for making this change

As described in #1596 

Enabling custom validation strips json schema errors of useful properties such as "property", "params", and "schemaPath".  All properties save "stack" are removed, preventing the error consumer from knowing where the error occurred or what rule it validated.

Additionally, custom errors do not provide a "property" prop, so the error consumer likewise does not know what property is encountering the custom error, just that the error happened 'somewhere'.

This PR fixes both these issues:

JSON Schema errors now keep their properties in the presence of custom validation.  This is done by not regenerating the entire error list, but instead keeping the old list and appending the custom errors to this list.

For custom errors, this PR modifies `toErrorList` to track the path of the error and generate a `property` prop containing the property path to the property that encountered the error.

I am not adding documentation, as the actual format of the `onError` errors array seems to be undocumented.  I can attempt to fill in some of the gaps here if you want to adopt the current ajv error objects as official api.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
