### PR TITLE
Fix issues with new playground

### DIFF
--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -2965,6 +2965,22 @@
         "fastq": "^1.6.0"
       }
     },
+    "@rjsf/core": {
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-GtciK9Qn4wAm4mvfakvumfW7NJyYZi7r6mjC+6JY2aAxpbIWsOHD2bzo3dhMI6ql5D1QCplUqFMy0vo6OHxXUQ==",
+      "requires": {
+        "@babel/runtime-corejs2": "^7.4.5",
+        "ajv": "^6.7.0",
+        "core-js": "^2.5.7",
+        "json-schema-merge-allof": "^0.6.0",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.7.2",
+        "react-app-polyfill": "^1.0.4",
+        "react-is": "^16.9.0",
+        "shortid": "^2.2.14"
+      }
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -39,12 +39,12 @@
   },
   "dependencies": {
     "@babel/runtime-corejs2": "^7.4.5",
+    "@material-ui/core": "^4.9.4",
     "ajv": "^6.7.0",
     "core-js": "^2.5.7",
     "json-schema-merge-allof": "^0.6.0",
     "jss": "^10.0.3",
     "lodash": "^4.17.15",
-    "@material-ui/core": "^4.9.4",
     "prop-types": "^15.7.2",
     "react-app-polyfill": "^1.0.4",
     "react-bootstrap": "^0.33.1",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@babel/runtime-corejs2": "^7.4.5",
     "@material-ui/core": "^4.9.4",
+    "@rjsf/core": "^2.0.0-alpha.2",
     "ajv": "^6.7.0",
     "core-js": "^2.5.7",
     "json-schema-merge-allof": "^0.6.0",

--- a/packages/playground/playground/app.js
+++ b/packages/playground/playground/app.js
@@ -8,6 +8,80 @@ const themes = {
     stylesheet:
       "//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css",
     theme: {},
+    subthemes: {
+      cerulean: {
+        stylesheet:
+          "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/cerulean/bootstrap.min.css",
+      },
+      cosmo: {
+        stylesheet:
+          "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/cosmo/bootstrap.min.css",
+      },
+      cyborg: {
+        stylesheet:
+          "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/cyborg/bootstrap.min.css",
+      },
+      darkly: {
+        stylesheet:
+          "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/darkly/bootstrap.min.css",
+      },
+      flatly: {
+        stylesheet:
+          "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/flatly/bootstrap.min.css",
+      },
+      journal: {
+        stylesheet:
+          "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/journal/bootstrap.min.css",
+      },
+      lumen: {
+        stylesheet:
+          "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/lumen/bootstrap.min.css",
+      },
+      paper: {
+        stylesheet:
+          "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/paper/bootstrap.min.css",
+      },
+      readable: {
+        stylesheet:
+          "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/readable/bootstrap.min.css",
+      },
+      sandstone: {
+        stylesheet:
+          "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/sandstone/bootstrap.min.css",
+      },
+      simplex: {
+        stylesheet:
+          "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/simplex/bootstrap.min.css",
+      },
+      slate: {
+        stylesheet:
+          "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/slate/bootstrap.min.css",
+      },
+      spacelab: {
+        stylesheet:
+          "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/spacelab/bootstrap.min.css",
+      },
+      "solarized-dark": {
+        stylesheet:
+          "//cdn.rawgit.com/aalpern/bootstrap-solarized/master/bootstrap-solarized-dark.css",
+      },
+      "solarized-light": {
+        stylesheet:
+          "//cdn.rawgit.com/aalpern/bootstrap-solarized/master/bootstrap-solarized-light.css",
+      },
+      superhero: {
+        stylesheet:
+          "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/superhero/bootstrap.min.css",
+      },
+      united: {
+        stylesheet:
+          "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/united/bootstrap.min.css",
+      },
+      yeti: {
+        stylesheet:
+          "//cdnjs.cloudflare.com/ajax/libs/bootswatch/3.3.6/yeti/bootstrap.min.css",
+      },
+    },
   },
   "material-ui": {
     stylesheet: "",

--- a/packages/playground/src/index.js
+++ b/packages/playground/src/index.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import MonacoEditor from "react-monaco-editor";
 import { samples } from "./samples";
 import "react-app-polyfill/ie11";
-import Form, { withTheme } from "react-jsonschema-form";
+import Form, { withTheme } from "@rjsf/core";
 import DemoFrame from "./DemoFrame";
 
 // deepEquals and shouldRender and isArguments are copied from rjsf-core. TODO: unify these utility functions.

--- a/packages/playground/src/index.js
+++ b/packages/playground/src/index.js
@@ -356,7 +356,7 @@ class Playground extends Component {
         liveOmit: false,
       },
       shareURL: null,
-      themeObj: {},
+      FormComponent: withTheme({}),
     };
   }
 
