### PR TITLE
Add support for additionalProperties for material-ui theme

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -164,6 +164,8 @@ declare module '@rjsf/core' {
         uiSchema: UiSchema;
         formContext: any;
         registry: FieldProps['registry'];
+        onDropPropertyClick: (key: string) => (event?: any) => void;
+        onKeyChange: (val?: any) => void;
     };
 
     export type ArrayFieldTemplateProps<T = any> = {
@@ -204,12 +206,15 @@ declare module '@rjsf/core' {
         TitleField: React.StatelessComponent<{ id: string; title: string; required: boolean }>;
         title: string;
         description: string;
+        disabled: boolean;
         properties: {
             content: React.ReactElement;
             name: string;
             disabled: boolean;
             readonly: boolean;
         }[];
+        onAddClick: (schema: JSONSchema7) => () => void;
+        readonly: boolean;
         required: boolean;
         schema: JSONSchema7;
         uiSchema: UiSchema;

--- a/packages/material-ui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/material-ui/src/FieldTemplate/FieldTemplate.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { FieldTemplateProps } from "@rjsf/core";
+import WrapIfAdditional from './WrapIfAdditional';
 
 import FormControl from "@material-ui/core/FormControl";
 import FormHelperText from "@material-ui/core/FormHelperText";
@@ -8,39 +9,34 @@ import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
 import Typography from "@material-ui/core/Typography";
 
-const FieldTemplate = ({
-  id,
-  children,
-  displayLabel,
-  required,
-  rawErrors = [],
-  rawHelp,
-  rawDescription,
-}: FieldTemplateProps) => {
+const FieldTemplate = (props: FieldTemplateProps) => {
+  var { id, rawHelp, rawErrors = [], required, children, displayLabel, rawDescription } = props;
   return (
-    <FormControl
-      fullWidth={true}
-      error={rawErrors.length ? true : false}
-      required={required}>
-      {children}
-      {displayLabel && rawDescription ? (
-        <Typography variant="caption" color="textSecondary">
-          {rawDescription}
-        </Typography>
-      ) : null}
-      {rawErrors.length > 0 && (
-        <List dense={true} disablePadding={true}>
-          {rawErrors.map((error, i: number) => {
-            return (
-              <ListItem key={i} disableGutters={true}>
-                <FormHelperText id={id}>{error}</FormHelperText>
-              </ListItem>
-            );
-          })}
-        </List>
-      )}
-      {rawHelp && <FormHelperText id={id}>{rawHelp}</FormHelperText>}
-    </FormControl>
+    <WrapIfAdditional {...props}>
+      <FormControl
+        fullWidth={true}
+        error={rawErrors.length ? true : false}
+        required={required}>
+        {children}
+        {displayLabel && rawDescription ? (
+          <Typography variant="caption" color="textSecondary">
+            {rawDescription}
+          </Typography>
+        ) : null}
+        {rawErrors.length > 0 && (
+          <List dense={true} disablePadding={true}>
+            {rawErrors.map((error, i: number) => {
+              return (
+                <ListItem key={i} disableGutters={true}>
+                  <FormHelperText id={id}>{error}</FormHelperText>
+                </ListItem>
+              );
+            })}
+          </List>
+        )}
+        {rawHelp && <FormHelperText id={id}>{rawHelp}</FormHelperText>}
+      </FormControl>
+    </WrapIfAdditional>
   );
 };
 

--- a/packages/material-ui/src/FieldTemplate/WrapIfAdditional.tsx
+++ b/packages/material-ui/src/FieldTemplate/WrapIfAdditional.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import Grid from '@material-ui/core/Grid';
+import TextField from '@material-ui/core/TextField';
+import Button from '@material-ui/core/Button';
+import RemoveIcon from '@material-ui/icons/Remove';
+
+import { utils } from '@rjsf/core';
+const { ADDITIONAL_PROPERTY_FLAG } = utils;
+
+import { FieldTemplateProps } from '@rjsf/core';
+
+const WrapIfAdditional = ({
+	children,
+	classNames,
+	disabled,
+	id,
+	label,
+	onDropPropertyClick,
+	onKeyChange,
+	readonly,
+	required,
+	schema
+}: FieldTemplateProps) => {
+	const keyLabel = `${label} Key`; // i18n ?
+	const additional = schema.hasOwnProperty(ADDITIONAL_PROPERTY_FLAG);
+
+	if (!additional) {
+		return <>{children}</>;
+	}
+
+	const handleBlur = (e: React.FocusEvent<HTMLTextAreaElement>) => onKeyChange(e.currentTarget.value);
+
+	return (
+		<div className={classNames}>
+			<Grid container spacing={2}>
+				<Grid item xs>
+					<TextField
+						id={`${id}-key`}
+						name={`${id}-key`}
+						disabled={disabled || readonly}
+						label={keyLabel}
+						required={required}
+						defaultValue={label}
+						inputProps={{ onBlur: handleBlur }}
+					/>
+				</Grid>
+				<Grid item xs={6}>
+					{children}
+				</Grid>
+				<Grid item xs>
+					<Button
+						variant="outlined"
+						color="secondary"
+						disabled={disabled || readonly}
+						onClick={onDropPropertyClick(label)}
+					>
+						<RemoveIcon />
+					</Button>
+				</Grid>
+			</Grid>
+		</div>
+	);
+};
+
+export default WrapIfAdditional;

--- a/packages/material-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/material-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -1,15 +1,48 @@
 import React from 'react';
 
 import Grid from '@material-ui/core/Grid';
-import { makeStyles } from '@material-ui/styles';
+import Button from '@material-ui/core/Button';
+import AddIcon from '@material-ui/icons/Add';
 
-import { ObjectFieldTemplateProps } from '@rjsf/core';
+import { makeStyles } from '@material-ui/styles';
+import { UiSchema, ObjectFieldTemplateProps, utils } from '@rjsf/core';
+import { JSONSchema7 } from 'json-schema';
+
+const { getUiOptions } = utils;
+
+type AddButtonProps = {
+  onClick: (e?: any) => void,
+  disabled: boolean
+};
+
+const AddButton = (props: AddButtonProps) => (
+  <Button {...props} color="secondary">
+    <AddIcon /> Add Item
+  </Button>
+);
 
 const useStyles = makeStyles({
   root: {
     marginTop: 10,
   },
 });
+
+const canExpand = function canExpand(formData: object, schema: JSONSchema7, uiSchema: UiSchema) {
+  if (!schema.additionalProperties) {
+    return false;
+  }
+  const uiOptions = getUiOptions(uiSchema) || {};
+  const expandable = uiOptions['expandable'];
+  if (expandable === false) {
+    return expandable;
+  }
+  // if ui:options.expandable was not explicitly set to false, we can add
+  // another property if we have not exceeded maxProperties yet
+  if (schema.maxProperties !== undefined) {
+    return Object.keys(formData).length < schema.maxProperties;
+  }
+  return true;
+};
 
 const ObjectFieldTemplate = ({
   DescriptionField,
@@ -20,6 +53,11 @@ const ObjectFieldTemplate = ({
   required,
   uiSchema,
   idSchema,
+  formData,
+  disabled,
+  readonly,
+  onAddClick,
+  schema
 }: ObjectFieldTemplateProps) => {
   const classes = useStyles();
 
@@ -50,6 +88,16 @@ const ObjectFieldTemplate = ({
           </Grid>
         ))}
       </Grid>
+      {canExpand(formData, schema, uiSchema) && (
+        <Grid container justify="flex-end">
+          <Grid item={true}>
+            <AddButton
+              onClick={onAddClick(schema)}
+              disabled={disabled || readonly}
+            />
+          </Grid>
+        </Grid>
+      )}
     </>
   );
 };

--- a/packages/material-ui/test/Object.test.tsx
+++ b/packages/material-ui/test/Object.test.tsx
@@ -17,4 +17,15 @@ describe("object fields", () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  test("additionalProperties", () => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      additionalProperties: true
+    };
+    const tree = renderer
+      .create(<Form schema={schema} formData={{foo: 'foo'}} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
@@ -1,5 +1,279 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`object fields additionalProperties 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="MuiFormControl-root MuiFormControl-fullWidth"
+  >
+    <div
+      className="MuiGrid-root makeStyles-root-5 MuiGrid-container MuiGrid-spacing-xs-2"
+    >
+      <div
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+        style={
+          Object {
+            "marginBottom": "10px",
+          }
+        }
+      >
+        <div
+          className="form-group field field-string"
+        >
+          <div
+            className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+            >
+              <div
+                className="MuiFormControl-root MuiTextField-root"
+              >
+                <label
+                  className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+                  data-shrink={false}
+                  htmlFor="root_foo-key"
+                  id="root_foo-key-label"
+                >
+                  foo Key
+                </label>
+                <div
+                  className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                  onClick={[Function]}
+                >
+                  <input
+                    aria-invalid={false}
+                    className="MuiInputBase-input MuiInput-input"
+                    defaultValue="foo"
+                    disabled={false}
+                    id="root_foo-key"
+                    name="root_foo-key"
+                    onAnimationStart={[Function]}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    required={false}
+                    type="text"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6"
+            >
+              <div
+                className="MuiFormControl-root MuiFormControl-fullWidth"
+              >
+                <div
+                  className="MuiFormControl-root MuiTextField-root"
+                  registry={
+                    Object {
+                      "ArrayFieldTemplate": [Function],
+                      "FieldTemplate": [Function],
+                      "ObjectFieldTemplate": [Function],
+                      "definitions": Object {},
+                      "fields": Object {
+                        "AnyOfField": [Function],
+                        "ArrayField": [Function],
+                        "BooleanField": [Function],
+                        "DescriptionField": [Function],
+                        "NullField": [Function],
+                        "NumberField": [Function],
+                        "ObjectField": [Function],
+                        "OneOfField": [Function],
+                        "SchemaField": [Function],
+                        "StringField": [Function],
+                        "TitleField": [Function],
+                        "UnsupportedField": [Function],
+                      },
+                      "formContext": Object {},
+                      "rootSchema": Object {
+                        "additionalProperties": true,
+                        "type": "object",
+                      },
+                      "widgets": Object {
+                        "AltDateTimeWidget": [Function],
+                        "AltDateWidget": [Function],
+                        "BaseInput": [Function],
+                        "CheckboxWidget": [Function],
+                        "CheckboxesWidget": [Function],
+                        "ColorWidget": [Function],
+                        "DateTimeWidget": [Function],
+                        "DateWidget": [Function],
+                        "EmailWidget": [Function],
+                        "FileWidget": [Function],
+                        "HiddenWidget": [Function],
+                        "PasswordWidget": [Function],
+                        "RadioWidget": [Function],
+                        "RangeWidget": [Function],
+                        "SelectWidget": [Function],
+                        "TextWidget": [Function],
+                        "TextareaWidget": [Function],
+                        "URLWidget": [Function],
+                        "UpDownWidget": [Function],
+                      },
+                    }
+                  }
+                >
+                  <label
+                    className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+                    data-shrink={false}
+                    htmlFor="root_foo"
+                    id="root_foo-label"
+                  >
+                    foo
+                  </label>
+                  <div
+                    className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                    onClick={[Function]}
+                  >
+                    <input
+                      aria-invalid={false}
+                      autoFocus={false}
+                      className="MuiInputBase-input MuiInput-input"
+                      disabled={false}
+                      id="root_foo"
+                      onAnimationStart={[Function]}
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      placeholder=""
+                      required={false}
+                      type="string"
+                      value="foo"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+            >
+              <button
+                className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedSecondary"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                tabIndex={0}
+                type="button"
+              >
+                <span
+                  className="MuiButton-label"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="MuiSvgIcon-root"
+                    focusable="false"
+                    role="presentation"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13H5v-2h14v2z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  className="MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="MuiGrid-root MuiGrid-container MuiGrid-justify-xs-flex-end"
+    >
+      <div
+        className="MuiGrid-root MuiGrid-item"
+      >
+        <button
+          className="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textSecondary"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          <span
+            className="MuiButton-label"
+          >
+            <svg
+              aria-hidden="true"
+              className="MuiSvgIcon-root"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+              />
+            </svg>
+             Add Item
+          </span>
+          <span
+            className="MuiTouchRipple-root"
+          />
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    className="MuiBox-root MuiBox-root-203"
+  >
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+      disabled={false}
+      onBlur={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="submit"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        Submit
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</form>
+`;
+
 exports[`object fields object 1`] = `
 <form
   className="rjsf"


### PR DESCRIPTION
### Reasons for making this change

Adding support for `additionalProperties` for the material-ui theme, partially solves #1927

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X ] **I'm adding or updating code**
  - [X ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
