### PR TITLE
[GH-2088][material-ui] fix: Text inputs render with invalid attribute

### DIFF
--- a/packages/material-ui/src/TextWidget/TextWidget.tsx
+++ b/packages/material-ui/src/TextWidget/TextWidget.tsx
@@ -44,6 +44,7 @@ const TextWidget = ({
     uiSchema
     /* TODO: , rootSchema */
   );
+  const inputType = (type || schema.type) === 'string' ?  'text' : `${type || schema.type}`
 
   return (
     <TextField
@@ -52,7 +53,7 @@ const TextWidget = ({
       autoFocus={autofocus}
       required={required}
       disabled={disabled || readonly}
-      type={type || (schema.type as string)}
+      type={inputType as string}
       value={value || value === 0 ? value : ""}
       error={rawErrors.length > 0}
       onChange={_onChange}

--- a/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
@@ -295,7 +295,7 @@ exports[`array fields fixed array 1`] = `
                             onFocus={[Function]}
                             placeholder=""
                             required={true}
-                            type="string"
+                            type="text"
                             value=""
                           />
                         </div>

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -870,7 +870,7 @@ exports[`single fields hidden label 1`] = `
           onFocus={[Function]}
           placeholder=""
           required={false}
-          type="string"
+          type="text"
           value=""
         />
       </div>
@@ -1861,7 +1861,7 @@ exports[`single fields string field regular 1`] = `
           onFocus={[Function]}
           placeholder=""
           required={false}
-          type="string"
+          type="text"
           value=""
         />
       </div>
@@ -1972,7 +1972,7 @@ exports[`single fields string field with placeholder 1`] = `
           onFocus={[Function]}
           placeholder="placeholder"
           required={false}
-          type="string"
+          type="text"
           value=""
         />
       </div>

--- a/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
@@ -137,7 +137,7 @@ exports[`object fields additionalProperties 1`] = `
                     onFocus={[Function]}
                     placeholder=""
                     required={false}
-                    type="string"
+                    type="text"
                     value="foo"
                   />
                 </div>
@@ -381,7 +381,7 @@ exports[`object fields object 1`] = `
                 onFocus={[Function]}
                 placeholder=""
                 required={false}
-                type="string"
+                type="text"
                 value=""
               />
             </div>


### PR DESCRIPTION
### Reasons for making this change

TextWidget generated <input type="string" ... >

As requested in #2206 (comment)

fix #2088

### Checklist

* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests
