### PR TITLE
Update peer dependency to support React 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 15.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/babel.config.js
+++ b/babel.config.js
@@ -16,7 +16,8 @@ module.exports = {
   ],
   plugins: [
     "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-proposal-optional-chaining"
+    "@babel/plugin-proposal-optional-chaining",
+    "rewiremock/babel"
   ],
   ignore,
 };

--- a/packages/antd/package-lock.json
+++ b/packages/antd/package-lock.json
@@ -3556,16 +3556,6 @@
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
-		"@babel/runtime-corejs2": {
-			"version": "7.13.10",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.13.10.tgz",
-			"integrity": "sha512-rZw5P1ZewO6XZTDxtXuAuAFUqfNXyM8HO/9WiaDd34Anka0uFTpo0RvBLeV775AEE/zKw3LQB+poZw/O9lrZBg==",
-			"dev": true,
-			"requires": {
-				"core-js": "^2.6.5",
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
 		"@babel/runtime-corejs3": {
 			"version": "7.9.2",
 			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
@@ -3851,25 +3841,6 @@
 				"@types/yargs": "^13.0.0"
 			}
 		},
-		"@rjsf/core": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@rjsf/core/-/core-2.5.1.tgz",
-			"integrity": "sha512-km8NYScXNONaL5BiSLS6wyDj49pOLZtn0iXg7Zxlm921uuf3o2AAX5SuZS5kB4Zj2zlrVMrXESexfX6bxdDYHw==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime-corejs2": "^7.8.7",
-				"@types/json-schema": "^7.0.4",
-				"ajv": "^6.7.0",
-				"core-js": "^2.5.7",
-				"json-schema-merge-allof": "^0.6.0",
-				"jsonpointer": "^4.0.1",
-				"lodash": "^4.17.15",
-				"prop-types": "^15.7.2",
-				"react-app-polyfill": "^1.0.4",
-				"react-is": "^16.9.0",
-				"shortid": "^2.2.14"
-			}
-		},
 		"@types/babel__core": {
 			"version": "7.1.7",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
@@ -3945,12 +3916,6 @@
 				"@types/istanbul-lib-coverage": "*",
 				"@types/istanbul-lib-report": "*"
 			}
-		},
-		"@types/json-schema": {
-			"version": "7.0.7",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-			"integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
-			"dev": true
 		},
 		"@types/json5": {
 			"version": "0.0.29",
@@ -4483,7 +4448,8 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
 			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"asn1": {
 			"version": "0.2.4",
@@ -4569,7 +4535,8 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
 			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"async-limiter": {
 			"version": "1.0.1",
@@ -4906,7 +4873,8 @@
 			"version": "1.13.1",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
 			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"bindings": {
 			"version": "1.5.0",
@@ -5270,6 +5238,7 @@
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
 			"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"anymatch": "^2.0.0",
 				"async-each": "^1.0.1",
@@ -5455,29 +5424,6 @@
 			"resolved": "https://registry.npmjs.org/component-indexof/-/component-indexof-0.0.3.tgz",
 			"integrity": "sha1-EdCRMSI5648yyPJa6csAL/6NPCQ=",
 			"dev": true
-		},
-		"compute-gcd": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
-			"integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
-			"dev": true,
-			"requires": {
-				"validate.io-array": "^1.0.3",
-				"validate.io-function": "^1.0.2",
-				"validate.io-integer-array": "^1.0.0"
-			}
-		},
-		"compute-lcm": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
-			"integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
-			"dev": true,
-			"requires": {
-				"compute-gcd": "^1.2.1",
-				"validate.io-array": "^1.0.3",
-				"validate.io-function": "^1.0.2",
-				"validate.io-integer-array": "^1.0.0"
-			}
 		},
 		"compute-scroll-into-view": {
 			"version": "1.0.13",
@@ -7551,6 +7497,7 @@
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"is-glob": "^3.1.0",
 				"path-dirname": "^1.0.0"
@@ -7561,6 +7508,7 @@
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"is-extglob": "^2.1.0"
 					}
@@ -8036,6 +7984,7 @@
 			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"binary-extensions": "^1.0.0"
 			}
@@ -8871,26 +8820,6 @@
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
 			"dev": true
 		},
