### PR TITLE
fix docs: fields prop allows to override OneOfField and AnyOfField

### DIFF
--- a/docs/advanced-customization/custom-widgets-fields.md
+++ b/docs/advanced-customization/custom-widgets-fields.md
@@ -54,7 +54,8 @@ The default fields you can override are:
  - `ArrayField`
  - `BooleanField`
  - `DescriptionField`
- - `MultiSchemaField`
+ - `OneOfField`
+ - `AnyOfField`
  - `NullField`
  - `NumberField`
  - `ObjectField`


### PR DESCRIPTION
### Reasons for making this change

Docs reference to `MultiSchemaField` as overridable, but actually `OneOfField` and `AnyOfField` should be overriden

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
