### PR TITLE
There shouldn;t be redundant name var

### DIFF
--- a/packages/fluent-ui/src/TextWidget/TextWidget.tsx
+++ b/packages/fluent-ui/src/TextWidget/TextWidget.tsx
@@ -81,7 +81,6 @@ const TextWidget = ({
       required={required}
       disabled={disabled}
       readOnly={readonly}
-      name={name}
       type={inputType as string}
       value={value ? value : ""}
       onChange={_onChange as any}


### PR DESCRIPTION
### Reasons for making this change
Fluent UI forms doesn't compile in ts at all because of this.
