### PR TITLE
Export ArrayFieldTemplate from material-ui

### DIFF
--- a/packages/material-ui/src/index.ts
+++ b/packages/material-ui/src/index.ts
@@ -4,6 +4,7 @@ export { default as Fields } from './Fields';
 export { default as FieldTemplate } from './FieldTemplate';
 export { default as MuiForm } from './MuiForm';
 export { default as ObjectFieldTemplate } from './ObjectFieldTemplate';
+export { default as ArrayFieldTemplate } from './ArrayFieldTemplate';
 export { default as Theme } from './Theme';
 export { default as Widgets } from './Widgets';
 


### PR DESCRIPTION
### Reasons for making this change

Currently the ArrayFieldTemplate is missing from the MUI exports. If there is currently no another way to import the component I suggest it be added here.
Issue: #2336 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

### Deploy preview

Once CI finishes, you should be able to view a deploy preview of the playground from this PR at this link: https://deploy-preview-[PR_NUMBER]--rjsf.netlify.app/