-		"json-schema-compare": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
-			"integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.4"
-			}
-		},
-		"json-schema-merge-allof": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.6.0.tgz",
-			"integrity": "sha512-LEw4VMQVRceOPLuGRWcxW5orTTiR9ZAtqTAe4rQUjNADTeR81bezBVFa0MqIwp0YmHIM1KkhSjZM7o+IQhaPbQ==",
-			"dev": true,
-			"requires": {
-				"compute-lcm": "^1.1.0",
-				"json-schema-compare": "^0.2.2",
-				"lodash": "^4.17.4"
-			}
-		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -8926,12 +8855,6 @@
 			"requires": {
 				"minimist": "^1.2.5"
 			}
-		},
-		"jsonpointer": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-			"integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
-			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -9521,12 +9444,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"nanoid": {
-			"version": "2.1.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-			"integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
-			"dev": true
-		},
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -9987,7 +9904,8 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
 			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"path-exists": {
 			"version": "3.0.0",
@@ -10847,37 +10765,6 @@
 				"prop-types": "^15.6.2"
 			}
 		},
-		"react-app-polyfill": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-1.0.6.tgz",
-			"integrity": "sha512-OfBnObtnGgLGfweORmdZbyEz+3dgVePQBb3zipiaDsMHV1NpWm0rDFYIVXFV/AK+x4VIIfWHhrdMIeoTLyRr2g==",
-			"dev": true,
-			"requires": {
-				"core-js": "^3.5.0",
-				"object-assign": "^4.1.1",
-				"promise": "^8.0.3",
-				"raf": "^3.4.1",
-				"regenerator-runtime": "^0.13.3",
-				"whatwg-fetch": "^3.0.0"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "3.9.1",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
-					"integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==",
-					"dev": true
-				},
-				"promise": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
-					"integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
-					"dev": true,
-					"requires": {
-						"asap": "~2.0.6"
-					}
-				}
-			}
-		},
 		"react-dom": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
@@ -10976,6 +10863,7 @@
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
 			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"graceful-fs": "^4.1.11",
 				"micromatch": "^3.1.10",
@@ -11492,15 +11380,6 @@
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
 			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
 			"dev": true
-		},
-		"shortid": {
-			"version": "2.2.16",
-			"resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
-			"integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
-			"dev": true,
-			"requires": {
-				"nanoid": "^2.1.0"
-			}
 		},
 		"side-channel": {
 			"version": "1.0.2",
@@ -12585,7 +12464,8 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
 			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"uri-js": {
 			"version": "4.2.2",
@@ -12682,43 +12562,6 @@
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
 			}
-		},
-		"validate.io-array": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
-			"integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00=",
-			"dev": true
-		},
-		"validate.io-function": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
-			"integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc=",
-			"dev": true
-		},
-		"validate.io-integer": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
-			"integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
-			"dev": true,
-			"requires": {
-				"validate.io-number": "^1.0.3"
-			}
-		},
-		"validate.io-integer-array": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
-			"integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
-			"dev": true,
-			"requires": {
-				"validate.io-array": "^1.0.3",
-				"validate.io-integer": "^1.0.4"
-			}
-		},
-		"validate.io-number": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
-			"integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg=",
-			"dev": true
 		},
 		"verror": {
 			"version": "1.10.0",
@@ -13191,12 +13034,6 @@
 			"requires": {
 				"iconv-lite": "0.4.24"
 			}
-		},
-		"whatwg-fetch": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-			"integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
-			"dev": true
 		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",

--- a/packages/bootstrap-4/package-lock.json
+++ b/packages/bootstrap-4/package-lock.json
@@ -1615,9 +1615,9 @@
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
-      "integrity": "sha1-vf1p1h5GTcyBslFZwnDXWnPBpjY=",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "dev": true
     },
     "@types/minimatch": {

--- a/packages/bootstrap-4/package.json
+++ b/packages/bootstrap-4/package.json
@@ -30,7 +30,7 @@
     "@babel/preset-react": "^7.0.0",
     "@rjsf/core": "^2.5.1",
     "@types/jest": "^24.0.15",
-    "@types/json-schema": "^7.0.3",
+    "@types/json-schema": "^7.0.7",
     "@types/react": "^16.9.23",
     "@types/react-dom": "^16.9.5",
     "@types/react-test-renderer": "^16.9.2",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -3674,6 +3674,16 @@
         }
       }
     },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -4527,6 +4537,12 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
