### PR TITLE
uses ReactIs.isValidElementType to check widget types

### DIFF
--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -2,6 +2,7 @@ import { ADDITIONAL_PROPERTY_FLAG } from "../../utils";
 import IconButton from "../IconButton";
 import React from "react";
 import PropTypes from "prop-types";
+import * as ReactIs from "react-is";
 import * as types from "../../types";
 
 import {
@@ -30,7 +31,7 @@ const COMPONENT_TYPES = {
 
 function getFieldComponent(schema, uiSchema, idSchema, fields) {
   const field = uiSchema["ui:field"];
-  if (typeof field === "function") {
+  if (typeof field !== "string" && ReactIs.isValidElementType(field)) {
     return field;
   }
   if (typeof field === "string" && field in fields) {

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -108,11 +108,7 @@ export function getWidget(schema, widget, registeredWidgets = {}) {
     return Widget.MergedWidget;
   }
 
-  if (
-    typeof widget === "function" ||
-    ReactIs.isForwardRef(React.createElement(widget)) ||
-    ReactIs.isMemo(widget)
-  ) {
+  if (typeof widget !== "string" && ReactIs.isValidElementType(widget)) {
     return mergeOptions(widget);
   }
 


### PR DESCRIPTION
### Reasons for making this change

Since React 16.3.0 components created by `React.forwardRef` may be an object. According to the guidelines, react-is should be used for type validation.

https://github.com/rjsf-team/react-jsonschema-form/issues/1209

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
