### PR TITLE
update options type in WidgetProps

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -106,7 +106,7 @@ declare module '@rjsf/core' {
         readonly: boolean;
         autofocus: boolean;
         onChange: (value: any) => void;
-        options: { [key: string]: boolean | null | number | string | object | Array<boolean | null | number | string | object> };
+        options: NonNullable<UiSchema['ui:options']>;
         formContext: any;
         onBlur: (id: string, value: boolean | number | string | null) => void;
         onFocus: (id: string, value: boolean | number | string | null) => void;

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -106,7 +106,7 @@ declare module '@rjsf/core' {
         readonly: boolean;
         autofocus: boolean;
         onChange: (value: any) => void;
-        options: { [key: string]: boolean | number | string | object | null };
+        options: { [key: string]: boolean | null | number | string | object | Array<boolean | null | number | string | object> };
         formContext: any;
         onBlur: (id: string, value: boolean | number | string | null) => void;
         onFocus: (id: string, value: boolean | number | string | null) => void;


### PR DESCRIPTION
### Reasons for making this change

Custom widget may have a ui:options with a value like 
```
"ui:options": {
    "priorityConsts": [
      "First main",
      "Second main"
    ]
 }
```

### Checklist

* [ ] **I'm updating documentation**
  - [ ] Update type in index.d.ts

