### PR TITLE
AJV  option turned on for referencing data in schema

### DIFF
--- a/packages/core/src/validate.js
+++ b/packages/core/src/validate.js
@@ -15,6 +15,7 @@ function createAjvInstance() {
     multipleOfPrecision: 8,
     schemaId: "auto",
     unknownFormats: "ignore",
+    $data: true,
   });
 
   // add custom formats


### PR DESCRIPTION
This option will enable to reference data from form to use it in schema. Switch this option to true should not affect anything else.

[Please describe them here]

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
