### PR TITLE
Add registry to custom FieldTemplate

### DIFF
--- a/docs/advanced-customization/custom-templates.md
+++ b/docs/advanced-customization/custom-templates.md
@@ -145,6 +145,7 @@ The following props are passed to a custom field template component:
 - `schema`: The schema object for this field.
 - `uiSchema`: The uiSchema object for this field.
 - `formContext`: The `formContext` object that you passed to Form.
+- `registry`: The `registry` object.
 
 > Note: you can only define a single global field template for a form, but you can set individual field templates per property using `"ui:FieldTemplate"`.
 

--- a/docs/advanced-customization/custom-templates.md
+++ b/docs/advanced-customization/custom-templates.md
@@ -65,6 +65,7 @@ The following props are passed to each `ArrayFieldTemplate`:
 - `title`: A string value containing the title for the array.
 - `formContext`: The `formContext` object that you passed to Form.
 - `formData`: The formData for this array.
+- `registry`: The `registry` object.
 
 The following props are part of each element in `items`:
 
@@ -207,6 +208,7 @@ The following props are passed to each `ObjectFieldTemplate`:
 - `idSchema`: An object containing the id for this object & ids for it's properties.
 - `formData`: The form data for the object.
 - `formContext`: The `formContext` object that you passed to Form.
+- `registry`: The `registry` object.
 
 The following props are part of each element in `properties`:
 

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -161,6 +161,7 @@ declare module '@rjsf/core' {
         schema: JSONSchema7;
         uiSchema: UiSchema;
         formContext: any;
+        registry: FieldProps['registry'];
     };
 
     export type ArrayFieldTemplateProps<T = any> = {

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -213,6 +213,7 @@ declare module '@rjsf/core' {
         idSchema: IdSchema;
         formData: T;
         formContext: any;
+        registry: FieldProps['registry'];
     };
 
     export type AjvError = {

--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -351,6 +351,7 @@ function SchemaFieldRender(props) {
     fields,
     schema,
     uiSchema,
+    registry,
   };
 
   const _AnyOfField = registry.fields.AnyOfField;

--- a/packages/core/test/FieldTemplate_test.js
+++ b/packages/core/test/FieldTemplate_test.js
@@ -91,4 +91,34 @@ describe("FieldTemplate", () => {
       });
     });
   });
+
+  describe("Custom FieldTemplate should have registry", () => {
+    function FieldTemplate(props) {
+      return (
+        <div>
+          Root Schema:{" "}
+          <span id="root-schema">
+            {JSON.stringify(props.registry.rootSchema)}
+          </span>
+        </div>
+      );
+    }
+
+    it("should allow access to root schema from registry", () => {
+      const schema = {
+        type: "object",
+        properties: { fooBarBaz: { type: "string" } },
+      };
+
+      const { node } = createFormComponent({
+        schema,
+        FieldTemplate,
+      });
+
+      expect(node.querySelectorAll("#root-schema")).to.have.length.of(1);
+      expect(node.querySelectorAll("#root-schema")[0].innerHTML).to.equal(
+        JSON.stringify(schema)
+      );
+    });
+  });
 });


### PR DESCRIPTION
### Reasons for making this change

Certain customizations one might want to do in a FieldTemplate may require access to things that are only contained into the registry, such as the rootSchema. Note that this is already done in the ObjectFieldTemplate and so this merely brings the properties that are passed down into alignment with that template.

### Checklist

* [X] **I'm updating documentation**
  - [X] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests
  - [X] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