+    "compare-module-exports": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/compare-module-exports/-/compare-module-exports-2.1.0.tgz",
+      "integrity": "sha512-3Lc0sTIuX1jmY2K2RrXRJOND6KsRTX2D4v3+eu1PDptsuJZVK4LZc852eZa9I+avj0NrUKlTNgqvccNOH6mbGg==",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -4736,6 +4752,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
       "dev": true
     },
     "core-js-compat": {
@@ -7997,6 +8019,12 @@
         "lodash.words": "^3.0.0"
       }
     },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
     "lodash._root": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
@@ -8032,6 +8060,31 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
+    },
+    "lodash.some": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
+      "dev": true
+    },
+    "lodash.template": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0"
+      }
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -11157,6 +11210,16 @@
         }
       }
     },
+    "react-17": {
+      "version": "npm:react@17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
     "react-codemirror2": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-4.3.0.tgz",
@@ -11398,6 +11461,12 @@
         "regenerate": "^1.4.0"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -11565,6 +11634,22 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
+    },
+    "rewiremock": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/rewiremock/-/rewiremock-3.14.3.tgz",
+      "integrity": "sha512-6BaUGfp7NtxBjisxcGN73nNiA2fS2AwhEk/9DMUqxfv5v0aDM1wpOYpj5GSArqsJi07YCfLhkD8C74LAN7+FkQ==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "compare-module-exports": "^2.1.0",
+        "lodash.some": "^4.6.0",
+        "lodash.template": "^4.4.0",
+        "node-libs-browser": "^2.1.0",
+        "path-parse": "^1.0.5",
+        "wipe-node-cache": "^2.1.2",
+        "wipe-webpack-cache": "^2.1.0"
+      }
     },
     "rimraf": {
       "version": "2.6.2",
@@ -13779,6 +13864,21 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "wipe-node-cache": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/wipe-node-cache/-/wipe-node-cache-2.1.2.tgz",
+      "integrity": "sha512-m7NXa8qSxBGMtdQilOu53ctMaIBXy93FOP04EC1Uf4bpsE+r+adfLKwIMIvGbABsznaSNxK/ErD4xXDyY5og9w==",
+      "dev": true
+    },
+    "wipe-webpack-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wipe-webpack-cache/-/wipe-webpack-cache-2.1.0.tgz",
+      "integrity": "sha512-OXzQMGpA7MnQQ8AG+uMl5mWR2ezy6fw1+DMHY+wzYP1qkF1jrek87psLBmhZEj+er4efO/GD4R8jXWFierobaA==",
+      "dev": true,
+      "requires": {
+        "wipe-node-cache": "^2.1.0"
+      }
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -11268,6 +11268,29 @@
         }
       }
     },
+    "react-dom-17": {
+      "version": "npm:react-dom@17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.2"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+          "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
+      }
+    },
     "react-is": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -11268,29 +11268,6 @@
         }
       }
     },
-    "react-dom-17": {
-      "version": "npm:react-dom@17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
-      },
-      "dependencies": {
-        "scheduler": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-          "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
-      }
-    },
     "react-is": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -2931,9 +2931,9 @@
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
-      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA=="
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
     },
     "@types/node": {
       "version": "12.6.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
     "react": ">=16"
   },
   "dependencies": {
-    "@types/json-schema": "^7.0.4",
+    "@types/json-schema": "^7.0.7",
     "ajv": "^6.7.0",
     "core-js-pure": "^3.6.5",
     "json-schema-merge-allof": "^0.6.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
     "start": "concurrently \"npm:build:* -- --watch\"",
     "tdd": "cross-env NODE_ENV=test mocha --require @babel/register --watch --require ./test/setup-jsdom.js test/**/*_test.js",
     "test": "cross-env BABEL_ENV=test NODE_ENV=test mocha --require @babel/register --require ./test/setup-jsdom.js test/**/*_test.js",
+    "test-react-17": "cross-env BABEL_ENV=test NODE_ENV=test USE_REACT_17=true mocha --require @babel/register --require ./test/setup-jsdom.js test/**/*_test.js",
     "test-coverage": "cross-env NODE_ENV=test nyc --reporter=lcov mocha --require @babel/register --require ./test/setup-jsdom.js test/**/*_test.js",
     "test-debug": "cross-env NODE_ENV=test mocha --require @babel/register --require ./test/setup-jsdom.js --debug-brk --inspect test/Form_test.js"
   },
@@ -33,7 +34,7 @@
     "index.d.ts"
   ],
   "engineStrict": false,
