### PR TITLE
fix the issue which errors in `onError` loose all ajv properties when…

### DIFF
--- a/packages/core/test/validate_test.js
+++ b/packages/core/test/validate_test.js
@@ -229,6 +229,7 @@ describe("Validation", () => {
         properties: {
           pass1: { type: "string" },
           pass2: { type: "string" },
+          numberWithMinimum: { type: "number", minimum: 5 },
         },
       };
 
@@ -239,20 +240,26 @@ describe("Validation", () => {
           }
           return errors;
         };
-        const formData = { pass1: "a", pass2: "b" };
+        const formData = { pass1: "a", pass2: "b", numberWithMinimum: 2 };
         const result = validateFormData(formData, schema, validate);
         errors = result.errors;
         errorSchema = result.errorSchema;
       });
 
       it("should return an error list", () => {
-        expect(errors).to.have.length.of(1);
-        expect(errors[0].stack).eql("pass2: passwords don't match.");
+        expect(errors).to.have.length.of(2);
+        expect(errors[0].property).eql(".numberWithMinimum");
+        expect(errors[0].message).eql("should be >= 5");
+        expect(errors[1].property).eql(".pass2");
+        expect(errors[1].stack).eql("pass2: passwords don't match.");
       });
 
       it("should return an errorSchema", () => {
         expect(errorSchema.pass2.__errors).to.have.length.of(1);
         expect(errorSchema.pass2.__errors[0]).eql("passwords don't match.");
+
+        expect(errorSchema.numberWithMinimum.__errors).to.have.length.of(1);
+        expect(errorSchema.numberWithMinimum.__errors[0]).eql("should be >= 5");
       });
     });
 
@@ -335,11 +342,11 @@ describe("Validation", () => {
           },
         })
       ).eql([
-        { stack: "root: err1" },
-        { stack: "root: err2" },
-        { stack: "b: err3" },
-        { stack: "b: err4" },
-        { stack: "c: err5" },
+        { property: ".", stack: "root: err1" },
+        { property: ".", stack: "root: err2" },
+        { property: ".a.b", stack: "b: err3" },
+        { property: ".a.b", stack: "b: err4" },
+        { property: ".c", stack: "c: err5" },
       ]);
     });
   });
@@ -502,7 +509,7 @@ describe("Validation", () => {
 
         submitForm(node);
         sinon.assert.calledWithMatch(onError.lastCall, [
-          { stack: "root: Invalid" },
+          { property: ".", stack: "root: Invalid" },
         ]);
       });
 
@@ -529,7 +536,7 @@ describe("Validation", () => {
 
         sinon.assert.calledWithMatch(onChange.lastCall, {
           errorSchema: { __errors: ["Invalid"] },
-          errors: [{ stack: "root: Invalid" }],
+          errors: [{ property: ".", stack: "root: Invalid" }],
           formData: "1234",
         });
       });
@@ -611,8 +618,18 @@ describe("Validation", () => {
         });
         submitForm(node);
         sinon.assert.calledWithMatch(onError.lastCall, [
-          { stack: "pass2: should NOT be shorter than 3 characters" },
-          { stack: "pass2: Passwords don't match" },
+          {
+            message: "should NOT be shorter than 3 characters",
+            name: "minLength",
+            params: { limit: 3 },
+            property: ".pass2",
+            schemaPath: "#/properties/pass2/minLength",
+            stack: ".pass2 should NOT be shorter than 3 characters",
+          },
+          {
+            property: ".pass2",
+            stack: "pass2: Passwords don't match",
+          },
         ]);
       });
 
@@ -650,7 +667,7 @@ describe("Validation", () => {
 
         submitForm(node);
         sinon.assert.calledWithMatch(onError.lastCall, [
-          { stack: "pass2: Passwords don't match" },
+          { property: ".0.pass2", stack: "pass2: Passwords don't match" },
         ]);
       });
 
@@ -678,7 +695,7 @@ describe("Validation", () => {
         });
         submitForm(node);
         sinon.assert.calledWithMatch(onError.lastCall, [
-          { stack: "root: Forbidden value: bbb" },
+          { property: ".", stack: "root: Forbidden value: bbb" },
         ]);
       });
     });


### PR DESCRIPTION
… a custom `validator` property is specified, and add related unit test
This is a fix for 1.x.

### Reasons for making this change

As described in rjsf-team#1596

Enabling custom validation strips json schema errors of useful properties such as "property", "params", and "schemaPath". All properties save "stack" are removed, preventing the error consumer from knowing where the error occurred or what rule it validated.

Additionally, custom errors do not provide a "property" prop, so the error consumer likewise does not know what property is encountering the custom error, just that the error happened 'somewhere'.

This PR fixes both these issues:

JSON Schema errors now keep their properties in the presence of custom validation. This is done by not regenerating the entire error list, but instead keeping the old list and appending the custom errors to this list.

For custom errors, this PR modifies toErrorList to track the path of the error and generate a property prop containing the property path to the property that encountered the error.

Code changes come from RoboPhred, I just submit this PR in version 1.X, I run the test in my computer, all passed

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
