### PR TITLE
fix: invalid Markdown in Form props reference

### DIFF
--- a/docs/api-reference/form-props.md
+++ b/docs/api-reference/form-props.md
@@ -201,7 +201,7 @@ render((
 
 ## schema
 
-Form schema. We support JSON schema draft-07 by default. See [Schema Reference]((https://json-schema.org/draft-07/json-schema-release-notes.html) for more information.
+Form schema. We support JSON schema draft-07 by default. See [Schema Reference](https://json-schema.org/draft-07/json-schema-release-notes.html) for more information.
 
 ## showErrorList
 


### PR DESCRIPTION
### Reasons for making this change

Fixes a small typo in the `Form` props reference which prevented a link from rendering correctly.

Thanks for this great library!

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
