### PR TITLE
Do not regenerate state if no input data has changed.

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -32,7 +32,7 @@ export default class Form extends Component {
 
   constructor(props) {
     super(props);
-    this.state = this.getStateFromProps(props, props.formData);
+    this.state = this.getStateFromProps(null, props.formData);
     if (
       this.props.onChange &&
       !deepEquals(this.state.formData, this.props.formData)
@@ -54,18 +54,28 @@ export default class Form extends Component {
     this.setState(nextState);
   }
 
-  getStateFromProps(props, inputFormData) {
+  getStateFromProps(nextProps, inputFormData) {
     const state = this.state || {};
-    const schema = "schema" in props ? props.schema : this.props.schema;
-    const uiSchema = "uiSchema" in props ? props.uiSchema : this.props.uiSchema;
+
+    const schema = nextProps ? nextProps.schema : this.props.schema;
+    const uiSchema = nextProps ? nextProps.uiSchema : this.props.uiSchema;
+    const liveValidate = nextProps
+      ? nextProps.liveValidate
+      : this.props.liveValidate;
+    const customFormats = nextProps
+      ? nextProps.customFormats
+      : this.props.customFormats;
+    const additionalMetaSchemas = nextProps
+      ? nextProps.additionalMetaSchemas
+      : this.props.additionalMetaSchemas;
+    const noValidate = nextProps ? nextProps.noValidate : this.props.noValidate;
+    const idPrefix = nextProps ? nextProps.idPrefix : this.props.idPrefix;
+
     const edit = typeof inputFormData !== "undefined";
-    const liveValidate = props.liveValidate || this.props.liveValidate;
-    const mustValidate = edit && !props.noValidate && liveValidate;
+    const mustValidate = edit && !noValidate && liveValidate;
     const { definitions } = schema;
     const formData = getDefaultFormState(schema, inputFormData, definitions);
     const retrievedSchema = retrieveSchema(schema, definitions, formData);
-    const customFormats = props.customFormats;
-    const additionalMetaSchemas = props.additionalMetaSchemas;
     const { errors, errorSchema } = mustValidate
       ? this.validate(formData, schema, additionalMetaSchemas, customFormats)
       : {
@@ -77,7 +87,7 @@ export default class Form extends Component {
       uiSchema["ui:rootFieldId"],
       definitions,
       formData,
-      props.idPrefix
+      idPrefix
     );
     return {
       schema,
@@ -172,7 +182,7 @@ export default class Form extends Component {
 
   onChange = (formData, newErrorSchema) => {
     if (isObject(formData) || Array.isArray(formData)) {
-      const newState = this.getStateFromProps(this.props, formData);
+      const newState = this.getStateFromProps(null, formData);
       formData = newState.formData;
     }
     const mustValidate = !this.props.noValidate && this.props.liveValidate;

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -57,6 +57,21 @@ export default class Form extends Component {
   getStateFromProps(nextProps, inputFormData) {
     const state = this.state || {};
 
+    if (
+      nextProps &&
+      inputFormData === state.formData &&
+      nextProps.schema === this.props.schema &&
+      nextProps.uiSchema === this.props.uiSchema &&
+      nextProps.liveValidate === this.props.liveValidate &&
+      nextProps.customFormats === this.props.customFormats &&
+      nextProps.additionalMetaSchemas === this.props.additionalMetaSchemas &&
+      nextProps.noValidate === this.props.noValidate &&
+      nextProps.idPrefix === this.props.idPrefix
+    ) {
+      // No data has changed, maintain state.
+      return state;
+    }
+
     const schema = nextProps ? nextProps.schema : this.props.schema;
     const uiSchema = nextProps ? nextProps.uiSchema : this.props.uiSchema;
     const liveValidate = nextProps

--- a/test/Form_test.js
+++ b/test/Form_test.js
@@ -974,7 +974,9 @@ describeRepeated("Form common", createFormComponent => {
     });
 
     describe("when the form data is set to null", () => {
-      beforeEach(() => comp.componentWillReceiveProps({ formData: null }));
+      beforeEach(() =>
+        comp.componentWillReceiveProps({ ...comp.props, formData: null })
+      );
 
       it("should call onChange", () => {
         sinon.assert.calledOnce(onChangeProp);
@@ -991,6 +993,7 @@ describeRepeated("Form common", createFormComponent => {
 
       beforeEach(() =>
         comp.componentWillReceiveProps({
+          ...comp.props,
           schema: newSchema,
           formData: "some value",
         })
@@ -1011,6 +1014,7 @@ describeRepeated("Form common", createFormComponent => {
 
       beforeEach(() =>
         comp.componentWillReceiveProps({
+          ...comp.props,
           schema: newSchema,
           formData: "something else",
         })
@@ -1030,7 +1034,11 @@ describeRepeated("Form common", createFormComponent => {
       };
 
       beforeEach(() =>
-        comp.componentWillReceiveProps({ schema: newSchema, formData: null })
+        comp.componentWillReceiveProps({
+          ...comp.props,
+          schema: newSchema,
+          formData: null,
+        })
       );
 
       it("should call onChange", () => {
@@ -1099,7 +1107,7 @@ describeRepeated("Form common", createFormComponent => {
       it("should update form state from new formData prop value", () => {
         const { comp } = createFormComponent(formProps);
 
-        comp.componentWillReceiveProps({ formData: "yo" });
+        comp.componentWillReceiveProps({ ...comp.props, formData: "yo" });
 
         expect(comp.state.formData).eql("yo");
       });
@@ -1108,6 +1116,7 @@ describeRepeated("Form common", createFormComponent => {
         const { comp } = createFormComponent(formProps);
 
         comp.componentWillReceiveProps({
+          ...comp.props,
           formData: "yo",
           schema: { type: "number" },
         });
@@ -1130,7 +1139,10 @@ describeRepeated("Form common", createFormComponent => {
           },
         });
 
-        comp.componentWillReceiveProps({ formData: { foo: "yo" } });
+        comp.componentWillReceiveProps({
+          ...comp.props,
+          formData: { foo: "yo" },
+        });
 
         expect(comp.state.formData).eql({ foo: "yo" });
       });
@@ -1146,7 +1158,7 @@ describeRepeated("Form common", createFormComponent => {
         };
         const { comp } = createFormComponent({ schema });
 
-        comp.componentWillReceiveProps({ formData: ["yo"] });
+        comp.componentWillReceiveProps({ ...comp.props, formData: ["yo"] });
 
         expect(comp.state.formData).eql(["yo"]);
       });
@@ -1916,6 +1928,7 @@ describeRepeated("Form common", createFormComponent => {
       const formData = { foo: "foo", bar: "bar" };
       const { comp, node } = createFormComponent({ schema, formData });
       comp.componentWillReceiveProps({
+        ...comp.props,
         schema: {
           type: "object",
           properties: {
@@ -1936,6 +1949,7 @@ describeRepeated("Form common", createFormComponent => {
       const formData = { foo: "foo", bar: "bar" };
       const { comp, node } = createFormComponent({ schema, formData });
       comp.componentWillReceiveProps({
+        ...comp.props,
         schema: {
           type: "object",
           properties: {
@@ -1983,6 +1997,7 @@ describeRepeated("Form common", createFormComponent => {
       const formData = { a: "int" };
       const { comp } = createFormComponent({ schema, formData });
       comp.componentWillReceiveProps({
+        ...comp.props,
         schema: {
           type: "object",
           properties: {
@@ -2017,6 +2032,7 @@ describeRepeated("Form common", createFormComponent => {
       };
       const { comp } = createFormComponent({ schema, formData });
       comp.componentWillReceiveProps({
+        ...comp.props,
         schema: {
           type: "object",
           properties: {

--- a/test/StringField_test.js
+++ b/test/StringField_test.js
@@ -1145,7 +1145,7 @@ describe("StringField", () => {
         liveValidate: true,
       });
 
-      comp.componentWillReceiveProps({ formData: "2012-12-12" });
+      comp.componentWillReceiveProps({ ...comp.props, formData: "2012-12-12" });
 
       expect(comp.state.errors).to.have.length.of(0);
     });

--- a/test/performance_test.js
+++ b/test/performance_test.js
@@ -29,7 +29,7 @@ describe("Rendering performance optimizations", () => {
       const { comp } = createFormComponent({ schema, uiSchema });
       sandbox.stub(comp, "render").returns(<div />);
 
-      comp.componentWillReceiveProps({ schema });
+      comp.componentWillReceiveProps({ ...comp.props, schema });
 
       sinon.assert.notCalled(comp.render);
     });
@@ -41,7 +41,7 @@ describe("Rendering performance optimizations", () => {
       const { comp } = createFormComponent({ schema, formData });
       sandbox.stub(comp, "render").returns(<div />);
 
-      comp.componentWillReceiveProps({ formData });
+      comp.componentWillReceiveProps({ ...comp.props, formData });
 
       sinon.assert.notCalled(comp.render);
     });

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -513,7 +513,7 @@ describe("Validation", () => {
           validate,
           liveValidate: true,
         });
-        comp.componentWillReceiveProps({ formData });
+        comp.componentWillReceiveProps({ ...comp.props, formData });
 
         expect(comp.state.errorSchema).eql({
           __errors: ["Invalid"],
@@ -595,7 +595,7 @@ describe("Validation", () => {
           validate,
           liveValidate: true,
         });
-        comp.componentWillReceiveProps({ formData });
+        comp.componentWillReceiveProps({ ...comp.props, formData });
 
         expect(comp.state.errorSchema).eql({
           __errors: [],
@@ -642,7 +642,7 @@ describe("Validation", () => {
           validate,
           liveValidate: true,
         });
-        comp.componentWillReceiveProps({ formData });
+        comp.componentWillReceiveProps({ ...comp.props, formData });
 
         expect(comp.state.errorSchema).eql({
           0: {
@@ -689,7 +689,10 @@ describe("Validation", () => {
           validate,
           liveValidate: true,
         });
-        comp.componentWillReceiveProps({ formData });
+        const newProps = { ...comp.props, formData };
+        console.log(comp.props);
+        console.log(newProps);
+        comp.componentWillReceiveProps({ ...comp.props, formData });
 
         expect(comp.state.errorSchema).eql({
           0: { __errors: [] },

--- a/test/validate_test.js
+++ b/test/validate_test.js
@@ -689,9 +689,6 @@ describe("Validation", () => {
           validate,
           liveValidate: true,
         });
-        const newProps = { ...comp.props, formData };
-        console.log(comp.props);
-        console.log(newProps);
         comp.componentWillReceiveProps({ ...comp.props, formData });
 
         expect(comp.state.errorSchema).eql({


### PR DESCRIPTION
### Reasons for making this change

RJSF regenerates state data on any property change and when its parent component changes, causing performance issues, data loss, and stack overflows, as documented in #1631.

This PR modifies getStateFromProps to return the same state if no new properties are detected.

To make this change, tests had to be updated to correctly call componentWillReceiveProps with all properties, as React normally calls it.  Previously, tests were only passing in one or two props, and getStateFromProps was set up to deal with this test-only behavior.

As usual, I am aiming to get this change into 1.x first, then port it to 2.x once it lands in 1.x

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
