### PR TITLE
Material UI: Fix anyOf up/down behavior

### DIFF
--- a/packages/material-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/material-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -76,7 +76,7 @@ const DefaultArrayItem = (props: any) => {
     fontWeight: 'bold',
   };
   return (
-    <Grid container={true} key={props.index} alignItems="center">
+    <Grid container={true} key={props.key} alignItems="center">
       <Grid item={true} xs>
         <Box mb={2}>
           <Paper elevation={2}>

--- a/packages/material-ui/src/TextWidget/TextWidget.tsx
+++ b/packages/material-ui/src/TextWidget/TextWidget.tsx
@@ -23,6 +23,8 @@ const TextWidget = ({
   autofocus,
   options,
   schema,
+  formContext,
+  rawErrors,
   ...textFieldProps
 }: TextWidgetProps) => {
   const _onChange = ({

--- a/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
@@ -231,7 +231,6 @@ exports[`array fields fixed array 1`] = `
                       >
                         <div
                           className="MuiFormControl-root MuiTextField-root"
-                          formContext={Object {}}
                           registry={
                             Object {
                               "ArrayFieldTemplate": [Function],
@@ -339,7 +338,6 @@ exports[`array fields fixed array 1`] = `
                       >
                         <div
                           className="MuiFormControl-root MuiTextField-root"
-                          formContext={Object {}}
                           registry={
                             Object {
                               "ArrayFieldTemplate": [Function],

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -14,7 +14,6 @@ exports[`single fields format color 1`] = `
     >
       <div
         className="MuiFormControl-root MuiTextField-root"
-        formContext={Object {}}
         registry={
           Object {
             "ArrayFieldTemplate": [Function],
@@ -134,7 +133,6 @@ exports[`single fields format date 1`] = `
     >
       <div
         className="MuiFormControl-root MuiTextField-root"
-        formContext={Object {}}
         registry={
           Object {
             "ArrayFieldTemplate": [Function],
@@ -251,7 +249,6 @@ exports[`single fields format datetime 1`] = `
     >
       <div
         className="MuiFormControl-root MuiTextField-root"
-        formContext={Object {}}
         registry={
           Object {
             "ArrayFieldTemplate": [Function],
@@ -413,7 +410,6 @@ exports[`single fields number field 0 1`] = `
     >
       <div
         className="MuiFormControl-root MuiTextField-root"
-        formContext={Object {}}
         registry={
           Object {
             "ArrayFieldTemplate": [Function],
@@ -532,7 +528,6 @@ exports[`single fields number field 1`] = `
     >
       <div
         className="MuiFormControl-root MuiTextField-root"
-        formContext={Object {}}
         registry={
           Object {
             "ArrayFieldTemplate": [Function],
@@ -703,7 +698,6 @@ exports[`single fields string field format email 1`] = `
     >
       <div
         className="MuiFormControl-root MuiTextField-root"
-        formContext={Object {}}
         registry={
           Object {
             "ArrayFieldTemplate": [Function],
@@ -823,7 +817,6 @@ exports[`single fields string field format uri 1`] = `
     >
       <div
         className="MuiFormControl-root MuiTextField-root"
-        formContext={Object {}}
         registry={
           Object {
             "ArrayFieldTemplate": [Function],
@@ -940,7 +933,6 @@ exports[`single fields string field regular 1`] = `
     >
       <div
         className="MuiFormControl-root MuiTextField-root"
-        formContext={Object {}}
         registry={
           Object {
             "ArrayFieldTemplate": [Function],

--- a/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
@@ -28,7 +28,6 @@ exports[`object fields object 1`] = `
           >
             <div
               className="MuiFormControl-root MuiTextField-root"
-              formContext={Object {}}
               registry={
                 Object {
                   "ArrayFieldTemplate": [Function],
@@ -133,7 +132,6 @@ exports[`object fields object 1`] = `
           >
             <div
               className="MuiFormControl-root MuiTextField-root"
-              formContext={Object {}}
               registry={
                 Object {
                   "ArrayFieldTemplate": [Function],


### PR DESCRIPTION
### Reasons for making this change

When no values are entered and only the option dropdown are changed the up/down buttons do not render the changes (the keys are reordered though).

This PR fixes #1775 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
