### PR TITLE
Fix codepen examples on the docs

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -2,7 +2,7 @@ $(function() {
 function escape(html) {
     return html.replace(/&/g, "&amp;").replace(/>/g, "&gt;").replace(/</g, "&lt;").replace(/"/g, "&quot;");
 }
-$(".jsx").each(function() {
+$(".language-jsx").each(function() {
     var text = escape($(this).text());
     if (text.indexOf("render") === -1) {
         return;


### PR DESCRIPTION
Interactive codepen examples on the docs stopped working after upgrading mkdocs to 1.1.2.