### PR TITLE
semantic-ui: don't replace 0 with the empty string

### DIFF
--- a/packages/semantic-ui/src/TextWidget/TextWidget.js
+++ b/packages/semantic-ui/src/TextWidget/TextWidget.js
@@ -37,7 +37,7 @@ function TextWidget({
       disabled={disabled || readonly}
       name={name}
       {...semanticProps}
-      value={value || ""}
+      value={value || value === 0 ? value : ""}
       onChange={_onChange}
       onBlur={_onBlur}
       onFocus={_onFocus}

--- a/packages/semantic-ui/src/UpDownWidget/UpDownWidget.js
+++ b/packages/semantic-ui/src/UpDownWidget/UpDownWidget.js
@@ -38,7 +38,7 @@ function UpDownWidget({
         disabled={disabled || readonly}
         name={name}
         {...semanticProps}
-        value={value || ""}
+        value={value || value === 0 ? value : ""}
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}


### PR DESCRIPTION
### Reasons for making this change

In the semantic-ui theme, passing `0` in `formData` causes it to be replaced with `""` on rendering of `TextWidget` and `UpDownWidget`.

This PR introduces the same fix for this as in https://github.com/rjsf-team/react-jsonschema-form/blob/978f48bb66f6a3b1abd991e4178fb50429a392b5/packages/material-ui/src/TextWidget/TextWidget.tsx#L57

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
