### PR TITLE
Handle array schema types class names in schema field

### DIFF
--- a/packages/antd/package-lock.json
+++ b/packages/antd/package-lock.json
@@ -3884,25 +3884,6 @@
 				"@types/yargs": "^13.0.0"
 			}
 		},
-		"@rjsf/core": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@rjsf/core/-/core-2.2.2.tgz",
-			"integrity": "sha512-4d6DHIiTJEkUq5vyl4LIxLGIYYKKnHcprf94oVchUtGQvRFjNUDFxeFQoyr90oaxcBMs2WDDcCgjcFaKVyfErg==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime-corejs2": "^7.8.7",
-				"@types/json-schema": "^7.0.4",
-				"ajv": "^6.7.0",
-				"core-js": "^2.5.7",
-				"json-schema-merge-allof": "^0.6.0",
-				"jsonpointer": "^4.0.1",
-				"lodash": "^4.17.15",
-				"prop-types": "^15.7.2",
-				"react-app-polyfill": "^1.0.4",
-				"react-is": "^16.9.0",
-				"shortid": "^2.2.14"
-			}
-		},
 		"@types/babel__core": {
 			"version": "7.1.7",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
@@ -3978,12 +3959,6 @@
 				"@types/istanbul-lib-coverage": "*",
 				"@types/istanbul-lib-report": "*"
 			}
-		},
-		"@types/json-schema": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-			"integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
-			"dev": true
 		},
 		"@types/json5": {
 			"version": "0.0.29",
@@ -5458,29 +5433,6 @@
 			"resolved": "https://registry.npmjs.org/component-indexof/-/component-indexof-0.0.3.tgz",
 			"integrity": "sha1-EdCRMSI5648yyPJa6csAL/6NPCQ=",
 			"dev": true
-		},
-		"compute-gcd": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.0.tgz",
-			"integrity": "sha1-/B7eW2UAHpUCJlAvRlQ4Y+T+oQ4=",
-			"dev": true,
-			"requires": {
-				"validate.io-array": "^1.0.3",
-				"validate.io-function": "^1.0.2",
-				"validate.io-integer-array": "^1.0.0"
-			}
-		},
-		"compute-lcm": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.0.tgz",
-			"integrity": "sha1-q9ltBAtBsKFm+JlEtci3xRHiGtU=",
-			"dev": true,
-			"requires": {
-				"compute-gcd": "^1.2.0",
-				"validate.io-array": "^1.0.3",
-				"validate.io-function": "^1.0.2",
-				"validate.io-integer-array": "^1.0.0"
-			}
 		},
 		"compute-scroll-into-view": {
 			"version": "1.0.13",
@@ -8836,26 +8788,6 @@
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
 			"dev": true
 		},
-		"json-schema-compare": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
-			"integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.4"
-			}
-		},
-		"json-schema-merge-allof": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.6.0.tgz",
-			"integrity": "sha512-LEw4VMQVRceOPLuGRWcxW5orTTiR9ZAtqTAe4rQUjNADTeR81bezBVFa0MqIwp0YmHIM1KkhSjZM7o+IQhaPbQ==",
-			"dev": true,
-			"requires": {
-				"compute-lcm": "^1.1.0",
-				"json-schema-compare": "^0.2.2",
-				"lodash": "^4.17.4"
-			}
-		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -8891,12 +8823,6 @@
 			"requires": {
 				"minimist": "^1.2.5"
 			}
-		},
-		"jsonpointer": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-			"integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
-			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -9477,12 +9403,6 @@
 			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
 			"dev": true,
 			"optional": true
-		},
-		"nanoid": {
-			"version": "2.1.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-			"integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
-			"dev": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -11433,15 +11353,6 @@
 			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
 			"dev": true
 		},
-		"shortid": {
-			"version": "2.2.15",
-			"resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
-			"integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
-			"dev": true,
-			"requires": {
-				"nanoid": "^2.1.0"
-			}
-		},
 		"side-channel": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.2.tgz",
