### PR TITLE
remove annoying console.log statement on Antd SelectWidget theme

### DIFF
--- a/packages/antd/src/widgets/SelectWidget/index.js
+++ b/packages/antd/src/widgets/SelectWidget/index.js
@@ -75,8 +75,6 @@ const SelectWidget = ({
   const stringify = (currentValue) =>
     Array.isArray(currentValue) ? value.map(String) : String(value);
 
-  console.log(placeholder);
-
   return (
     <Select
       autoFocus={autofocus}


### PR DESCRIPTION
### Reasons for making this change

There is an informational console.log which should be removed on the SelectWidget Antd theme widget

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

### Deploy preview

Once CI finishes, you should be able to view a deploy preview of the playground from this PR at this link: https://deploy-preview-[PR_NUMBER]--rjsf.netlify.app/