### PR TITLE
feat: exposing findSchemaDefinition out of the utils lib

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -540,7 +540,7 @@ export function optionsList(schema) {
   }
 }
 
-function findSchemaDefinition($ref, rootSchema = {}) {
+export function findSchemaDefinition($ref, rootSchema = {}) {
   const origRef = $ref;
   if ($ref.startsWith("#")) {
     // Decode URI fragment representation.


### PR DESCRIPTION
### Reasons for making this change

Working on some resolving some bugs in a custom `SchemaField` that we've got, and I needed access to this so I could parse a `$ref`. Couldn't use it because it wasn't being exposed!

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
