### PR TITLE
remove componentWillReceiveProps from altdatewidget

### DIFF
--- a/packages/core/src/components/widgets/AltDateWidget.js
+++ b/packages/core/src/components/widgets/AltDateWidget.js
@@ -63,8 +63,12 @@ class AltDateWidget extends Component {
     this.state = parseDateString(props.value, props.time);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    this.setState(parseDateString(nextProps.value, nextProps.time));
+  componentDidUpdate(prevProps, prevState) {
+    if (
+      prevProps.value !== parseDateString(this.props.value, this.props.time)
+    ) {
+      this.setState(parseDateString(this.props.value, this.props.time));
+    }
   }
 
   shouldComponentUpdate(nextProps, nextState) {

--- a/packages/core/test/StringField_test.js
+++ b/packages/core/test/StringField_test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { expect } from "chai";
-import { Simulate } from "react-dom/test-utils";
+import { act, Simulate } from "react-dom/test-utils";
 import sinon from "sinon";
 
 import { parseDateString, toDateString, utcToLocal } from "../src/utils";
@@ -909,25 +909,26 @@ describe("StringField", () => {
         uiSchema,
       });
 
-      Simulate.change(node.querySelector("#root_year"), {
-        target: { value: 2012 },
+      act(() => {
+        Simulate.change(node.querySelector("#root_year"), {
+          target: { value: 2012 },
+        });
+        Simulate.change(node.querySelector("#root_month"), {
+          target: { value: 10 },
+        });
+        Simulate.change(node.querySelector("#root_day"), {
+          target: { value: 2 },
+        });
+        Simulate.change(node.querySelector("#root_hour"), {
+          target: { value: 1 },
+        });
+        Simulate.change(node.querySelector("#root_minute"), {
+          target: { value: 2 },
+        });
+        Simulate.change(node.querySelector("#root_second"), {
+          target: { value: 3 },
+        });
       });
-      Simulate.change(node.querySelector("#root_month"), {
-        target: { value: 10 },
-      });
-      Simulate.change(node.querySelector("#root_day"), {
-        target: { value: 2 },
-      });
-      Simulate.change(node.querySelector("#root_hour"), {
-        target: { value: 1 },
-      });
-      Simulate.change(node.querySelector("#root_minute"), {
-        target: { value: 2 },
-      });
-      Simulate.change(node.querySelector("#root_second"), {
-        target: { value: 3 },
-      });
-
       sinon.assert.calledWithMatch(onChange.lastCall, {
         formData: "2012-10-02T01:02:03.000Z",
       });
@@ -1179,16 +1180,17 @@ describe("StringField", () => {
         uiSchema,
       });
 
-      Simulate.change(node.querySelector("#root_year"), {
-        target: { value: 2012 },
+      act(() => {
+        Simulate.change(node.querySelector("#root_year"), {
+          target: { value: 2012 },
+        });
+        Simulate.change(node.querySelector("#root_month"), {
+          target: { value: 10 },
+        });
+        Simulate.change(node.querySelector("#root_day"), {
+          target: { value: 2 },
+        });
       });
-      Simulate.change(node.querySelector("#root_month"), {
-        target: { value: 10 },
-      });
-      Simulate.change(node.querySelector("#root_day"), {
-        target: { value: 2 },
-      });
-
       sinon.assert.calledWithMatch(onChange.lastCall, {
         formData: "2012-10-02",
       });


### PR DESCRIPTION
### Reasons for making this change

Another step towards making RJSF strict mode compatible, this time without functional components :)

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

### Deploy preview

Once CI finishes, you should be able to view a deploy preview of the playground from this PR at this link: https://deploy-preview-[PR_NUMBER]--rjsf.netlify.app/