### PR TITLE
Support multipleOf, min, and max for numbers in Antd

### DIFF
--- a/packages/antd/src/widgets/TextWidget/index.js
+++ b/packages/antd/src/widgets/TextWidget/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 
 import Input from 'antd/lib/input';
 import InputNumber from 'antd/lib/input-number';
+import { rangeSpec } from '@rjsf/core/lib/utils'
 
 const INPUT_STYLE = {
   width: '100%',
@@ -34,6 +35,9 @@ const TextWidget = ({
 
   const handleFocus = ({ target }) => onFocus(id, target.value);
 
+  const step = schema.type === 'number' ? 'any' : undefined // non-integer numbers shouldn't have a default step of 1
+  const stepProps = rangeSpec(schema) // sets step, min, and max from the schema
+
   return schema.type === 'number' || schema.type === 'integer' ? (
     <InputNumber
       disabled={disabled || (readonlyAsDisabled && readonly)}
@@ -45,6 +49,8 @@ const TextWidget = ({
       placeholder={placeholder}
       style={INPUT_STYLE}
       type="number"
+      step={step}
+      {...stepProps}
       value={value}
     />
   ) : (

--- a/packages/antd/src/widgets/UpDownWidget/index.js
+++ b/packages/antd/src/widgets/UpDownWidget/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import InputNumber from 'antd/lib/input-number';
+import { rangeSpec } from '@rjsf/core/lib/utils'
 
 const INPUT_STYLE = {
   width: '100%',
@@ -18,7 +19,7 @@ const UpDownWidget = ({
   placeholder,
   readonly,
   // required,
-  // schema,
+  schema,
   value,
 }) => {
   const { readonlyAsDisabled = true } = formContext;
@@ -28,6 +29,9 @@ const UpDownWidget = ({
   const handleBlur = ({ target }) => onBlur(id, target.value);
 
   const handleFocus = ({ target }) => onFocus(id, target.value);
+
+  const step = schema.type === 'number' ? 'any' : undefined // non-integer numbers shouldn't have a default step of 1
+  const stepProps = rangeSpec(schema) // sets step, min, and max from the schema
 
   return (
     <InputNumber
@@ -40,6 +44,8 @@ const UpDownWidget = ({
       placeholder={placeholder}
       style={INPUT_STYLE}
       type="number"
+      step={step}
+      {...stepProps}
       value={value}
     />
   );


### PR DESCRIPTION
### Reasons for making this change

- Antd does not properly support multipleOf, min, and max for type="number" or "integer"
- It also defaults to step = 1 for all "numbers", which can cause a browser validation error for decimal input (i.e. 0.9)

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
