### PR TITLE
Fix crashing when arrayfield has a formdata set to null

### DIFF
--- a/packages/core/src/components/fields/ArrayField.js
+++ b/packages/core/src/components/fields/ArrayField.js
@@ -224,8 +224,8 @@ class ArrayField extends Component {
         updatedKeyedFormData: false,
       };
     }
-    const nextFormData = nextProps.formData;
-    const previousKeyedFormData = prevState.keyedFormData;
+    const nextFormData = nextProps.formData || [];
+    const previousKeyedFormData = prevState.keyedFormData || [];
     const newKeyedFormData =
       nextFormData.length === previousKeyedFormData.length
         ? previousKeyedFormData.map((previousKeyedFormDatum, index) => {

--- a/packages/core/test/ArrayField_test.js
+++ b/packages/core/test/ArrayField_test.js
@@ -142,7 +142,7 @@ describe("ArrayField", () => {
       expect(node.querySelectorAll(".field-string")).to.have.length.of(0);
     });
   });
-  
+
   describe("Nullable array formData", () => {
     const schema = {
       type: "object",

--- a/packages/core/test/ArrayField_test.js
+++ b/packages/core/test/ArrayField_test.js
@@ -123,6 +123,26 @@ describe("ArrayField", () => {
     });
   });
 
+  describe("Malformed nested array formData", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        foo: {
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+    };
+
+    it("should contain no field in the list when nested array formData is explicitly null", () => {
+      const { node } = createFormComponent({
+        schema,
+        formData: { foo: null },
+      });
+      expect(node.querySelectorAll(".field-string")).to.have.length.of(0);
+    });
+  });
+
   describe("List of inputs", () => {
     const schema = {
       type: "array",

--- a/packages/core/test/ArrayField_test.js
+++ b/packages/core/test/ArrayField_test.js
@@ -142,6 +142,33 @@ describe("ArrayField", () => {
       expect(node.querySelectorAll(".field-string")).to.have.length.of(0);
     });
   });
+  
+  describe("Nullable array formData", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        foo: {
+          type: ["array", "null"],
+          items: { type: "string" },
+        },
+      },
+    };
+
+    it("should contain no field in the list when nested array formData is explicitly null", () => {
+      const { node } = createFormComponent({
+        schema,
+        formData: { foo: null },
+      });
+      expect(node.querySelectorAll(".field-string")).to.have.length.of(0);
+    });
+    it("should contain a field in the list when nested array formData is a single item", () => {
+      const { node } = createFormComponent({
+        schema,
+        formData: { foo: ["test"] },
+      });
+      expect(node.querySelectorAll(".field-string")).to.have.length.of(1);
+    });
+  });
 
   describe("List of inputs", () => {
     const schema = {


### PR DESCRIPTION
### Reasons for making this change

Fixed edge case in ArrayField component that would sometimes cause a runtime error. Fixes #2153 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
