### PR TITLE
fix: anyOf/oneOf not load options with $ref correctly

### DIFF
--- a/packages/core/src/components/fields/MultiSchemaField.js
+++ b/packages/core/src/components/fields/MultiSchemaField.js
@@ -119,6 +119,9 @@ class AnyOfField extends Component {
     const { selectedOption } = this.state;
     const { widget = "select", ...uiOptions } = getUiOptions(uiSchema);
     const Widget = getWidget({ type: "number" }, widget, widgets);
+    const optionsSchema = options.map(option =>
+      retrieveSchema(option, registry.rootSchema, formData)
+    );
 
     const option = options[selectedOption] || null;
     let optionSchema;
@@ -131,7 +134,7 @@ class AnyOfField extends Component {
         : Object.assign({}, option, { type: baseType });
     }
 
-    const enumOptions = options.map((option, index) => ({
+    const enumOptions = optionsSchema.map((option, index) => ({
       label: option.title || `Option ${index + 1}`,
       value: index,
     }));

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -221,9 +221,23 @@ function computeDefaults(
   } else if ("oneOf" in schema) {
     schema =
       schema.oneOf[getMatchingOption(undefined, schema.oneOf, rootSchema)];
+    return computeDefaults(
+      schema,
+      defaults,
+      rootSchema,
+      formData,
+      includeUndefinedValues
+    );
   } else if ("anyOf" in schema) {
     schema =
       schema.anyOf[getMatchingOption(undefined, schema.anyOf, rootSchema)];
+    return computeDefaults(
+      schema,
+      defaults,
+      rootSchema,
+      formData,
+      includeUndefinedValues
+    );
   }
 
   // Not defaults defined for this node, fallback to generic typed ones.

--- a/packages/core/test/anyOf_test.js
+++ b/packages/core/test/anyOf_test.js
@@ -67,12 +67,17 @@ describe("anyOf", () => {
             },
           },
           {
+            $ref: "#/definitions/bar",
+          },
+        ],
+        definitions: {
+          bar: {
             type: "object",
             properties: {
               foo: { type: "string", default: "defaultbar" },
             },
           },
-        ],
+        },
       },
     });
     sinon.assert.calledWithMatch(onChange.lastCall, {
@@ -826,6 +831,46 @@ describe("anyOf", () => {
 
       expect(node.querySelectorAll("input#root_foo")).to.have.length.of(1);
       expect(node.querySelectorAll("input#root_bar")).to.have.length.of(1);
+    });
+
+    it("should correctly set the label of the options", () => {
+      const schema = {
+        type: "object",
+        anyOf: [
+          {
+            title: "Foo",
+            properties: {
+              foo: { type: "string" },
+            },
+          },
+          {
+            properties: {
+              bar: { type: "string" },
+            },
+          },
+          {
+            $ref: "#/definitions/baz",
+          },
+        ],
+        definitions: {
+          baz: {
+            title: "Baz",
+            properties: {
+              baz: { type: "string" },
+            },
+          },
+        },
+      };
+
+      const { node } = createFormComponent({
+        schema,
+      });
+
+      const $select = node.querySelector("select");
+
+      expect($select.options[0].text).eql("Foo");
+      expect($select.options[1].text).eql("Option 2");
+      expect($select.options[2].text).eql("Baz");
     });
   });
 });

--- a/packages/core/test/oneOf_test.js
+++ b/packages/core/test/oneOf_test.js
@@ -67,12 +67,17 @@ describe("oneOf", () => {
             },
           },
           {
+            $ref: "#/definitions/bar",
+          },
+        ],
+        definitions: {
+          bar: {
             type: "object",
             properties: {
               foo: { type: "string", default: "defaultbar" },
             },
           },
-        ],
+        },
       },
     });
 
@@ -610,6 +615,46 @@ describe("oneOf", () => {
       Simulate.click(node.querySelector(".array-item-add button"));
 
       expect($select.value).to.eql($select.options[1].value);
+    });
+
+    it("should correctly set the label of the options", () => {
+      const schema = {
+        type: "object",
+        oneOf: [
+          {
+            title: "Foo",
+            properties: {
+              foo: { type: "string" },
+            },
+          },
+          {
+            properties: {
+              bar: { type: "string" },
+            },
+          },
+          {
+            $ref: "#/definitions/baz",
+          },
+        ],
+        definitions: {
+          baz: {
+            title: "Baz",
+            properties: {
+              baz: { type: "string" },
+            },
+          },
+        },
+      };
+
+      const { node } = createFormComponent({
+        schema,
+      });
+
+      const $select = node.querySelector("select");
+
+      expect($select.options[0].text).eql("Foo");
+      expect($select.options[1].text).eql("Option 2");
+      expect($select.options[2].text).eql("Baz");
     });
   });
 });


### PR DESCRIPTION
### Reasons for making this change

This fixes oneOf/anyOf not updating default value and label correctly if $ref is used.

Here is a simple [example](https://rjsf-team.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6eyJjb2RlIjoiY3VzdG9tX2ljb25zIiwiY29uZmlnIjp7ImFsbG93ZWRfdHlwZXMiOlsicmV3cmV3cSBzZGFkYSJdLCJtaW5fc2l6ZXMiOnt9fX0sInNjaGVtYSI6eyJ0eXBlIjoib2JqZWN0IiwiYW55T2YiOlt7IiRyZWYiOiIjL2RlZmluaXRpb25zL2JheiJ9LHsidGl0bGUiOiJGb28iLCJwcm9wZXJ0aWVzIjp7ImZvbyI6eyJ0eXBlIjoic3RyaW5nIn19fSx7InByb3BlcnRpZXMiOnsiYmFyIjp7InR5cGUiOiJzdHJpbmcifX19XSwiZGVmaW5pdGlvbnMiOnsiYmF6Ijp7InRpdGxlIjoiQmF6IiwicHJvcGVydGllcyI6eyJiYXoiOnsidHlwZSI6InN0cmluZyJ9fX19fSwidWlTY2hlbWEiOnsiY29uZmlnIjp7InR5cGVfdGFiIjp7InVpOndpZGdldCI6ImhpZGRlbiJ9LCJ0eXBlX2ZpZWxkc2V0Ijp7InVpOndpZGdldCI6ImhpZGRlbiJ9LCJ0eXBlX3NlbGVjdCI6eyJ1aTp3aWRnZXQiOiJoaWRkZW4ifSwidHlwZV9vcHRpb24iOnsidWk6d2lkZ2V0IjoiaGlkZGVuIn0sInR5cGVfdXBsb2FkIjp7InVpOndpZGdldCI6ImhpZGRlbiJ9LCJ0eXBlX2NvbnRlbnQiOnsidWk6d2lkZ2V0IjoiaGlkZGVuIn0sInR5cGVfc3RyaW5nIjp7InVpOndpZGdldCI6ImhpZGRlbiJ9fX0sInRoZW1lIjoiZGVmYXVsdCIsImxpdmVTZXR0aW5ncyI6eyJ2YWxpZGF0ZSI6dHJ1ZSwiZGlzYWJsZSI6ZmFsc2UsIm9taXRFeHRyYURhdGEiOmZhbHNlLCJsaXZlT21pdCI6ZmFsc2V9fQ==) that show clearly that the default value is not set if the first item is using $ref and the title still shows `Option 1` even though it has a title.

#2202 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
