### PR TITLE
Make formData accessible in a custom FieldTemplate

### DIFF
--- a/docs/advanced-customization/custom-templates.md
+++ b/docs/advanced-customization/custom-templates.md
@@ -146,6 +146,7 @@ The following props are passed to a custom field template component:
 - `schema`: The schema object for this field.
 - `uiSchema`: The uiSchema object for this field.
 - `formContext`: The `formContext` object that you passed to Form.
+- `formData`: The formData for this field.
 - `registry`: The `registry` object.
 
 > Note: you can only define a single global field template for a form, but you can set individual field templates per property using `"ui:FieldTemplate"`.

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -143,7 +143,7 @@ declare module '@rjsf/core' {
 
     export type Field = React.StatelessComponent<FieldProps> | React.ComponentClass<FieldProps>;
 
-    export type FieldTemplateProps = {
+    export type FieldTemplateProps<T = any> = {
         id: string;
         classNames: string;
         label: string;
@@ -163,6 +163,7 @@ declare module '@rjsf/core' {
         schema: JSONSchema7;
         uiSchema: UiSchema;
         formContext: any;
+        formData: T;
         onKeyChange: (value: string) => () => void;
         onDropPropertyClick: (value: string) => () => void;
         registry: FieldProps['registry'];

--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -330,6 +330,7 @@ function SchemaFieldRender(props) {
     displayLabel,
     classNames,
     formContext,
+    formData,
     fields,
     schema,
     uiSchema,


### PR DESCRIPTION
### Reasons for making this change

I have a similar need to access the `formData` for the field about to be rendered in the `FieldTemplate`.

Fixes #1678.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
