### PR TITLE
Add note about `action` prop being just for markup

### DIFF
--- a/docs/api-reference/form-props.md
+++ b/docs/api-reference/form-props.md
@@ -6,7 +6,9 @@ The value of this prop will be passed to the `accept-charset` [HTML attribute on
 
 ## action
 
-The value of this prop will be passed to the `action` [HTML attribute on the form](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-action).
+The value of this prop will be passed to the `action` [HTML attribute on the form](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-action). 
+
+N.B.: This just renders the `action` attribute in the HTML markup, there is no real network request being sent on submit. Instead react-jsonschema-form catches the submit event with `event.preventDefault()`and then calls the [`onSubmit`](#onSubmit) function where you could send a request programmatically with `fetch` or similar.
 
 ## additionalMetaSchemas
 


### PR DESCRIPTION
This really puzzled me for some time, until I read the source code. I would have expected that submit happens *unless* I do a `event.preventDefault()`. But turned out that this is done be RJSF already and it is the other way around: By default no network request unless I submit. Which is fine, just I wished I knew :)

### Reasons for making this change

[Please describe them here]

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
