### PR TITLE
Pass `name` to FieldTemplate

### DIFF
--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -332,6 +332,7 @@ function SchemaFieldRender(props) {
     classNames,
     formContext,
     fields,
+    name,
     schema,
     uiSchema,
     registry,


### PR DESCRIPTION
### Reasons for making this change

Add otherwise unavailable `name` prop from SchemaField to FieldTemplate.

This helps customizations based on the name when creating a custom FieldTemplate.

Somehow related to https://github.com/rjsf-team/react-jsonschema-form/issues/1824 and the part
> Unfortunately, using a ObjectFieldTemplate it is not easy to override the id using the idPrefix and property name because both are not passed to the ObjectFieldTemplate. So no easy workaround afais, instead needs a fix here. FWIW, btw I think it would be great if ObjectField would also pass its name to ObjectFieldTemplate.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