@@ -12622,43 +12533,6 @@
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
 			}
-		},
-		"validate.io-array": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
-			"integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00=",
-			"dev": true
-		},
-		"validate.io-function": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
-			"integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc=",
-			"dev": true
-		},
-		"validate.io-integer": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
-			"integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
-			"dev": true,
-			"requires": {
-				"validate.io-number": "^1.0.3"
-			}
-		},
-		"validate.io-integer-array": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
-			"integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
-			"dev": true,
-			"requires": {
-				"validate.io-array": "^1.0.3",
-				"validate.io-integer": "^1.0.4"
-			}
-		},
-		"validate.io-number": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
-			"integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg=",
-			"dev": true
 		},
 		"verror": {
 			"version": "1.10.0",

--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -296,10 +296,13 @@ function SchemaFieldRender(props) {
   const errors = __errors;
   const help = uiSchema["ui:help"];
   const hidden = uiSchema["ui:widget"] === "hidden";
+  const fieldTypeClasses = Array.isArray(schema.type)
+    ? schema.type.map(type => `field-${type}`)
+    : [`field-${schema.type}`];
   const classNames = [
     "form-group",
     "field",
-    `field-${schema.type}`,
+    ...fieldTypeClasses,
     errors && errors.length > 0 ? "field-error has-error has-danger" : "",
     uiSchema.classNames,
   ]

--- a/packages/core/test/SchemaField_test.js
+++ b/packages/core/test/SchemaField_test.js
@@ -247,6 +247,23 @@ describe("SchemaField", () => {
 
       expect(node.querySelectorAll(".foo")).to.have.length.of(1);
     });
+
+    it("should handle schema properties with array types correctly", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: {
+            type: ["string", "null"],
+          },
+        },
+      };
+
+      const { node } = createFormComponent({ schema });
+
+      expect(
+        node.querySelectorAll(".field.form-group.field-string.field-null")
+      ).to.have.length.of(1);
+    });
   });
 
   describe("label support", () => {

--- a/packages/fluent-ui/package-lock.json
+++ b/packages/fluent-ui/package-lock.json
@@ -1319,24 +1319,6 @@
         "regenerator-runtime": "^0.13.2"
       }
     },
