### PR TITLE
[GH-2089][semantic-ui] fix: Text inputs render with invalid attribute

### DIFF
--- a/packages/semantic-ui/src/TextWidget/TextWidget.js
+++ b/packages/semantic-ui/src/TextWidget/TextWidget.js
@@ -26,11 +26,13 @@ function TextWidget({
     onChange(value === "" ? options.emptyValue : value);
   const _onBlur = () => onBlur && onBlur(id, value);
   const _onFocus = () => onFocus && onFocus(id, value);
+  const inputType = schema.type === 'string' ?  'text' : `${schema.type}`
+  
   return (
     <Form.Input
       key={id}
       id={id}
-      type={schema.type}
+      type={inputType}
       label={schema.title || label}
       required={required}
       autoFocus={autofocus}

--- a/packages/semantic-ui/src/TextWidget/TextWidget.js
+++ b/packages/semantic-ui/src/TextWidget/TextWidget.js
@@ -26,7 +26,7 @@ function TextWidget({
     onChange(value === "" ? options.emptyValue : value);
   const _onBlur = () => onBlur && onBlur(id, value);
   const _onFocus = () => onFocus && onFocus(id, value);
-  const inputType = schema.type === 'string' ?  'text' : `${schema.type}`
+  const inputType = schema.type === 'string' ?  'text' : `${schema.type}`;
   
   return (
     <Form.Input

--- a/packages/semantic-ui/test/__snapshots__/Array.test.js.snap
+++ b/packages/semantic-ui/test/__snapshots__/Array.test.js.snap
@@ -215,7 +215,7 @@ exports[`array fields fixed array 1`] = `
                         onChange={[Function]}
                         onFocus={[Function]}
                         required={true}
-                        type="string"
+                        type="text"
                         value=""
                       />
                     </div>

--- a/packages/semantic-ui/test/__snapshots__/Form.test.js.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.js.snap
@@ -186,7 +186,7 @@ exports[`single fields string field regular 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          type="string"
+          type="text"
           value=""
         />
       </div>

--- a/packages/semantic-ui/test/__snapshots__/Object.test.js.snap
+++ b/packages/semantic-ui/test/__snapshots__/Object.test.js.snap
@@ -31,7 +31,7 @@ exports[`object fields object 1`] = `
             onChange={[Function]}
             onFocus={[Function]}
             required={false}
-            type="string"
+            type="text"
             value=""
           />
         </div>


### PR DESCRIPTION
### Reasons for making this change

TextWidget generated <input type="string" ... >

As requested in https://github.com/rjsf-team/react-jsonschema-form/pull/2206#issuecomment-767825753

fix #2089

### Checklist

* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests
