### PR TITLE
docs: fix link to ajv bug

### DIFF
--- a/docs/usage/validation.md
+++ b/docs/usage/validation.md
@@ -113,7 +113,7 @@ Each element in the `errors` list passed to `transformErrors` has the following 
 - `params`: an object with the error params returned by ajv ([see doc](https://github.com/epoberezkin/ajv/tree/6a671057ea6aae690b5967ee26a0ddf8452c6297#error-parameters) for more info).
 - `property`: a string in Javascript property accessor notation to the data path of the field with the error. For example, `.name` or `['first-name']`.
 - `stack`: full error name, for example ".name is a required property".
-- `schemaPath`: JSON pointer to the schema of the keyword that failed validation. For example, `#/fields/firstName/required`. (Note: this may sometimes be wrong due to a [https://github.com/epoberezkin/ajv/issues/512](bug in ajv)).
+- `schemaPath`: JSON pointer to the schema of the keyword that failed validation. For example, `#/fields/firstName/required`. (Note: this may sometimes be wrong due to a [bug in ajv](https://github.com/epoberezkin/ajv/issues/512)).
 
 ## Error List Display
 


### PR DESCRIPTION
### Reasons for making this change

* Usage of Markdown for link generation was used the wrong way.

If this is related to existing tickets, include links to them as well.

### Checklist

* [x] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
