### PR TITLE
Allow for descending date range.

### DIFF
--- a/docs/form-customization.md
+++ b/docs/form-customization.md
@@ -129,6 +129,14 @@ uiSchema: {
 },
 ```
 
+You can also specify negative values which will be treated relative to the current year, so if it is 2020 and the range is set as follows.
+
+```
+   yearsRange: [-18, -120],
+```
+
+Years from 2002-1900 will be shown.
+
 #### For `number` and `integer` fields
 
   * `updown`: an `input[type=number]` updown selector;

--- a/docs/form-customization.md
+++ b/docs/form-customization.md
@@ -112,7 +112,7 @@ Please note that, even though they are standardized, `datetime-local` and `date`
 
 ![](https://i.imgur.com/VF5tY60.png)
 
-You can customize the list of years displayed in the `year` dropdown by providing a ``yearsRange`` property to ``ui:options`` in your uiSchema. Its also possible to remove the `Now` and `Clear` buttons with the `hideNowButton` and `hideClearButton` options.
+You can customize the list of years displayed in the `year` dropdown by providing a ``yearsRange`` property to ``ui:options`` in your uiSchema. The range can be descending by specifying the larger value first. Its also possible to remove the `Now` and `Clear` buttons with the `hideNowButton` and `hideClearButton` options.
 
 ```jsx
 uiSchema: {

--- a/packages/core/src/components/widgets/AltDateWidget.js
+++ b/packages/core/src/components/widgets/AltDateWidget.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import { shouldRender, parseDateString, toDateString, pad } from "../../utils";
 
 function rangeOptions(start, stop) {
+  if (start > stop) return rangeOptions(stop, start).reverse();
   let options = [];
   for (let i = start; i <= stop; i++) {
     options.push({ value: i, label: pad(i, 2) });

--- a/packages/core/src/components/widgets/AltDateWidget.js
+++ b/packages/core/src/components/widgets/AltDateWidget.js
@@ -4,6 +4,8 @@ import PropTypes from "prop-types";
 import { shouldRender, parseDateString, toDateString, pad } from "../../utils";
 
 function rangeOptions(start, stop) {
+  if (start < 0) start = new Date().getFullYear() + start;
+  if (stop < 0) stop = new Date().getFullYear() + stop;
   if (start > stop) return rangeOptions(stop, start).reverse();
   let options = [];
   for (let i = start; i <= stop; i++) {


### PR DESCRIPTION
### Reasons for making this change

Change to make the `yearsRange` option support descending values.

If this is related to existing tickets, include links to them as well.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
