### PR TITLE
fix: readonly checkbox for bootstrap-4

### DIFF
--- a/packages/bootstrap-4/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/bootstrap-4/src/CheckboxWidget/CheckboxWidget.tsx
@@ -36,8 +36,7 @@ const CheckboxWidget = (props: WidgetProps) => {
           label={desc}
           checked={typeof value === "undefined" ? false : value}
           required={required}
-          disabled={disabled}
-          readOnly={readonly}
+          disabled={disabled || readonly}
           autoFocus={autofocus}
           onChange={_onChange}
           type="checkbox"

--- a/packages/bootstrap-4/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/bootstrap-4/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -73,8 +73,7 @@ const CheckboxesWidget = ({
                 onChange={_onChange(option)}
                 onBlur={_onBlur}
                 onFocus={_onFocus}
-                disabled={disabled || itemDisabled || false}
-                readOnly={readonly}
+                disabled={disabled || readonly || itemDisabled || false}
               />
             </Form>
           ) : (
@@ -91,8 +90,7 @@ const CheckboxesWidget = ({
                 onChange={_onChange(option)}
                 onBlur={_onBlur}
                 onFocus={_onFocus}
-                disabled={disabled || itemDisabled || false}
-                readOnly={readonly}
+                disabled={disabled || readonly || itemDisabled || false}
               />
             </Form>
           );

--- a/packages/bootstrap-4/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/bootstrap-4/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -73,7 +73,7 @@ const CheckboxesWidget = ({
                 onChange={_onChange(option)}
                 onBlur={_onBlur}
                 onFocus={_onFocus}
-                disabled={disabled || readonly || itemDisabled || false}
+                disabled={disabled || itemDisabled || readonly}
               />
             </Form>
           ) : (

--- a/packages/bootstrap-4/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/bootstrap-4/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -90,7 +90,7 @@ const CheckboxesWidget = ({
                 onChange={_onChange(option)}
                 onBlur={_onBlur}
                 onFocus={_onFocus}
-                disabled={disabled || readonly || itemDisabled || false}
+                disabled={disabled || itemDisabled || readonly}
               />
             </Form>
           );

--- a/packages/bootstrap-4/test/__snapshots__/CheckboxWidget.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/CheckboxWidget.test.tsx.snap
@@ -11,12 +11,11 @@ exports[`CheckboxWidget simple 1`] = `
       autoFocus={true}
       checked="value"
       className="form-check-input"
-      disabled={false}
+      disabled={true}
       id="_id"
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}
-      readOnly={true}
       required={true}
       type="checkbox"
     />

--- a/packages/bootstrap-4/test/__snapshots__/CheckboxesWidget.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/CheckboxesWidget.test.tsx.snap
@@ -21,12 +21,11 @@ Array [
           autoFocus={true}
           checked={true}
           className="custom-control-input position-static"
-          disabled={false}
+          disabled={true}
           id="_id_0"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          readOnly={true}
           required={true}
           type="checkbox"
         />
@@ -57,12 +56,11 @@ Array [
           autoFocus={true}
           checked={true}
           className="custom-control-input position-static"
-          disabled={false}
+          disabled={true}
           id="_id_0"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          readOnly={true}
           required={true}
           type="checkbox"
         />

--- a/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
@@ -24,7 +24,6 @@ exports[`single fields checkbox field 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          readOnly={false}
           type="checkbox"
         />
       </div>
@@ -66,7 +65,6 @@ exports[`single fields checkbox field 2`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          readOnly={false}
           type="checkbox"
         />
       </div>
@@ -115,7 +113,6 @@ exports[`single fields checkboxes field 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
-            readOnly={false}
             required={false}
             type="checkbox"
           />
@@ -143,7 +140,6 @@ exports[`single fields checkboxes field 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
-            readOnly={false}
             required={false}
             type="checkbox"
           />
@@ -171,7 +167,6 @@ exports[`single fields checkboxes field 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
-            readOnly={false}
             required={false}
             type="checkbox"
           />
@@ -199,7 +194,6 @@ exports[`single fields checkboxes field 1`] = `
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
-            readOnly={false}
             required={false}
             type="checkbox"
           />


### PR DESCRIPTION
### Reasons for making this change

fixes #2259 

`"ui:readonly": true` was ignored with the bootstrap-4 theme as `readOnly` is not a valid property of the component Form.Check of react-bootstrap


### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

### Deploy preview

Once CI finishes, you should be able to view a deploy preview of the playground from this PR at this link: https://deploy-preview-[PR_NUMBER]--rjsf.netlify.app/

### Test 

#### Checkbox
JSONSchema:
```json
{
  "title": "A choice",
  "type": "boolean"
}
```
UISchema:
```json
{
  "ui:readonly": true
}
```

#### Checkboxes
JSONSchema:
```json
{
  "type": "array",
  "title": "A multiple-choice list",
  "items": {
    "type": "string",
    "enum": ["foo", "bar", "fuzz", "qux"]
  },
  "uniqueItems": true
}
```
UISchema:
```json
{
  "ui:widget": "checkboxes",
  "ui:readonly": true
}
```

