### PR TITLE
docs: remove extra commas to fix #1801

### DIFF
--- a/docs/advanced-customization/custom-templates.md
+++ b/docs/advanced-customization/custom-templates.md
@@ -34,7 +34,7 @@ function ArrayFieldTemplate(props) {
 
 render((
   <Form schema={schema}
-        ArrayFieldTemplate={ArrayFieldTemplate} />,
+        ArrayFieldTemplate={ArrayFieldTemplate} />
 ), document.getElementById("app"));
 ```
 
@@ -111,7 +111,7 @@ function CustomFieldTemplate(props) {
 
 render((
   <Form schema={schema}
-        FieldTemplate={CustomFieldTemplate} />,
+        FieldTemplate={CustomFieldTemplate} />
 ), document.getElementById("app"));
 ```
 
@@ -179,7 +179,7 @@ function ObjectFieldTemplate(props) {
 
 render((
   <Form schema={schema}
-        ObjectFieldTemplate={ObjectFieldTemplate} />,
+        ObjectFieldTemplate={ObjectFieldTemplate} />
 ), document.getElementById("app"));
 ```
 

--- a/docs/advanced-customization/custom-widgets-fields.md
+++ b/docs/advanced-customization/custom-widgets-fields.md
@@ -113,7 +113,7 @@ const uiSchema = {
 
 render((
   <Form schema={schema}
-        uiSchema={uiSchema} />,
+        uiSchema={uiSchema} />
 ), document.getElementById("app"));
 ```
 

--- a/docs/api-reference/form-props.md
+++ b/docs/api-reference/form-props.md
@@ -115,7 +115,7 @@ const schema = {
 
 render((
   <Form schema={schema}
-        idPrefix={"rjsf_prefix"}/>,
+        idPrefix={"rjsf_prefix"}/>
 ), document.getElementById("app"));
 ```
 

--- a/docs/usage/validation.md
+++ b/docs/usage/validation.md
@@ -263,7 +263,7 @@ const extraErrors = {
 
 render((
   <Form schema={schema}
-        extraErrors={extraErrors} />,
+        extraErrors={extraErrors} />
 ), document.getElementById("app"));
 ```
 


### PR DESCRIPTION
### Reasons for making this change

Fixes #1801 

Removing extra commas makes the example working.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
