### PR TITLE
Remove extraneous dependabot config, Add github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,28 +9,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-
-  - package-ecosystem: "npm"
-    directory: "packages/antd"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "npm"
-    directory: "packages/core"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "npm"
-    directory: "packages/fluent-ui"
-    schedule:
-      interval: "daily"
- 
-  - package-ecosystem: "npm"
-    directory: "packages/playground"
-    schedule:
-      interval: "daily"
- 
-  - package-ecosystem: "npm"
-    directory: "packages/semantic-ui"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
### Reasons for making this change

It turns out, we don't actually need per-package config. The root `/` config already monitors all package.json's in the `packages` directory.

![image](https://user-images.githubusercontent.com/1689183/85738691-3829c080-b6ce-11ea-9280-e250744b962e.png)


Also add github actions -- see https://help.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-github-dependabot