### PR TITLE
Fix regular expression for number field cached formData value (#2157)

### DIFF
--- a/packages/core/src/components/fields/NumberField.js
+++ b/packages/core/src/components/fields/NumberField.js
@@ -73,11 +73,17 @@ class NumberField extends React.Component {
       // Construct a regular expression that checks for a string that consists
       // of the formData value suffixed with zero or one '.' characters and zero
       // or more '0' characters
-      const re = new RegExp(`${value}`.replace(".", "\\.") + "\\.?0*$");
+      const re = new RegExp("^" + `${value}`.replace(".", "\\.") + "\\.?0*$");
 
-      // If the cached "lastValue" is a match, use that instead of the formData
-      // value to prevent the input value from changing in the UI
-      if (lastValue.match(re)) {
+      let normalizedLastValue = `${lastValue}`;
+      if (`${lastValue}`.charAt(0) === ".") {
+        normalizedLastValue = `0${lastValue}`;
+      }
+
+      // If the normalized cached "lastValue" is a match, use the "lastValue"
+      // instead of the formData value to prevent the input value from changing
+      // in the UI
+      if (normalizedLastValue.match(re)) {
         value = lastValue;
       }
     }

--- a/packages/core/test/NumberField_test.js
+++ b/packages/core/test/NumberField_test.js
@@ -299,6 +299,26 @@ describe("NumberField", () => {
         expect($input.value).eql(".00");
       });
 
+      it("should not used cached value when substring matches", () => {
+        const schema = {
+          type: "number",
+        };
+        const { comp, node } = createFormComponent({
+          schema,
+          formData: 11,
+        });
+
+        Simulate.change(node.querySelector("input"), {
+          target: { value: "11" },
+        });
+
+        setProps(comp, {
+          schema,
+          formData: 1,
+        });
+        expect(node.querySelector("input").value).eql("1");
+      });
+
       it("should update input values correctly when formData prop changes", () => {
         const schema = {
           type: "number",


### PR DESCRIPTION
Use a ^ to ensure regex matches the entire new value and not just the
end of the value.

Normalize the cache value with a leading zero when it starts with a
decimal character as is done in handleChange.

Co-authored-by: Landon Bradshaw <landon.bradshaw@gmail.com>

Fixes #2157

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