-  "engines":{
+  "engines": {
     "node": ">=12"
   },
   "peerDependencies": {
@@ -90,6 +91,7 @@
     "nyc": "^13.2.0",
     "prettier": "^1.15.1",
     "react": "^16.9.0",
+    "react-17": "npm:react@^17.0.2",
     "react-codemirror2": "^4.1.0",
     "react-dom": "^16.9.0",
     "react-monaco-editor": "^0.26.2",
@@ -97,6 +99,7 @@
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",
     "redbox-react": "^1.3.3",
+    "rewiremock": "^3.14.3",
     "rimraf": "^2.5.4",
     "sinon": "^9.0.2",
     "style-loader": "^0.13.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -94,7 +94,6 @@
     "react-17": "npm:react@^17.0.2",
     "react-codemirror2": "^4.1.0",
     "react-dom": "^16.9.0",
-    "react-dom-17": "npm:react-dom@^17.0.2",
     "react-monaco-editor": "^0.26.2",
     "react-portal": "^4.2.0",
     "react-transform-catch-errors": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -94,6 +94,7 @@
     "react-17": "npm:react@^17.0.2",
     "react-codemirror2": "^4.1.0",
     "react-dom": "^16.9.0",
+    "react-dom-17": "npm:react-dom@^17.0.2",
     "react-monaco-editor": "^0.26.2",
     "react-portal": "^4.2.0",
     "react-transform-catch-errors": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
     "node": ">=12"
   },
   "peerDependencies": {
-    "react": "^16.0.0 || ^17.0.0"
+    "react": "^16.x || ^17.x"
   },
   "dependencies": {
     "@types/json-schema": "^7.0.7",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
     "node": ">=12"
   },
   "peerDependencies": {
-    "react": ">=16"
+    "react": "^16.0.0 || ^17.0.0"
   },
   "dependencies": {
     "@types/json-schema": "^7.0.7",

--- a/packages/core/test/Form_test.js
+++ b/packages/core/test/Form_test.js
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import sinon from "sinon";
+import rewiremock from "rewiremock";
 import React from "react";
 import { renderIntoDocument, Simulate } from "react-dom/test-utils";
 import { findDOMNode } from "react-dom";
@@ -15,6 +16,9 @@ import {
   describeRepeated,
   submitForm,
 } from "./test_utils";
+
+// Rewrite React import to use React 17 if we're running the test-react-17 npm script
+rewiremock("react").by(process.env.USE_REACT_17 ? "react-17" : "react");
 
 describeRepeated("Form common", createFormComponent => {
   let sandbox;

--- a/packages/fluent-ui/package-lock.json
+++ b/packages/fluent-ui/package-lock.json
@@ -1958,9 +1958,9 @@
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
-      "integrity": "sha1-vf1p1h5GTcyBslFZwnDXWnPBpjY=",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "dev": true
     },
     "@types/lodash": {

--- a/packages/fluent-ui/package.json
+++ b/packages/fluent-ui/package.json
@@ -33,7 +33,7 @@
     "@material-ui/icons": "^4.2.1",
     "@rjsf/core": "^2.5.1",
     "@types/jest": "^24.0.15",
-    "@types/json-schema": "^7.0.3",
+    "@types/json-schema": "^7.0.7",
     "@types/lodash": "^4.14.152",
     "@types/react": "^16.9.23",
     "@types/react-dom": "^16.9.8",

--- a/packages/material-ui/package-lock.json
+++ b/packages/material-ui/package-lock.json
@@ -1684,9 +1684,9 @@
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
-      "integrity": "sha1-vf1p1h5GTcyBslFZwnDXWnPBpjY=",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "dev": true
     },
     "@types/minimatch": {

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -29,7 +29,7 @@
     "@material-ui/icons": "^4.2.1",
     "@rjsf/core": "^2.5.1",
     "@types/jest": "^24.0.15",
-    "@types/json-schema": "^7.0.3",
+    "@types/json-schema": "^7.0.7",
     "@types/react": "^16.9.23",
     "@types/react-dom": "^16.9.5",
     "@types/react-test-renderer": "^16.9.2",

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -3016,25 +3016,6 @@
         }
       }
     },
-    "@hypnosphi/create-react-context": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
-      "integrity": "sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==",
-      "requires": {
-        "gud": "^1.0.0",
-        "warning": "^4.0.3"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
-      }
-    },
     "@material-ui/core": {
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.9.4.tgz",
@@ -3142,103 +3123,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@rjsf/antd": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@rjsf/antd/-/antd-2.5.1.tgz",
-      "integrity": "sha512-xBzsQF2XIlePPIDBva353YXByuTXTVt8zL1DNUIMCPJ81w4Ai2W0KO9rSaJDrtWaOUTdn8PZEhs1ElYrLb+dQQ=="
-    },
-    "@rjsf/bootstrap-4": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@rjsf/bootstrap-4/-/bootstrap-4-2.5.1.tgz",
-      "integrity": "sha512-USijizR4MkYtMOdbZWt3HDDc9vWmMvmiskqXwV2jEUBMPSu1UG0bZS2HKzqfnMJcJRT1P7Tj4O3sGwgE+7FCpw==",
-      "requires": {
-        "react-icons": "^3.10.0"
-      }
-    },
-    "@rjsf/core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-2.5.1.tgz",
-      "integrity": "sha512-km8NYScXNONaL5BiSLS6wyDj49pOLZtn0iXg7Zxlm921uuf3o2AAX5SuZS5kB4Zj2zlrVMrXESexfX6bxdDYHw==",
-      "requires": {
-        "@babel/runtime-corejs2": "^7.8.7",
-        "@types/json-schema": "^7.0.4",
-        "ajv": "^6.7.0",
-        "core-js": "^2.5.7",
-        "json-schema-merge-allof": "^0.6.0",
-        "jsonpointer": "^4.0.1",
-        "lodash": "^4.17.15",
-        "prop-types": "^15.7.2",
-        "react-app-polyfill": "^1.0.4",
-        "react-is": "^16.9.0",
-        "shortid": "^2.2.14"
-      },
-      "dependencies": {
-        "@babel/runtime-corejs2": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.13.10.tgz",
-          "integrity": "sha512-rZw5P1ZewO6XZTDxtXuAuAFUqfNXyM8HO/9WiaDd34Anka0uFTpo0RvBLeV775AEE/zKw3LQB+poZw/O9lrZBg==",
-          "requires": {
-            "core-js": "^2.6.5",
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "core-js": {
-          "version": "2.6.12",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-        },
-        "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-        }
-      }
-    },
-    "@rjsf/fluent-ui": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@rjsf/fluent-ui/-/fluent-ui-2.5.1.tgz",
-      "integrity": "sha512-upI/kpMrvnugq1tuxiPickWmOSKxoxfqA8//SiXm+KY4mw2SyKYWYZrJefyH5+RGwJ+4lANWbkb89e1KQQ5Ypw==",
-      "requires": {
-        "lodash": "^4.17.15",
-        "lodash-es": "^4.17.15"
-      }
-    },
-    "@rjsf/material-ui": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@rjsf/material-ui/-/material-ui-2.5.1.tgz",
-      "integrity": "sha512-ooKxQJO12+i1xCGtknMZDxWSbVlSEgQ5U1I7lJ+uI/MvwAg3Rz9wb2cTEF3ErBczT7EEW+j1lR19rxBjFd78MA=="
-    },
-    "@rjsf/semantic-ui": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@rjsf/semantic-ui/-/semantic-ui-2.5.1.tgz",
-      "integrity": "sha512-ipDg96yPhII3z+m/6KvlH6zfbKmDcf89gCREwLIDa0iWp2akRnzxPYLa2KusmT/TqYds3M4qMOie+4Xq/MA3mg==",
-      "requires": {
-        "@babel/runtime-corejs2": "^7.9.2",
-        "semantic-ui-css": "^2.4.1",
-        "semantic-ui-react": "^0.87.3"
-      },
-      "dependencies": {
-        "@babel/runtime-corejs2": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.13.10.tgz",
-          "integrity": "sha512-rZw5P1ZewO6XZTDxtXuAuAFUqfNXyM8HO/9WiaDd34Anka0uFTpo0RvBLeV775AEE/zKw3LQB+poZw/O9lrZBg==",
-          "requires": {
-            "core-js": "^2.6.5",
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "core-js": {
-          "version": "2.6.12",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-        },
-        "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-        }
-      }
-    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -3246,15 +3130,6 @@
       "dev": true,
       "requires": {
         "any-observable": "^0.3.0"
-      }
-    },
-    "@semantic-ui-react/event-stack": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-3.1.2.tgz",
-      "integrity": "sha512-Yd0Qf7lPCIjzJ9bZYfurlNu2RDXT6KKSyubHfYK3WjRauhxCsq6Fk2LMRI9DEvShoEU+AsLSv3NGkqXAcVp0zg==",
-      "requires": {
-        "exenv": "^1.2.2",
-        "prop-types": "^15.6.2"
       }
     },
     "@sinonjs/commons": {
@@ -3327,7 +3202,8 @@
     "@types/json-schema": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
+      "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -4868,7 +4744,8 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
     },
     "caniuse-api": {
       "version": "1.6.1",
@@ -5888,6 +5765,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dev": true,
       "requires": {
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.1",
@@ -5900,7 +5778,8 @@
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
         }
       }
     },
