### PR TITLE
Update RangeWidget to display value on hover

### DIFF
--- a/packages/material-ui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/material-ui/src/RangeWidget/RangeWidget.tsx
@@ -41,6 +41,7 @@ const RangeWidget = ({
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
+        valueLabelDisplay="auto"
         {...sliderProps}
       />
     </>


### PR DESCRIPTION
### Reasons for making this change

Currently there is no visual indication of the value in the Material UI `<RangeWidget />`, adding this property and specifying 'auto' will make the value appear when hovering over the slider.

Addresses #1674

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
