### PR TITLE
feat: Fix invalid "pId" attribute in AddButton (Bootstrap-4)

### DIFF
--- a/packages/bootstrap-4/src/AddButton/AddButton.tsx
+++ b/packages/bootstrap-4/src/AddButton/AddButton.tsx
@@ -2,11 +2,11 @@ import React from "react";
 
 import { AddButtonProps } from "@rjsf/core";
 import Button from "react-bootstrap/Button";
-import { AiOutlinePlus } from "react-icons/ai";
+import { BsPlus } from "react-icons/bs";
 
 const AddButton: React.FC<AddButtonProps> = props => (
   <Button {...props} color="primary" style={{width: "100%"}} className="ml-1">
-    <AiOutlinePlus/>
+    <BsPlus/>
   </Button>
 );
 

--- a/packages/bootstrap-4/src/DescriptionField/DescriptionField.tsx
+++ b/packages/bootstrap-4/src/DescriptionField/DescriptionField.tsx
@@ -7,7 +7,7 @@ export interface DescriptionFieldProps extends Partial<FieldProps> {
 
 const DescriptionField = ({ description }: Partial<FieldProps>) => {
   if (description) {
-    return <div><div className="mb-5">{description}</div></div>;
+    return <div><div className="mb-3">{description}</div></div>;
   }
 
   return null;

--- a/packages/bootstrap-4/test/__snapshots__/AddButton.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/AddButton.test.tsx.snap
@@ -16,7 +16,6 @@ exports[`AddButton simple 1`] = `
   <svg
     fill="currentColor"
     height="1em"
-    pId="10297"
     stroke="currentColor"
     strokeWidth="0"
     style={
@@ -24,20 +23,19 @@ exports[`AddButton simple 1`] = `
         "color": undefined,
       }
     }
-    t="1551322312294"
-    version="1.1"
-    viewBox="0 0 1024 1024"
+    viewBox="0 0 16 16"
     width="1em"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <defs />
     <path
-      d="M474 152m8 0l60 0q8 0 8 8l0 704q0 8-8 8l-60 0q-8 0-8-8l0-704q0-8 8-8Z"
-      pId="10298"
+      clipRule="evenodd"
+      d="M8 3.5a.5.5 0 01.5.5v4a.5.5 0 01-.5.5H4a.5.5 0 010-1h3.5V4a.5.5 0 01.5-.5z"
+      fillRule="evenodd"
     />
     <path
-      d="M168 474m8 0l672 0q8 0 8 8l0 60q0 8-8 8l-672 0q-8 0-8-8l0-60q0-8 8-8Z"
-      pId="10299"
+      clipRule="evenodd"
+      d="M7.5 8a.5.5 0 01.5-.5h4a.5.5 0 010 1H8.5V12a.5.5 0 01-1 0V8z"
+      fillRule="evenodd"
     />
   </svg>
 </button>

--- a/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
@@ -47,7 +47,6 @@ exports[`array fields array 1`] = `
                     <svg
                       fill="currentColor"
                       height="1em"
-                      pId="10297"
                       stroke="currentColor"
                       strokeWidth="0"
                       style={
@@ -55,20 +54,19 @@ exports[`array fields array 1`] = `
                           "color": undefined,
                         }
                       }
-                      t="1551322312294"
-                      version="1.1"
-                      viewBox="0 0 1024 1024"
+                      viewBox="0 0 16 16"
                       width="1em"
                       xmlns="http://www.w3.org/2000/svg"
                     >
-                      <defs />
                       <path
-                        d="M474 152m8 0l60 0q8 0 8 8l0 704q0 8-8 8l-60 0q-8 0-8-8l0-704q0-8 8-8Z"
-                        pId="10298"
+                        clipRule="evenodd"
+                        d="M8 3.5a.5.5 0 01.5.5v4a.5.5 0 01-.5.5H4a.5.5 0 010-1h3.5V4a.5.5 0 01.5-.5z"
+                        fillRule="evenodd"
                       />
                       <path
-                        d="M168 474m8 0l672 0q8 0 8 8l0 60q0 8-8 8l-672 0q-8 0-8-8l0-60q0-8 8-8Z"
-                        pId="10299"
+                        clipRule="evenodd"
+                        d="M7.5 8a.5.5 0 01.5-.5h4a.5.5 0 010 1H8.5V12a.5.5 0 01-1 0V8z"
+                        fillRule="evenodd"
                       />
                     </svg>
                   </button>

--- a/packages/bootstrap-4/test/__snapshots__/ArrayFieldTemplate.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/ArrayFieldTemplate.test.tsx.snap
@@ -39,7 +39,6 @@ exports[`ArrayFieldTemplate simple 1`] = `
                 <svg
                   fill="currentColor"
                   height="1em"
-                  pId="10297"
                   stroke="currentColor"
                   strokeWidth="0"
                   style={
@@ -47,20 +46,19 @@ exports[`ArrayFieldTemplate simple 1`] = `
                       "color": undefined,
                     }
                   }
-                  t="1551322312294"
-                  version="1.1"
-                  viewBox="0 0 1024 1024"
+                  viewBox="0 0 16 16"
                   width="1em"
                   xmlns="http://www.w3.org/2000/svg"
                 >
-                  <defs />
                   <path
-                    d="M474 152m8 0l60 0q8 0 8 8l0 704q0 8-8 8l-60 0q-8 0-8-8l0-704q0-8 8-8Z"
-                    pId="10298"
+                    clipRule="evenodd"
+                    d="M8 3.5a.5.5 0 01.5.5v4a.5.5 0 01-.5.5H4a.5.5 0 010-1h3.5V4a.5.5 0 01.5-.5z"
+                    fillRule="evenodd"
                   />
                   <path
-                    d="M168 474m8 0l672 0q8 0 8 8l0 60q0 8-8 8l-672 0q-8 0-8-8l0-60q0-8 8-8Z"
-                    pId="10299"
+                    clipRule="evenodd"
+                    d="M7.5 8a.5.5 0 01.5-.5h4a.5.5 0 010 1H8.5V12a.5.5 0 01-1 0V8z"
+                    fillRule="evenodd"
                   />
                 </svg>
               </button>

--- a/packages/bootstrap-4/test/__snapshots__/DescriptionField.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/DescriptionField.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`DescriptionField should return h2 element when description is being passed as props 1`] = `
 <div>
   <div
-    className="mb-5"
+    className="mb-3"
   >
     SOME THING
   </div>


### PR DESCRIPTION
### Reasons for making this change

Fixes #2043 

1. `<AiOutlinePlus>` contains a "pId" attribute out of the box which is deemed invalid by React and throws a warning. Since this is a problem related to the used third-party package itself ([ref](https://github.com/react-icons/react-icons/issues/276)), I superseded `react-icons/ai` with `react-icons/bs` which doesn't throw any such warnings.

2. Decreased the margin-bottom of the DescriptionField widget as it was uneven as compared to the other themes.


### Checklist

* [ ] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