@@ -5973,6 +5852,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
       "requires": {
         "foreach": "^2.0.5",
         "object-keys": "^1.0.8"
@@ -6943,11 +6823,6 @@
         }
       }
     },
-    "exenv": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50="
-    },
     "expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -7435,7 +7310,8 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -7517,7 +7393,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -7698,11 +7575,6 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
-    "gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
-    },
     "handle-thing": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
@@ -7750,6 +7622,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
       "requires": {
         "function-bind": "^1.0.2"
       }
@@ -7772,7 +7645,8 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -8584,7 +8458,8 @@
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -8643,7 +8518,8 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -8780,6 +8656,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -8887,11 +8764,6 @@
         "istanbul-lib-coverage": "^2.0.3",
         "semver": "^5.5.0"
       }
-    },
-    "jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
     "js-base64": {
       "version": "2.4.5",
@@ -9029,11 +8901,6 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
-    },
-    "jsonpointer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg=="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -9225,11 +9092,6 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
       "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
       "dev": true
-    },
-    "keyboard-key": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keyboard-key/-/keyboard-key-1.1.0.tgz",
-      "integrity": "sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ=="
     },
     "keycode": {
       "version": "2.2.0",
@@ -9713,11 +9575,6 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-    },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -11744,17 +11601,20 @@
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
     },
     "object-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
