### PR TITLE
Fix dead link for definitely not compliant `enumNames` property

### DIFF
--- a/docs/usage/single.md
+++ b/docs/usage/single.md
@@ -57,7 +57,7 @@ render((
 
 ### Custom labels for `enum` fields
 
-This library supports the [`enumNames`](https://github.com/json-schema/json-schema/wiki/enumNames-%28v5-proposal%29) property for `enum` fields, which allows defining custom labels for each option of an `enum`:
+This library supports a custom `enumNames` property for `enum` fields, which however is not JSON-Schema compliant (see below for a compliant approach). The `enumNames` property allows defining custom labels for each option of an `enum`:
 
 ```jsx
 const schema = {

--- a/docs/usage/single.md
+++ b/docs/usage/single.md
@@ -57,7 +57,7 @@ render((
 
 ### Custom labels for `enum` fields
 
-This library supports a custom `enumNames` property for `enum` fields, which however is not JSON-Schema compliant (see below for a compliant approach). The `enumNames` property allows defining custom labels for each option of an `enum`:
+This library supports a custom [`enumNames`](https://github.com/rjsf-team/react-jsonschema-form/issues/57) property for `enum` fields, which, however is not JSON-Schema compliant (see below for a compliant approach). The `enumNames` property allows defining custom labels for each option of an `enum`:
 
 ```jsx
 const schema = {


### PR DESCRIPTION
### Reasons for making this change

Fix dead link for definitely not compliant `enumNames` property. Could not find it in any draft or current spec. Since it was descussed for draft-05 I guess it will not be included. Anyways, the link is dead

If this is related to existing tickets, include links to them as well.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