-    "@babel/runtime-corejs2": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.5.tgz",
-      "integrity": "sha512-LJwyb1ac//Jr2zrGTTaNJhrP1wYCgVw9rzHbQPogKXCTLQ60EEWgeNtuqs6cLsq64O557SYzziCrOxNp0rRi8w==",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-          "dev": true
-        }
-      }
-    },
     "@babel/runtime-corejs3": {
       "version": "7.9.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
@@ -1793,33 +1775,6 @@
       "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.46.tgz",
       "integrity": "sha512-Zhu/rW6XwkQC9ZXt7IWxDpMAyYIyNsT5ZF0gMfFDXnZCKNPm9GZca8HV5AYB1X6gvPGiz8gV60I+o9+KSH+aTw==",
       "dev": true
-    },
-    "@rjsf/core": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-2.2.1.tgz",
-      "integrity": "sha512-XUpUUF1EParZjFIfgZXzu0lP8YWK/R+38UfXuP7JEu8NqopRdw6J4XqVhcYjJtdULsi3lr279CSOmJuyzokJGg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime-corejs2": "^7.8.7",
-        "@types/json-schema": "^7.0.4",
-        "ajv": "^6.7.0",
-        "core-js": "^2.5.7",
-        "json-schema-merge-allof": "^0.6.0",
-        "jsonpointer": "^4.0.1",
-        "lodash": "^4.17.15",
-        "prop-types": "^15.7.2",
-        "react-app-polyfill": "^1.0.4",
-        "react-is": "^16.9.0",
-        "shortid": "^2.2.14"
-      },
-      "dependencies": {
-        "@types/json-schema": {
-          "version": "7.0.5",
-          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-          "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
-          "dev": true
-        }
-      }
     },
     "@rollup/plugin-commonjs": {
       "version": "11.0.2",
@@ -2501,12 +2456,6 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
       }
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
     },
     "asn1": {
       "version": "0.2.4",
@@ -3437,29 +3386,6 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
-    },
-    "compute-gcd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.0.tgz",
-      "integrity": "sha1-/B7eW2UAHpUCJlAvRlQ4Y+T+oQ4=",
-      "dev": true,
-      "requires": {
-        "validate.io-array": "^1.0.3",
-        "validate.io-function": "^1.0.2",
-        "validate.io-integer-array": "^1.0.0"
-      }
-    },
-    "compute-lcm": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.0.tgz",
-      "integrity": "sha1-q9ltBAtBsKFm+JlEtci3xRHiGtU=",
-      "dev": true,
-      "requires": {
-        "compute-gcd": "^1.2.0",
-        "validate.io-array": "^1.0.3",
-        "validate.io-function": "^1.0.2",
-        "validate.io-integer-array": "^1.0.0"
-      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -6766,26 +6692,6 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
-    "json-schema-compare": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
-      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.4"
-      }
-    },
-    "json-schema-merge-allof": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.6.0.tgz",
-      "integrity": "sha512-LEw4VMQVRceOPLuGRWcxW5orTTiR9ZAtqTAe4rQUjNADTeR81bezBVFa0MqIwp0YmHIM1KkhSjZM7o+IQhaPbQ==",
-      "dev": true,
-      "requires": {
-        "compute-lcm": "^1.1.0",
-        "json-schema-compare": "^0.2.2",
-        "lodash": "^4.17.4"
-      }
-    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -6821,12 +6727,6 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
-    },
-    "jsonpointer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
-      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -7328,12 +7228,6 @@
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true,
       "optional": true
-    },
-    "nanoid": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
-      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -7968,15 +7862,6 @@
         }
       }
     },
-    "promise": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
-      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
-      "dev": true,
-      "requires": {
-        "asap": "~2.0.6"
-      }
-    },
     "prompts": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
@@ -8026,15 +7911,6 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
-    "raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
-      "requires": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "react": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
@@ -8044,28 +7920,6 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
-      }
-    },
-    "react-app-polyfill": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-1.0.6.tgz",
-      "integrity": "sha512-OfBnObtnGgLGfweORmdZbyEz+3dgVePQBb3zipiaDsMHV1NpWm0rDFYIVXFV/AK+x4VIIfWHhrdMIeoTLyRr2g==",
-      "dev": true,
-      "requires": {
-        "core-js": "^3.5.0",
-        "object-assign": "^4.1.1",
-        "promise": "^8.0.3",
-        "raf": "^3.4.1",
-        "regenerator-runtime": "^0.13.3",
-        "whatwg-fetch": "^3.0.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
-          "dev": true
-        }
       }
     },
     "react-dom": {
@@ -8711,15 +8565,6 @@
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
-    },
-    "shortid": {
-      "version": "2.2.15",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
-      "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
-      "dev": true,
-      "requires": {
-        "nanoid": "^2.1.0"
-      }
     },
     "side-channel": {
       "version": "1.0.2",
@@ -9845,43 +9690,6 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
-    "validate.io-array": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
-      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00=",
-      "dev": true
-    },
-    "validate.io-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
-      "integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc=",
-      "dev": true
-    },
-    "validate.io-integer": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
-      "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
-      "dev": true,
-      "requires": {
-        "validate.io-number": "^1.0.3"
-      }
-    },
-    "validate.io-integer-array": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
-      "integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
-      "dev": true,
-      "requires": {
-        "validate.io-array": "^1.0.3",
-        "validate.io-integer": "^1.0.4"
-      }
-    },
-    "validate.io-number": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
-      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg=",
-      "dev": true
-    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -9934,12 +9742,6 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.2.0.tgz",
-      "integrity": "sha512-SdGPoQMMnzVYThUbSrEvqTlkvC1Ux27NehaJ/GUHBfNrh5Mjg+1/uRyFMwVnxO2MrikMWvWAqUGgQOfVU4hT7w==",
-      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/packages/material-ui/package-lock.json
+++ b/packages/material-ui/package-lock.json
@@ -1129,24 +1129,6 @@
         "regenerator-runtime": "^0.13.2"
       }
     },
