### PR TITLE
allow booleans to have descriptions

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -397,9 +397,6 @@ export function getDisplayLabel(schema, uiSchema, rootSchema) {
   if (schema.type === "object") {
     displayLabel = false;
   }
-  if (schema.type === "boolean" && !uiSchema["ui:widget"]) {
-    displayLabel = false;
-  }
   if (uiSchema["ui:field"]) {
     displayLabel = false;
   }


### PR DESCRIPTION
### Reasons for making this change

Descriptions for boolean checkboxes were being ignored.

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).
fixes #2203 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

### Deploy preview

Once CI finishes, you should be able to view a deploy preview of the playground from this PR at this link: https://deploy-preview-[PR_NUMBER]--rjsf.netlify.app/