### PR TITLE
Add missing props to onChange call

### DIFF
--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -282,7 +282,7 @@ export default class Form extends Component {
     }
     this.setState(
       state,
-      () => this.props.onChange && this.props.onChange(state)
+      () => this.props.onChange && this.props.onChange(this.state)
     );
   };
 

--- a/packages/core/test/Form_test.js
+++ b/packages/core/test/Form_test.js
@@ -842,7 +842,7 @@ describeRepeated("Form common", createFormComponent => {
   });
 
   describe("Change handler", () => {
-    it("should call provided change handler on form state change", () => {
+    it("should call provided change handler on form state change with schema and uiSchema", () => {
       const schema = {
         type: "object",
         properties: {
@@ -851,12 +851,17 @@ describeRepeated("Form common", createFormComponent => {
           },
         },
       };
+      const uiSchema = {
+        foo: { "ui:field": "textarea" },
+      };
+
       const formData = {
         foo: "",
       };
       const onChange = sandbox.spy();
       const { node } = createFormComponent({
         schema,
+        uiSchema,
         formData,
         onChange,
       });
@@ -869,6 +874,8 @@ describeRepeated("Form common", createFormComponent => {
         formData: {
           foo: "new",
         },
+        schema,
+        uiSchema,
       });
     });
   });
@@ -1326,7 +1333,7 @@ describeRepeated("Form common", createFormComponent => {
             target: { value: "short" },
           });
           sinon.assert.calledWithMatch(onChange.lastCall, {
-            errorSchema: undefined,
+            errorSchema: {},
           });
         });
 
@@ -1427,7 +1434,7 @@ describeRepeated("Form common", createFormComponent => {
           });
 
           sinon.assert.calledWithMatch(onChange.lastCall, {
-            errorSchema: undefined,
+            errorSchema: {},
           });
         });
       });


### PR DESCRIPTION
### Reasons for making this change

Resolves https://github.com/rjsf-team/react-jsonschema-form/issues/1750


### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
