### PR TITLE
Fix broken themes link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -74,7 +74,7 @@ render((
 
 ## Theming
 
-For more information on what themes we support, see [Using Themes](/usage/themes.md).
+For more information on what themes we support, see [Using Themes](usage/themes).
 
 
 <!--


### PR DESCRIPTION
### Reasons for making this change

The link for *Using Themes* is invalid on the docs site https://react-jsonschema-form.readthedocs.io/en/latest/ 

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
