### PR TITLE
Fix display of 0 for UpDownWidget (bootstrap-4 and material-ui)

### DIFF
--- a/packages/bootstrap-4/src/UpDownWidget/UpDownWidget.tsx
+++ b/packages/bootstrap-4/src/UpDownWidget/UpDownWidget.tsx
@@ -38,7 +38,7 @@ const UpDownWidget = ({
         type="number"
         disabled={disabled}
         readOnly={readonly}
-        value={value != null ? value : ""}
+        value={value || value === 0 ? value : ""}
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}

--- a/packages/bootstrap-4/src/UpDownWidget/UpDownWidget.tsx
+++ b/packages/bootstrap-4/src/UpDownWidget/UpDownWidget.tsx
@@ -38,7 +38,7 @@ const UpDownWidget = ({
         type="number"
         disabled={disabled}
         readOnly={readonly}
-        value={value ? value : ""}
+        value={value != null ? value : ""}
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}

--- a/packages/bootstrap-4/test/UpDownWidget.test.tsx
+++ b/packages/bootstrap-4/test/UpDownWidget.test.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import UpDownWidget from "../src/UpDownWidget";
+import renderer from "react-test-renderer";
+import { makeWidgetMockProps } from "./helpers/createMocks";
+
+describe("UpDownWidget", () => {
+  test("renders 0 as 0 and not ''", () => {
+    const tree = renderer
+      .create(<UpDownWidget {...{ ...makeWidgetMockProps({}), value: 0 }} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/bootstrap-4/test/__snapshots__/UpDownWidget.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/UpDownWidget.test.tsx.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UpDownWidget renders 0 as 0 and not '' 1`] = `
+<div
+  className="mb-0 form-group"
+>
+  <label
+    className="form-label"
+  >
+    Some simple label
+    *
+  </label>
+  <input
+    autoFocus={true}
+    className="form-control"
+    disabled={false}
+    id="_id"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    readOnly={true}
+    required={true}
+    type="number"
+    value={0}
+  />
+</div>
+`;

--- a/packages/material-ui/src/UpDownWidget/UpDownWidget.tsx
+++ b/packages/material-ui/src/UpDownWidget/UpDownWidget.tsx
@@ -40,7 +40,7 @@ const UpDownWidget = ({
         required={required}
         type="number"
         disabled={disabled || readonly}
-        value={value != null ? value : ''}
+        value={value || value === 0 ? value : ''}
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}

--- a/packages/material-ui/src/UpDownWidget/UpDownWidget.tsx
+++ b/packages/material-ui/src/UpDownWidget/UpDownWidget.tsx
@@ -40,7 +40,7 @@ const UpDownWidget = ({
         required={required}
         type="number"
         disabled={disabled || readonly}
-        value={value ? value : ''}
+        value={value != null ? value : ''}
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}

--- a/packages/material-ui/test/UpDownWidget.test.tsx
+++ b/packages/material-ui/test/UpDownWidget.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { JSONSchema7 } from "json-schema";
+import renderer from "react-test-renderer";
+import { WidgetProps } from "@rjsf/core";
+import UpDownWidget from "../src/UpDownWidget/UpDownWidget";
+
+export const mockSchema: JSONSchema7 = {
+  type: "array",
+  items: {
+    type: "string",
+  },
+};
+
+export const mockEventHandlers = (): void => void 0;
+
+describe("UpDownWidget", () => {
+  test("renders 0 as 0 and not ''", () => {
+    const props: WidgetProps = {
+      uiSchema: {},
+      schema: mockSchema,
+      required: true,
+      disabled: false,
+      readonly: true,
+      autofocus: true,
+      label: "Some simple label",
+      onChange: mockEventHandlers,
+      onBlur: mockEventHandlers,
+      onFocus: mockEventHandlers,
+      multiple: false,
+      rawErrors: [""],
+      options: {},
+      formContext: {},
+      id: "_id",
+      value: 0,
+    };
+    const tree = renderer.create(<UpDownWidget {...props} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/material-ui/test/__snapshots__/UpDownWidget.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/UpDownWidget.test.tsx.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UpDownWidget renders 0 as 0 and not '' 1`] = `
+<div
+  className="MuiFormControl-root MuiFormControl-fullWidth"
+>
+  <label
+    className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled Mui-required Mui-required"
+    data-shrink={true}
+  >
+    Some simple label
+    <span
+      className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+    >
+       
+      *
+    </span>
+  </label>
+  <div
+    className="MuiInputBase-root MuiInput-root MuiInput-underline Mui-disabled Mui-disabled MuiInputBase-formControl MuiInput-formControl"
+    onClick={[Function]}
+    required={true}
+  >
+    <input
+      aria-invalid={false}
+      autoFocus={true}
+      className="MuiInputBase-input MuiInput-input Mui-disabled Mui-disabled"
+      disabled={true}
+      id="_id"
+      onAnimationStart={[Function]}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      required={true}
+      type="number"
+      value={0}
+    />
+  </div>
+</div>
+`;


### PR DESCRIPTION
https://github.com/rjsf-team/react-jsonschema-form/issues/2042

### Reasons for making this change

We render data from an endpoint that contains numeric 0s. When we load up the data in @rjsf/bootstrap-4, values that come back from the server as `0` are `''` in inputs. Updating an existing model currently breaks `0` field values by setting them to `null`.

fixes #2042

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

### Deploy preview

Once CI finishes, you should be able to view a deploy preview of the playground from this PR at this link: https://deploy-preview-[PR_NUMBER]--rjsf.netlify.app/