### PR TITLE
Add rawErrors to WidgetProps interface

### DIFF
--- a/docs/advanced-customization/custom-widgets-fields.md
+++ b/docs/advanced-customization/custom-widgets-fields.md
@@ -133,6 +133,7 @@ The following props are passed to custom widget components:
 - `onFocus`: The input focus event handler; call it with the the widget id and value;
 - `options`: A map of options passed as a prop to the component (see [Custom widget options](#custom-widget-options)).
 - `formContext`: The `formContext` object that you passed to Form.
+- `rawErrors`: An array of strings listing all generated error messages from encountered errors for this widget.
 
 > Note: Prior to v0.35.0, the `options` prop contained the list of options (`label` and `value`) for `enum` fields. Since v0.35.0, it now exposes this list as the `enumOptions` property within the `options` object.
 

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -110,6 +110,7 @@ declare module '@rjsf/core' {
         onFocus: (id: string, value: boolean | number | string | null) => void;
         label: string;
         multiple: boolean;
+        rawErrors: string[];
     }
 
     export type Widget = React.StatelessComponent<WidgetProps> | React.ComponentClass<WidgetProps>;


### PR DESCRIPTION
### Reasons for making this change
The type is lying, there is a property rawErrors.
<img width="605" alt="Screenshot 2020-04-11 at 23 03 48" src="https://user-images.githubusercontent.com/8804297/79054892-0f566b00-7c49-11ea-8499-a662e46be98d.png">

I couldn't find a related tickets, sorry if I didn't see properly.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests if needed (not needed in this case)
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
