### PR TITLE
Build and deploy playground on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,15 @@ jobs:
     - run: npm run cs-check
       env:
         CI: true
+    - name: Deploy playground to GitHub Pages
+      if: github.ref == 'refs/head/master'
+      uses: crazy-max/ghaction-github-pages@v1.4.0
+      with:
+        keep_history: true
+        target-branch: gh-pages
+        build_dir: packages/playground/build
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   
   docs:
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,21 @@ jobs:
     - run: npm run cs-check
       env:
         CI: true
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/head/master'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 13.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 13.x
+    - run: npm install
+    - run: npm run bootstrap
+    - run: npm run build
     - name: Deploy playground to GitHub Pages
-      if: github.ref == 'refs/head/master'
       uses: crazy-max/ghaction-github-pages@v1.4.0
       with:
         keep_history: true


### PR DESCRIPTION
### Reasons for making this change

Build and deploy the playground on the master branch through CI.
