### PR TITLE
#1761- Don't return empty divs; return null instead

### DIFF
--- a/packages/material-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/material-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -41,7 +41,7 @@ const ArrayFieldTitle = ({
   required,
 }: ArrayFieldTitleProps) => {
   if (!title) {
-    return <div />;
+    return null;
   }
 
   const id = `${idSchema.$id}__title`;
@@ -60,7 +60,7 @@ const ArrayFieldDescription = ({
   description,
 }: ArrayFieldDescriptionProps) => {
   if (!description) {
-    return <div />;
+    return null;
   }
 
   const id = `${idSchema.$id}__description`;

--- a/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
@@ -15,7 +15,6 @@ exports[`array fields array 1`] = `
       <div
         className="MuiBox-root MuiBox-root-33"
       >
-        <div />
         <div
           className="MuiGrid-root MuiGrid-container"
         >
@@ -168,7 +167,6 @@ exports[`array fields fixed array 1`] = `
       <div
         className="MuiBox-root MuiBox-root-178"
       >
-        <div />
         <div
           className="MuiGrid-root MuiGrid-container"
         >


### PR DESCRIPTION
This was partially done by https://github.com/rjsf-team/react-jsonschema-form/commit/b096c999650a732690d34f3cf26d101b33c1a074

material-ui package is still returning some empty divs on ArrayFieldTemplate

	modified:   packages/material-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
	modified:   packages/material-ui/test/__snapshots__/Array.test.tsx.snap

### Reasons for making this change

fixes https://github.com/rjsf-team/react-jsonschema-form/issues/1761

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
