### PR TITLE
Fix fluent ui imports

### DIFF
--- a/packages/fluent-ui/src/DescriptionField/DescriptionField.tsx
+++ b/packages/fluent-ui/src/DescriptionField/DescriptionField.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { FieldProps } from "@rjsf/core";
 
-import { Text } from "office-ui-fabric-react/lib/Text";
+import { Text } from "@fluentui/react";
 
 const DescriptionField = ({ description }: FieldProps) => {
   if (description) {


### PR DESCRIPTION
Use:

```
import { Text } from "@fluentui/react";
```

This way, libraries that use this library and can't accept ES6 code won't need to transpile this code.