### PR TITLE
Fix #1188 Better logging in case of problems in oneOf dependencies

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -789,7 +789,7 @@ function withDependentSchema(
   );
 }
 
-function withExactlyOneSubschema(
+export function withExactlyOneSubschema(
   schema,
   rootSchema,
   formData,
@@ -812,9 +812,17 @@ function withExactlyOneSubschema(
       return errors.length === 0;
     }
   });
-  if (validSubschemas.length !== 1) {
+
+  if (validSubschemas.length === 0) {
     console.warn(
-      "ignoring oneOf in dependencies because there isn't exactly one subschema that is valid"
+      `ignoring oneOf in dependencies for "${dependencyKey}" because there is no subSchema that is valid`
+    );
+    return schema;
+  }
+
+  if (validSubschemas.length > 1) {
+    console.warn(
+      `ignoring oneOf in dependencies for "${dependencyKey}" because there isn't exactly one subschema that is valid`
     );
     return schema;
   }


### PR DESCRIPTION
### Reasons for making this change

Referring to #1188, to improve the log in case of oneOf dependencies not matching, I added the `dependencyKey` in the warning message. I also made two different logs, one in case of no match found and the other in case or more than one match found, I think it could be useful. 
I also added a unit test for `withExactlyOneSubschema()` function, let me know if the test makes sense for you.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