-      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
+      "dev": true
     },
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -11777,6 +11637,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -14145,14 +14006,6 @@
       "resolved": "https://registry.npmjs.org/react-frame-component/-/react-frame-component-4.1.1.tgz",
       "integrity": "sha512-NfJp90AvYA1R6+uSYafQ+n+UM2HjHqi4WGHeprVXa6quU9d8o6ZFRzQ36uemY82dlkZFzf2jigFx6E4UzNFajA=="
     },
-    "react-icons": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-3.11.0.tgz",
-      "integrity": "sha512-JRgiI/vdF6uyBgyZhVyYJUZAop95Sy4XDe/jmT3R/bKliFWpO/uZBwvSjWEdxwzec7SYbEPNPck0Kff2tUGM2Q==",
-      "requires": {
-        "camelcase": "^5.0.0"
-      }
-    },
     "react-is": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
@@ -14212,30 +14065,6 @@
             "loose-envify": "^1.4.0",
             "prop-types": "^15.6.2",
             "react-lifecycles-compat": "^3.0.4"
-          }
-        }
-      }
-    },
-    "react-popper": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.11.tgz",
-      "integrity": "sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "@hypnosphi/create-react-context": "^0.3.1",
-        "deep-equal": "^1.1.1",
-        "popper.js": "^1.14.4",
-        "prop-types": "^15.6.1",
-        "typed-styles": "^0.0.7",
-        "warning": "^4.0.2"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "requires": {
-            "loose-envify": "^1.0.0"
           }
         }
       }
@@ -14458,6 +14287,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
       "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -14467,6 +14297,7 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
           "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
           "requires": {
             "object-keys": "^1.0.12"
           }
@@ -14475,6 +14306,7 @@
           "version": "1.17.0",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
           "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+          "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
@@ -14493,6 +14325,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -14503,6 +14336,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
           "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
           }
@@ -14510,12 +14344,14 @@
         "is-callable": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+          "dev": true
         },
         "is-regex": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
           "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "dev": true,
           "requires": {
             "has": "^1.0.3"
           }
@@ -14524,6 +14360,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
           "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+          "dev": true,
           "requires": {
             "has-symbols": "^1.0.1"
           }
@@ -14531,7 +14368,8 @@
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
         }
       }
     },
