### PR TITLE
Support for basic template registry

### DIFF
--- a/packages/core/src/components/fields/ObjectField.js
+++ b/packages/core/src/components/fields/ObjectField.js
@@ -2,6 +2,8 @@ import AddButton from "../AddButton";
 import React, { Component } from "react";
 import * as types from "../../types";
 
+import VerticalPillObjectFieldTemplate from "../templates/VerticalPillObjectFieldTemplate";
+
 import {
   orderProperties,
   retrieveSchema,
@@ -152,6 +154,21 @@ class ObjectField extends Component {
     };
   };
 
+  getObjectFieldTemplate(template) {
+    if (typeof template === "string" || template instanceof String) {
+      const templates = {
+        VerticalPillObjectFieldTemplate: VerticalPillObjectFieldTemplate,
+      };
+      if (template in templates) {
+        return templates[template];
+      } else {
+        throw new Error("Template name is not registered: " + template);
+      }
+    } else {
+      return template;
+    }
+  }
+
   getDefaultValue(type) {
     switch (type) {
       case "string":
@@ -240,9 +257,9 @@ class ObjectField extends Component {
     }
 
     const Template =
-      uiSchema["ui:ObjectFieldTemplate"] ||
-      registry.ObjectFieldTemplate ||
-      DefaultObjectFieldTemplate;
+      this.getObjectFieldTemplate(
+        uiSchema["ui:ObjectFieldTemplate"] || registry.ObjectFieldTemplate
+      ) || DefaultObjectFieldTemplate;
 
     const templateProps = {
       title: uiSchema["ui:title"] || title,

--- a/packages/core/src/components/templates/VerticalPillObjectFieldTemplate.js
+++ b/packages/core/src/components/templates/VerticalPillObjectFieldTemplate.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function VerticalPillObjectFieldTemplate(props) {
+  return <div>Vertical Pills not implemented</div>;
+}

--- a/packages/core/test/ObjectFieldTemplate_test.js
+++ b/packages/core/test/ObjectFieldTemplate_test.js
@@ -62,6 +62,24 @@ describe("ObjectFieldTemplate", () => {
     }).node;
     sharedIts();
   });
+  describe("with template configured by name in ui:ObjectFieldTemplate", () => {
+    node = createFormComponent({
+      schema: {
+        type: "object",
+        properties: { foo: { type: "string" }, bar: { type: "string" } },
+      },
+      uiSchema: {
+        "ui:description": "foobar",
+        "ui:ObjectFieldTemplate": "VerticalPillObjectFieldTemplate",
+      },
+      formData,
+      fields: {
+        TitleField,
+        DescriptionField,
+      },
+    }).node;
+    sharedIts();
+  });
   describe("with template configured in ui:ObjectFieldTemplate", () => {
     node = createFormComponent({
       schema: {


### PR DESCRIPTION
### Reasons for making this change

As discussed in https://github.com/rjsf-team/react-jsonschema-form/issues/1632, I want to contribute ObjectFieldTemplates of various kinds. For example, a multi-tab form

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
