### PR TITLE
Fix missing ArrayFieldTemplate export

### DIFF
--- a/packages/semantic-ui/src/index.js
+++ b/packages/semantic-ui/src/index.js
@@ -4,6 +4,7 @@ export { default as Fields } from './Fields';
 export { default as FieldTemplate } from './FieldTemplate';
 export { default as SemanticUIForm } from './SemanticUIForm';
 export { default as ObjectFieldTemplate } from './ObjectFieldTemplate';
+export { default as ArrayFieldTemplate } from "./ArrayFieldTemplate";
 export { default as Theme } from './Theme';
 export { default as Widgets } from './Widgets';
 


### PR DESCRIPTION
### Reasons for making this change

The export of `ArrayFieldTemplate` is missing in the `index.js` in the Semantic-UI package. This is causing issues when testing forms with `jest` or it require custom imports.