### PR TITLE
fix: MultiSchema getting incorrect id in arrays

### DIFF
--- a/docs/3.x upgrade guide.md
+++ b/docs/3.x upgrade guide.md
@@ -26,29 +26,29 @@ Now any option with a reference will be resolved/dereferenced when given as prop
 
 ### Generate correct ids when arrays are combined with `anyOf`/`oneOf`
 
-Previously when you have arrays inside `anyOf` or `oneOf`, the parent isn't
-used to generate ids. For example, given a schema such as
+In v2, with arrays inside `anyOf` or `oneOf`, the parent name
+was not used to generate ids. For example, given a schema such as
 
-```
+```json
 {
-  type: "object",
-  properties: {
-    items: {
-      type: "array",
-      items: {
-        type: "object",
-        anyOf: [
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "anyOf": [
           {
-            properties: {
-              foo: {
-                type: "string",
+            "properties": {
+              "foo": {
+                "type": "string",
               },
             },
           },
           {
-            properties: {
-              bar: {
-                type: "string",
+            "properties": {
+              "bar": {
+                "type": "string",
               },
             },
           },
@@ -60,8 +60,8 @@ used to generate ids. For example, given a schema such as
 ```
 
 We would get fields with id `root_foo` and `root_bar`. As you can imagine, we
-can end up with duplicated ids if there's actually a `foo` or a `bar` in the
+could end up with duplicated ids if there's actually a `foo` or a `bar` in the
 root of the schema.
 
-From V3, the child fields will correctly use the parent id when generating
-it's own id. Such as `root_items_0_foo`.
+From v3, the child fields will correctly use the parent id when generating
+its own id. Such as `root_items_0_foo`.

--- a/docs/3.x upgrade guide.md
+++ b/docs/3.x upgrade guide.md
@@ -64,4 +64,4 @@ could end up with duplicated ids if there's actually a `foo` or a `bar` in the
 root of the schema.
 
 From v3, the child fields will correctly use the parent id when generating
-its own id. Such as `root_items_0_foo`.
+its own id, generating ids such as `root_items_0_foo`.

--- a/docs/3.x upgrade guide.md
+++ b/docs/3.x upgrade guide.md
@@ -23,3 +23,45 @@ From `@babel/preset-env`'s docs
 Before an option could include a `$ref`.
 
 Now any option with a reference will be resolved/dereferenced when given as props for `MultiSchemaField`.
+
+### Generate correct ids when arrays are combined with `anyOf`/`oneOf`
+
+Previously when you have arrays inside `anyOf` or `oneOf`, the parent isn't
+used to generate ids. For example, given a schema such as
+
+```
+{
+  type: "object",
+  properties: {
+    items: {
+      type: "array",
+      items: {
+        type: "object",
+        anyOf: [
+          {
+            properties: {
+              foo: {
+                type: "string",
+              },
+            },
+          },
+          {
+            properties: {
+              bar: {
+                type: "string",
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+We would get fields with id `root_foo` and `root_bar`. As you can imagine, we
+can end up with duplicated ids if there's actually a `foo` or a `bar` in the
+root of the schema.
+
+From V3, the child fields will correctly use the parent id when generating
+it's own id. Such as `root_items_0_foo`.

--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -243,7 +243,7 @@ function SchemaFieldRender(props) {
   let idSchema = props.idSchema;
   const schema = retrieveSchema(props.schema, rootSchema, formData);
   idSchema = mergeObjects(
-    toIdSchema(schema, null, rootSchema, formData, idPrefix),
+    toIdSchema(schema, idSchema.$id, rootSchema, formData, idPrefix),
     idSchema
   );
   const FieldComponent = getFieldComponent(schema, uiSchema, idSchema, fields);

--- a/packages/core/test/anyOf_test.js
+++ b/packages/core/test/anyOf_test.js
@@ -810,7 +810,9 @@ describe("anyOf", () => {
 
       expect(node.querySelectorAll("select")).to.have.length.of(1);
 
-      expect(node.querySelectorAll("input#root_foo")).to.have.length.of(1);
+      expect(node.querySelectorAll("input#root_items_0_foo")).to.have.length.of(
+        1
+      );
     });
 
     it("should not change the selected option when switching order of items for anyOf inside array items", () => {
@@ -995,8 +997,12 @@ describe("anyOf", () => {
         target: { value: $select.options[1].value },
       });
 
-      expect(node.querySelectorAll("input#root_foo")).to.have.length.of(1);
-      expect(node.querySelectorAll("input#root_bar")).to.have.length.of(1);
+      expect(node.querySelectorAll("input#root_items_0_foo")).to.have.length.of(
+        1
+      );
+      expect(node.querySelectorAll("input#root_items_0_bar")).to.have.length.of(
+        1
+      );
     });
 
     it("should correctly infer the selected option based on value", () => {

--- a/packages/core/test/anyOf_test.js
+++ b/packages/core/test/anyOf_test.js
@@ -1081,13 +1081,19 @@ describe("anyOf", () => {
         },
       });
 
-      const idSelects = node.querySelectorAll("select#root_id");
+      const rootId = node.querySelector("select#root_id");
+      expect(rootId.value).eql("chain");
 
-      expect(idSelects).to.have.length(4);
-      expect(idSelects[0].value).eql("chain");
-      expect(idSelects[1].value).eql("map");
-      expect(idSelects[2].value).eql("transform");
-      expect(idSelects[3].value).eql("to_absolute");
+      const componentId = node.querySelector("select#root_components_0_id");
+      expect(componentId.value).eql("map");
+
+      const fnId = node.querySelector("select#root_components_0_fn_id");
+      expect(fnId.value).eql("transform");
+
+      const transformerId = node.querySelector(
+        "select#root_components_0_fn_transformer_id"
+      );
+      expect(transformerId.value).eql("to_absolute");
     });
   });
 });

--- a/packages/core/test/oneOf_test.js
+++ b/packages/core/test/oneOf_test.js
@@ -494,7 +494,7 @@ describe("oneOf", () => {
 
     expect($select.value).eql("1");
 
-    Simulate.change(node.querySelector("input#root_bar"), {
+    Simulate.change(node.querySelector("input#root_items_bar"), {
       target: { value: "Lorem ipsum dolor sit amet" },
     });
 
@@ -584,8 +584,12 @@ describe("oneOf", () => {
         target: { value: $select.options[1].value },
       });
 
-      expect(node.querySelectorAll("input#root_foo")).to.have.length.of(1);
-      expect(node.querySelectorAll("input#root_bar")).to.have.length.of(1);
+      expect(node.querySelectorAll("input#root_items_0_foo")).to.have.length.of(
+        1
+      );
+      expect(node.querySelectorAll("input#root_items_0_bar")).to.have.length.of(
+        1
+      );
     });
   });
 

--- a/packages/core/test/oneOf_test.js
+++ b/packages/core/test/oneOf_test.js
@@ -771,12 +771,18 @@ describe("oneOf", () => {
       },
     });
 
-    const idSelects = node.querySelectorAll("select#root_id");
+    const rootId = node.querySelector("select#root_id");
+    expect(rootId.value).eql("chain");
 
-    expect(idSelects).to.have.length(4);
-    expect(idSelects[0].value).eql("chain");
-    expect(idSelects[1].value).eql("map");
-    expect(idSelects[2].value).eql("transform");
-    expect(idSelects[3].value).eql("to_absolute");
+    const componentId = node.querySelector("select#root_components_0_id");
+    expect(componentId.value).eql("map");
+
+    const fnId = node.querySelector("select#root_components_0_fn_id");
+    expect(fnId.value).eql("transform");
+
+    const transformerId = node.querySelector(
+      "select#root_components_0_fn_transformer_id"
+    );
+    expect(transformerId.value).eql("to_absolute");
   });
 });


### PR DESCRIPTION
Fixes #2197

### Reasons for making this change

When MultiSchemaField is part of an array the idSchema is incorrectly generated. This commit fixes that by making sure the parent id is passed to `toIdSchema`.

#2197

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
