### PR TITLE
fixed link to ajv issue on incorrect schemaPath

### DIFF
--- a/docs/usage/validation.md
+++ b/docs/usage/validation.md
@@ -1,6 +1,6 @@
 # Validation
 
-When the form is submitted, the form data is validated to conform to the given JSON schema; this library uses the [ajv](https://github.com/epoberezkin/ajv) validator by default.
+When the form is submitted, the form data is validated to conform to the given JSON schema; this library uses the [ajv](https://github.com/ajv-validator/ajv) validator by default.
 
 ## Live validation
 
@@ -110,10 +110,10 @@ Each element in the `errors` list passed to `transformErrors` has the following 
 
 - `name`: name of the error, for example, "required" or "minLength"
 - `message`: message, for example, "is a required property" or "should NOT be shorter than 3 characters"
-- `params`: an object with the error params returned by ajv ([see doc](https://github.com/epoberezkin/ajv/tree/6a671057ea6aae690b5967ee26a0ddf8452c6297#error-parameters) for more info).
+- `params`: an object with the error params returned by ajv ([see doc](https://github.com/ajv-validator/ajv/tree/6a671057ea6aae690b5967ee26a0ddf8452c6297#error-parameters) for more info).
 - `property`: a string in Javascript property accessor notation to the data path of the field with the error. For example, `.name` or `['first-name']`.
 - `stack`: full error name, for example ".name is a required property".
-- `schemaPath`: JSON pointer to the schema of the keyword that failed validation. For example, `#/fields/firstName/required`. (Note: this may sometimes be wrong due to a [bug in ajv](https://github.com/epoberezkin/ajv/issues/512)).
+- `schemaPath`: JSON pointer to the schema of the keyword that failed validation. For example, `#/fields/firstName/required`. (Note: this may sometimes be wrong due to a [bug in ajv](https://github.com/ajv-validator/ajv/issues/512)).
 
 ## Error List Display
 
@@ -224,7 +224,7 @@ render((
 ), document.getElementById("app"));
 ```
 
-Format values can be anything AJV’s [`addFormat` method](https://github.com/epoberezkin/ajv/tree/6a671057ea6aae690b5967ee26a0ddf8452c6297#addformatstring-name-stringregexpfunctionobject-format---ajv) accepts.
+Format values can be anything AJV’s [`addFormat` method](https://github.com/ajv-validator/ajv/tree/6a671057ea6aae690b5967ee26a0ddf8452c6297#addformatstring-name-stringregexpfunctionobject-format---ajv) accepts.
 
 ## Async validation
 

--- a/packages/core/test/validate_test.js
+++ b/packages/core/test/validate_test.js
@@ -305,7 +305,7 @@ describe("Validation", () => {
         expect(errors).to.have.length.of(1);
         expect(errors[0].name).eql("type");
         expect(errors[0].property).eql(".properties['foo'].required");
-        expect(errors[0].schemaPath).eql("#/definitions/stringArray/type"); // TODO: This schema path is wrong due to a bug in ajv; change this test when https://github.com/epoberezkin/ajv/issues/512 is fixed.
+        expect(errors[0].schemaPath).eql("#/definitions/stringArray/type"); // TODO: This schema path is wrong due to a bug in ajv; change this test when https://github.com/ajv-validator/ajv/issues/512 is fixed.
         expect(errors[0].message).eql("should be array");
       });
 


### PR DESCRIPTION
ajv repostiory has been moved/renamed so link gave 404

### Reasons for making this change

Looks like ajv validator project has been moved to dedicated repository so old link is not valid anymore. 

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
