### PR TITLE
Add missing material theme string widgets

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -390,6 +390,10 @@ declare module '@rjsf/core' {
 
         export function toDateString(dateObject: DateObject, time?: boolean): string;
 
+        export function utcToLocal(jsonDate: string): string;
+
+        export function localToUTC(dateString: string): Date;
+
         export function pad(num: number, size: number): string;
 
         export function setState(instance: React.Component, state: any, callback: Function): void;

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -109,6 +109,7 @@ declare module '@rjsf/core' {
         onBlur: (id: string, value: boolean | number | string | null) => void;
         onFocus: (id: string, value: boolean | number | string | null) => void;
         label: string;
+        type: string;
         multiple: boolean;
         rawErrors: string[];
     }

--- a/packages/core/src/components/widgets/DateTimeWidget.js
+++ b/packages/core/src/components/widgets/DateTimeWidget.js
@@ -1,36 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { pad } from "../../utils";
-
-export function utcToLocal(jsonDate) {
-  if (!jsonDate) {
-    return "";
-  }
-
-  // required format of `"yyyy-MM-ddThh:mm" followed by optional ":ss" or ":ss.SSS"
-  // https://html.spec.whatwg.org/multipage/input.html#local-date-and-time-state-(type%3Ddatetime-local)
-  // > should be a _valid local date and time string_ (not GMT)
-
-  // Note - date constructor passed local ISO-8601 does not correctly
-  // change time to UTC in node pre-8
-  const date = new Date(jsonDate);
-
-  const yyyy = pad(date.getFullYear(), 4);
-  const MM = pad(date.getMonth() + 1, 2);
-  const dd = pad(date.getDate(), 2);
-  const hh = pad(date.getHours(), 2);
-  const mm = pad(date.getMinutes(), 2);
-  const ss = pad(date.getSeconds(), 2);
-  const SSS = pad(date.getMilliseconds(), 3);
-
-  return `${yyyy}-${MM}-${dd}T${hh}:${mm}:${ss}.${SSS}`;
-}
-
-export function localToUTC(dateString) {
-  if (dateString) {
-    return new Date(dateString).toJSON();
-  }
-}
+import { utcToLocal, localToUTC } from "../../utils";
 
 function DateTimeWidget(props) {
   const {

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1048,6 +1048,36 @@ export function toDateString(
   return time ? datetime : datetime.slice(0, 10);
 }
 
+export function utcToLocal(jsonDate) {
+  if (!jsonDate) {
+    return "";
+  }
+
+  // required format of `"yyyy-MM-ddThh:mm" followed by optional ":ss" or ":ss.SSS"
+  // https://html.spec.whatwg.org/multipage/input.html#local-date-and-time-state-(type%3Ddatetime-local)
+  // > should be a _valid local date and time string_ (not GMT)
+
+  // Note - date constructor passed local ISO-8601 does not correctly
+  // change time to UTC in node pre-8
+  const date = new Date(jsonDate);
+
+  const yyyy = pad(date.getFullYear(), 4);
+  const MM = pad(date.getMonth() + 1, 2);
+  const dd = pad(date.getDate(), 2);
+  const hh = pad(date.getHours(), 2);
+  const mm = pad(date.getMinutes(), 2);
+  const ss = pad(date.getSeconds(), 2);
+  const SSS = pad(date.getMilliseconds(), 3);
+
+  return `${yyyy}-${MM}-${dd}T${hh}:${mm}:${ss}.${SSS}`;
+}
+
+export function localToUTC(dateString) {
+  if (dateString) {
+    return new Date(dateString).toJSON();
+  }
+}
+
 export function pad(num, size) {
   let s = String(num);
   while (s.length < size) {

--- a/packages/core/test/StringField_test.js
+++ b/packages/core/test/StringField_test.js
@@ -3,8 +3,7 @@ import { expect } from "chai";
 import { Simulate } from "react-dom/test-utils";
 import sinon from "sinon";
 
-import { parseDateString, toDateString } from "../src/utils";
-import { utcToLocal } from "../src/components/widgets/DateTimeWidget";
+import { parseDateString, toDateString, utcToLocal } from "../src/utils";
 import { createFormComponent, createSandbox, submitForm } from "./test_utils";
 
 describe("StringField", () => {

--- a/packages/material-ui/src/ColorWidget/ColorWidget.tsx
+++ b/packages/material-ui/src/ColorWidget/ColorWidget.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { WidgetProps } from "@rjsf/core";
+import TextWidget from "../TextWidget";
+
+const ColorWidget = (props: WidgetProps) => {
+  return <TextWidget type="color" {...props} />;
+};
+
+export default ColorWidget;

--- a/packages/material-ui/src/ColorWidget/ColorWidget.tsx
+++ b/packages/material-ui/src/ColorWidget/ColorWidget.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/core";
-import TextWidget from "../TextWidget";
+import TextWidget, { TextWidgetProps } from "../TextWidget";
 
-const ColorWidget = (props: WidgetProps) => {
+const ColorWidget = (props: TextWidgetProps) => {
   return <TextWidget type="color" {...props} />;
 };
 

--- a/packages/material-ui/src/ColorWidget/index.ts
+++ b/packages/material-ui/src/ColorWidget/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./ColorWidget";
+export * from "./ColorWidget";

--- a/packages/material-ui/src/DateTimeWidget/DateTimeWidget.tsx
+++ b/packages/material-ui/src/DateTimeWidget/DateTimeWidget.tsx
@@ -3,7 +3,15 @@ import { WidgetProps } from "@rjsf/core";
 import TextWidget from "../TextWidget";
 
 const DateTimeWidget = (props: WidgetProps) => {
-  return <TextWidget type="datetime-local" {...props} />;
+  return (
+    <TextWidget
+      type="datetime-local"
+      InputLabelProps={{
+        shrink: true,
+      }}
+      {...props}
+    />
+  );
 };
 
 export default DateTimeWidget;

--- a/packages/material-ui/src/DateTimeWidget/DateTimeWidget.tsx
+++ b/packages/material-ui/src/DateTimeWidget/DateTimeWidget.tsx
@@ -1,7 +1,15 @@
 import React from "react";
+import { utils } from "@rjsf/core";
 import TextWidget, { TextWidgetProps } from "../TextWidget";
 
+const { localToUTC, utcToLocal } = utils;
+
 const DateTimeWidget = (props: TextWidgetProps) => {
+  const value = utcToLocal(props.value);
+  const onChange = (value: any) => {
+    props.onChange(localToUTC(value));
+  };
+
   return (
     <TextWidget
       type="datetime-local"
@@ -9,6 +17,8 @@ const DateTimeWidget = (props: TextWidgetProps) => {
         shrink: true,
       }}
       {...props}
+      value={value}
+      onChange={onChange}
     />
   );
 };

--- a/packages/material-ui/src/DateTimeWidget/DateTimeWidget.tsx
+++ b/packages/material-ui/src/DateTimeWidget/DateTimeWidget.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { WidgetProps } from "@rjsf/core";
+import TextWidget from "../TextWidget";
+
+const DateTimeWidget = (props: WidgetProps) => {
+  return <TextWidget type="datetime-local" {...props} />;
+};
+
+export default DateTimeWidget;

--- a/packages/material-ui/src/DateTimeWidget/DateTimeWidget.tsx
+++ b/packages/material-ui/src/DateTimeWidget/DateTimeWidget.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/core";
-import TextWidget from "../TextWidget";
+import TextWidget, { TextWidgetProps } from "../TextWidget";
 
-const DateTimeWidget = (props: WidgetProps) => {
+const DateTimeWidget = (props: TextWidgetProps) => {
   return (
     <TextWidget
       type="datetime-local"

--- a/packages/material-ui/src/DateTimeWidget/index.ts
+++ b/packages/material-ui/src/DateTimeWidget/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./DateTimeWidget";
+export * from "./DateTimeWidget";

--- a/packages/material-ui/src/DateWidget/DateWidget.tsx
+++ b/packages/material-ui/src/DateWidget/DateWidget.tsx
@@ -3,7 +3,15 @@ import { WidgetProps } from "@rjsf/core";
 import TextWidget from "../TextWidget";
 
 const DateWidget = (props: WidgetProps) => {
-  return <TextWidget type="date" {...props} />;
+  return (
+    <TextWidget
+      type="date"
+      InputLabelProps={{
+        shrink: true,
+      }}
+      {...props}
+    />
+  );
 };
 
 export default DateWidget;

--- a/packages/material-ui/src/DateWidget/DateWidget.tsx
+++ b/packages/material-ui/src/DateWidget/DateWidget.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/core";
-import TextWidget from "../TextWidget";
+import TextWidget, { TextWidgetProps } from "../TextWidget";
 
-const DateWidget = (props: WidgetProps) => {
+const DateWidget = (props: TextWidgetProps) => {
   return (
     <TextWidget
       type="date"

--- a/packages/material-ui/src/DateWidget/DateWidget.tsx
+++ b/packages/material-ui/src/DateWidget/DateWidget.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { WidgetProps } from "@rjsf/core";
+import TextWidget from "../TextWidget";
+
+const DateWidget = (props: WidgetProps) => {
+  return <TextWidget type="date" {...props} />;
+};
+
+export default DateWidget;

--- a/packages/material-ui/src/DateWidget/index.ts
+++ b/packages/material-ui/src/DateWidget/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./DateWidget";
+export * from "./DateWidget";

--- a/packages/material-ui/src/EmailWidget/EmailWidget.tsx
+++ b/packages/material-ui/src/EmailWidget/EmailWidget.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/core";
-import TextWidget from "../TextWidget";
+import TextWidget, { TextWidgetProps } from "../TextWidget";
 
-const EmailWidget = (props: WidgetProps) => {
+const EmailWidget = (props: TextWidgetProps) => {
   return <TextWidget type="email" {...props} />;
 };
 

--- a/packages/material-ui/src/EmailWidget/EmailWidget.tsx
+++ b/packages/material-ui/src/EmailWidget/EmailWidget.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { WidgetProps } from "@rjsf/core";
+import TextWidget from "../TextWidget";
+
+const EmailWidget = (props: WidgetProps) => {
+  return <TextWidget type="email" {...props} />;
+};
+
+export default EmailWidget;

--- a/packages/material-ui/src/EmailWidget/index.ts
+++ b/packages/material-ui/src/EmailWidget/index.ts
@@ -1,0 +1,2 @@
+export { default } from './EmailWidget';
+export * from './EmailWidget';

--- a/packages/material-ui/src/TextWidget/TextWidget.tsx
+++ b/packages/material-ui/src/TextWidget/TextWidget.tsx
@@ -1,9 +1,13 @@
 import React from "react";
 
 import FormControl from "@material-ui/core/FormControl";
-import TextField from "@material-ui/core/TextField";
+import TextField, {
+  StandardTextFieldProps as TextFieldProps,
+} from "@material-ui/core/TextField";
 
 import { WidgetProps } from "@rjsf/core";
+
+type TextWidgetProps = WidgetProps & TextFieldProps;
 
 const TextWidget = ({
   id,
@@ -19,7 +23,8 @@ const TextWidget = ({
   autofocus,
   options,
   schema,
-}: WidgetProps) => {
+  ...textFieldProps
+}: TextWidgetProps) => {
   const _onChange = ({
     target: { value },
   }: React.ChangeEvent<HTMLInputElement>) =>
@@ -41,12 +46,12 @@ const TextWidget = ({
         autoFocus={autofocus}
         required={required}
         disabled={disabled || readonly}
-        name={name}
         type={type || (schema.type as string)}
         value={value || value === 0 ? value : ""}
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
+        {...(textFieldProps as TextFieldProps)}
       />
     </FormControl>
   );

--- a/packages/material-ui/src/TextWidget/TextWidget.tsx
+++ b/packages/material-ui/src/TextWidget/TextWidget.tsx
@@ -7,7 +7,7 @@ import TextField, {
 
 import { WidgetProps } from "@rjsf/core";
 
-type TextWidgetProps = WidgetProps & TextFieldProps;
+export type TextWidgetProps = WidgetProps & TextFieldProps;
 
 const TextWidget = ({
   id,

--- a/packages/material-ui/src/TextWidget/TextWidget.tsx
+++ b/packages/material-ui/src/TextWidget/TextWidget.tsx
@@ -1,15 +1,16 @@
-import React from 'react';
+import React from "react";
 
-import FormControl from '@material-ui/core/FormControl';
-import TextField from '@material-ui/core/TextField';
+import FormControl from "@material-ui/core/FormControl";
+import TextField from "@material-ui/core/TextField";
 
-import { WidgetProps } from '@rjsf/core';
+import { WidgetProps } from "@rjsf/core";
 
 const TextWidget = ({
   id,
   required,
   readonly,
   disabled,
+  type,
   label,
   value,
   onChange,
@@ -22,7 +23,7 @@ const TextWidget = ({
   const _onChange = ({
     target: { value },
   }: React.ChangeEvent<HTMLInputElement>) =>
-    onChange(value === '' ? options.emptyValue : value);
+    onChange(value === "" ? options.emptyValue : value);
   const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
     onBlur(id, value);
   const _onFocus = ({
@@ -33,8 +34,7 @@ const TextWidget = ({
     <FormControl
       fullWidth={true}
       //error={!!rawErrors}
-      required={required}
-    >
+      required={required}>
       <TextField
         id={id}
         label={label || schema.title}
@@ -42,8 +42,8 @@ const TextWidget = ({
         required={required}
         disabled={disabled || readonly}
         name={name}
-        type={schema.type as string}
-        value={value || (value === 0) ? value : ''}
+        type={type || (schema.type as string)}
+        value={value || value === 0 ? value : ""}
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}

--- a/packages/material-ui/src/URLWidget/URLWidget.tsx
+++ b/packages/material-ui/src/URLWidget/URLWidget.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/core";
-import TextWidget from "../TextWidget";
+import TextWidget, { TextWidgetProps } from "../TextWidget";
 
-const URLWidget = (props: WidgetProps) => {
+const URLWidget = (props: TextWidgetProps) => {
   return <TextWidget type="url" {...props} />;
 };
 

--- a/packages/material-ui/src/URLWidget/URLWidget.tsx
+++ b/packages/material-ui/src/URLWidget/URLWidget.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { WidgetProps } from "@rjsf/core";
+import TextWidget from "../TextWidget";
+
+const URLWidget = (props: WidgetProps) => {
+  return <TextWidget type="url" {...props} />;
+};
+
+export default URLWidget;

--- a/packages/material-ui/src/URLWidget/index.ts
+++ b/packages/material-ui/src/URLWidget/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./URLWidget";
+export * from "./URLWidget";

--- a/packages/material-ui/src/Widgets/Widgets.ts
+++ b/packages/material-ui/src/Widgets/Widgets.ts
@@ -1,16 +1,25 @@
-import CheckboxWidget from '../CheckboxWidget/CheckboxWidget';
-import CheckboxesWidget from '../CheckboxesWidget/CheckboxesWidget';
-import PasswordWidget from '../PasswordWidget/PasswordWidget';
-import RadioWidget from '../RadioWidget/RadioWidget';
-import RangeWidget from '../RangeWidget/RangeWidget';
-import SelectWidget from '../SelectWidget/SelectWidget';
-import TextareaWidget from '../TextareaWidget/TextareaWidget';
-import TextWidget from '../TextWidget/TextWidget';
-import UpDownWidget from '../UpDownWidget/UpDownWidget';
+import CheckboxWidget from "../CheckboxWidget/CheckboxWidget";
+import CheckboxesWidget from "../CheckboxesWidget/CheckboxesWidget";
+import ColorWidget from "../ColorWidget/ColorWidget";
+import DateWidget from "../DateWidget/DateWidget";
+import DateTimeWidget from "../DateTimeWidget/DateTimeWidget";
+import EmailWidget from "../EmailWidget/EmailWidget";
+import PasswordWidget from "../PasswordWidget/PasswordWidget";
+import RadioWidget from "../RadioWidget/RadioWidget";
+import RangeWidget from "../RangeWidget/RangeWidget";
+import SelectWidget from "../SelectWidget/SelectWidget";
+import TextareaWidget from "../TextareaWidget/TextareaWidget";
+import TextWidget from "../TextWidget/TextWidget";
+import UpDownWidget from "../UpDownWidget/UpDownWidget";
+import URLWidget from "../URLWidget/URLWidget";
 
 export default {
   CheckboxWidget,
   CheckboxesWidget,
+  ColorWidget,
+  DateWidget,
+  DateTimeWidget,
+  EmailWidget,
   PasswordWidget,
   RadioWidget,
   RangeWidget,
@@ -18,4 +27,5 @@ export default {
   TextareaWidget,
   TextWidget,
   UpDownWidget,
+  URLWidget,
 };

--- a/packages/material-ui/test/Form.test.tsx
+++ b/packages/material-ui/test/Form.test.tsx
@@ -82,4 +82,28 @@ describe("single fields", () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+  test("format color", () => {
+    const schema: JSONSchema7 = {
+      type: "string",
+      format: "color",
+    };
+    const tree = renderer.create(<Form schema={schema} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  test("format date", () => {
+    const schema: JSONSchema7 = {
+      type: "string",
+      format: "date",
+    };
+    const tree = renderer.create(<Form schema={schema} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  test("format datetime", () => {
+    const schema: JSONSchema7 = {
+      type: "string",
+      format: "datetime",
+    };
+    const tree = renderer.create(<Form schema={schema} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
@@ -193,6 +193,62 @@ exports[`array fields fixed array 1`] = `
                       >
                         <div
                           className="MuiFormControl-root MuiTextField-root"
+                          formContext={Object {}}
+                          registry={
+                            Object {
+                              "ArrayFieldTemplate": [Function],
+                              "FieldTemplate": [Function],
+                              "ObjectFieldTemplate": [Function],
+                              "definitions": Object {},
+                              "fields": Object {
+                                "AnyOfField": [Function],
+                                "ArrayField": [Function],
+                                "BooleanField": [Function],
+                                "DescriptionField": [Function],
+                                "NullField": [Function],
+                                "NumberField": [Function],
+                                "ObjectField": [Function],
+                                "OneOfField": [Function],
+                                "SchemaField": [Function],
+                                "StringField": [Function],
+                                "TitleField": [Function],
+                                "UnsupportedField": [Function],
+                              },
+                              "formContext": Object {},
+                              "rootSchema": Object {
+                                "items": Array [
+                                  Object {
+                                    "type": "string",
+                                  },
+                                  Object {
+                                    "type": "number",
+                                  },
+                                ],
+                                "type": "array",
+                              },
+                              "widgets": Object {
+                                "AltDateTimeWidget": [Function],
+                                "AltDateWidget": [Function],
+                                "BaseInput": [Function],
+                                "CheckboxWidget": [Function],
+                                "CheckboxesWidget": [Function],
+                                "ColorWidget": [Function],
+                                "DateTimeWidget": [Function],
+                                "DateWidget": [Function],
+                                "EmailWidget": [Function],
+                                "FileWidget": [Function],
+                                "HiddenWidget": [Function],
+                                "PasswordWidget": [Function],
+                                "RadioWidget": [Function],
+                                "RangeWidget": [Function],
+                                "SelectWidget": [Function],
+                                "TextWidget": [Function],
+                                "TextareaWidget": [Function],
+                                "URLWidget": [Function],
+                                "UpDownWidget": [Function],
+                              },
+                            }
+                          }
                         >
                           <div
                             className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -204,11 +260,11 @@ exports[`array fields fixed array 1`] = `
                               className="MuiInputBase-input MuiInput-input"
                               disabled={false}
                               id="root_0"
-                              name="nodejs"
                               onAnimationStart={[Function]}
                               onBlur={[Function]}
                               onChange={[Function]}
                               onFocus={[Function]}
+                              placeholder=""
                               required={true}
                               type="string"
                               value=""
@@ -245,6 +301,62 @@ exports[`array fields fixed array 1`] = `
                       >
                         <div
                           className="MuiFormControl-root MuiTextField-root"
+                          formContext={Object {}}
+                          registry={
+                            Object {
+                              "ArrayFieldTemplate": [Function],
+                              "FieldTemplate": [Function],
+                              "ObjectFieldTemplate": [Function],
+                              "definitions": Object {},
+                              "fields": Object {
+                                "AnyOfField": [Function],
+                                "ArrayField": [Function],
+                                "BooleanField": [Function],
+                                "DescriptionField": [Function],
+                                "NullField": [Function],
+                                "NumberField": [Function],
+                                "ObjectField": [Function],
+                                "OneOfField": [Function],
+                                "SchemaField": [Function],
+                                "StringField": [Function],
+                                "TitleField": [Function],
+                                "UnsupportedField": [Function],
+                              },
+                              "formContext": Object {},
+                              "rootSchema": Object {
+                                "items": Array [
+                                  Object {
+                                    "type": "string",
+                                  },
+                                  Object {
+                                    "type": "number",
+                                  },
+                                ],
+                                "type": "array",
+                              },
+                              "widgets": Object {
+                                "AltDateTimeWidget": [Function],
+                                "AltDateWidget": [Function],
+                                "BaseInput": [Function],
+                                "CheckboxWidget": [Function],
+                                "CheckboxesWidget": [Function],
+                                "ColorWidget": [Function],
+                                "DateTimeWidget": [Function],
+                                "DateWidget": [Function],
+                                "EmailWidget": [Function],
+                                "FileWidget": [Function],
+                                "HiddenWidget": [Function],
+                                "PasswordWidget": [Function],
+                                "RadioWidget": [Function],
+                                "RangeWidget": [Function],
+                                "SelectWidget": [Function],
+                                "TextWidget": [Function],
+                                "TextareaWidget": [Function],
+                                "URLWidget": [Function],
+                                "UpDownWidget": [Function],
+                              },
+                            }
+                          }
                         >
                           <div
                             className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -256,11 +368,11 @@ exports[`array fields fixed array 1`] = `
                               className="MuiInputBase-input MuiInput-input"
                               disabled={false}
                               id="root_1"
-                              name="nodejs"
                               onAnimationStart={[Function]}
                               onBlur={[Function]}
                               onChange={[Function]}
                               onFocus={[Function]}
+                              placeholder=""
                               required={true}
                               type="number"
                               value=""

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -387,11 +387,11 @@ exports[`single fields number field 0 1`] = `
             className="MuiInputBase-input MuiInput-input"
             disabled={false}
             id="root"
-            name="nodejs"
             onAnimationStart={[Function]}
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            placeholder=""
             required={false}
             type="number"
             value={0}
@@ -448,8 +448,7 @@ exports[`single fields number field 1`] = `
             },
             "formContext": Object {},
             "rootSchema": Object {
-              "format": "email",
-              "type": "string",
+              "type": "number",
             },
             "widgets": Object {
               "AltDateTimeWidget": [Function],
@@ -579,7 +578,7 @@ exports[`single fields string field format email 1`] = `
             },
             "formContext": Object {},
             "rootSchema": Object {
-              "format": "uri",
+              "format": "email",
               "type": "string",
             },
             "widgets": Object {
@@ -677,6 +676,7 @@ exports[`single fields string field format uri 1`] = `
             },
             "formContext": Object {},
             "rootSchema": Object {
+              "format": "uri",
               "type": "string",
             },
             "widgets": Object {
@@ -751,6 +751,54 @@ exports[`single fields string field regular 1`] = `
     >
       <div
         className="MuiFormControl-root MuiTextField-root"
+        formContext={Object {}}
+        registry={
+          Object {
+            "ArrayFieldTemplate": [Function],
+            "FieldTemplate": [Function],
+            "ObjectFieldTemplate": [Function],
+            "definitions": Object {},
+            "fields": Object {
+              "AnyOfField": [Function],
+              "ArrayField": [Function],
+              "BooleanField": [Function],
+              "DescriptionField": [Function],
+              "NullField": [Function],
+              "NumberField": [Function],
+              "ObjectField": [Function],
+              "OneOfField": [Function],
+              "SchemaField": [Function],
+              "StringField": [Function],
+              "TitleField": [Function],
+              "UnsupportedField": [Function],
+            },
+            "formContext": Object {},
+            "rootSchema": Object {
+              "type": "string",
+            },
+            "widgets": Object {
+              "AltDateTimeWidget": [Function],
+              "AltDateWidget": [Function],
+              "BaseInput": [Function],
+              "CheckboxWidget": [Function],
+              "CheckboxesWidget": [Function],
+              "ColorWidget": [Function],
+              "DateTimeWidget": [Function],
+              "DateWidget": [Function],
+              "EmailWidget": [Function],
+              "FileWidget": [Function],
+              "HiddenWidget": [Function],
+              "PasswordWidget": [Function],
+              "RadioWidget": [Function],
+              "RangeWidget": [Function],
+              "SelectWidget": [Function],
+              "TextWidget": [Function],
+              "TextareaWidget": [Function],
+              "URLWidget": [Function],
+              "UpDownWidget": [Function],
+            },
+          }
+        }
       >
         <div
           className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -1,5 +1,152 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`single fields format color 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="MuiFormControl-root MuiFormControl-fullWidth"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth"
+    >
+      <div
+        className="MuiFormControl-root MuiTextField-root"
+      >
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            name="nodejs"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={false}
+            type="color"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-info"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields format date 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="MuiFormControl-root MuiFormControl-fullWidth"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth"
+    >
+      <div
+        className="MuiFormControl-root MuiTextField-root"
+      >
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            name="nodejs"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={false}
+            type="date"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-info"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields format datetime 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="MuiFormControl-root MuiFormControl-fullWidth"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth"
+    >
+      <div
+        className="MuiFormControl-root MuiTextField-root"
+      >
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            name="nodejs"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={false}
+            type="datetime-local"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-info"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields null field 1`] = `
 <form
   className="rjsf"

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -14,6 +14,55 @@ exports[`single fields format color 1`] = `
     >
       <div
         className="MuiFormControl-root MuiTextField-root"
+        formContext={Object {}}
+        registry={
+          Object {
+            "ArrayFieldTemplate": [Function],
+            "FieldTemplate": [Function],
+            "ObjectFieldTemplate": [Function],
+            "definitions": Object {},
+            "fields": Object {
+              "AnyOfField": [Function],
+              "ArrayField": [Function],
+              "BooleanField": [Function],
+              "DescriptionField": [Function],
+              "NullField": [Function],
+              "NumberField": [Function],
+              "ObjectField": [Function],
+              "OneOfField": [Function],
+              "SchemaField": [Function],
+              "StringField": [Function],
+              "TitleField": [Function],
+              "UnsupportedField": [Function],
+            },
+            "formContext": Object {},
+            "rootSchema": Object {
+              "format": "color",
+              "type": "string",
+            },
+            "widgets": Object {
+              "AltDateTimeWidget": [Function],
+              "AltDateWidget": [Function],
+              "BaseInput": [Function],
+              "CheckboxWidget": [Function],
+              "CheckboxesWidget": [Function],
+              "ColorWidget": [Function],
+              "DateTimeWidget": [Function],
+              "DateWidget": [Function],
+              "EmailWidget": [Function],
+              "FileWidget": [Function],
+              "HiddenWidget": [Function],
+              "PasswordWidget": [Function],
+              "RadioWidget": [Function],
+              "RangeWidget": [Function],
+              "SelectWidget": [Function],
+              "TextWidget": [Function],
+              "TextareaWidget": [Function],
+              "URLWidget": [Function],
+              "UpDownWidget": [Function],
+            },
+          }
+        }
       >
         <div
           className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -25,11 +74,11 @@ exports[`single fields format color 1`] = `
             className="MuiInputBase-input MuiInput-input"
             disabled={false}
             id="root"
-            name="nodejs"
             onAnimationStart={[Function]}
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            placeholder=""
             required={false}
             type="color"
             value=""
@@ -63,6 +112,55 @@ exports[`single fields format date 1`] = `
     >
       <div
         className="MuiFormControl-root MuiTextField-root"
+        formContext={Object {}}
+        registry={
+          Object {
+            "ArrayFieldTemplate": [Function],
+            "FieldTemplate": [Function],
+            "ObjectFieldTemplate": [Function],
+            "definitions": Object {},
+            "fields": Object {
+              "AnyOfField": [Function],
+              "ArrayField": [Function],
+              "BooleanField": [Function],
+              "DescriptionField": [Function],
+              "NullField": [Function],
+              "NumberField": [Function],
+              "ObjectField": [Function],
+              "OneOfField": [Function],
+              "SchemaField": [Function],
+              "StringField": [Function],
+              "TitleField": [Function],
+              "UnsupportedField": [Function],
+            },
+            "formContext": Object {},
+            "rootSchema": Object {
+              "format": "date",
+              "type": "string",
+            },
+            "widgets": Object {
+              "AltDateTimeWidget": [Function],
+              "AltDateWidget": [Function],
+              "BaseInput": [Function],
+              "CheckboxWidget": [Function],
+              "CheckboxesWidget": [Function],
+              "ColorWidget": [Function],
+              "DateTimeWidget": [Function],
+              "DateWidget": [Function],
+              "EmailWidget": [Function],
+              "FileWidget": [Function],
+              "HiddenWidget": [Function],
+              "PasswordWidget": [Function],
+              "RadioWidget": [Function],
+              "RangeWidget": [Function],
+              "SelectWidget": [Function],
+              "TextWidget": [Function],
+              "TextareaWidget": [Function],
+              "URLWidget": [Function],
+              "UpDownWidget": [Function],
+            },
+          }
+        }
       >
         <div
           className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -74,11 +172,11 @@ exports[`single fields format date 1`] = `
             className="MuiInputBase-input MuiInput-input"
             disabled={false}
             id="root"
-            name="nodejs"
             onAnimationStart={[Function]}
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            placeholder=""
             required={false}
             type="date"
             value=""
@@ -112,6 +210,55 @@ exports[`single fields format datetime 1`] = `
     >
       <div
         className="MuiFormControl-root MuiTextField-root"
+        formContext={Object {}}
+        registry={
+          Object {
+            "ArrayFieldTemplate": [Function],
+            "FieldTemplate": [Function],
+            "ObjectFieldTemplate": [Function],
+            "definitions": Object {},
+            "fields": Object {
+              "AnyOfField": [Function],
+              "ArrayField": [Function],
+              "BooleanField": [Function],
+              "DescriptionField": [Function],
+              "NullField": [Function],
+              "NumberField": [Function],
+              "ObjectField": [Function],
+              "OneOfField": [Function],
+              "SchemaField": [Function],
+              "StringField": [Function],
+              "TitleField": [Function],
+              "UnsupportedField": [Function],
+            },
+            "formContext": Object {},
+            "rootSchema": Object {
+              "format": "datetime",
+              "type": "string",
+            },
+            "widgets": Object {
+              "AltDateTimeWidget": [Function],
+              "AltDateWidget": [Function],
+              "BaseInput": [Function],
+              "CheckboxWidget": [Function],
+              "CheckboxesWidget": [Function],
+              "ColorWidget": [Function],
+              "DateTimeWidget": [Function],
+              "DateWidget": [Function],
+              "EmailWidget": [Function],
+              "FileWidget": [Function],
+              "HiddenWidget": [Function],
+              "PasswordWidget": [Function],
+              "RadioWidget": [Function],
+              "RangeWidget": [Function],
+              "SelectWidget": [Function],
+              "TextWidget": [Function],
+              "TextareaWidget": [Function],
+              "URLWidget": [Function],
+              "UpDownWidget": [Function],
+            },
+          }
+        }
       >
         <div
           className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -123,11 +270,11 @@ exports[`single fields format datetime 1`] = `
             className="MuiInputBase-input MuiInput-input"
             disabled={false}
             id="root"
-            name="nodejs"
             onAnimationStart={[Function]}
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            placeholder=""
             required={false}
             type="datetime-local"
             value=""
@@ -181,6 +328,54 @@ exports[`single fields number field 0 1`] = `
     >
       <div
         className="MuiFormControl-root MuiTextField-root"
+        formContext={Object {}}
+        registry={
+          Object {
+            "ArrayFieldTemplate": [Function],
+            "FieldTemplate": [Function],
+            "ObjectFieldTemplate": [Function],
+            "definitions": Object {},
+            "fields": Object {
+              "AnyOfField": [Function],
+              "ArrayField": [Function],
+              "BooleanField": [Function],
+              "DescriptionField": [Function],
+              "NullField": [Function],
+              "NumberField": [Function],
+              "ObjectField": [Function],
+              "OneOfField": [Function],
+              "SchemaField": [Function],
+              "StringField": [Function],
+              "TitleField": [Function],
+              "UnsupportedField": [Function],
+            },
+            "formContext": Object {},
+            "rootSchema": Object {
+              "type": "number",
+            },
+            "widgets": Object {
+              "AltDateTimeWidget": [Function],
+              "AltDateWidget": [Function],
+              "BaseInput": [Function],
+              "CheckboxWidget": [Function],
+              "CheckboxesWidget": [Function],
+              "ColorWidget": [Function],
+              "DateTimeWidget": [Function],
+              "DateWidget": [Function],
+              "EmailWidget": [Function],
+              "FileWidget": [Function],
+              "HiddenWidget": [Function],
+              "PasswordWidget": [Function],
+              "RadioWidget": [Function],
+              "RangeWidget": [Function],
+              "SelectWidget": [Function],
+              "TextWidget": [Function],
+              "TextareaWidget": [Function],
+              "URLWidget": [Function],
+              "UpDownWidget": [Function],
+            },
+          }
+        }
       >
         <div
           className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -230,6 +425,55 @@ exports[`single fields number field 1`] = `
     >
       <div
         className="MuiFormControl-root MuiTextField-root"
+        formContext={Object {}}
+        registry={
+          Object {
+            "ArrayFieldTemplate": [Function],
+            "FieldTemplate": [Function],
+            "ObjectFieldTemplate": [Function],
+            "definitions": Object {},
+            "fields": Object {
+              "AnyOfField": [Function],
+              "ArrayField": [Function],
+              "BooleanField": [Function],
+              "DescriptionField": [Function],
+              "NullField": [Function],
+              "NumberField": [Function],
+              "ObjectField": [Function],
+              "OneOfField": [Function],
+              "SchemaField": [Function],
+              "StringField": [Function],
+              "TitleField": [Function],
+              "UnsupportedField": [Function],
+            },
+            "formContext": Object {},
+            "rootSchema": Object {
+              "format": "email",
+              "type": "string",
+            },
+            "widgets": Object {
+              "AltDateTimeWidget": [Function],
+              "AltDateWidget": [Function],
+              "BaseInput": [Function],
+              "CheckboxWidget": [Function],
+              "CheckboxesWidget": [Function],
+              "ColorWidget": [Function],
+              "DateTimeWidget": [Function],
+              "DateWidget": [Function],
+              "EmailWidget": [Function],
+              "FileWidget": [Function],
+              "HiddenWidget": [Function],
+              "PasswordWidget": [Function],
+              "RadioWidget": [Function],
+              "RangeWidget": [Function],
+              "SelectWidget": [Function],
+              "TextWidget": [Function],
+              "TextareaWidget": [Function],
+              "URLWidget": [Function],
+              "UpDownWidget": [Function],
+            },
+          }
+        }
       >
         <div
           className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -241,11 +485,11 @@ exports[`single fields number field 1`] = `
             className="MuiInputBase-input MuiInput-input"
             disabled={false}
             id="root"
-            name="nodejs"
             onAnimationStart={[Function]}
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            placeholder=""
             required={false}
             type="number"
             value=""
@@ -312,6 +556,55 @@ exports[`single fields string field format email 1`] = `
     >
       <div
         className="MuiFormControl-root MuiTextField-root"
+        formContext={Object {}}
+        registry={
+          Object {
+            "ArrayFieldTemplate": [Function],
+            "FieldTemplate": [Function],
+            "ObjectFieldTemplate": [Function],
+            "definitions": Object {},
+            "fields": Object {
+              "AnyOfField": [Function],
+              "ArrayField": [Function],
+              "BooleanField": [Function],
+              "DescriptionField": [Function],
+              "NullField": [Function],
+              "NumberField": [Function],
+              "ObjectField": [Function],
+              "OneOfField": [Function],
+              "SchemaField": [Function],
+              "StringField": [Function],
+              "TitleField": [Function],
+              "UnsupportedField": [Function],
+            },
+            "formContext": Object {},
+            "rootSchema": Object {
+              "format": "uri",
+              "type": "string",
+            },
+            "widgets": Object {
+              "AltDateTimeWidget": [Function],
+              "AltDateWidget": [Function],
+              "BaseInput": [Function],
+              "CheckboxWidget": [Function],
+              "CheckboxesWidget": [Function],
+              "ColorWidget": [Function],
+              "DateTimeWidget": [Function],
+              "DateWidget": [Function],
+              "EmailWidget": [Function],
+              "FileWidget": [Function],
+              "HiddenWidget": [Function],
+              "PasswordWidget": [Function],
+              "RadioWidget": [Function],
+              "RangeWidget": [Function],
+              "SelectWidget": [Function],
+              "TextWidget": [Function],
+              "TextareaWidget": [Function],
+              "URLWidget": [Function],
+              "UpDownWidget": [Function],
+            },
+          }
+        }
       >
         <div
           className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -323,11 +616,11 @@ exports[`single fields string field format email 1`] = `
             className="MuiInputBase-input MuiInput-input"
             disabled={false}
             id="root"
-            name="nodejs"
             onAnimationStart={[Function]}
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            placeholder=""
             required={false}
             type="email"
             value=""
@@ -361,6 +654,54 @@ exports[`single fields string field format uri 1`] = `
     >
       <div
         className="MuiFormControl-root MuiTextField-root"
+        formContext={Object {}}
+        registry={
+          Object {
+            "ArrayFieldTemplate": [Function],
+            "FieldTemplate": [Function],
+            "ObjectFieldTemplate": [Function],
+            "definitions": Object {},
+            "fields": Object {
+              "AnyOfField": [Function],
+              "ArrayField": [Function],
+              "BooleanField": [Function],
+              "DescriptionField": [Function],
+              "NullField": [Function],
+              "NumberField": [Function],
+              "ObjectField": [Function],
+              "OneOfField": [Function],
+              "SchemaField": [Function],
+              "StringField": [Function],
+              "TitleField": [Function],
+              "UnsupportedField": [Function],
+            },
+            "formContext": Object {},
+            "rootSchema": Object {
+              "type": "string",
+            },
+            "widgets": Object {
+              "AltDateTimeWidget": [Function],
+              "AltDateWidget": [Function],
+              "BaseInput": [Function],
+              "CheckboxWidget": [Function],
+              "CheckboxesWidget": [Function],
+              "ColorWidget": [Function],
+              "DateTimeWidget": [Function],
+              "DateWidget": [Function],
+              "EmailWidget": [Function],
+              "FileWidget": [Function],
+              "HiddenWidget": [Function],
+              "PasswordWidget": [Function],
+              "RadioWidget": [Function],
+              "RangeWidget": [Function],
+              "SelectWidget": [Function],
+              "TextWidget": [Function],
+              "TextareaWidget": [Function],
+              "URLWidget": [Function],
+              "UpDownWidget": [Function],
+            },
+          }
+        }
       >
         <div
           className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -372,11 +713,11 @@ exports[`single fields string field format uri 1`] = `
             className="MuiInputBase-input MuiInput-input"
             disabled={false}
             id="root"
-            name="nodejs"
             onAnimationStart={[Function]}
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            placeholder=""
             required={false}
             type="url"
             value=""
@@ -421,11 +762,11 @@ exports[`single fields string field regular 1`] = `
             className="MuiInputBase-input MuiInput-input"
             disabled={false}
             id="root"
-            name="nodejs"
             onAnimationStart={[Function]}
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            placeholder=""
             required={false}
             type="string"
             value=""

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -160,21 +160,34 @@ exports[`single fields string field format email 1`] = `
   <div
     className="MuiFormControl-root MuiFormControl-fullWidth"
   >
-    <input
-      autoFocus={false}
-      className="form-control"
-      disabled={false}
-      id="root"
-      list={null}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      placeholder=""
-      readOnly={false}
-      required={false}
-      type="email"
-      value=""
-    />
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth"
+    >
+      <div
+        className="MuiFormControl-root MuiTextField-root"
+      >
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            name="nodejs"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={false}
+            type="email"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
   </div>
   <div>
     <button
@@ -196,21 +209,34 @@ exports[`single fields string field format uri 1`] = `
   <div
     className="MuiFormControl-root MuiFormControl-fullWidth"
   >
-    <input
-      autoFocus={false}
-      className="form-control"
-      disabled={false}
-      id="root"
-      list={null}
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      placeholder=""
-      readOnly={false}
-      required={false}
-      type="url"
-      value=""
-    />
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth"
+    >
+      <div
+        className="MuiFormControl-root MuiTextField-root"
+      >
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            name="nodejs"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={false}
+            type="url"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
   </div>
   <div>
     <button

--- a/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
@@ -28,6 +28,62 @@ exports[`object fields object 1`] = `
           >
             <div
               className="MuiFormControl-root MuiTextField-root"
+              formContext={Object {}}
+              registry={
+                Object {
+                  "ArrayFieldTemplate": [Function],
+                  "FieldTemplate": [Function],
+                  "ObjectFieldTemplate": [Function],
+                  "definitions": Object {},
+                  "fields": Object {
+                    "AnyOfField": [Function],
+                    "ArrayField": [Function],
+                    "BooleanField": [Function],
+                    "DescriptionField": [Function],
+                    "NullField": [Function],
+                    "NumberField": [Function],
+                    "ObjectField": [Function],
+                    "OneOfField": [Function],
+                    "SchemaField": [Function],
+                    "StringField": [Function],
+                    "TitleField": [Function],
+                    "UnsupportedField": [Function],
+                  },
+                  "formContext": Object {},
+                  "rootSchema": Object {
+                    "properties": Object {
+                      "a": Object {
+                        "type": "string",
+                      },
+                      "b": Object {
+                        "type": "number",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "widgets": Object {
+                    "AltDateTimeWidget": [Function],
+                    "AltDateWidget": [Function],
+                    "BaseInput": [Function],
+                    "CheckboxWidget": [Function],
+                    "CheckboxesWidget": [Function],
+                    "ColorWidget": [Function],
+                    "DateTimeWidget": [Function],
+                    "DateWidget": [Function],
+                    "EmailWidget": [Function],
+                    "FileWidget": [Function],
+                    "HiddenWidget": [Function],
+                    "PasswordWidget": [Function],
+                    "RadioWidget": [Function],
+                    "RangeWidget": [Function],
+                    "SelectWidget": [Function],
+                    "TextWidget": [Function],
+                    "TextareaWidget": [Function],
+                    "URLWidget": [Function],
+                    "UpDownWidget": [Function],
+                  },
+                }
+              }
             >
               <label
                 className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
@@ -47,11 +103,11 @@ exports[`object fields object 1`] = `
                   className="MuiInputBase-input MuiInput-input"
                   disabled={false}
                   id="root_a"
-                  name="nodejs"
                   onAnimationStart={[Function]}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
+                  placeholder=""
                   required={false}
                   type="string"
                   value=""
@@ -77,6 +133,62 @@ exports[`object fields object 1`] = `
           >
             <div
               className="MuiFormControl-root MuiTextField-root"
+              formContext={Object {}}
+              registry={
+                Object {
+                  "ArrayFieldTemplate": [Function],
+                  "FieldTemplate": [Function],
+                  "ObjectFieldTemplate": [Function],
+                  "definitions": Object {},
+                  "fields": Object {
+                    "AnyOfField": [Function],
+                    "ArrayField": [Function],
+                    "BooleanField": [Function],
+                    "DescriptionField": [Function],
+                    "NullField": [Function],
+                    "NumberField": [Function],
+                    "ObjectField": [Function],
+                    "OneOfField": [Function],
+                    "SchemaField": [Function],
+                    "StringField": [Function],
+                    "TitleField": [Function],
+                    "UnsupportedField": [Function],
+                  },
+                  "formContext": Object {},
+                  "rootSchema": Object {
+                    "properties": Object {
+                      "a": Object {
+                        "type": "string",
+                      },
+                      "b": Object {
+                        "type": "number",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "widgets": Object {
+                    "AltDateTimeWidget": [Function],
+                    "AltDateWidget": [Function],
+                    "BaseInput": [Function],
+                    "CheckboxWidget": [Function],
+                    "CheckboxesWidget": [Function],
+                    "ColorWidget": [Function],
+                    "DateTimeWidget": [Function],
+                    "DateWidget": [Function],
+                    "EmailWidget": [Function],
+                    "FileWidget": [Function],
+                    "HiddenWidget": [Function],
+                    "PasswordWidget": [Function],
+                    "RadioWidget": [Function],
+                    "RangeWidget": [Function],
+                    "SelectWidget": [Function],
+                    "TextWidget": [Function],
+                    "TextareaWidget": [Function],
+                    "URLWidget": [Function],
+                    "UpDownWidget": [Function],
+                  },
+                }
+              }
             >
               <label
                 className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
@@ -96,11 +208,11 @@ exports[`object fields object 1`] = `
                   className="MuiInputBase-input MuiInput-input"
                   disabled={false}
                   id="root_b"
-                  name="nodejs"
                   onAnimationStart={[Function]}
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
+                  placeholder=""
                   required={false}
                   type="number"
                   value=""


### PR DESCRIPTION
### Reasons for making this change

Several string widgets are missing from the material theme, specifically color, date, date time, email and URI. Without these widgets using the various formats for fields with type 'string' will fall back to the bootstrap theme. This PR adds support for all of those widgets in material UI with the same reuse pattern as in the bootstrap theme (pass back the `TextWidget` with a more specific type, see https://github.com/rjsf-team/react-jsonschema-form/blob/master/packages/core/src/components/widgets/ColorWidget.js for an example).

_Note that I needed to add 'type' to the `WidgetProps` to support this. The bootstrap widgets do not have their props typed so I believe this is why that wasn't an issue before._

Here is an example schema that you can use in the playground to see what happens when you use the material theme.

```json
{
  "title": "String Widgets",
  "description": "String Widgets",
  "type": "object",
  "properties": {
    "date": {
      "type": "string",
      "title": "Date Widget",
      "format": "date"
    },
    "dateTime": {
      "type": "string",
      "title": "Date Time Widget",
      "format": "date-time"
    },
    "email": {
      "type": "string",
      "title": "Email Widget",
      "format": "email"
    },
    "uri": {
      "type": "string",
      "title": "URI Widget",
      "format": "uri"
    },
    "color": {
      "type": "string",
      "title": "Color Widget",
      "format": "color"
    }
  }
}

```

There is a similar PR just for the date widget in #1765 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
