### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "packages/antd"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "packages/core"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "packages/fluent-ui"
+    schedule:
+      interval: "daily"
+ 
+  - package-ecosystem: "npm"
+    directory: "packages/playground"
+    schedule:
+      interval: "daily"
+ 
+  - package-ecosystem: "npm"
+    directory: "packages/semantic-ui"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION

### Reasons for making this change

Gives us automatic dependency updates -- should make it easier to handle updates for all our subpackages.