### PR TITLE
semantic-ui: fix classNames

### DIFF
--- a/packages/semantic-ui/src/FieldTemplate/FieldTemplate.js
+++ b/packages/semantic-ui/src/FieldTemplate/FieldTemplate.js
@@ -4,7 +4,7 @@ import { Form } from "semantic-ui-react";
 import DescriptionField from "../DescriptionField";
 import HelpField from "../HelpField";
 import RawErrors from "../RawErrors";
-import { getSemanticProps, MaybeWrap } from "../util";
+import { cleanClassNames, getSemanticProps, MaybeWrap } from "../util";
 
 function FieldTemplate({
   id,
@@ -22,7 +22,13 @@ function FieldTemplate({
   const { wrapLabel, wrapContent, errorOptions } = semanticProps;
   return (
     <Form.Group key={id} widths="equal" grouped>
-      <MaybeWrap wrap={wrapContent} className="sui-field-content">
+      <MaybeWrap
+        wrap={wrapContent}
+        className={cleanClassNames([
+          className,
+          classNames,
+          "sui-field-content",
+        ])}>
         {children}
         {displayLabel && rawDescription && (
           <MaybeWrap wrap={wrapLabel} className="sui-field-label">

--- a/packages/semantic-ui/test/ClassNames.test.js
+++ b/packages/semantic-ui/test/ClassNames.test.js
@@ -1,0 +1,57 @@
+import { expect } from "chai";
+import React from 'react';
+
+import { SemanticUIForm } from "../src";
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+
+describe("testing classNames presence", () => {
+  let container;
+
+     beforeEach(() => {
+       container = document.createElement('div');
+       document.body.appendChild(container);
+     });
+
+     afterEach(() => {
+       document.body.removeChild(container);
+       container = null;
+     });
+
+     describe("custom classNames", () => {
+       const schema = {
+         type: "object",
+         properties: {
+           foo: {
+             type: "string",
+           },
+           bar: {
+             type: "string",
+           },
+         },
+       };
+
+       const uiSchema = {
+         foo: {
+           classNames: "class-for-foo",
+         },
+         bar: {
+           classNames: "class-for-bar another-for-bar",
+         },
+       };
+
+       it("should apply custom class names to target widgets", () => {
+           act(() => {
+            ReactDOM.render(<SemanticUIForm schema={schema} uiSchema={uiSchema}
+            formContext={{ semantic: { wrapLabel: true, wrapContent: true } }}
+            />, container);
+          });
+         const [stringField1, stringField2] =
+           container.querySelectorAll(".sui-field-content");
+         expect(stringField1.querySelectorAll(".class-for-foo")).to.exist;
+         expect(stringField2.querySelectorAll(".class-for-bar")).to.exist;
+
+       });
+     });
+
+});


### PR DESCRIPTION
### Reasons for making this change

Semantic-UI Fields did not receive classNames attribute form: check [playground](https://rjsf-team.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6e30sInNjaGVtYSI6eyJwcm9wZXJ0aWVzIjp7ImZpZWxkIjp7InR5cGUiOiJzdHJpbmcifX19LCJ1aVNjaGVtYSI6eyJjbGFzc05hbWVzIjoiZXh0cmFDbGFzcyJ9LCJ0aGVtZSI6InNlbWFudGljLXVpIiwibGl2ZVNldHRpbmdzIjp7InZhbGlkYXRlIjp0cnVlLCJkaXNhYmxlIjpmYWxzZSwib21pdEV4dHJhRGF0YSI6ZmFsc2UsImxpdmVPbWl0IjpmYWxzZX19)

If this is related to existing tickets, include links to them as well.

### Checklist

> no need to update documentation, the feature was described already there

* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed

