### PR TITLE
fix: submit event bubbling with React 17

### DIFF
--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -407,6 +407,7 @@ export default class Form extends Component {
     if (this.formElement) {
       this.formElement.dispatchEvent(
         new CustomEvent("submit", {
+          bubbles: true,
           cancelable: true,
         })
       );


### PR DESCRIPTION
### Reasons for making this change
React 17 has changed the way event handlers are attached - [more info](https://reactjs.org/blog/2020/10/20/react-v17.html#changes-to-event-delegation) and because of that, submit event doesn't bubble up unless you explicitly tell it to bubble.
This issue affects submitting the form programmatically.

fixes #2104