### PR TITLE
fix: playground crashes when input is cleared

### DIFF
--- a/packages/playground/src/app.js
+++ b/packages/playground/src/app.js
@@ -440,7 +440,7 @@ class Playground extends Component {
 
   setLiveSettings = ({ formData }) => this.setState({ liveSettings: formData });
 
-  onFormDataChange = ({ formData }) =>
+  onFormDataChange = ({ formData = "" }) =>
     this.setState({ formData, shareURL: null });
 
   onShare = () => {


### PR DESCRIPTION
### Reasons for making this change

This PR fixes the playground crash issue described in #2254. I've changed just a single line to prevent the handler function from receiving `undefined` as an argument.

### Checklist

* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests - not needed
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