-    "@babel/runtime-corejs2": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.5.tgz",
-      "integrity": "sha512-LJwyb1ac//Jr2zrGTTaNJhrP1wYCgVw9rzHbQPogKXCTLQ60EEWgeNtuqs6cLsq64O557SYzziCrOxNp0rRi8w==",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-          "dev": true
-        }
-      }
-    },
     "@babel/runtime-corejs3": {
       "version": "7.9.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
@@ -1518,33 +1500,6 @@
         "@babel/runtime": "^7.4.4",
         "prop-types": "^15.7.2",
         "react-is": "^16.8.6"
-      }
-    },
-    "@rjsf/core": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-2.2.1.tgz",
-      "integrity": "sha512-XUpUUF1EParZjFIfgZXzu0lP8YWK/R+38UfXuP7JEu8NqopRdw6J4XqVhcYjJtdULsi3lr279CSOmJuyzokJGg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime-corejs2": "^7.8.7",
-        "@types/json-schema": "^7.0.4",
-        "ajv": "^6.7.0",
-        "core-js": "^2.5.7",
-        "json-schema-merge-allof": "^0.6.0",
-        "jsonpointer": "^4.0.1",
-        "lodash": "^4.17.15",
-        "prop-types": "^15.7.2",
-        "react-app-polyfill": "^1.0.4",
-        "react-is": "^16.9.0",
-        "shortid": "^2.2.14"
-      },
-      "dependencies": {
-        "@types/json-schema": {
-          "version": "7.0.5",
-          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-          "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
-          "dev": true
-        }
       }
     },
     "@rollup/plugin-commonjs": {
@@ -2086,12 +2041,6 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
       }
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
     },
     "asn1": {
       "version": "0.2.4",
@@ -3022,29 +2971,6 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
-    },
-    "compute-gcd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.0.tgz",
-      "integrity": "sha1-/B7eW2UAHpUCJlAvRlQ4Y+T+oQ4=",
-      "dev": true,
-      "requires": {
-        "validate.io-array": "^1.0.3",
-        "validate.io-function": "^1.0.2",
-        "validate.io-integer-array": "^1.0.0"
-      }
-    },
-    "compute-lcm": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.0.tgz",
-      "integrity": "sha1-q9ltBAtBsKFm+JlEtci3xRHiGtU=",
-      "dev": true,
-      "requires": {
-        "compute-gcd": "^1.2.0",
-        "validate.io-array": "^1.0.3",
-        "validate.io-function": "^1.0.2",
-        "validate.io-integer-array": "^1.0.0"
-      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -6351,26 +6277,6 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
-    "json-schema-compare": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
-      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.4"
-      }
-    },
-    "json-schema-merge-allof": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.6.0.tgz",
-      "integrity": "sha512-LEw4VMQVRceOPLuGRWcxW5orTTiR9ZAtqTAe4rQUjNADTeR81bezBVFa0MqIwp0YmHIM1KkhSjZM7o+IQhaPbQ==",
-      "dev": true,
-      "requires": {
-        "compute-lcm": "^1.1.0",
-        "json-schema-compare": "^0.2.2",
-        "lodash": "^4.17.4"
-      }
-    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -6406,12 +6312,6 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
-    },
-    "jsonpointer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
-      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -6909,12 +6809,6 @@
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true,
       "optional": true
-    },
-    "nanoid": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
-      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -7521,15 +7415,6 @@
         }
       }
     },
