### PR TITLE
Drop support for node 10, improve build process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 15.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -31,10 +31,10 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 16.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v2.1.2
       with:
-        node-version: 16.x
+        node-version: 14.x
     - run: npm ci
     - run: npm run build
     - name: Deploy playground to GitHub Pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -19,7 +19,7 @@ jobs:
       uses: actions/setup-node@v2.1.2
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
+    - run: npm ci
     - run: npm run build
     - run: npm test
     - run: npm run lint
@@ -31,11 +31,11 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 13.x
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v2.1.2
       with:
-        node-version: 13.x
-    - run: npm install
+        node-version: 16.x
+    - run: npm ci
     - run: npm run build
     - name: Deploy playground to GitHub Pages
       uses: crazy-max/ghaction-github-pages@v2.2.0

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -19,7 +19,7 @@
   ],
   "engineStrict": false,
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "jest": {
     "moduleNameMapper": {

--- a/packages/bootstrap-4/package.json
+++ b/packages/bootstrap-4/package.json
@@ -20,7 +20,7 @@
   },
   "engineStrict": false,
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
   ],
   "engineStrict": false,
   "engines":{
-    "node": ">=10"
+    "node": ">=12"
   },
   "peerDependencies": {
     "react": ">=16"

--- a/packages/fluent-ui/package.json
+++ b/packages/fluent-ui/package.json
@@ -15,7 +15,7 @@
   },
   "engineStrict": false,
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "peerDependencies": {
     "@fluentui/react": "^7.114.2",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -29,7 +29,7 @@
   ],
   "engineStrict": false,
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "peerDependencies": {
     "react": ">=16"

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -15,7 +15,7 @@
   ],
   "engineStrict": false,
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "build": "npm run build:cjs && npm run build:es",


### PR DESCRIPTION
- Drop support for node 10
- Improve build process (use `npm ci`, and also use node 14 for deploys to the playground)