### PR TITLE
Ignore dependabot PRs for Netlify deploy previews

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,8 @@
   base = ""
   publish = "packages/playground/build"
   command = "npm run bootstrap && npm run build"
+  # Ignore dependabot PRs for deploy previews
+  ignore = "git log -1 --pretty=%an | grep dependabot[bot]"
 
 [build.environment]
   SHOW_NETLIFY_BADGE = "true"


### PR DESCRIPTION
### Reasons for making this change

Otherwise, we'll run out of build minutes.

This change is based off https://www.netlify.com/blog/2020/04/27/ignore-unnecessary-builds-to-optimize-your-build-times/