### PR TITLE
Fixes two example issues within the documentation

### DIFF
--- a/docs/usage/arrays.md
+++ b/docs/usage/arrays.md
@@ -105,7 +105,7 @@ const uiSchema = {
 };
 
 render((
-  <Form schema={schema} uiSchema={schema} />
+  <Form schema={schema} uiSchema={uiSchema} />
 ), document.getElementById("app"));
 ```
 
@@ -151,7 +151,7 @@ const uiSchema = {
 };
 
 render((
-  <Form schema={schema} uiSchema={schema} />
+  <Form schema={schema} uiSchema={uiSchema} />
 ), document.getElementById("app"));
 ```
 


### PR DESCRIPTION
### Reasons for making this change

Fixes two issues found within the `arrays.md` documentation:
- `orderable` was not honoring `uiSchema` in the example
- `removable` was not honoring `uiSchema` in the example

If this is related to existing tickets, include links to them as well.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
