### PR TITLE
Fix input type when schema type is integer

### DIFF
--- a/packages/bootstrap-4/src/TextWidget/TextWidget.tsx
+++ b/packages/bootstrap-4/src/TextWidget/TextWidget.tsx
@@ -34,7 +34,7 @@ const TextWidget = ({
   const _onFocus = ({
     target: { value },
   }: React.FocusEvent<HTMLInputElement>) => onFocus(id, value);
-  const inputType = (type || schema.type) === 'string' ?  'text' : `${type || schema.type}`
+  const inputType = ((type || schema.type) === 'string' || schema.type === 'integer') ?  'text' : `${type || schema.type}`
   
   // const classNames = [rawErrors.length > 0 ? "is-invalid" : "", type === 'file' ? 'custom-file-label': ""]
   return (

--- a/packages/bootstrap-4/test/TextWidget.test.tsx
+++ b/packages/bootstrap-4/test/TextWidget.test.tsx
@@ -10,4 +10,11 @@ describe("TextWidget", () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  test("schema integer type as string", () => {
+    const tree = renderer
+      .create(<TextWidget {...makeWidgetMockProps({})} schema={{type: 'string'}} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/bootstrap-4/test/__snapshots__/TextWidget.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/TextWidget.test.tsx.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TextWidget schema integer type as string 1`] = `
+<div
+  className="mb-0 form-group"
+>
+  <label
+    className="text-danger form-label"
+  >
+    Some simple label
+    *
+  </label>
+  <input
+    autoFocus={true}
+    className="is-invalid form-control"
+    disabled={false}
+    id="_id"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    readOnly={true}
+    required={true}
+    type="text"
+    value="value"
+  />
+</div>
+`;
+
 exports[`TextWidget simple 1`] = `
 <div
   className="mb-0 form-group"

--- a/packages/fluent-ui/src/TextWidget/TextWidget.tsx
+++ b/packages/fluent-ui/src/TextWidget/TextWidget.tsx
@@ -69,7 +69,7 @@ const TextWidget = ({
   }: React.FocusEvent<HTMLInputElement>) => onFocus(id, value);
 
   const uiProps = _pick(options.props || {}, allowedProps);
-  const inputType = schema.type === 'string' ?  'text' : `${schema.type}`
+  const inputType = (schema.type === 'string' || schema.type === 'integer') ? 'text' : `${schema.type}`
 
   return (
     <TextField

--- a/packages/fluent-ui/test/TextWidget.test.tsx
+++ b/packages/fluent-ui/test/TextWidget.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import TextWidget from "../src/TextWidget";
+import renderer from "react-test-renderer";
+
+const noop = () => undefined;
+describe("TextWidget", () => {
+  const props = {
+    schema: {
+      type: 'string'
+    },
+    uiSchema: {},
+    formContext: {},
+    options: {},
+    id: "id",
+    label: 'test',
+    autofocus: false,
+    readonly: false,
+    required: false,
+    multiple: false,
+    disabled: false,
+    rawErrors: [""],
+    value: "value",
+    onChange: noop,
+    onBlur: noop,
+    onFocus: noop,
+  }
+  test("schema integer type as string", () => {
+    const tree = renderer
+      .create(<TextWidget {...props} schema={{ type: "integer" }} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/fluent-ui/test/__snapshots__/TextWidget.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/TextWidget.test.tsx.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextWidget schema integer type as string 1`] = `
+<div
+  className="ms-TextField root-41"
+>
+  <div
+    className="ms-TextField-wrapper"
+  >
+    <label
+      className="ms-Label root-49"
+      htmlFor="id"
+      id="TextFieldLabel3"
+    >
+      test
+    </label>
+    <div
+      className="ms-TextField-fieldGroup fieldGroup-42"
+    >
+      <input
+        aria-invalid={false}
+        aria-labelledby="TextFieldLabel3"
+        autoFocus={false}
+        className="ms-TextField-field field-43"
+        disabled={false}
+        id="id"
+        name="nodejs"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        readOnly={false}
+        required={false}
+        type="text"
+        value="value"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/packages/material-ui/src/TextWidget/TextWidget.tsx
+++ b/packages/material-ui/src/TextWidget/TextWidget.tsx
@@ -44,7 +44,7 @@ const TextWidget = ({
     uiSchema
     /* TODO: , rootSchema */
   );
-  const inputType = (type || schema.type) === 'string' ?  'text' : `${type || schema.type}`
+  const inputType = ((type || schema.type) === 'string' || schema.type === 'integer') ?  'text' : `${type || schema.type}`
 
   return (
     <TextField

--- a/packages/material-ui/test/TextWidget.test.tsx
+++ b/packages/material-ui/test/TextWidget.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import TextWidget from "../src/TextWidget";
+import renderer from "react-test-renderer";
+
+const noop = () => undefined;
+describe("TextWidget", () => {
+  const props = {
+    schema: {
+      type: 'string'
+    },
+    uiSchema: {},
+    formContext: {},
+    options: {},
+    id: "id",
+    label: 'test',
+    autofocus: false,
+    readonly: false,
+    required: false,
+    disabled: false,
+    multiple: false,
+    rawErrors: [""],
+    value: "value",
+    onChange: noop,
+    onBlur: noop,
+    onFocus: noop,
+  }
+  test("schema integer type as string", () => {
+    const tree = renderer
+      .create(<TextWidget {...props} schema={{ type: "integer" }} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/material-ui/test/__snapshots__/TextWidget.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/TextWidget.test.tsx.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextWidget schema integer type as string 1`] = `
+<div
+  className="MuiFormControl-root MuiTextField-root"
+  multiple={false}
+>
+  <label
+    className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink Mui-error Mui-error MuiFormLabel-filled"
+    data-shrink={true}
+    htmlFor="id"
+    id="id-label"
+  >
+    test
+  </label>
+  <div
+    className="MuiInputBase-root MuiInput-root MuiInput-underline Mui-error Mui-error MuiInputBase-formControl MuiInput-formControl"
+    onClick={[Function]}
+  >
+    <input
+      aria-invalid={true}
+      autoFocus={false}
+      className="MuiInputBase-input MuiInput-input"
+      disabled={false}
+      id="id"
+      onAnimationStart={[Function]}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      required={false}
+      type="text"
+      value="value"
+    />
+  </div>
+</div>
+`;

--- a/packages/semantic-ui/src/TextWidget/TextWidget.js
+++ b/packages/semantic-ui/src/TextWidget/TextWidget.js
@@ -26,7 +26,7 @@ function TextWidget({
     onChange(value === "" ? options.emptyValue : value);
   const _onBlur = () => onBlur && onBlur(id, value);
   const _onFocus = () => onFocus && onFocus(id, value);
-  const inputType = schema.type === 'string' ?  'text' : `${schema.type}`;
+  const inputType = (schema.type === 'string' || schema.type === 'integer') ?  'text' : `${schema.type}`;
   
   return (
     <Form.Input

--- a/packages/semantic-ui/test/TextWidget.test.js
+++ b/packages/semantic-ui/test/TextWidget.test.js
@@ -16,10 +16,10 @@ describe("TextWidget", () => {
     options: {},
     formContext: {},
     id: "id",
-  }
+  };
   test("schema integer type as string", () => {
     const tree = renderer
-      .create(<TextWidget {...props} schema={{type: 'integer'}} />)
+      .create(<TextWidget {...props} schema={{ type: 'integer' }} />)
       .toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/semantic-ui/test/TextWidget.test.js
+++ b/packages/semantic-ui/test/TextWidget.test.js
@@ -1,0 +1,26 @@
+import React from "react";
+import TextWidget from "../src/TextWidget";
+import renderer from "react-test-renderer";
+
+const noop = () => undefined;
+describe("TextWidget", () => {
+  const props = {
+    uiSchema: {},
+    onChange: noop,
+    onBlur: noop,
+    onFocus: noop,
+    label: 'test',
+    disabled: false,
+    rawErrors: [""],
+    value: "value",
+    options: {},
+    formContext: {},
+    id: "id",
+  }
+  test("schema integer type as string", () => {
+    const tree = renderer
+      .create(<TextWidget {...props} schema={{type: 'integer'}} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/semantic-ui/test/__snapshots__/TextWidget.test.js.snap
+++ b/packages/semantic-ui/test/__snapshots__/TextWidget.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextWidget schema integer type as string 1`] = `
+<div
+  className="field"
+>
+  <label
+    htmlFor="id"
+  >
+    test
+  </label>
+  <div
+    className="ui input"
+  >
+    <input
+      id="id"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      type="text"
+      value="value"
+    />
+  </div>
+</div>
+`;


### PR DESCRIPTION
### Reasons for making this change

Fixing wrong input type, when integer type used in schema.

#2223 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
