### PR TITLE
Properly hide rows when ui:widget is hidden (bootstrap-4)

### DIFF
--- a/packages/bootstrap-4/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/bootstrap-4/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -33,7 +33,7 @@ const ObjectFieldTemplate = ({
       )}
       <Container fluid className="p-0">
         {properties.map((element: any, index: number) => (
-          <Row key={index} style={{ marginBottom: "10px" }}>
+          <Row key={index} style={{ marginBottom: "10px" }} className={(element.content.uiSchema["ui:widget"] === "hidden")?"d-none":undefined} >
             <Col xs={12}> {element.content}</Col>
           </Row>
         ))}

--- a/packages/bootstrap-4/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/bootstrap-4/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -33,7 +33,7 @@ const ObjectFieldTemplate = ({
       )}
       <Container fluid className="p-0">
         {properties.map((element: any, index: number) => (
-          <Row key={index} style={{ marginBottom: "10px" }} className={(element.content.uiSchema["ui:widget"] === "hidden")?"d-none":undefined} >
+          <Row key={index} style={{ marginBottom: "10px" }} className={(element.content.props.uiSchema["ui:widget"] === "hidden")?"d-none":undefined} >
             <Col xs={12}> {element.content}</Col>
           </Row>
         ))}


### PR DESCRIPTION
### Reasons for making this change

When `ui:widget` is `hidden`, add class `d-none` to `Row` so that the corresponding row is properly hided. This fix is for `bootstrap-4`, but basically the other themes can also be patched in the same way.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