@@ -14906,30 +14744,6 @@
       "dev": true,
       "requires": {
         "node-forge": "0.9.0"
-      }
-    },
-    "semantic-ui-css": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.4.1.tgz",
-      "integrity": "sha512-Pkp0p9oWOxlH0kODx7qFpIRYpK1T4WJOO4lNnpNPOoWKCrYsfHqYSKgk5fHfQtnWnsAKy7nLJMW02bgDWWFZFg==",
-      "requires": {
-        "jquery": "x.*"
-      }
-    },
-    "semantic-ui-react": {
-      "version": "0.87.3",
-      "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-0.87.3.tgz",
-      "integrity": "sha512-YJgFYEheeFBMm/epZpIpWKF9glgSShdLPiY8zoUi+KJ0IKtLtbI8RbMD/ELbZkY+SO/IWbK/f/86pWt3PVvMVA==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "@semantic-ui-react/event-stack": "^3.1.0",
-        "classnames": "^2.2.6",
-        "keyboard-key": "^1.0.4",
-        "lodash": "^4.17.11",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.7.0",
-        "react-popper": "^1.3.3",
-        "shallowequal": "^1.1.0"
       }
     },
     "semver": {
@@ -15646,6 +15460,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
       "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
@@ -15655,6 +15470,7 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
           "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
           "requires": {
             "object-keys": "^1.0.12"
           }
@@ -15662,7 +15478,8 @@
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
         }
       }
     },
@@ -15670,6 +15487,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
       "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
@@ -15679,6 +15497,7 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
           "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "dev": true,
           "requires": {
             "object-keys": "^1.0.12"
           }
@@ -15686,7 +15505,8 @@
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
         }
       }
     },
@@ -16205,11 +16025,6 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.18"
       }
-    },
-    "typed-styles": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
-      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/packages/semantic-ui/package-lock.json
+++ b/packages/semantic-ui/package-lock.json
@@ -2862,16 +2862,6 @@
         }
       }
     },
-    "@babel/runtime-corejs2": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.13.10.tgz",
-      "integrity": "sha512-rZw5P1ZewO6XZTDxtXuAuAFUqfNXyM8HO/9WiaDd34Anka0uFTpo0RvBLeV775AEE/zKw3LQB+poZw/O9lrZBg==",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "@babel/runtime-corejs3": {
       "version": "7.10.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.3.tgz",
@@ -3705,51 +3695,6 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
-      }
-    },
-    "@rjsf/core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-2.5.1.tgz",
-      "integrity": "sha512-km8NYScXNONaL5BiSLS6wyDj49pOLZtn0iXg7Zxlm921uuf3o2AAX5SuZS5kB4Zj2zlrVMrXESexfX6bxdDYHw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime-corejs2": "^7.8.7",
-        "@types/json-schema": "^7.0.4",
-        "ajv": "^6.7.0",
-        "core-js": "^2.5.7",
-        "json-schema-merge-allof": "^0.6.0",
-        "jsonpointer": "^4.0.1",
-        "lodash": "^4.17.15",
-        "prop-types": "^15.7.2",
-        "react-app-polyfill": "^1.0.4",
-        "react-is": "^16.9.0",
-        "shortid": "^2.2.14"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
-        }
       }
     },
     "@samverschueren/stream-to-observable": {
@@ -4618,7 +4563,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "async-exit-hook": {
       "version": "2.0.1",
@@ -5070,7 +5016,8 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "bindings": {
       "version": "1.5.0",
@@ -5623,6 +5570,7 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
       "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
@@ -6018,29 +5966,6 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
-    "compute-gcd": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
-      "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
-      "dev": true,
-      "requires": {
-        "validate.io-array": "^1.0.3",
-        "validate.io-function": "^1.0.2",
-        "validate.io-integer-array": "^1.0.0"
-      }
-    },
-    "compute-lcm": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
-      "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
-      "dev": true,
-      "requires": {
-        "compute-gcd": "^1.2.1",
-        "validate.io-array": "^1.0.3",
-        "validate.io-function": "^1.0.2",
-        "validate.io-integer-array": "^1.0.0"
-      }
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6162,12 +6087,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-      "dev": true
-    },
-    "core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
       "dev": true
     },
     "core-js-compat": {
@@ -8803,6 +8722,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-glob": "^3.1.0",
         "path-dirname": "^1.0.0"
@@ -8813,6 +8733,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^2.1.0"
           }
@@ -9591,6 +9512,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "binary-extensions": "^1.0.0"
       }
