### PR TITLE
Include @rjsf/core types and use JSONSchema7 type instead of JSONSchema6

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -2,14 +2,14 @@
 
 declare module '@rjsf/core' {
     import * as React from 'react';
-    import { JSONSchema6, JSONSchema6Type } from 'json-schema';
+    import { JSONSchema7, JSONSchema7Type } from 'json-schema';
 
     type ErrorSchema = {
         [k: string]: ErrorSchema;
     };
 
     export interface FormProps<T> {
-        schema: JSONSchema6;
+        schema: JSONSchema7;
         disabled?: boolean;
         uiSchema?: UiSchema;
         formData?: T;
@@ -96,7 +96,7 @@ declare module '@rjsf/core' {
             Exclude<keyof React.HTMLAttributes<HTMLElement>, 'onBlur' | 'onFocus'>
         > {
         id: string;
-        schema: JSONSchema6;
+        schema: JSONSchema7;
         value: any;
         required: boolean;
         disabled: boolean;
@@ -115,7 +115,7 @@ declare module '@rjsf/core' {
 
     export interface FieldProps<T = any>
         extends Pick<React.HTMLAttributes<HTMLElement>, Exclude<keyof React.HTMLAttributes<HTMLElement>, 'onBlur'>> {
-        schema: JSONSchema6;
+        schema: JSONSchema7;
         uiSchema: UiSchema;
         idSchema: IdSchema;
         formData: T;
@@ -156,7 +156,7 @@ declare module '@rjsf/core' {
         disabled: boolean;
         displayLabel: boolean;
         fields: Field[];
-        schema: JSONSchema6;
+        schema: JSONSchema7;
         uiSchema: UiSchema;
         formContext: any;
     };
@@ -185,7 +185,7 @@ declare module '@rjsf/core' {
         onAddClick: (event: any) => (event: any) => void;
         readonly: boolean;
         required: boolean;
-        schema: JSONSchema6;
+        schema: JSONSchema7;
         uiSchema: UiSchema;
         title: string;
         formContext: any;
@@ -205,7 +205,7 @@ declare module '@rjsf/core' {
             readonly: boolean;
         }[];
         required: boolean;
-        schema: JSONSchema6;
+        schema: JSONSchema7;
         uiSchema: UiSchema;
         idSchema: IdSchema;
         formData: T;
@@ -224,7 +224,7 @@ declare module '@rjsf/core' {
         errorSchema: FormValidation;
         errors: AjvError[];
         formContext: any;
-        schema: JSONSchema6;
+        schema: JSONSchema7;
         uiSchema: UiSchema;
     };
 
@@ -234,7 +234,7 @@ declare module '@rjsf/core' {
         errors: AjvError[];
         errorSchema: FormValidation;
         idSchema: IdSchema;
-        schema: JSONSchema6;
+        schema: JSONSchema7;
         uiSchema: UiSchema;
         status?: string;
     }
@@ -270,7 +270,7 @@ declare module '@rjsf/core' {
 }
 
 declare module '@rjsf/core/lib/components/fields/SchemaField' {
-    import { JSONSchema6 } from 'json-schema';
+    import { JSONSchema7 } from 'json-schema';
     import { FieldProps, UiSchema, IdSchema, FormValidation } from '@rjsf/core';
 
     export type SchemaFieldProps<T = any> = Pick<
@@ -282,41 +282,41 @@ declare module '@rjsf/core/lib/components/fields/SchemaField' {
 }
 
 declare module '@rjsf/core/lib/utils' {
-    import { JSONSchema6, JSONSchema6Definition, JSONSchema6Type, JSONSchema6TypeName } from 'json-schema';
+    import { JSONSchema7, JSONSchema7Definition, JSONSchema7Type, JSONSchema7TypeName } from 'json-schema';
     import { FieldProps, UiSchema, IdSchema, PathSchema, Widget } from '@rjsf/core';
 
     export const ADDITIONAL_PROPERTY_FLAG: string;
 
     export function getDefaultRegistry(): FieldProps['registry'];
 
-    export function getSchemaType(schema: JSONSchema6): string;
+    export function getSchemaType(schema: JSONSchema7): string;
 
     export function getWidget(
-        schema: JSONSchema6,
+        schema: JSONSchema7,
         widget: Widget,
         registeredWidgets?: { [name: string]: Widget },
     ): Widget | Error;
 
     export function hasWidget(
-        schema: JSONSchema6,
+        schema: JSONSchema7,
         widget: Widget,
         registeredWidgets?: { [name: string]: Widget },
     ): boolean;
 
     export function computeDefaults<T = any>(
-        schema: JSONSchema6,
-        parentDefaults: JSONSchema6['default'][],
+        schema: JSONSchema7,
+        parentDefaults: JSONSchema7['default'][],
         definitions: FieldProps['registry']['definitions'],
         rawFormData?: T,
         includeUndefinedValues?: boolean,
-    ): JSONSchema6['default'][];
+    ): JSONSchema7['default'][];
 
     export function getDefaultFormState<T = any>(
-        schema: JSONSchema6,
+        schema: JSONSchema7,
         formData: T,
         definitions?: FieldProps['registry']['definitions'],
         includeUndefinedValues?: boolean,
-    ): T | JSONSchema6['default'][];
+    ): T | JSONSchema7['default'][];
 
     export function getUiOptions(uiSchema: UiSchema): UiSchema['ui:options'];
 
@@ -328,52 +328,52 @@ declare module '@rjsf/core/lib/utils' {
 
     export function orderProperties(properties: [], order: []): [];
 
-    export function isConstant(schema: JSONSchema6): boolean;
+    export function isConstant(schema: JSONSchema7): boolean;
 
-    export function toConstant(schema: JSONSchema6): JSONSchema6Type | JSONSchema6['const'] | Error;
+    export function toConstant(schema: JSONSchema7): JSONSchema7Type | JSONSchema7['const'] | Error;
 
-    export function isSelect(_schema: JSONSchema6, definitions?: FieldProps['registry']['definitions']): boolean;
+    export function isSelect(_schema: JSONSchema7, definitions?: FieldProps['registry']['definitions']): boolean;
 
-    export function isMultiSelect(schema: JSONSchema6, definitions?: FieldProps['registry']['definitions']): boolean;
+    export function isMultiSelect(schema: JSONSchema7, definitions?: FieldProps['registry']['definitions']): boolean;
 
     export function isFilesArray(
-        schema: JSONSchema6,
+        schema: JSONSchema7,
         uiSchema: UiSchema,
         definitions?: FieldProps['registry']['definitions'],
     ): boolean;
 
-    export function isFixedItems(schema: JSONSchema6): boolean;
+    export function isFixedItems(schema: JSONSchema7): boolean;
 
-    export function allowAdditionalItems(schema: JSONSchema6): boolean;
+    export function allowAdditionalItems(schema: JSONSchema7): boolean;
 
-    export function optionsList(schema: JSONSchema6): { label: string; value: string }[];
+    export function optionsList(schema: JSONSchema7): { label: string; value: string }[];
 
-    export function guessType(value: any): JSONSchema6TypeName;
+    export function guessType(value: any): JSONSchema7TypeName;
 
     export function stubExistingAdditionalProperties<T = any>(
-        schema: JSONSchema6,
+        schema: JSONSchema7,
         definitions?: FieldProps['registry']['definitions'],
         formData?: T,
-    ): JSONSchema6;
+    ): JSONSchema7;
 
     export function resolveSchema<T = any>(
-        schema: JSONSchema6Definition,
+        schema: JSONSchema7Definition,
         definitions?: FieldProps['registry']['definitions'],
         formData?: T,
-    ): JSONSchema6;
+    ): JSONSchema7;
 
     export function retrieveSchema<T = any>(
-        schema: JSONSchema6Definition,
+        schema: JSONSchema7Definition,
         definitions?: FieldProps['registry']['definitions'],
         formData?: T,
-    ): JSONSchema6;
+    ): JSONSchema7;
 
     export function deepEquals<T>(a: T, b: T): boolean;
 
     export function shouldRender(comp: React.Component, nextProps: any, nextState: any): boolean;
 
     export function toIdSchema<T = any>(
-        schema: JSONSchema6Definition,
+        schema: JSONSchema7Definition,
         id: string,
         definitions: FieldProps['registry']['definitions'],
         formData?: T,
@@ -381,7 +381,7 @@ declare module '@rjsf/core/lib/utils' {
     ): IdSchema | IdSchema[];
 
     export function toPathSchema<T = any>(
-        schema: JSONSchema6Definition,
+        schema: JSONSchema7Definition,
         name: string | undefined,
         definitions: FieldProps['registry']['definitions'],
         formData?: T,
@@ -412,22 +412,22 @@ declare module '@rjsf/core/lib/utils' {
         step?: number;
     }
 
-    export function rangeSpec(schema: JSONSchema6): IRangeSpec;
+    export function rangeSpec(schema: JSONSchema7): IRangeSpec;
 
     export function getMatchingOption(
         formData: any,
-        options: JSONSchema6[],
+        options: JSONSchema7[],
         definitions: FieldProps['registry']['definitions'],
     ): number;
 }
 
 declare module '@rjsf/core/lib/validate' {
-    import { JSONSchema6Definition } from 'json-schema';
+    import { JSONSchema7Definition } from 'json-schema';
     import { AjvError, ErrorSchema, FormProps } from '@rjsf/core';
 
     export default function validateFormData<T = any>(
         formData: T,
-        schema: JSONSchema6Definition,
+        schema: JSONSchema7Definition,
         customValidate?: FormProps<T>['validate'],
         transformErrors?: FormProps<T>['transformErrors'],
         additionalMetaSchemas?: FormProps<T>['additionalMetaSchemas'],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,10 +28,10 @@
   },
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",
-  "typings": "index.d.ts",
   "files": [
     "dist",
-    "lib"
+    "lib",
+    "index.d.ts"
   ],
   "engineStrict": false,
   "engines": {
@@ -129,6 +129,5 @@
   "homepage": "https://github.com/mozilla-services/react-jsonschema-form#readme",
   "publishConfig": {
     "access": "public"
-  },
-  "types": "index.d.ts"
+  }
 }


### PR DESCRIPTION
### Reasons for making this change
typescript currently doesn't work with this and it should use schema v7 rather than 6

@epicfaace 

Fixes to package.json as per comments at https://github.com/rjsf-team/react-jsonschema-form/commit/f3be67e7fe45c4c6437b72a4866f7073090fc58b

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
