### PR TITLE
Remove authors from package.json

### DIFF
--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -92,7 +92,6 @@
     "json",
     "rjsf-antd"
   ],
-  "author": "Delyan Ruskov <d.ruskov@gmail.com>",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/mozilla-services/react-jsonschema-form/issues"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -119,7 +119,6 @@
     "type": "git",
     "url": "git+https://github.com/mozilla-services/react-jsonschema-form.git"
   },
-  "author": "Nicolas Perriault <nperriault@mozilla.com>",
   "keywords": [
     "react",
     "form",

--- a/packages/fluent-ui/package.json
+++ b/packages/fluent-ui/package.json
@@ -48,7 +48,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "author": "",
   "keywords": [
     "Fluent UI",
     "react-jsonschema-form",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -47,7 +47,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "author": "Agustin N. R. Ramirez <agustin.ramirez@cybertec.at>",
   "contributors": [
     "Lorenz Henk <lorenz.henk@cybertec.at>"
   ],

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -126,7 +126,6 @@
     "type": "git",
     "url": "git+https://github.com/mozilla-services/react-jsonschema-form.git"
   },
-  "author": "Nicolas Perriault <nperriault@mozilla.com>",
   "keywords": [
     "react",
     "form",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -100,10 +100,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "author": "Jacques Nel <jacqueswho@gmail.com>",
-  "contributors": [
-    "Jacques Nel <jacqueswho@gmail.com>"
-  ],
   "keywords": [
     "Semantic UI",
     "react-jsonschema-form",


### PR DESCRIPTION
### Reasons for making this change

For #1211.

TODO: we should add a root-level AUTHORS file and figure out how to make it automatically / periodically sync with github contributors instead.