### PR TITLE
Fix type of parameter widget in getWidget and hasWidget functions

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -285,13 +285,13 @@ declare module '@rjsf/core' {
 
         export function getWidget(
             schema: JSONSchema7,
-            widget: Widget,
+            widget: Widget | string,
             registeredWidgets?: { [name: string]: Widget },
-        ): Widget | Error;
+        ): Widget;
 
         export function hasWidget(
             schema: JSONSchema7,
-            widget: Widget,
+            widget: Widget | string,
             registeredWidgets?: { [name: string]: Widget },
         ): boolean;
 


### PR DESCRIPTION
### Reasons for making this change

These two functions receive `widget` that can be `Widget | string`, but in typings, this is not expressed.

More details can be found here where I add the same changes in V1: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46374

If this is related to existing tickets, include links to them as well.

### Extra information

I committed the changes made when I ran `npm install` for each package, but if there is any problem you can just comment in the PR and I can remove the commits

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
