### PR TITLE
validate: pass formData to transformErrors

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -109,7 +109,7 @@ render((
 Validation error messages are provided by the JSON Schema validation by default. If you need to change these messages or make any other modifications to the errors from the JSON Schema validation, you can define a transform function that receives the list of JSON Schema errors and returns a new list.
 
 ```js
-function transformErrors(errors) {
+function transformErrors(errors, formData) {
   return errors.map(error => {
     if (error.name === "pattern") {
       error.message = "Only digits are allowed"

--- a/packages/core/src/validate.js
+++ b/packages/core/src/validate.js
@@ -229,7 +229,7 @@ export default function validateFormData(
     ];
   }
   if (typeof transformErrors === "function") {
-    errors = transformErrors(errors);
+    errors = transformErrors(errors, formData);
   }
 
   let errorSchema = toErrorSchema(errors);

--- a/packages/core/test/validate_test.js
+++ b/packages/core/test/validate_test.js
@@ -353,9 +353,14 @@ describe("Validation", () => {
         [illFormedKey]: { type: "string" },
       },
     };
-    const newErrorMessage = "Better error message";
-    const transformErrors = errors => {
-      return [Object.assign({}, errors[0], { message: newErrorMessage })];
+    const getNewErrorMessage = value =>
+      `Better error message with value: ${value}`;
+    const transformErrors = (errors, formData) => {
+      formData;
+      const value = eval("formData" + errors[0].property);
+      return [
+        Object.assign({}, errors[0], { message: getNewErrorMessage(value) }),
+      ];
     };
 
     let errors;
@@ -372,7 +377,7 @@ describe("Validation", () => {
 
     it("should use transformErrors function", () => {
       expect(errors).not.to.be.empty;
-      expect(errors[0].message).to.equal(newErrorMessage);
+      expect(errors[0].message).to.equal(getNewErrorMessage(42));
     });
   });
 

--- a/packages/playground/src/samples/validation.js
+++ b/packages/playground/src/samples/validation.js
@@ -5,11 +5,13 @@ function validate({ pass1, pass2 }, errors) {
   return errors;
 }
 
-function transformErrors(errors) {
+function transformErrors(errors, formData) {
   return errors.map(error => {
     if (error.name === "minimum" && error.property === "instance.age") {
       return Object.assign({}, error, {
-        message: "You need to be 18 because of some legal thing",
+        message:
+          "You need to be 18 because of some legal thing, current value: " +
+          formData.age,
       });
     }
     return error;


### PR DESCRIPTION
### Reasons for making this change

`transformErrors()` might need access to the data.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