@@ -12065,26 +11987,6 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
-    "json-schema-compare": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
-      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.4"
-      }
-    },
-    "json-schema-merge-allof": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.6.0.tgz",
-      "integrity": "sha512-LEw4VMQVRceOPLuGRWcxW5orTTiR9ZAtqTAe4rQUjNADTeR81bezBVFa0MqIwp0YmHIM1KkhSjZM7o+IQhaPbQ==",
-      "dev": true,
-      "requires": {
-        "compute-lcm": "^1.1.0",
-        "json-schema-compare": "^0.2.2",
-        "lodash": "^4.17.4"
-      }
-    },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
@@ -12111,12 +12013,6 @@
       "requires": {
         "minimist": "^1.2.0"
       }
-    },
-    "jsonpointer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
-      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -15896,7 +15792,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "path-exists": {
       "version": "3.0.0",
@@ -16907,15 +16804,6 @@
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
-    "raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
-      "requires": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -16974,37 +16862,6 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
-      }
-    },
-    "react-app-polyfill": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-1.0.6.tgz",
-      "integrity": "sha512-OfBnObtnGgLGfweORmdZbyEz+3dgVePQBb3zipiaDsMHV1NpWm0rDFYIVXFV/AK+x4VIIfWHhrdMIeoTLyRr2g==",
-      "dev": true,
-      "requires": {
-        "core-js": "^3.5.0",
-        "object-assign": "^4.1.1",
-        "promise": "^8.0.3",
-        "raf": "^3.4.1",
-        "regenerator-runtime": "^0.13.3",
-        "whatwg-fetch": "^3.0.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.9.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
-          "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==",
-          "dev": true
-        },
-        "promise": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
-          "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
-          "dev": true,
-          "requires": {
-            "asap": "~2.0.6"
-          }
-        }
       }
     },
     "react-codemirror2": {
@@ -17206,6 +17063,7 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
       "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
@@ -19272,7 +19130,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "update-notifier": {
       "version": "3.0.1",
@@ -19466,43 +19325,6 @@
       "requires": {
         "builtins": "^1.0.3"
       }
-    },
-    "validate.io-array": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
-      "integrity": "sha1-W1osr9j4uFq7L4hroVPy2Tond00=",
-      "dev": true
-    },
-    "validate.io-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
-      "integrity": "sha1-NDoZgC7TsZaCaceA5VjpNBHAutc=",
-      "dev": true
-    },
-    "validate.io-integer": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
-      "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
-      "dev": true,
-      "requires": {
-        "validate.io-number": "^1.0.3"
-      }
-    },
-    "validate.io-integer-array": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
-      "integrity": "sha1-LKveAzKTpry+Bj/q/pHq9GsToIk=",
-      "dev": true,
-      "requires": {
-        "validate.io-array": "^1.0.3",
-        "validate.io-integer": "^1.0.4"
-      }
-    },
-    "validate.io-number": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
-      "integrity": "sha1-9j/+2iSL8opnqNSODjtGGhZluvg=",
-      "dev": true
     },
     "vary": {
       "version": "1.1.2",


### PR DESCRIPTION
This PR updates the peer dependency to support React 16 and 17 at the same time. 
Discussion [here](https://github.com/rjsf-team/react-jsonschema-form/issues/2104#issuecomment-806213821).

Tests: I've also introduced a _very_ basic starting point for testing with React 16 and React 17 at the same time, inspired by [this article](https://medium.com/welldone-software/two-ways-to-run-tests-on-different-versions-of-the-same-library-f-e-react-17-react-16-afb7f861d1e9). Note that we are using mocha, not jest and so `moduleNameMapper` was swapped for an external library, `rewiremock`.

Discussion around this change [here](https://github.com/rjsf-team/react-jsonschema-form/issues/2104#issuecomment-806653044).

You can run `npm run test` and `npm run test-react-17`. To see it working, you can `console.log(REACT_VERSION, React.version)` in the `Form_test.js` file when running each test and it'll tell you which React it imported. 

Current limitations: I'm not swapping `react-dom` and I'm not testing React 17 for tests not in this file. This is a POC for discussion or hopefully someone else can take it and expand upon it. I'd assume we'd want to decide if we want to test both React 16 and 17 across the entire sweet, or just a few tests.

I'm totally happy to just scrap this approach - just putting it up for discussion.

Lastly: this PR also relies on [this PR](https://github.com/rjsf-team/react-jsonschema-form/pull/2310). Once it lands, I'll merge upstream into this which should make this PR a lot smaller - just a couple files.
