### PR TITLE
Render a select widget for arrays if specified in the ui schema

### DIFF
--- a/docs/usage/arrays.md
+++ b/docs/usage/arrays.md
@@ -158,7 +158,7 @@ render((
 
 ## Multiple-choice list
 
-The default behavior for array fields is a list of text inputs with add/remove buttons. There are two alternative widgets for picking multiple elements from a list of choices. Typically this applies when a schema has an `enum` list for the `items` property of an `array` field, and the `uniqueItems` property set to `true`.
+The default behavior for array fields is a list of text inputs with add/remove buttons. There are two alternative widgets for picking multiple elements from a list of choices. This applies when a schema has an `enum` list for the `items` property of an `array` field and the `uniqueItems` property set to `true`, or when the `ui:widget` is set to `select`.
 
 Example:
 

--- a/packages/antd/src/templates/ArrayFieldTemplate/index.js
+++ b/packages/antd/src/templates/ArrayFieldTemplate/index.js
@@ -138,7 +138,7 @@ const ArrayFieldTemplate = ({
   if (isFilesArray(schema, uiSchema, rootSchema)) {
     return renderFiles();
   }
-  if (isMultiSelect(schema, rootSchema)) {
+  if (isMultiSelect(schema, uiSchema, rootSchema)) {
     return renderMultiSelect();
   }
 

--- a/packages/bootstrap-4/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/bootstrap-4/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -14,7 +14,7 @@ const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
   const { schema, registry = getDefaultRegistry() } = props;
 
   // TODO: update types so we don't have to cast registry as any
-  if (isMultiSelect(schema, (registry as any).rootSchema)) {
+  if (isMultiSelect(schema, props.uiSchema, (registry as any).rootSchema)) {
     return <DefaultFixedArrayFieldTemplate {...props} />;
   } else {
     return <DefaultNormalArrayFieldTemplate {...props} />;

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -335,7 +335,7 @@ declare module '@rjsf/core' {
 
         export function isSelect(_schema: JSONSchema7, definitions?: FieldProps['registry']['definitions']): boolean;
 
-        export function isMultiSelect(schema: JSONSchema7, definitions?: FieldProps['registry']['definitions']): boolean;
+        export function isMultiSelect(schema: JSONSchema7, uiSchema: UiSchema, definitions?: FieldProps['registry']['definitions']): boolean;
 
         export function isFilesArray(
             schema: JSONSchema7,

--- a/packages/core/src/components/fields/ArrayField.js
+++ b/packages/core/src/components/fields/ArrayField.js
@@ -448,7 +448,7 @@ class ArrayField extends Component {
     if (isFilesArray(schema, uiSchema, rootSchema)) {
       return this.renderFiles();
     }
-    if (isMultiSelect(schema, rootSchema)) {
+    if (isMultiSelect(schema, uiSchema, rootSchema)) {
       return this.renderMultiSelect();
     }
     return this.renderNormalArray();

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -272,7 +272,8 @@ function computeDefaults(
         });
       }
       if (schema.minItems) {
-        if (!isMultiSelect(schema, rootSchema)) {
+        // The UI schema is not important when calculating the defaults, so we just pass a default empty object.
+        if (!isMultiSelect(schema, {}, rootSchema)) {
           const defaultsLength = defaults ? defaults.length : 0;
           if (schema.minItems > defaultsLength) {
             const defaultEntries = defaults || [];
@@ -389,7 +390,7 @@ export function getDisplayLabel(schema, uiSchema, rootSchema) {
   let { label: displayLabel = true } = uiOptions;
   if (schema.type === "array") {
     displayLabel =
-      isMultiSelect(schema, rootSchema) ||
+      isMultiSelect(schema, uiSchema, rootSchema) ||
       isFilesArray(schema, uiSchema, rootSchema);
   }
   if (schema.type === "object") {
@@ -528,7 +529,10 @@ export function isSelect(_schema, rootSchema = {}) {
   return false;
 }
 
-export function isMultiSelect(schema, rootSchema = {}) {
+export function isMultiSelect(schema, uiSchema, rootSchema = {}) {
+  if (uiSchema["ui:widget"] === "select") {
+    return true;
+  }
   if (!schema.uniqueItems || !schema.items) {
     return false;
   }

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -1323,6 +1323,17 @@ describe("utils", () => {
       };
       expect(isMultiSelect(schema)).to.be.false;
     });
+
+    it("should be true if widget is select", () => {
+      const schema = {
+        items: { foo: { type: "string" } },
+      };
+      const uiSchema = {
+        "ui:widget": "select",
+      };
+
+      expect(isMultiSelect(schema, uiSchema)).to.be.true;
+    });
   });
 
   describe("isFilesArray()", () => {

--- a/packages/fluent-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/fluent-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -8,7 +8,7 @@ import AddButton from "../AddButton/AddButton";
 import IconButton from "../IconButton/IconButton";
 
 const rightJustify = {
-  float: "right"
+  float: "right",
 } as React.CSSProperties;
 
 const { isMultiSelect, getDefaultRegistry } = utils;
@@ -17,7 +17,7 @@ const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
   const { schema, registry = getDefaultRegistry() } = props;
 
   // TODO: update types so we don't have to cast registry as any
-  if (isMultiSelect(schema, (registry as any).rootSchema)) {
+  if (isMultiSelect(schema, props.uiSchema, (registry as any).rootSchema)) {
     return <DefaultFixedArrayFieldTemplate {...props} />;
   } else {
     return <DefaultNormalArrayFieldTemplate {...props} />;
@@ -70,11 +70,11 @@ const DefaultArrayItem = (props: any) => {
     <div key={props.key} className="ms-Grid" dir="ltr">
       <div className="ms-Grid-row">
         <div className="ms-Grid-col ms-sm6 ms-md8 ms-lg9">
-          <div className="ms-Grid-row">
-          {props.children}
-          </div>
+          <div className="ms-Grid-row">{props.children}</div>
         </div>
-        <div className="ms-Grid-col ms-sm6 ms-md4 ms-lg3" style={{textAlign: "right"}}>
+        <div
+          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
+          style={{ textAlign: "right" }}>
           <IconButton
             icon="arrow-up"
             className="array-item-move-up"

--- a/packages/material-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/material-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -1,26 +1,23 @@
-import React from 'react';
+import React from "react";
 
-import { utils } from '@rjsf/core';
+import { utils } from "@rjsf/core";
 
-import Box from '@material-ui/core/Box';
-import Grid from '@material-ui/core/Grid';
-import Paper from '@material-ui/core/Paper';
+import Box from "@material-ui/core/Box";
+import Grid from "@material-ui/core/Grid";
+import Paper from "@material-ui/core/Paper";
 
-import { ArrayFieldTemplateProps, IdSchema } from '@rjsf/core';
+import { ArrayFieldTemplateProps, IdSchema } from "@rjsf/core";
 
-import AddButton from '../AddButton/AddButton';
-import IconButton from '../IconButton/IconButton';
+import AddButton from "../AddButton/AddButton";
+import IconButton from "../IconButton/IconButton";
 
-const {
-  isMultiSelect,
-  getDefaultRegistry,
-} = utils;
+const { isMultiSelect, getDefaultRegistry } = utils;
 
 const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
   const { schema, registry = getDefaultRegistry() } = props;
 
   // TODO: update types so we don't have to cast registry as any
-  if (isMultiSelect(schema, (registry as any).rootSchema)) {
+  if (isMultiSelect(schema, props.uiSchema, (registry as any).rootSchema)) {
     return <DefaultFixedArrayFieldTemplate {...props} />;
   } else {
     return <DefaultNormalArrayFieldTemplate {...props} />;
@@ -73,7 +70,7 @@ const DefaultArrayItem = (props: any) => {
     flex: 1,
     paddingLeft: 6,
     paddingRight: 6,
-    fontWeight: 'bold',
+    fontWeight: "bold",
   };
   return (
     <Grid container={true} key={props.key} alignItems="center">
@@ -130,23 +127,21 @@ const DefaultFixedArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
         key={`array-field-title-${props.idSchema.$id}`}
         TitleField={props.TitleField}
         idSchema={props.idSchema}
-        title={props.uiSchema['ui:title'] || props.title}
+        title={props.uiSchema["ui:title"] || props.title}
         required={props.required}
       />
 
-      {(props.uiSchema['ui:description'] || props.schema.description) && (
+      {(props.uiSchema["ui:description"] || props.schema.description) && (
         <div
           className="field-description"
-          key={`field-description-${props.idSchema.$id}`}
-        >
-          {props.uiSchema['ui:description'] || props.schema.description}
+          key={`field-description-${props.idSchema.$id}`}>
+          {props.uiSchema["ui:description"] || props.schema.description}
         </div>
       )}
 
       <div
         className="row array-item-list"
-        key={`array-item-list-${props.idSchema.$id}`}
-      >
+        key={`array-item-list-${props.idSchema.$id}`}>
         {props.items && props.items.map(DefaultArrayItem)}
       </div>
 
@@ -169,17 +164,17 @@ const DefaultNormalArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
           key={`array-field-title-${props.idSchema.$id}`}
           TitleField={props.TitleField}
           idSchema={props.idSchema}
-          title={props.uiSchema['ui:title'] || props.title}
+          title={props.uiSchema["ui:title"] || props.title}
           required={props.required}
         />
 
-        {(props.uiSchema['ui:description'] || props.schema.description) && (
+        {(props.uiSchema["ui:description"] || props.schema.description) && (
           <ArrayFieldDescription
             key={`array-field-description-${props.idSchema.$id}`}
             DescriptionField={props.DescriptionField}
             idSchema={props.idSchema}
             description={
-              props.uiSchema['ui:description'] || props.schema.description
+              props.uiSchema["ui:description"] || props.schema.description
             }
           />
         )}


### PR DESCRIPTION
### Reasons for making this change

Currently it is impossible to render a multiselect for an array that doesn't have an enum. This is useful when the array is open-ended and can contain any strings provided in a multiselect input. It also makes it more consistent as a behavior when compared with how it is decided whether it is a files widget or not.

Related tickets:
https://github.com/rjsf-team/react-jsonschema-form/pull/1196
https://github.com/rjsf-team/react-jsonschema-form/issues/774
https://github.com/rjsf-team/react-jsonschema-form/issues/939
https://github.com/rjsf-team/react-jsonschema-form/issues/1645
https://github.com/rjsf-team/react-jsonschema-form/issues/1570
https://github.com/rjsf-team/react-jsonschema-form/issues/1385

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
