### PR TITLE
Fixes Material-UI inline checkboxes

### DIFF
--- a/packages/material-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/material-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -60,7 +60,7 @@ const CheckboxesWidget = ({
       <FormLabel required={required} htmlFor={id}>
         {label || schema.title}
       </FormLabel>
-      <FormGroup>
+      <FormGroup row={!!inline}>
         {(enumOptions as any).map((option: any, index: number) => {
           const checked = value.indexOf(option.value) !== -1;
           const itemDisabled =
@@ -76,13 +76,7 @@ const CheckboxesWidget = ({
               onFocus={_onFocus}
             />
           );
-          return inline ? (
-            <FormControlLabel
-              control={checkbox}
-              key={index}
-              label={option.label}
-            />
-          ) : (
+          return (
             <FormControlLabel
               control={checkbox}
               key={index}


### PR DESCRIPTION
### Reasons for making this change

Fixes an issue when setting the UI to display checkboxes inline does not honor the configuration. This fix only applies to the material-ui package.

![Selection_001](https://user-images.githubusercontent.com/6046654/92475826-02b05180-f1ac-11ea-9662-0fff21e6b1ad.png)


Fixes #2021 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
