### PR TITLE
ui:anyOfDiscriminatorField to choose between available options

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "postinstall": "lerna bootstrap",
     "publish": "lerna publish",
+    "prepare": "npm run build",
     "changed": "lerna changed",
     "test": "lerna run test",
     "lint": "lerna run lint",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "postinstall": "lerna bootstrap",
     "publish": "lerna publish",
-    "prepare": "npm run build",
     "changed": "lerna changed",
     "test": "lerna run test",
     "lint": "lerna run lint",


### PR DESCRIPTION
### Reasons for making this change

I need `anyOf` to represent things like discriminated unions:  https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html#discriminating-unions.

typescript:
```ts
type NetworkLoadingState = {
  state: "loading";
};

type NetworkFailedState = {
  state: "failed";
  code: number;
};

type NetworkSuccessState = {
  state: "success";
  response: {
    title: string;
    duration: number;
    summary: string;
  };
};

// Create a type which represents only one of the above types
// but you aren't sure which it is yet.
type NetworkState =
  | NetworkLoadingState
  | NetworkFailedState
  | NetworkSuccessState;
```

JSON schema:
```json
{
    "$schema": "http://json-schema.org/draft-07/schema#",
    "anyOf": [
        {
            "additionalProperties": false,
            "properties": {
                "state": {
                    "enum": [
                        "loading"
                    ],
                    "type": "string"
                }
            },
            "required": [
                "state"
            ],
            "type": "object"
        },
        {
            "additionalProperties": false,
            "properties": {
                "code": {
                    "type": "number"
                },
                "state": {
                    "enum": [
                        "failed"
                    ],
                    "type": "string"
                }
            },
            "required": [
                "code",
                "state"
            ],
            "type": "object"
        },
        {
            "additionalProperties": false,
            "properties": {
                "response": {
                    "additionalProperties": false,
                    "properties": {
                        "duration": {
                            "type": "number"
                        },
                        "summary": {
                            "type": "string"
                        },
                        "title": {
                            "type": "string"
                        }
                    },
                    "required": [
                        "duration",
                        "summary",
                        "title"
                    ],
                    "type": "object"
                },
                "state": {
                    "enum": [
                        "success"
                    ],
                    "type": "string"
                }
            },
            "required": [
                "response",
                "state"
            ],
            "type": "object"
        }
    ]
}
```

I've added `ui:anyOfDiscriminatorField` to allow one of the fields inside each `anyOf` option to discriminate between options.

There is still some work to do, I need for example to hide the discriminator field inside the inner `SchemaFiled` and update the `formData` inside the `AnyOfField.onOptionChange` method.

Just want to check if this feature would be interesting for the rjsf community or I should just overwrite this in my app.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
