### PR TITLE
Semantic UI SelectWidget Should Support Labels

### DIFF
--- a/packages/semantic-ui/src/SelectWidget/SelectWidget.js
+++ b/packages/semantic-ui/src/SelectWidget/SelectWidget.js
@@ -64,6 +64,7 @@ function SelectWidget({
   id,
   options,
   name,
+  label,
   required,
   disabled,
   readonly,
@@ -98,6 +99,7 @@ function SelectWidget({
     <Form.Dropdown
       key={id}
       name={name}
+      label={label}
       multiple={typeof multiple === "undefined" ? false : multiple}
       value={typeof value === "undefined" ? emptyValue : value}
       disabled={disabled}

--- a/packages/semantic-ui/src/SelectWidget/SelectWidget.js
+++ b/packages/semantic-ui/src/SelectWidget/SelectWidget.js
@@ -99,7 +99,7 @@ function SelectWidget({
     <Form.Dropdown
       key={id}
       name={name}
-      label={label}
+      label={label || schema.title}
       multiple={typeof multiple === "undefined" ? false : multiple}
       value={typeof value === "undefined" ? emptyValue : value}
       disabled={disabled}


### PR DESCRIPTION
### Reasons for making this change

The semantic ui select widget does not allow for labels on the dropdown. Without it, there is no way to tell which field is being edited. Other UI components already do this.

See example [here](https://rjsf-team.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6eyJxdWVzdGlvblBvb2xpbmciOnt9LCJhY3Rpdml0eVR5cGUiOiJjb2tlIn0sInNjaGVtYSI6eyIkc2NoZW1hIjoiaHR0cDovL2pzb24tc2NoZW1hLm9yZy9kcmFmdC0wNy9zY2hlbWEiLCIkaWQiOiJodHRwOi8vZXhhbXBsZS5jb20vZXhhbXBsZS5qc29uIiwidHlwZSI6Im9iamVjdCIsInRpdGxlIjoiVGVzdCIsInJlcXVpcmVkIjpbImRyb3Bkb3duIl0sImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjpmYWxzZSwicHJvcGVydGllcyI6eyJzb2RhIjp7IiRpZCI6IiMvcHJvcGVydGllcy9zb2RhIiwidHlwZSI6InN0cmluZyIsInRpdGxlIjoiU29kYSBUeXBlIiwiZW51bSI6WyJjb2tlIiwicGVwc2kiXX19fSwidWlTY2hlbWEiOnsiZmlyc3ROYW1lIjp7InVpOmF1dG9mb2N1cyI6dHJ1ZSwidWk6ZW1wdHlWYWx1ZSI6IiIsInVpOmF1dG9jb21wbGV0ZSI6ImZhbWlseS1uYW1lIn0sImxhc3ROYW1lIjp7InVpOmVtcHR5VmFsdWUiOiIiLCJ1aTphdXRvY29tcGxldGUiOiJnaXZlbi1uYW1lIn0sImFnZSI6eyJ1aTp3aWRnZXQiOiJ1cGRvd24iLCJ1aTp0aXRsZSI6IkFnZSBvZiBwZXJzb24iLCJ1aTpkZXNjcmlwdGlvbiI6IihlYXJ0aGlhbiB5ZWFyKSJ9LCJiaW8iOnsidWk6d2lkZ2V0IjoidGV4dGFyZWEifSwicGFzc3dvcmQiOnsidWk6d2lkZ2V0IjoicGFzc3dvcmQiLCJ1aTpoZWxwIjoiSGludDogTWFrZSBpdCBzdHJvbmchIn0sImRhdGUiOnsidWk6d2lkZ2V0IjoiYWx0LWRhdGV0aW1lIn0sInRlbGVwaG9uZSI6eyJ1aTpvcHRpb25zIjp7ImlucHV0VHlwZSI6InRlbCJ9fX0sInRoZW1lIjoic2VtYW50aWMtdWkiLCJsaXZlU2V0dGluZ3MiOnsidmFsaWRhdGUiOmZhbHNlLCJkaXNhYmxlIjpmYWxzZSwib21pdEV4dHJhRGF0YSI6ZmFsc2UsImxpdmVPbWl0IjpmYWxzZX19).

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
