### PR TITLE
fix: avoid mixing CJS require in ESM modules

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -4,7 +4,7 @@ import mergeAllOf from "json-schema-merge-allof";
 import fill from "core-js/library/fn/array/fill";
 import union from "lodash/union";
 import jsonpointer from "jsonpointer";
-import fields from "./components/fields"
+import fields from "./components/fields";
 import widgets from "./components/widgets";
 import validateFormData, { isValid } from "./validate";
 

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -2,9 +2,11 @@ import React from "react";
 import * as ReactIs from "react-is";
 import mergeAllOf from "json-schema-merge-allof";
 import fill from "core-js/library/fn/array/fill";
-import validateFormData, { isValid } from "./validate";
 import union from "lodash/union";
 import jsonpointer from "jsonpointer";
+import fields from "./components/fields"
+import widgets from "./components/widgets";
+import validateFormData, { isValid } from "./validate";
 
 export const ADDITIONAL_PROPERTY_FLAG = "__additional_property";
 
@@ -78,8 +80,8 @@ export function canExpand(schema, uiSchema, formData) {
 
 export function getDefaultRegistry() {
   return {
-    fields: require("./components/fields").default,
-    widgets: require("./components/widgets").default,
+    fields,
+    widgets,
     definitions: {},
     rootSchema: {},
     formContext: {},


### PR DESCRIPTION
### Reasons for making this change

Fixes https://github.com/rjsf-team/react-jsonschema-form/issues/1893
Mixing CommonJS `require` in ESM modules is incorrect. It works in webpack, however a lot of other bundlers do not support that.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
