### PR TITLE
Bootstrap: Fix warning when textarea value is null

### DIFF
--- a/packages/core/src/components/widgets/TextareaWidget.js
+++ b/packages/core/src/components/widgets/TextareaWidget.js
@@ -22,7 +22,7 @@ function TextareaWidget(props) {
     <textarea
       id={id}
       className="form-control"
-      value={typeof value === "undefined" ? "" : value}
+      value={value ? value : ""}
       placeholder={placeholder}
       required={required}
       disabled={disabled}


### PR DESCRIPTION
### Reasons for making this change

If you view the Sandbox for Nullable with Bootstrap (default) you'll see a warning about value being null. This prevents that warning (and the resulting problems of an uncontrolled component).

<img width="1146" alt="Screen Shot 2020-06-14 at 9 33 34 PM" src="https://user-images.githubusercontent.com/86314/84610944-5b609e80-ae8a-11ea-8c11-cc1f81b89eb5.png">


### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
