### PR TITLE
Add support for extra props on material-ui SelectWidget

### DIFF
--- a/packages/material-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/material-ui/src/SelectWidget/SelectWidget.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 
 import MenuItem from "@material-ui/core/MenuItem";
-import TextField from "@material-ui/core/TextField";
+import TextField, {
+  StandardTextFieldProps as TextFieldProps,
+} from "@material-ui/core/TextField";
 
 import { WidgetProps } from "@rjsf/core";
 import { utils } from "@rjsf/core";
@@ -55,6 +57,7 @@ const SelectWidget = ({
   onBlur,
   onFocus,
   rawErrors = [],
+  ...textFieldProps
 }: WidgetProps) => {
   const { enumOptions, enumDisabled } = options;
 
@@ -89,7 +92,8 @@ const SelectWidget = ({
       }}
       SelectProps={{
         multiple: typeof multiple === "undefined" ? false : multiple,
-      }}>
+      }}
+      {...(textFieldProps as TextFieldProps)}>
       {(enumOptions as any).map(({ value, label }: any, i: number) => {
         const disabled: any =
           enumDisabled && (enumDisabled as any).indexOf(value) != -1;


### PR DESCRIPTION
### Reasons for making this change

For the material-ui theme, the TextWidget supports feeding in extra props, but the SelectWidget does not.  They use the same underlying TestField component.

If this is related to existing tickets, include links to them as well.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
