### PR TITLE
#1765 - Material UI theme not showing title for date fields

### DIFF
--- a/packages/material-ui/src/DateWidget/DateWidget.tsx
+++ b/packages/material-ui/src/DateWidget/DateWidget.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import FormControl from '@material-ui/core/FormControl';
+import TextField from '@material-ui/core/TextField';
+
+import { WidgetProps } from '@rjsf/core';
+
+const DateWidget = ({
+  id,
+  required,
+  readonly,
+  disabled,
+  label,
+  value,
+  onChange,
+  onBlur,
+  onFocus,
+  autofocus,
+  options,
+  schema,
+}: WidgetProps) => {
+  const _onChange = ({
+    target: { value },
+  }: React.ChangeEvent<HTMLInputElement>) =>
+    onChange(value === '' ? options.emptyValue : value);
+  const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
+    onBlur(id, value);
+  const _onFocus = ({
+    target: { value },
+  }: React.FocusEvent<HTMLInputElement>) => onFocus(id, value);
+
+  return (
+    <FormControl
+      fullWidth={true}
+      //error={!!rawErrors}
+      required={required}
+    >
+      <TextField
+        id={id}
+        label={label || schema.title}
+        autoFocus={autofocus}
+        required={required}
+        disabled={disabled || readonly}
+        name={name}
+        type='date'
+        value={value ? value : ''}
+        onChange={_onChange}
+        onBlur={_onBlur}
+        onFocus={_onFocus}
+        InputLabelProps={{
+          shrink: true,
+        }}
+      />
+    </FormControl>
+  );
+};
+
+export default DateWidget;

--- a/packages/material-ui/src/DateWidget/index.ts
+++ b/packages/material-ui/src/DateWidget/index.ts
@@ -1,0 +1,2 @@
+export { default } from './DateWidget';
+export * from './DateWidget';

--- a/packages/material-ui/src/Widgets/Widgets.ts
+++ b/packages/material-ui/src/Widgets/Widgets.ts
@@ -1,5 +1,6 @@
 import CheckboxWidget from '../CheckboxWidget/CheckboxWidget';
 import CheckboxesWidget from '../CheckboxesWidget/CheckboxesWidget';
+import DateWidget from '../DateWidget/DateWidget';
 import PasswordWidget from '../PasswordWidget/PasswordWidget';
 import RadioWidget from '../RadioWidget/RadioWidget';
 import RangeWidget from '../RangeWidget/RangeWidget';
@@ -11,6 +12,7 @@ import UpDownWidget from '../UpDownWidget/UpDownWidget';
 export default {
   CheckboxWidget,
   CheckboxesWidget,
+  DateWidget,
   PasswordWidget,
   RadioWidget,
   RangeWidget,

--- a/packages/material-ui/test/DateWidget.test.tsx
+++ b/packages/material-ui/test/DateWidget.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import Form from "../src/index";
+import { JSONSchema7 } from "json-schema";
+import renderer from "react-test-renderer";
+
+describe("DateWidget", () => {
+  test("Render date input with title property defined", () => {
+      const schema: JSONSchema7 = {
+        type: "string", format: "date",  title: "date title" 
+      };
+      const tree = renderer.create(<Form schema={schema} />).toJSON();
+      expect(tree).toMatchSnapshot();
+  });
+  test("Render date input without title property defined", () => {
+      //The label of this input should be set based on the name of the property name, "dateNoTitle"
+      const schema: JSONSchema7 = {
+        type: "object",
+        properties: {
+          dateNoTitle: { type: "string", format: "date" }
+        }
+      };
+      const tree = renderer.create(<Form schema={schema} />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+});
+

--- a/packages/material-ui/test/__snapshots__/DateWidget.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/DateWidget.test.tsx.snap
@@ -1,0 +1,132 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DateWidget Render date input with title property defined 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="MuiFormControl-root MuiFormControl-fullWidth"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth"
+    >
+      <div
+        className="MuiFormControl-root MuiTextField-root"
+      >
+        <label
+          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+          data-shrink={true}
+          htmlFor="root"
+          id="root-label"
+        >
+          date title
+        </label>
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            name="nodejs"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={false}
+            type="date"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-info"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`DateWidget Render date input without title property defined 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="MuiFormControl-root MuiFormControl-fullWidth"
+  >
+    <div
+      className="MuiGrid-root makeStyles-root-57 MuiGrid-container MuiGrid-spacing-xs-2"
+    >
+      <div
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+        style={
+          Object {
+            "marginBottom": "10px",
+          }
+        }
+      >
+        <div
+          className="MuiFormControl-root MuiFormControl-fullWidth"
+        >
+          <div
+            className="MuiFormControl-root MuiFormControl-fullWidth"
+          >
+            <div
+              className="MuiFormControl-root MuiTextField-root"
+            >
+              <label
+                className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink"
+                data-shrink={true}
+                htmlFor="root_dateNoTitle"
+                id="root_dateNoTitle-label"
+              >
+                dateNoTitle
+              </label>
+              <div
+                className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                onClick={[Function]}
+              >
+                <input
+                  aria-invalid={false}
+                  autoFocus={false}
+                  className="MuiInputBase-input MuiInput-input"
+                  disabled={false}
+                  id="root_dateNoTitle"
+                  name="nodejs"
+                  onAnimationStart={[Function]}
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  required={false}
+                  type="date"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-info"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;


### PR DESCRIPTION
Implements a native datepicker as documented here  https://material-ui.com/components/pickers/

 Changes to be committed:
	new file:   packages/material-ui/src/DateWidget/DateWidget.tsx
	new file:   packages/material-ui/src/DateWidget/index.ts
	modified:   packages/material-ui/src/Widgets/Widgets.ts
	new file:   packages/material-ui/test/DateWidget.test.tsx
	new file:   packages/material-ui/test/__snapshots__/DateWidget.test.tsx.snap

### Reasons for making this change

fixes #1765

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