-    "promise": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
-      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
-      "dev": true,
-      "requires": {
-        "asap": "~2.0.6"
-      }
-    },
     "prompts": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
@@ -7579,15 +7464,6 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
-    "raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
-      "requires": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "react": {
       "version": "16.11.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.11.0.tgz",
@@ -7597,28 +7473,6 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
-      }
-    },
-    "react-app-polyfill": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-1.0.6.tgz",
-      "integrity": "sha512-OfBnObtnGgLGfweORmdZbyEz+3dgVePQBb3zipiaDsMHV1NpWm0rDFYIVXFV/AK+x4VIIfWHhrdMIeoTLyRr2g==",
-      "dev": true,
-      "requires": {
-        "core-js": "^3.5.0",
-        "object-assign": "^4.1.1",
-        "promise": "^8.0.3",
-        "raf": "^3.4.1",
-        "regenerator-runtime": "^0.13.3",
-        "whatwg-fetch": "^3.0.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
-          "dev": true
-        }
       }
     },
     "react-dom": {
@@ -8264,15 +8118,6 @@
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
-    },
-    "shortid": {
-      "version": "2.2.15",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.15.tgz",
-      "integrity": "sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==",
-      "dev": true,
-      "requires": {
-        "nanoid": "^2.1.0"
-      }
     },
     "side-channel": {
       "version": "1.0.2",
@@ -9398,43 +9243,6 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
-    "validate.io-array": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
-      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00=",
-      "dev": true
-    },
-    "validate.io-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
-      "integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc=",
-      "dev": true
-    },
-    "validate.io-integer": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
-      "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
-      "dev": true,
-      "requires": {
-        "validate.io-number": "^1.0.3"
-      }
-    },
-    "validate.io-integer-array": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
-      "integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
-      "dev": true,
-      "requires": {
-        "validate.io-array": "^1.0.3",
-        "validate.io-integer": "^1.0.4"
-      }
-    },
-    "validate.io-number": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
-      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg=",
-      "dev": true
-    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -9487,12 +9295,6 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.2.0.tgz",
-      "integrity": "sha512-SdGPoQMMnzVYThUbSrEvqTlkvC1Ux27NehaJ/GUHBfNrh5Mjg+1/uRyFMwVnxO2MrikMWvWAqUGgQOfVU4hT7w==",
-      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -3113,97 +3113,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@rjsf/antd": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@rjsf/antd/-/antd-2.2.0.tgz",
-      "integrity": "sha512-zOxN/l3fNFAM45fTQx/lHlwQV9jtgBo8PIpoIDSSgsTJ9rgTKLSg6C4oJPUiDKRKsjsrJSSUKAp2L+wlWx9wTQ=="
-    },
-    "@rjsf/core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-2.2.0.tgz",
-      "integrity": "sha512-VJs+X0/mwgLZphPUJ6sxftCqrVwZE1dEcc8zpUcKXeGwL7HFDQ8N2JAbCT549Z/91bDQKOGXTde9yqcajN3Jaw==",
-      "requires": {
-        "@babel/runtime-corejs2": "^7.8.7",
-        "@types/json-schema": "^7.0.4",
-        "ajv": "^6.7.0",
-        "core-js": "^2.5.7",
-        "json-schema-merge-allof": "^0.6.0",
-        "jsonpointer": "^4.0.1",
-        "lodash": "^4.17.15",
-        "prop-types": "^15.7.2",
-        "react-app-polyfill": "^1.0.4",
-        "react-is": "^16.9.0",
-        "shortid": "^2.2.14"
-      },
-      "dependencies": {
-        "@babel/runtime-corejs2": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.3.tgz",
-          "integrity": "sha512-enKvnR/kKFbZFgXYo165wtSA5OeiTlgsnU4jV3vpKRhfWUJjLS6dfVcjIPeRcgJbgEgdgu0I+UyBWqu6c0GumQ==",
-          "requires": {
-            "core-js": "^2.6.5",
-            "regenerator-runtime": "^0.13.4"
-          },
-          "dependencies": {
-            "core-js": {
-              "version": "2.6.11",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-              "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
-            }
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
-        }
-      }
-    },
-    "@rjsf/fluent-ui": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@rjsf/fluent-ui/-/fluent-ui-2.2.0.tgz",
-      "integrity": "sha512-/1n+hMi7wRaGXDYrtxgTHmrFuBg0AZD7f6ieiJattAdTf0d5j2qTqNpjHxdk1Oz8DDO9x1/K4uu5TPhW9vE5Vg==",
-      "requires": {
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
-      }
-    },
-    "@rjsf/material-ui": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@rjsf/material-ui/-/material-ui-2.2.0.tgz",
-      "integrity": "sha512-toKVaDvEuoSC/A4pIYPgJoyGzQEX+2chKBja1gaB7zTJ1uGoWna9+HQ2skxzixgIg/2o4kgqCRU7wdTDg+OgJg=="
-    },
-    "@rjsf/semantic-ui": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@rjsf/semantic-ui/-/semantic-ui-2.2.0.tgz",
-      "integrity": "sha512-m5jEaQdO9/WQ7pesCrOmdqJ2Wyosfw0igd1pV5Q1zKtVvRkMOWt1MNbefQDYtY3wKdd020At+NedgVVfNsndZQ==",
-      "requires": {
-        "@babel/runtime-corejs2": "^7.9.2",
-        "semantic-ui-css": "^2.4.1",
-        "semantic-ui-react": "^0.87.3"
-      },
-      "dependencies": {
-        "@babel/runtime-corejs2": {
-          "version": "7.10.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.10.3.tgz",
-          "integrity": "sha512-enKvnR/kKFbZFgXYo165wtSA5OeiTlgsnU4jV3vpKRhfWUJjLS6dfVcjIPeRcgJbgEgdgu0I+UyBWqu6c0GumQ==",
-          "requires": {
-            "core-js": "^2.6.5",
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "core-js": {
-          "version": "2.6.11",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
-        },
-        "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
-        }
-      }
-    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -3211,15 +3120,6 @@
       "dev": true,
       "requires": {
         "any-observable": "^0.3.0"
-      }
-    },
-    "@semantic-ui-react/event-stack": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-3.1.1.tgz",
-      "integrity": "sha512-SA7VOu/tY3OkooR++mm9voeQrJpYXjJaMHO1aFCcSouS2xhqMR9Gnz0LEGLOR0h9ueWPBKaQzKIrx3FTTJZmUQ==",
-      "requires": {
-        "exenv": "^1.2.2",
-        "prop-types": "^15.6.2"
       }
     },
     "@sinonjs/commons": {
@@ -3292,7 +3192,8 @@
     "@types/json-schema": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
+      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -5478,25 +5379,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "create-react-context": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
-      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
-      "requires": {
-        "gud": "^1.0.0",
-        "warning": "^4.0.3"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
-      }
-    },
     "create-react-ref": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/create-react-ref/-/create-react-ref-0.1.0.tgz",
