### PR TITLE
[GH-2087][bootstrap-4] fix: Text inputs render with invalid attribute

### DIFF
--- a/packages/bootstrap-4/src/TextWidget/TextWidget.tsx
+++ b/packages/bootstrap-4/src/TextWidget/TextWidget.tsx
@@ -34,7 +34,8 @@ const TextWidget = ({
   const _onFocus = ({
     target: { value },
   }: React.FocusEvent<HTMLInputElement>) => onFocus(id, value);
-
+  const inputType = (type || schema.type) === 'string' ?  'text' : `${type || schema.type}`
+  
   // const classNames = [rawErrors.length > 0 ? "is-invalid" : "", type === 'file' ? 'custom-file-label': ""]
   return (
     <Form.Group className="mb-0">
@@ -50,7 +51,7 @@ const TextWidget = ({
         readOnly={readonly}
         className={rawErrors.length > 0 ? "is-invalid" : ""}
         list={schema.examples ? `examples_${id}` : undefined}
-        type={type || (schema.type as string)}
+        type={inputType}
         value={value || value === 0 ? value : ""}
         onChange={_onChange}
         onBlur={_onBlur}

--- a/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
@@ -199,7 +199,7 @@ exports[`array fields fixed array 1`] = `
                         onFocus={[Function]}
                         readOnly={false}
                         required={true}
-                        type="string"
+                        type="text"
                         value=""
                       />
                     </div>

--- a/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
@@ -775,7 +775,7 @@ exports[`single fields string field regular 1`] = `
         onChange={[Function]}
         onFocus={[Function]}
         readOnly={false}
-        type="string"
+        type="text"
         value=""
       />
     </div>
@@ -816,7 +816,7 @@ exports[`single fields string field with placeholder 1`] = `
         onChange={[Function]}
         onFocus={[Function]}
         readOnly={false}
-        type="string"
+        type="text"
         value=""
       />
     </div>

--- a/packages/bootstrap-4/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Object.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`object fields object 1`] = `
                 onFocus={[Function]}
                 readOnly={false}
                 required={false}
-                type="string"
+                type="text"
                 value=""
               />
             </div>


### PR DESCRIPTION
### Reasons for making this change

TextWidget generated <input type="string" ... >

As requested in #2206 (comment)

fix #2087

### Checklist

* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests
