### PR TITLE
fix: check for uiSchema on getDisplayLabel

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -400,7 +400,7 @@ export function getDisplayLabel(schema, uiSchema, rootSchema) {
   if (schema.type === "boolean" && !uiSchema["ui:widget"]) {
     displayLabel = false;
   }
-  if (uiSchema["ui:field"]) {
+  if (uiSchema && uiSchema["ui:field"]) {
     displayLabel = false;
   }
   return displayLabel;


### PR DESCRIPTION
### Reasons for making this change

utils getDisplayLabel does not check if uiSchema prop exists

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