@@ -5782,6 +5664,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dev": true,
       "requires": {
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.1",
@@ -5794,7 +5677,8 @@
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
         }
       }
     },
@@ -5867,6 +5751,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
       "requires": {
         "foreach": "^2.0.5",
         "object-keys": "^1.0.8"
@@ -6815,11 +6700,6 @@
         }
       }
     },
-    "exenv": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
-    },
     "expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -7261,7 +7141,8 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -7899,7 +7780,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -8080,11 +7962,6 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
-    "gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
-    },
     "handle-thing": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
@@ -8132,6 +8009,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
       "requires": {
         "function-bind": "^1.0.2"
       }
@@ -8154,7 +8032,8 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -8933,7 +8812,8 @@
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -8992,7 +8872,8 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -9129,6 +9010,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -9236,11 +9118,6 @@
         "istanbul-lib-coverage": "^2.0.3",
         "semver": "^5.5.0"
       }
-    },
-    "jquery": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
-      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "js-base64": {
       "version": "2.4.5",
@@ -9378,11 +9255,6 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
-    },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -9574,11 +9446,6 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
       "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
       "dev": true
-    },
-    "keyboard-key": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keyboard-key/-/keyboard-key-1.1.0.tgz",
-      "integrity": "sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ=="
     },
     "keycode": {
       "version": "2.2.0",
@@ -10062,11 +9929,6 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-    },
-    "lodash-es": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -12115,17 +11977,20 @@
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
     },
     "object-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
-      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
+      "dev": true
     },
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -12148,6 +12013,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -14559,30 +14425,6 @@
         }
       }
     },
-    "react-popper": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
-      "integrity": "sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "create-react-context": "^0.3.0",
-        "deep-equal": "^1.1.1",
-        "popper.js": "^1.14.4",
-        "prop-types": "^15.6.1",
-        "typed-styles": "^0.0.7",
-        "warning": "^4.0.2"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
-      }
-    },
     "react-portal": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.0.tgz",
@@ -14794,6 +14636,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
       "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -14803,6 +14646,7 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
           "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
           "requires": {
             "object-keys": "^1.0.12"
           }
@@ -14811,6 +14655,7 @@
           "version": "1.17.0",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
           "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -14829,6 +14674,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -14839,6 +14685,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
           "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
           }
@@ -14846,12 +14693,14 @@
         "is-callable": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
           "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
@@ -14860,6 +14709,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
           "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "dev": true,
           "requires": {
             "has-symbols": "^1.0.1"
           }
@@ -14867,7 +14717,8 @@
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
         }
       }
     },
@@ -15242,30 +15093,6 @@
       "dev": true,
       "requires": {
         "node-forge": "0.9.0"
-      }
-    },
-    "semantic-ui-css": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.4.1.tgz",
-      "integrity": "sha512-Pkp0p9oWOxlH0kODx7qFpIRYpK1T4WJOO4lNnpNPOoWKCrYsfHqYSKgk5fHfQtnWnsAKy7nLJMW02bgDWWFZFg==",
-      "requires": {
-        "jquery": "x.*"
-      }
-    },
-    "semantic-ui-react": {
-      "version": "0.87.3",
-      "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-0.87.3.tgz",
-      "integrity": "sha512-YJgFYEheeFBMm/epZpIpWKF9glgSShdLPiY8zoUi+KJ0IKtLtbI8RbMD/ELbZkY+SO/IWbK/f/86pWt3PVvMVA==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "@semantic-ui-react/event-stack": "^3.1.0",
-        "classnames": "^2.2.6",
-        "keyboard-key": "^1.0.4",
-        "lodash": "^4.17.11",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.7.0",
-        "react-popper": "^1.3.3",
-        "shallowequal": "^1.1.0"
       }
     },
     "semver": {
@@ -15967,6 +15794,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
       "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
@@ -15976,6 +15804,7 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
           "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
           "requires": {
             "object-keys": "^1.0.12"
           }
@@ -15983,7 +15812,8 @@
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
         }
       }
     },
@@ -15991,6 +15821,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
       "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
@@ -16000,6 +15831,7 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
           "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
           "requires": {
             "object-keys": "^1.0.12"
           }
@@ -16007,7 +15839,8 @@
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
         }
       }
     },
@@ -16485,11 +16318,6 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.18"
       }
-    },
-    "typed-styles": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
-      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "typedarray": {
       "version": "0.0.6",


### PR DESCRIPTION
### Reasons for making this change

In an attempt to style some fields, I noticed that schema properties with array types (i.e. `type: ["string", "null"]`) would be rendered with the class name `field-string,null` because the array was converted into a string. This makes it impossible to apply styles consistently to field types.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
