### PR TITLE
Set schema errors to empty to clear schema errors when re-rendered

### DIFF
--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -374,13 +374,14 @@ export default class Form extends Component {
       errors = [];
     }
 
-    this.setState({ 
-      formData: newFormData,
-      errors: errors,
-      errorSchema: errorSchema,
-      schemaValidationErrors: [],
-      schemaValidationErrorSchema: [] 
-    },
+    this.setState(
+      {
+        formData: newFormData,
+        errors: errors,
+        errorSchema: errorSchema,
+        schemaValidationErrors: [],
+        schemaValidationErrorSchema: [],
+      },
       () => {
         if (this.props.onSubmit) {
           this.props.onSubmit(

--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -375,7 +375,7 @@ export default class Form extends Component {
     }
 
     this.setState(
-      { formData: newFormData, errors: errors, errorSchema: errorSchema },
+      { formData: newFormData, errors: errors, errorSchema: errorSchema, schemaValidationErrors: [], schemaValidationErrorSchema: [] },
       () => {
         if (this.props.onSubmit) {
           this.props.onSubmit(

--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -374,8 +374,13 @@ export default class Form extends Component {
       errors = [];
     }
 
-    this.setState(
-      { formData: newFormData, errors: errors, errorSchema: errorSchema, schemaValidationErrors: [], schemaValidationErrorSchema: [] },
+    this.setState({ 
+      formData: newFormData,
+      errors: errors,
+      errorSchema: errorSchema,
+      schemaValidationErrors: [],
+      schemaValidationErrorSchema: [] 
+    },
       () => {
         if (this.props.onSubmit) {
           this.props.onSubmit(


### PR DESCRIPTION
### Reasons for making this change

fixes https://github.com/rjsf-team/react-jsonschema-form/issues/2102

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
