### PR TITLE
feat(bootstrap-4): support additionalProperties & hide hidden fields

### DIFF
--- a/packages/bootstrap-4/src/AddButton/AddButton.tsx
+++ b/packages/bootstrap-4/src/AddButton/AddButton.tsx
@@ -5,7 +5,7 @@ import Button from "react-bootstrap/Button";
 import { BsPlus } from "react-icons/bs";
 
 const AddButton: React.FC<AddButtonProps> = props => (
-  <Button {...props} color="primary" style={{width: "100%"}} className="ml-1">
+  <Button {...props} block>
     <BsPlus/>
   </Button>
 );

--- a/packages/bootstrap-4/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/bootstrap-4/src/FieldTemplate/FieldTemplate.tsx
@@ -5,6 +5,8 @@ import { FieldTemplateProps } from "@rjsf/core";
 import Form from "react-bootstrap/Form";
 import ListGroup from "react-bootstrap/ListGroup";
 
+import WrapIfAdditional from "./WrapIfAdditional";
+
 const FieldTemplate = ({
   id,
   children,
@@ -12,36 +14,60 @@ const FieldTemplate = ({
   rawErrors = [],
   rawHelp,
   rawDescription,
+  classNames,
+  disabled,
+  hidden,
+  label,
+  onDropPropertyClick,
+  onKeyChange,
+  readonly,
+  required,
+  schema,
 }: FieldTemplateProps) => {
+  if (hidden) {
+    return <div className="hidden">{children}</div>;
+  }
+
   return (
-    <Form.Group>
-      {children}
-      {displayLabel && rawDescription ? (
-        <Form.Text className={rawErrors.length > 0 ? "text-danger" : "text-muted"}>
-          {rawDescription}
-        </Form.Text>
-      ) : null}
-      {rawErrors.length > 0 && (
-        <ListGroup as="ul">
-          {rawErrors.map((error: string) => {
-            return (
-              <ListGroup.Item as="li" key={error} className="border-0 m-0 p-0">
-                <small className="m-0 text-danger">
-                  {error}
-                </small>
-              </ListGroup.Item>
-            );
-          })}
-        </ListGroup>
-      )}
-      {rawHelp && (
-        <Form.Text
-          className={rawErrors.length > 0 ? "text-danger" : "text-muted"}
-          id={id}>
-          {rawHelp}
-        </Form.Text>
-      )}
-    </Form.Group>
+    <WrapIfAdditional
+      classNames={classNames}
+      disabled={disabled}
+      id={id}
+      label={label}
+      onDropPropertyClick={onDropPropertyClick}
+      onKeyChange={onKeyChange}
+      readonly={readonly}
+      required={required}
+      schema={schema}>
+      <Form.Group>
+        {children}
+        {displayLabel && rawDescription && (
+          <Form.Text className={rawErrors.length > 0 ? "text-danger" : "text-muted"}>
+            {rawDescription}
+          </Form.Text>
+        )}
+        {rawErrors.length > 0 && (
+          <ListGroup as="ul">
+            {rawErrors.map((error: string) => {
+              return (
+                <ListGroup.Item as="li" key={error} className="border-0 m-0 p-0">
+                  <small className="m-0 text-danger">
+                    {error}
+                  </small>
+                </ListGroup.Item>
+              );
+            })}
+          </ListGroup>
+        )}
+        {rawHelp && (
+          <Form.Text
+            className={rawErrors.length > 0 ? "text-danger" : "text-muted"}
+            id={id}>
+            {rawHelp}
+          </Form.Text>
+        )}
+      </Form.Group>
+    </WrapIfAdditional>
   );
 };
 

--- a/packages/bootstrap-4/src/FieldTemplate/WrapIfAdditional.tsx
+++ b/packages/bootstrap-4/src/FieldTemplate/WrapIfAdditional.tsx
@@ -1,0 +1,80 @@
+
+import React from "react";
+
+import { utils } from "@rjsf/core";
+import { JSONSchema7 } from "json-schema";
+
+import Row from "react-bootstrap/Row";
+import Col from "react-bootstrap/Col";
+import Form from "react-bootstrap/Form";
+
+import IconButton from "../IconButton/IconButton";
+
+const { ADDITIONAL_PROPERTY_FLAG } = utils;
+
+type WrapIfAdditionalProps = {
+  children: React.ReactElement;
+  classNames: string;
+  disabled: boolean;
+  id: string;
+  label: string;
+  onDropPropertyClick: (index: string) => (event?: any) => void;
+  onKeyChange: (index: string) => (event?: any) => void;
+  readonly: boolean;
+  required: boolean;
+  schema: JSONSchema7;
+};
+
+const WrapIfAdditional = ({
+  children,
+  disabled,
+  id,
+  label,
+  onDropPropertyClick,
+  onKeyChange,
+  readonly,
+  required,
+  schema,
+}: WrapIfAdditionalProps) => {
+  const keyLabel = `${label} Key`; // i18n ?
+  const additional = schema.hasOwnProperty(ADDITIONAL_PROPERTY_FLAG);
+
+  if (!additional) {
+    return children;
+  }
+
+  const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
+    onKeyChange(target.value);
+
+  return (
+    <Row key={`${id}-key`}>
+      <Col xs={5}>
+        <Form.Group>
+          <Form.Label>{keyLabel}</Form.Label>
+          <Form.Control
+            required={required}
+            defaultValue={label}
+            disabled={disabled || readonly}
+            id={`${id}-key`}
+            name={`${id}-key`}
+            onBlur={!readonly ? handleBlur : undefined}
+            type="text"
+          />
+        </Form.Group>
+      </Col>
+      <Col xs={6}>
+        {children}
+      </Col>
+      <Col xs={1} className="py-4">
+        <IconButton
+          icon="remove"
+          tabIndex={-1}
+          disabled={disabled || readonly}
+          onClick={onDropPropertyClick(label)}
+        />
+      </Col>
+    </Row>
+  );
+};
+
+export default WrapIfAdditional;

--- a/packages/bootstrap-4/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/bootstrap-4/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -1,10 +1,14 @@
 import React from "react";
 
-import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 
 import { ObjectFieldTemplateProps } from "@rjsf/core";
+import { utils } from '@rjsf/core';
+
+import AddButton from "../AddButton/AddButton";
+
+const { canExpand } = utils;
 
 const ObjectFieldTemplate = ({
   DescriptionField,
@@ -15,6 +19,11 @@ const ObjectFieldTemplate = ({
   required,
   uiSchema,
   idSchema,
+  schema,
+  formData,
+  onAddClick,
+  disabled,
+  readonly
 }: ObjectFieldTemplateProps) => {
   return (
     <>
@@ -31,13 +40,19 @@ const ObjectFieldTemplate = ({
           description={description}
         />
       )}
-      <Container fluid className="p-0">
-        {properties.map((element: any, index: number) => (
-          <Row key={index} style={{ marginBottom: "10px" }}>
-            <Col xs={12}> {element.content}</Col>
-          </Row>
-        ))}
-      </Container>
+      {properties.map(({content}) => content)}
+
+      {canExpand(schema, uiSchema, formData) && (
+        <Row>
+          <Col xs={{ offset: 9, span: 3 }} className="py-4">
+            <AddButton
+              onClick={onAddClick(schema)}
+              disabled={disabled || readonly}
+              className="object-property-expand"
+            />
+          </Col>
+        </Row>
+      )}
     </>
   );
 };

--- a/packages/bootstrap-4/test/__snapshots__/AddButton.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/AddButton.test.tsx.snap
@@ -2,15 +2,9 @@
 
 exports[`AddButton simple 1`] = `
 <button
-  className="ml-1 btn btn-primary"
-  color="primary"
+  className="someClass btn btn-primary btn-block"
   disabled={false}
   onClick={[Function]}
-  style={
-    Object {
-      "width": "100%",
-    }
-  }
   type="button"
 >
   <svg

--- a/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
@@ -33,15 +33,9 @@ exports[`array fields array 1`] = `
                 >
                    
                   <button
-                    className="ml-1 btn btn-primary"
-                    color="primary"
+                    className="array-item-add btn btn-primary btn-block"
                     disabled={false}
                     onClick={[Function]}
-                    style={
-                      Object {
-                        "width": "100%",
-                      }
-                    }
                     type="button"
                   >
                     <svg

--- a/packages/bootstrap-4/test/__snapshots__/ArrayFieldTemplate.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/ArrayFieldTemplate.test.tsx.snap
@@ -25,15 +25,9 @@ exports[`ArrayFieldTemplate simple 1`] = `
             >
                
               <button
-                className="ml-1 btn btn-primary"
-                color="primary"
+                className="array-item-add btn btn-primary btn-block"
                 disabled={false}
                 onClick={[Function]}
-                style={
-                  Object {
-                    "width": "100%",
-                  }
-                }
                 type="button"
               >
                 <svg

--- a/packages/bootstrap-4/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Object.test.tsx.snap
@@ -10,87 +10,55 @@ exports[`object fields object 1`] = `
     className="form-group"
   >
     <div
-      className="p-0 container-fluid"
+      className="form-group"
     >
       <div
-        className="row"
-        style={
-          Object {
-            "marginBottom": "10px",
-          }
-        }
+        className="mb-0 form-group"
       >
-        <div
-          className="col-12"
+        <label
+          className="form-label"
         >
-           
-          <div
-            className="form-group"
-          >
-            <div
-              className="mb-0 form-group"
-            >
-              <label
-                className="form-label"
-              >
-                a
-              </label>
-              <input
-                autoFocus={false}
-                className="form-control"
-                disabled={false}
-                id="root_a"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                readOnly={false}
-                required={false}
-                type="text"
-                value=""
-              />
-            </div>
-          </div>
-        </div>
+          a
+        </label>
+        <input
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root_a"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          readOnly={false}
+          required={false}
+          type="text"
+          value=""
+        />
       </div>
+    </div>
+    <div
+      className="form-group"
+    >
       <div
-        className="row"
-        style={
-          Object {
-            "marginBottom": "10px",
-          }
-        }
+        className="mb-0 form-group"
       >
-        <div
-          className="col-12"
+        <label
+          className="form-label"
         >
-           
-          <div
-            className="form-group"
-          >
-            <div
-              className="mb-0 form-group"
-            >
-              <label
-                className="form-label"
-              >
-                b
-              </label>
-              <input
-                autoFocus={false}
-                className="form-control"
-                disabled={false}
-                id="root_b"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                readOnly={false}
-                required={false}
-                type="number"
-                value=""
-              />
-            </div>
-          </div>
-        </div>
+          b
+        </label>
+        <input
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root_b"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          readOnly={false}
+          required={false}
+          type="number"
+          value=""
+        />
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Reasons for making this change

Bootstrap 4 theme doesn't support `additionalProperties`. See https://github.com/rjsf-team/react-jsonschema-form/issues/1927

Also, hidden fields still have an empty form group messing up the layout. 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
