### PR TITLE
fix: label background with variant outlined

### DIFF
--- a/packages/material-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/material-ui/src/SelectWidget/SelectWidget.tsx
@@ -84,6 +84,7 @@ const SelectWidget = ({
       <Select
         multiple={typeof multiple === 'undefined' ? false : multiple}
         value={typeof value === 'undefined' ? emptyValue : value}
+        label={label || schema.title}
         required={required}
         disabled={disabled || readonly}
         autoFocus={autofocus}


### PR DESCRIPTION
### Reasons for making this change

The label does not have the white background when using variant outlined TextFields.
This image shows the changes

![image](https://user-images.githubusercontent.com/389775/83963238-a44c9d80-a861-11ea-85de-a2fa939058fb.png)


