### PR TITLE
Fixed disabled option for antd selects.

### DIFF
--- a/packages/antd/src/widgets/SelectWidget/index.js
+++ b/packages/antd/src/widgets/SelectWidget/index.js
@@ -94,7 +94,7 @@ const SelectWidget = ({
     >
       {enumOptions.map(({ value: optionValue, label: optionLabel }) => (
         <Select.Option
-          disabled={enumDisabled && enumDisabled.indexOf(value) !== -1}
+          disabled={enumDisabled && enumDisabled.indexOf(optionValue) !== -1}
           key={String(optionValue)}
           value={String(optionValue)}
         >


### PR DESCRIPTION
### Reasons for making this change

I found bug with disabled options for antd select widget.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
