### PR TITLE
Pin NODE_VERSION to fix netlify builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,4 @@
 
 [build.environment]
   SHOW_NETLIFY_BADGE = "true"
+  NODE_VERSION = "14"


### PR DESCRIPTION
### Reasons for making this change

Pin NODE_VERSION to fix netlify builds for deploy previews (sample failing build: https://app.netlify.com/sites/rjsf/deploys/60552838e557fe00079ddea4)