### PR TITLE
Use `ui:emptyValue` for SelectWidget instead of forcing to `undefined`

### DIFF
--- a/packages/bootstrap-4/src/SelectWidget/SelectWidget.tsx
+++ b/packages/bootstrap-4/src/SelectWidget/SelectWidget.tsx
@@ -5,42 +5,11 @@ import Form from "react-bootstrap/Form";
 import { WidgetProps } from "@rjsf/core";
 import { utils } from "@rjsf/core";
 
-const { asNumber, guessType } = utils;
-
-const nums = new Set(["number", "integer"]);
-
-/**
- * This is a silly limitation in the DOM where option change event values are
- * always retrieved as strings.
- */
-const processValue = (schema: any, value: any) => {
-  // "enum" is a reserved word, so only "type" and "items" can be destructured
-  const { type, items } = schema;
-  if (value === "") {
-    return undefined;
-  } else if (type === "array" && items && nums.has(items.type)) {
-    return value.map(asNumber);
-  } else if (type === "boolean") {
-    return value === "true";
-  } else if (type === "number") {
-    return asNumber(value);
-  }
-
-  // If type is undefined, but an enum is present, try and infer the type from
-  // the enum values
-  if (schema.enum) {
-    if (schema.enum.every((x: any) => guessType(x) === "number")) {
-      return asNumber(value);
-    } else if (schema.enum.every((x: any) => guessType(x) === "boolean")) {
-      return value === "true";
-    }
-  }
-
-  return value;
-};
+const { processNewValue } = utils;
 
 const SelectWidget = ({
   schema,
+  uiSchema,
   id,
   options,
   label,
@@ -95,19 +64,19 @@ const SelectWidget = ({
           onBlur &&
           ((event: React.FocusEvent) => {
             const newValue = getValue(event, multiple);
-            onBlur(id, processValue(schema, newValue));
+            onBlur(id, processNewValue({ schema, uiSchema, newValue }));
           })
         }
         onFocus={
           onFocus &&
           ((event: React.FocusEvent) => {
             const newValue = getValue(event, multiple);
-            onFocus(id, processValue(schema, newValue));
+            onFocus(id, processNewValue({ schema, uiSchema, newValue }));
           })
         }
         onChange={(event: React.ChangeEvent) => {
           const newValue = getValue(event, multiple);
-          onChange(processValue(schema, newValue));
+          onChange(processNewValue({ schema, uiSchema, newValue }));
         }}>
         {!multiple && schema.default === undefined && (
           <option value="">{placeholder}</option>

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -351,6 +351,8 @@ declare module '@rjsf/core' {
 
         export function optionsList(schema: JSONSchema7): { label: string; value: string }[];
 
+        export function processNewValue({ schema: JSONSchema7, uiSchema: UiSchema, newValue: string }): undefined | boolean | string | number | array;
+
         export function guessType(value: any): JSONSchema7TypeName;
 
         export function stubExistingAdditionalProperties<T = any>(

--- a/packages/core/src/components/widgets/SelectWidget.js
+++ b/packages/core/src/components/widgets/SelectWidget.js
@@ -1,39 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { asNumber, guessType } from "../../utils";
-
-const nums = new Set(["number", "integer"]);
-
-/**
- * This is a silly limitation in the DOM where option change event values are
- * always retrieved as strings.
- */
-function processValue(schema, value) {
-  // "enum" is a reserved word, so only "type" and "items" can be destructured
-  const { type, items } = schema;
-  if (value === "") {
-    return undefined;
-  } else if (type === "array" && items && nums.has(items.type)) {
-    return value.map(asNumber);
-  } else if (type === "boolean") {
-    return value === "true";
-  } else if (type === "number") {
-    return asNumber(value);
-  }
-
-  // If type is undefined, but an enum is present, try and infer the type from
-  // the enum values
-  if (schema.enum) {
-    if (schema.enum.every(x => guessType(x) === "number")) {
-      return asNumber(value);
-    } else if (schema.enum.every(x => guessType(x) === "boolean")) {
-      return value === "true";
-    }
-  }
-
-  return value;
-}
+import { processNewValue } from "../../utils";
 
 function getValue(event, multiple) {
   if (multiple) {
@@ -49,6 +17,7 @@ function getValue(event, multiple) {
 function SelectWidget(props) {
   const {
     schema,
+    uiSchema,
     id,
     options,
     value,
@@ -77,19 +46,19 @@ function SelectWidget(props) {
         onBlur &&
         (event => {
           const newValue = getValue(event, multiple);
-          onBlur(id, processValue(schema, newValue));
+          onBlur(id, processNewValue({ schema, uiSchema, newValue }));
         })
       }
       onFocus={
         onFocus &&
         (event => {
           const newValue = getValue(event, multiple);
-          onFocus(id, processValue(schema, newValue));
+          onFocus(id, processNewValue({ schema, uiSchema, newValue }));
         })
       }
       onChange={event => {
         const newValue = getValue(event, multiple);
-        onChange(processValue(schema, newValue));
+        onChange(processNewValue({ schema, uiSchema, newValue }));
       }}>
       {!multiple && schema.default === undefined && (
         <option value="">{placeholder}</option>

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -584,7 +584,7 @@ const nums = new Set(["number", "integer"]);
 /**
  * Turn a DOM event form value into its formData counterpart.
  *
- * It is especially used in `SelectWidget` widgets.
+ * It is currently only used in `SelectWidget` widgets.
  *
  * @example turn "24" into 24 if the field is numeric
  * @example turn the user choice of an "empty value" (`""`) into the `ui:emptyValue` alternative, `undefined` otherwise

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -594,7 +594,7 @@ export function processNewValue({ schema, uiSchema, newValue }) {
   const { type, items } = schema;
 
   if (newValue === "") {
-    return undefined;
+    return "ui:emptyValue" in uiSchema ? uiSchema["ui:emptyValue"] : undefined;
   } else if (type === "array" && items && nums.has(items.type)) {
     return newValue.map(asNumber);
   } else if (type === "boolean") {

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -3375,6 +3375,24 @@ describe("utils", () => {
         })
       ).eql(undefined);
     });
+
+    it("should return the enforced `ui:emptyValue` if an empty string is provided", () => {
+      expect(
+        processNewValue({
+          schema: {},
+          uiSchema: { "ui:emptyValue": "alt" },
+          newValue: "",
+        })
+      ).eql("alt");
+
+      expect(
+        processNewValue({
+          schema: { enum: ["@*", ""] },
+          uiSchema: { "ui:emptyValue": "alt" },
+          newValue: "",
+        })
+      ).eql("alt");
+    });
   });
 
   describe("toDateString()", () => {

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -18,6 +18,7 @@ import {
   mergeObjects,
   pad,
   parseDateString,
+  processNewValue,
   retrieveSchema,
   shouldRender,
   toDateString,
@@ -3358,6 +3359,21 @@ describe("utils", () => {
         minute: 0,
         second: 0,
       });
+    });
+  });
+
+  describe("processNewValue()", () => {
+    it("should return undefined if choice is blank", () => {
+      expect(processNewValue({ schema: {}, uiSchema: {}, newValue: "" })).eql(
+        undefined
+      );
+      expect(
+        processNewValue({
+          schema: { enum: ["@*", ""] },
+          uiSchema: {},
+          newValue: "",
+        })
+      ).eql(undefined);
     });
   });
 

--- a/packages/fluent-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/fluent-ui/src/SelectWidget/SelectWidget.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
 import { Label, Dropdown, IDropdownOption } from "@fluentui/react";
-import { WidgetProps } from "@rjsf/core";
+import { WidgetProps, utils } from "@rjsf/core";
 import _pick from "lodash/pick";
+
+const { processNewValue } = utils
 
 // Keys of IDropdownProps from @fluentui/react
 const allowedProps = [
@@ -51,6 +53,7 @@ const allowedProps = [
 
 const SelectWidget = ({
   schema,
+  uiSchema,
   id,
   options,
   label,
@@ -76,17 +79,17 @@ const SelectWidget = ({
     if (multiple) {
       const valueOrDefault = value || [];
       if (item.selected) {
-        onChange([...valueOrDefault, item.key]);
+        onChange(processNewValue({ schema, uiSchema, newValue: [...valueOrDefault, item.key] }));
       } else {
-        onChange(valueOrDefault.filter((key: any) => key !== item.key));
+        onChange(processNewValue({ schema, uiSchema, newValue: valueOrDefault.filter((key: any) => key !== item.key) }));
       }
     } else {
-      onChange(item.key);
+      onChange(processNewValue({ schema, uiSchema, newValue: item.key }));
     }
   };
-  const _onBlur = (e: any) => onBlur(id, e.target.value);
+  const _onBlur = (e: any) => onBlur(id, processNewValue({ schema, uiSchema, newValue: e.target.value }));
 
-  const _onFocus = (e: any) => onFocus(id, e.target.value);
+  const _onFocus = (e: any) => onFocus(id, processNewValue({ schema, uiSchema, newValue: e.target.value }))
 
   const newOptions = (enumOptions as {value: any, label: any}[]).map(option => ({
     key: option.value,

--- a/packages/material-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/material-ui/src/SelectWidget/SelectWidget.tsx
@@ -6,42 +6,11 @@ import TextField from "@material-ui/core/TextField";
 import { WidgetProps } from "@rjsf/core";
 import { utils } from "@rjsf/core";
 
-const { asNumber, guessType } = utils;
-
-const nums = new Set(["number", "integer"]);
-
-/**
- * This is a silly limitation in the DOM where option change event values are
- * always retrieved as strings.
- */
-const processValue = (schema: any, value: any) => {
-  // "enum" is a reserved word, so only "type" and "items" can be destructured
-  const { type, items } = schema;
-  if (value === "") {
-    return undefined;
-  } else if (type === "array" && items && nums.has(items.type)) {
-    return value.map(asNumber);
-  } else if (type === "boolean") {
-    return value === "true";
-  } else if (type === "number") {
-    return asNumber(value);
-  }
-
-  // If type is undefined, but an enum is present, try and infer the type from
-  // the enum values
-  if (schema.enum) {
-    if (schema.enum.every((x: any) => guessType(x) === "number")) {
-      return asNumber(value);
-    } else if (schema.enum.every((x: any) => guessType(x) === "boolean")) {
-      return value === "true";
-    }
-  }
-
-  return value;
-};
+const { processNewValue } = utils
 
 const SelectWidget = ({
   schema,
+  uiSchema,
   id,
   options,
   label,
@@ -63,13 +32,13 @@ const SelectWidget = ({
   const _onChange = ({
     target: { value },
   }: React.ChangeEvent<{ name?: string; value: unknown }>) =>
-    onChange(processValue(schema, value));
+    onChange(processNewValue({ schema, uiSchema, newValue: value }));
   const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
-    onBlur(id, processValue(schema, value));
+    onBlur(id, processNewValue({ schema, uiSchema, newValue: value }));
   const _onFocus = ({
     target: { value },
   }: React.FocusEvent<HTMLInputElement>) =>
-    onFocus(id, processValue(schema, value));
+    onFocus(id, processNewValue({ schema, uiSchema, newValue: value }));
 
   return (
     <TextField

--- a/packages/semantic-ui/src/SelectWidget/SelectWidget.js
+++ b/packages/semantic-ui/src/SelectWidget/SelectWidget.js
@@ -6,9 +6,7 @@ import { utils } from '@rjsf/core';
 import PropTypes from "prop-types";
 import { getSemanticProps } from "../util";
 
-const { asNumber, guessType } = utils;
-
-const nums = new Set(["number", "integer"]);
+const { processNewValue } = utils;
 
 /**
  * * Returns and creates an array format required for semantic drop down
@@ -29,38 +27,9 @@ function createDefaultValueOptionsForDropDown(enumOptions, enumDisabled) {
   return options;
 }
 
-/**
- * This is a silly limitation in the DOM where option change event values are
- * always retrieved as strings.
- */
-const processValue = (schema, value) => {
-  // "enum" is a reserved word, so only "type" and "items" can be destructured
-  const { type, items } = schema;
-  if (value === "") {
-    return undefined;
-  } else if (type === "array" && items && nums.has(items.type)) {
-    return value.map(asNumber);
-  } else if (type === "boolean") {
-    return value === "true" || value === true;
-  } else if (type === "number") {
-    return asNumber(value);
-  }
-
-  // If type is undefined, but an enum is present, try and infer the type from
-  // the enum values
-  if (schema.enum) {
-    if (schema.enum.every(x => guessType(x) === "number")) {
-      return asNumber(value);
-    } else if (schema.enum.every(x => guessType(x) === "boolean")) {
-      return value === "true";
-    }
-  }
-
-  return value;
-};
-
 function SelectWidget({
   schema,
+  uiSchema,
   id,
   options,
   name,
@@ -86,14 +55,14 @@ function SelectWidget({
     event,
     // eslint-disable-next-line no-shadow
     { value }
-  ) => onChange && onChange(processValue(schema, value));
+  ) => onChange && onChange(processNewValue({ schema, uiSchema, newValue: value }));
   // eslint-disable-next-line no-shadow
   const _onBlur = ({ target: { value } }) =>
-    onBlur && onBlur(id, processValue(schema, value));
+    onBlur && onBlur(id, processNewValue({ schema, uiSchema, newValue: value }));
   const _onFocus = ({
     // eslint-disable-next-line no-shadow
     target: { value },
-  }) => onFocus && onFocus(id, processValue(schema, value));
+  }) => onFocus && onFocus(id, processNewValue({ schema, uiSchema, newValue: value }));
   return (
     <Form.Dropdown
       key={id}


### PR DESCRIPTION
### Reasons for making this change

This is related to #1041.

It is actually making `SelectWidget` as described in the documentation here: https://react-jsonschema-form.readthedocs.io/en/latest/usage/validation/#the-case-of-empty-strings

### Checklist

* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed

fixes #1041

cc @mogztter

