### PR TITLE
🚑 Remove 'name' attribute from SelectWidget (Bootstrap-4)

### DIFF
--- a/packages/bootstrap-4/src/SelectWidget/SelectWidget.tsx
+++ b/packages/bootstrap-4/src/SelectWidget/SelectWidget.tsx
@@ -84,7 +84,6 @@ const SelectWidget = ({
         as="select"
         custom
         id={id}
-        name={name}
         value={typeof value === "undefined" ? emptyValue : value}
         required={required}
         multiple={multiple}

--- a/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
@@ -113,7 +113,6 @@ exports[`array fields checkboxes 1`] = `
         disabled={false}
         id="root"
         multiple={true}
-        name="nodejs"
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}

--- a/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
@@ -588,7 +588,6 @@ exports[`single fields select field 1`] = `
         className="custom-select"
         disabled={false}
         id="root"
-        name="nodejs"
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}


### PR DESCRIPTION
### Reasons for making this change

Removes `name` attribute from SelectWidget (Bootstrap-4). This change conforms to the SelectWidget in `core` package.

Fixes issue #2011 

### Checklist

* [ ] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