@@ -418,7 +418,7 @@ class Playground extends Component {
       theme,
       subthemes,
       subtheme: null,
-      themeObj,
+      FormComponent: withTheme(themeObj),
       stylesheet,
     });
   };
@@ -474,15 +474,13 @@ class Playground extends Component {
       validate,
       theme,
       subtheme,
-      themeObj,
+      FormComponent,
       ArrayFieldTemplate,
       ObjectFieldTemplate,
       transformErrors,
     } = this.state;
 
     const { themes } = this.props;
-
-    const FormComponent = withTheme(themeObj);
 
     return (
       <div className="container-fluid">

--- a/packages/playground/src/index.js
+++ b/packages/playground/src/index.js
@@ -255,17 +255,46 @@ class Selector extends Component {
 }
 
 function ThemeSelector({ theme, themes, select }) {
-  const themeSchema = {
+  const schema = {
     type: "string",
     enum: Object.keys(themes),
+  };
+  const uiSchema = {
+    "ui:placeholder": "Select theme",
   };
   return (
     <Form
       className="form_rjsf_themeSelector"
       idPrefix="rjsf_themeSelector"
-      schema={themeSchema}
+      schema={schema}
+      uiSchema={uiSchema}
       formData={theme}
-      onChange={({ formData }) => select(formData, themes[formData])}>
+      onChange={({ formData }) =>
+        formData && select(formData, themes[formData])
+      }>
+      <div />
+    </Form>
+  );
+}
+
+function SubthemeSelector({ subtheme, subthemes, select }) {
+  const schema = {
+    type: "string",
+    enum: Object.keys(subthemes),
+  };
+  const uiSchema = {
+    "ui:placeholder": "Select subtheme",
+  };
+  return (
+    <Form
+      className="form_rjsf_subthemeSelector"
+      idPrefix="rjsf_subthemeSelector"
+      schema={schema}
+      uiSchema={uiSchema}
+      formData={subtheme}
+      onChange={({ formData }) =>
+        formData && select(formData, subthemes[formData])
+      }>
       <div />
     </Form>
   );
@@ -319,6 +348,7 @@ class Playground extends Component {
       formData,
       validate,
       theme: "default",
+      subtheme: null,
       liveSettings: {
         validate: true,
         disable: false,
@@ -380,12 +410,23 @@ class Playground extends Component {
   onExtraErrorsEdited = extraErrors =>
     this.setState({ extraErrors, shareURL: null });
 
-  onThemeSelected = (theme, { stylesheet, theme: themeObj, editor } = {}) => {
+  onThemeSelected = (
+    theme,
+    { subthemes, stylesheet, theme: themeObj } = {}
+  ) => {
     this.setState({
       theme,
+      subthemes,
+      subtheme: null,
       themeObj,
       stylesheet,
-      editor: editor ? editor : "default",
+    });
+  };
+
+  onSubthemeSelected = (subtheme, { stylesheet }) => {
+    this.setState({
+      subtheme,
+      stylesheet,
     });
   };
 
@@ -432,6 +473,7 @@ class Playground extends Component {
       liveSettings,
       validate,
       theme,
+      subtheme,
       themeObj,
       ArrayFieldTemplate,
       ObjectFieldTemplate,
@@ -465,8 +507,13 @@ class Playground extends Component {
                 theme={theme}
                 select={this.onThemeSelected}
               />
-              <br />
-              <br />
+              {themes[theme].subthemes && (
+                <SubthemeSelector
+                  subthemes={themes[theme].subthemes}
+                  subtheme={subtheme}
+                  select={this.onSubthemeSelected}
+                />
+              )}
               <CopyLink shareURL={this.state.shareURL} onShare={this.onShare} />
             </div>
           </div>

--- a/packages/playground/src/samples/allOf.js
+++ b/packages/playground/src/samples/allOf.js
@@ -5,7 +5,8 @@ module.exports = {
       {
         properties: {
           lorem: {
-            type: ["string", "number"],
+            type: ["string", "boolean"],
+            default: true,
           },
         },
       },
@@ -13,7 +14,6 @@ module.exports = {
         properties: {
           lorem: {
             type: "boolean",
-            minLength: 5,
           },
           ipsum: {
             type: "string",


### PR DESCRIPTION
Fixes #1620 

- Add options to select subthemes, so the old bootstrap subthemes (such as cerulean, etc.) are back
![image](https://user-images.githubusercontent.com/1689183/75635692-09db1f00-5bcd-11ea-94cb-1af1eed6ef02.png)

- Fix blurring when typing issue
- Use @rjsf/core instead of react-jsonschema-form package for the playground
- Fix allOf example