### PR TITLE
fix: distinguish between 0 and undefined in getMatchingOption

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -423,7 +423,7 @@ declare module '@rjsf/core' {
             formData: any,
             options: JSONSchema7[],
             definitions: FieldProps['registry']['definitions'],
-        ): number;
+        ): number | undefined;
 
         export function schemaRequiresTrueValue(schema: JSONSchema7): boolean;
     }

--- a/packages/core/src/components/fields/MultiSchemaField.js
+++ b/packages/core/src/components/fields/MultiSchemaField.js
@@ -46,7 +46,7 @@ class AnyOfField extends Component {
     const { rootSchema } = this.props.registry;
 
     let option = getMatchingOption(formData, options, rootSchema);
-    if (option != undefined) {
+    if (option !== undefined) {
       return option;
     }
     // If the form data matches none of the options, use the currently selected

--- a/packages/core/src/components/fields/MultiSchemaField.js
+++ b/packages/core/src/components/fields/MultiSchemaField.js
@@ -46,7 +46,7 @@ class AnyOfField extends Component {
     const { rootSchema } = this.props.registry;
 
     let option = getMatchingOption(formData, options, rootSchema);
-    if (option !== 0) {
+    if (option != undefined) {
       return option;
     }
     // If the form data matches none of the options, use the currently selected

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -218,10 +218,10 @@ function computeDefaults(
     );
   } else if ("oneOf" in schema) {
     schema =
-      schema.oneOf[getMatchingOption(undefined, schema.oneOf, rootSchema)];
+      schema.oneOf[getMatchingOption(undefined, schema.oneOf, rootSchema) || 0];
   } else if ("anyOf" in schema) {
     schema =
-      schema.anyOf[getMatchingOption(undefined, schema.anyOf, rootSchema)];
+      schema.anyOf[getMatchingOption(undefined, schema.anyOf, rootSchema) || 0];
   }
 
   // Not defaults defined for this node, fallback to generic typed ones.
@@ -722,12 +722,12 @@ function resolveDependencies(schema, rootSchema, formData) {
   if ("oneOf" in resolvedSchema) {
     resolvedSchema =
       resolvedSchema.oneOf[
-        getMatchingOption(formData, resolvedSchema.oneOf, rootSchema)
+        getMatchingOption(formData, resolvedSchema.oneOf, rootSchema) || 0
       ];
   } else if ("anyOf" in resolvedSchema) {
     resolvedSchema =
       resolvedSchema.anyOf[
-        getMatchingOption(formData, resolvedSchema.anyOf, rootSchema)
+        getMatchingOption(formData, resolvedSchema.anyOf, rootSchema) || 0
       ];
   }
   return processDependencies(
@@ -1226,7 +1226,8 @@ export function getMatchingOption(formData, options, rootSchema) {
       return i;
     }
   }
-  return 0;
+
+  return undefined;
 }
 
 // Check to see if a schema specifies that a value must be true

--- a/packages/core/test/anyOf_test.js
+++ b/packages/core/test/anyOf_test.js
@@ -186,6 +186,13 @@ describe("anyOf", () => {
 
     expect(node.querySelectorAll("#root_foo")).to.have.length.of(0);
     expect(node.querySelectorAll("#root_bar")).to.have.length.of(1);
+
+    Simulate.change($select, {
+      target: { value: $select.options[0].value },
+    });
+
+    expect(node.querySelectorAll("#root_foo")).to.have.length.of(1);
+    expect(node.querySelectorAll("#root_bar")).to.have.length.of(0);
   });
 
   it("should handle change events", () => {

--- a/packages/core/test/oneOf_test.js
+++ b/packages/core/test/oneOf_test.js
@@ -187,6 +187,13 @@ describe("oneOf", () => {
 
     expect(node.querySelectorAll("#root_foo")).to.have.length.of(0);
     expect(node.querySelectorAll("#root_bar")).to.have.length.of(1);
+
+    Simulate.change($select, {
+      target: { value: $select.options[0].value },
+    });
+
+    expect(node.querySelectorAll("#root_foo")).to.have.length.of(1);
+    expect(node.querySelectorAll("#root_bar")).to.have.length.of(0);
   });
 
   it("should handle change events", () => {


### PR DESCRIPTION
### Reasons for making this change

Updating the data for a form with oneOf or anyOf didn't correctly update the form UI if the new data complies with the first option.

The reason for this was that `getMatchingOption`, the function that determines what option the data adheres to didn't differentiate between 0 (the first option should be selected) and undefined (the data doesn't match any of the options), for which the most common fallback is 0 (selecting the first option).
MultiSchemaField needs to do something else based on this difference, so `getMatchingOption` now returns `undefined` when data doesn't match any of the options and all places where the function is called handle this new return value.

Minimal steps to reproduce:

1. View the One Of example in the playground
1. Fill in some text in the form
1. Copy the formData
1. Make the form select the second option, either using the select input or by changing the formData to comply with the second option
1. Reset the formData using the copied data
1. Observe the second option is still selected and its form is still shown

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
