### PR TITLE
Fix the `module` path for bootstrap-4, fluent-ui, material-ui

### DIFF
--- a/packages/bootstrap-4/package.json
+++ b/packages/bootstrap-4/package.json
@@ -2,7 +2,7 @@
   "name": "@rjsf/bootstrap-4",
   "version": "2.3.0",
   "main": "dist/index.js",
-  "module": "dist/rjsf-bootstrap-4.esm.js",
+  "module": "dist/bootstrap-4.esm.js",
   "typings": "dist/index.d.ts",
   "description": "Bootstrap 4 theme, fields and widgets for react-jsonschema-form",
   "files": [

--- a/packages/fluent-ui/package.json
+++ b/packages/fluent-ui/package.json
@@ -2,7 +2,7 @@
   "name": "@rjsf/fluent-ui",
   "version": "2.3.0",
   "main": "dist/index.js",
-  "module": "dist/rjsf-fluent-ui.esm.js",
+  "module": "dist/fluent-ui.esm.js",
   "typings": "dist/index.d.ts",
   "description": "Fluent UI theme, fields and widgets for react-jsonschema-form",
   "files": [

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -2,7 +2,7 @@
   "name": "@rjsf/material-ui",
   "version": "2.3.0",
   "main": "dist/index.js",
-  "module": "dist/rjsf-material-ui.esm.js",
+  "module": "dist/material-ui.esm.js",
   "typings": "dist/index.d.ts",
   "description": "Material UI theme, fields and widgets for react-jsonschema-form",
   "files": [


### PR DESCRIPTION

### Reasons for making this change

The `module` path in the `@rjsf/bootstrap-4` package.json is incorrect

If this is related to existing tickets, include links to them as well.

### Checklist

* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
