### PR TITLE
Fix netlify builds

### DIFF
--- a/netlify-ignore.sh
+++ b/netlify-ignore.sh
@@ -1,0 +1,1 @@
+git log -1 --pretty=%an | grep dependabot[bot]

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   publish = "packages/playground/build"
   command = "npm run build"
   # Ignore dependabot PRs for deploy previews
-  ignore = "git log -1 --pretty=%an | grep dependabot[bot]"
+  ignore = "./dependabot-ignore.sh"
 
 [build.environment]
   SHOW_NETLIFY_BADGE = "true"


### PR DESCRIPTION
### Reasons for making this change

Fix netlify builds by using a separate `.sh` file to run the dependabot ignore command.