### PR TITLE
Remove type from WidgetProps

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -111,7 +111,6 @@ declare module '@rjsf/core' {
         onBlur: (id: string, value: boolean | number | string | null) => void;
         onFocus: (id: string, value: boolean | number | string | null) => void;
         label: string;
-        type: string;
         multiple: boolean;
         rawErrors: string[];
     }


### PR DESCRIPTION
### Reasons for making this change


See https://github.com/MLH-Fellowship/react-jsonschema-form/pull/37#issuecomment-648918733.

It looks like `type` is never passed down to widgets (see, for example, https://github.com/rjsf-team/react-jsonschema-form/blob/626eb843b74cb14fa35f079ba26a8685ce0d1c3b/packages/core/src/components/fields/ArrayField.js#L560-L567), and it's also [not documented](https://github.com/sempostma/react-jsonschema-form/blob/995480322651928607e1ee48d850c7f1d75c4e9b/docs/advanced-customization/custom-widgets-fields.md#L122), so we should remove `type` from `WidgetProps`.