### PR TITLE
Enhancement: Allow rawErrors to be an Array of PropTypes.any #941

### DIFF
--- a/docs/advanced-customization/custom-templates.md
+++ b/docs/advanced-customization/custom-templates.md
@@ -133,7 +133,7 @@ The following props are passed to a custom field template component:
 - `rawDescription`: A string containing any `ui:description` uiSchema directive defined.
 - `children`: The field or widget component instance for this field row.
 - `errors`: A component instance listing any encountered errors for this field.
-- `rawErrors`: An array of strings listing all generated error messages from encountered errors for this field.
+- `rawErrors`: An array of strings or objects listing all generated error messages from encountered errors for this field.
 - `help`: A component instance rendering any `ui:help` uiSchema directive defined.
 - `rawHelp`: A string containing any `ui:help` uiSchema directive defined. **NOTE:** `rawHelp` will be `undefined` if passed `ui:help` is a React component instead of a string.
 - `hidden`: A boolean value stating if the field should be hidden.

--- a/docs/advanced-customization/custom-widgets-fields.md
+++ b/docs/advanced-customization/custom-widgets-fields.md
@@ -133,7 +133,7 @@ The following props are passed to custom widget components:
 - `onFocus`: The input focus event handler; call it with the the widget id and value;
 - `options`: A map of options passed as a prop to the component (see [Custom widget options](#custom-widget-options)).
 - `formContext`: The `formContext` object that you passed to Form.
-- `rawErrors`: An array of strings listing all generated error messages from encountered errors for this widget.
+- `rawErrors`: An array of strings or objects listing all generated error messages from encountered errors for this widget.
 
 > Note: Prior to v0.35.0, the `options` prop contained the list of options (`label` and `value`) for `enum` fields. Since v0.35.0, it now exposes this list as the `enumOptions` property within the `options` object.
 

--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -152,7 +152,7 @@ if (process.env.NODE_ENV !== "production") {
     label: PropTypes.string,
     children: PropTypes.node.isRequired,
     errors: PropTypes.element,
-    rawErrors: PropTypes.arrayOf(PropTypes.string),
+    rawErrors: PropTypes.arrayOf(PropTypes.any),
     help: PropTypes.element,
     rawHelp: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     description: PropTypes.element,

--- a/packages/core/src/types.js
+++ b/packages/core/src/types.js
@@ -22,7 +22,7 @@ export const fieldProps = {
   onBlur: PropTypes.func,
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func,
-  rawErrors: PropTypes.arrayOf(PropTypes.string),
+  rawErrors: PropTypes.arrayOf(PropTypes.any),
   readonly: PropTypes.bool,
   registry: registry.isRequired,
   required: PropTypes.bool,

--- a/packages/core/test/validate_test.js
+++ b/packages/core/test/validate_test.js
@@ -354,8 +354,19 @@ describe("Validation", () => {
       },
     };
     const newErrorMessage = "Better error message";
+    const newObjectErrorMessage = {
+      message: "Better error message with params",
+      params: {
+        type: "string",
+        property: ".foo",
+      },
+    };
+
     const transformErrors = errors => {
-      return [Object.assign({}, errors[0], { message: newErrorMessage })];
+      return [
+        Object.assign({}, errors[0], { message: newErrorMessage }),
+        { message: newObjectErrorMessage },
+      ];
     };
 
     let errors;
@@ -373,6 +384,11 @@ describe("Validation", () => {
     it("should use transformErrors function", () => {
       expect(errors).not.to.be.empty;
       expect(errors[0].message).to.equal(newErrorMessage);
+    });
+
+    it("should allow object error messages", () => {
+      expect(errors).not.to.be.empty;
+      expect(errors[1].message).to.equal(newObjectErrorMessage);
     });
   });
 


### PR DESCRIPTION
 On branch issue/941
 Changes to be committed:

- 	Updates documentation:   docs/advanced-customization/custom-templates.md
- 	Updates documentation:   docs/advanced-customization/custom-widgets-fields.md
- 	Updates prop types of errors:   packages/core/src/components/fields/SchemaField.js
- 	Updates prop types of errors:   packages/core/src/types.js
- 	Update a test using error message objects:  packages/core/test/validate_test.js

### Reasons for making this change

This PR related #941

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
