### PR TITLE
Release to npm using CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,10 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
-        node-version: [8.x, 9.x, 10.x, 11.x, 12.x, 13.x]
+        node-version: [8.x, 9.x, 10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,8 +24,6 @@ jobs:
     - run: npm test
     - run: npm run lint
     - run: npm run cs-check
-      env:
-        CI: true
 
   deploy:
     runs-on: ubuntu-latest
@@ -51,9 +47,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   
   docs:
-      
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,6 @@ jobs:
       - run: npm test
       - run: npm run lint
       - run: npm run cs-check
-      - run: npx lerna publish from-git --yes
+      - run: npx lerna publish from-package --yes
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: Release
 on:
-  release:
-    types: [published]
+  # release:
+  #   types: [published]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   release_to_npm:
@@ -18,6 +20,9 @@ jobs:
       - run: npm test
       - run: npm run lint
       - run: npm run cs-check
-      - run: npx lerna publish from-package --yes
+      - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npx lerna publish from-package --yes
+      - if: always()
+        run: rm .npmrc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: Release
 on:
-  # release:
-  #   types: [published]
-  pull_request:
-    branches: [ master ]
+  release:
+    types: [published]
 
 jobs:
   release_to_npm:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: Release
 on:
-  release:
-    types: [published]
+  # release:
+  #   types: [published]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   release_to_npm:
@@ -21,6 +23,6 @@ jobs:
       - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: npx lerna publish from-package --yes
+      - run: npx lerna publish from-package --yes --no-verify-access
       - if: always()
         run: rm .npmrc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+on:
+  # release:
+  #   types: [published]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  release_to_npm:
+    name: Release to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: 14.x
+      - run: npm install
+      - run: npm run build
+      - run: npm test
+      - run: npm run lint
+      - run: npm run cs-check
+      - run: npx lerna publish from-git --yes
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -41,15 +41,17 @@ The full report can be seen by opening `./coverage/lcov-report/index.html`.
 
 ## Releasing
 
-To release, run:
+To release, go to the master branch and then run:
 
 ```bash
 lerna version
-lerna run build
-lerna publish from-git
 ```
 
-Make sure you use [semver](https://semver.org/) for version numbering. Once a new version has been released, create a release in the Github "Releases" tab and add the version history.
+Make sure you use [semver](https://semver.org/) for version numbering when selecting the version.
+The command above will create a new version tag and push it to GitHub. Then, create a release in
+the Github "Releases" tab and add a description of the changes in the new release.
+
+This will trigger a GitHub Actions pipeline that will build and publish the package to npm.
 
 ### Releasing docs
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -53,6 +53,10 @@ the Github "Releases" tab and add a description of the changes in the new releas
 
 This will trigger a GitHub Actions pipeline that will build and publish all packages to npm.
 
+The package is published through an automation token belonging to the
+[rjsf-bot](https://www.npmjs.com/~rjsf-bot) user on npm. This token
+is stored as the `NPM_TOKEN` secret on GitHub Actions.
+
 ### Releasing docs
 
 Docs are automatically released using [Read The Docs](https://readthedocs.org/) based on the latest commits from the `master` branch.


### PR DESCRIPTION
### Reasons for making this change

Release to npm using CI. This will ensure that releases are more reproducible and is better than me having to build code on my computer manually (related: https://github.com/rjsf-team/react-jsonschema-form/issues/2271).

I've also cleaned up the ci.yml file a bit. I've added additional node versions (node 14, since it's used for release) and dropped some intermediate node versions on the CI builds.

The npm credentials are from the rjsf-bot user (info in https://github.com/rjsf-team/secrets/blob/main/README.md).