### PR TITLE
Update react is/1209 valid element type

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -11206,9 +11206,9 @@
       }
     },
     "react-is": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-monaco-editor": {
       "version": "0.26.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
     "index.d.ts"
   ],
   "engineStrict": false,
-  "engines":{
+  "engines": {
     "node": ">=12"
   },
   "peerDependencies": {
@@ -47,7 +47,7 @@
     "jsonpointer": "^4.0.1",
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
-    "react-is": "^16.9.0",
+    "react-is": "^16.13.1",
     "shortid": "^2.2.14"
   },
   "devDependencies": {

--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -1,6 +1,7 @@
 import IconButton from "../IconButton";
 import React from "react";
 import PropTypes from "prop-types";
+import * as ReactIs from "react-is";
 import * as types from "../../types";
 
 import {
@@ -28,7 +29,7 @@ const COMPONENT_TYPES = {
 
 function getFieldComponent(schema, uiSchema, idSchema, fields) {
   const field = uiSchema["ui:field"];
-  if (typeof field === "function") {
+  if (typeof field !== "string" && ReactIs.isValidElementType(field)) {
     return field;
   }
   if (typeof field === "string" && field in fields) {

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -126,11 +126,7 @@ export function getWidget(schema, widget, registeredWidgets = {}) {
     return Widget.MergedWidget;
   }
 
-  if (
-    typeof widget === "function" ||
-    ReactIs.isForwardRef(React.createElement(widget)) ||
-    ReactIs.isMemo(widget)
-  ) {
+  if (typeof widget !== "string" && ReactIs.isValidElementType(widget)) {
     return mergeOptions(widget);
   }
 

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -3602,6 +3602,37 @@ describe("utils", () => {
       const Widget = React.memo(props => <div {...props} />);
       expect(getWidget(schema, Widget)({})).eql(<Widget options={{}} />);
     });
+
+    it("should not fail on components using Suspense", done => {
+      const LazilyLoaded = React.lazy(() =>
+        Promise.resolve({ default: props => <div {...props} /> })
+      );
+      const Widget = props => (
+        <React.Suspense fallback={null}>
+          <LazilyLoaded {...props} />
+        </React.Suspense>
+      );
+
+      expect(getWidget(schema, Widget)({})).eql(<Widget options={{}} />);
+      done();
+    });
+
+    it("should not fail on components using Suspense in registered widgets", done => {
+      const LazilyLoaded = React.lazy(() =>
+        Promise.resolve({ default: props => <div {...props} /> })
+      );
+      const Widget = props => (
+        <React.Suspense fallback={null}>
+          <LazilyLoaded {...props} />
+        </React.Suspense>
+      );
+      const widgetName = "lazyDiv";
+
+      expect(getWidget(schema, widgetName, { [widgetName]: Widget })({})).eql(
+        <Widget options={{}} />
+      );
+      done();
+    });
   });
 
   describe("getDisplayLabel", () => {


### PR DESCRIPTION
### Reasons for making this change

 This adds a test around my project's desire to break a moment (and moment-tz) dependency out of our main rjsf chunk by using React's Suspense.

This is an update to @jonathanhawleypeters's existent PR in #1737.

If this is related to existing tickets, include links to them as well.

I believe there are a few, but among others:

#1209
#2039

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
