### PR TITLE
fix description display in antd theme

### DIFF
--- a/packages/antd/src/templates/FieldTemplate/index.js
+++ b/packages/antd/src/templates/FieldTemplate/index.js
@@ -64,7 +64,7 @@ const FieldTemplate = ({
       ) : (
         <Form.Item
           colon={colon}
-          // extra={!!rawDescription && description}
+          extra={!!rawDescription && rawDescription}
           hasFeedback={schema.type !== 'array' && schema.type !== 'object'}
           help={(!!rawHelp && help) || (!!rawErrors && renderFieldErrors())}
           htmlFor={id}


### PR DESCRIPTION
### Reasons for making this change

Right now the description would not display when using antd theme

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [*] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
