### PR TITLE
Antd Select - make search work by label ,not value

### DIFF
--- a/packages/antd/src/widgets/SelectWidget/index.js
+++ b/packages/antd/src/widgets/SelectWidget/index.js
@@ -89,11 +89,13 @@ const SelectWidget = ({
       placeholder={placeholder}
       style={SELECT_STYLE}
       value={typeof value !== 'undefined' ? stringify(value) : undefined}
+      filterOption={(input, option) =>
+        option.children.toLowerCase().indexOf(input.toLowerCase()) >= 0
+      }
     >
       {enumOptions.map(({ value: optionValue, label: optionLabel }) => (
         <Select.Option
           disabled={enumDisabled && enumDisabled.indexOf(optionValue) !== -1}
-          key={String(optionValue)}
           value={String(optionValue)}
         >
           {optionLabel}


### PR DESCRIPTION
### Reasons for making this change

Antd Select widget allows to search in the option array. The current code makes the Select search by the key, not the value - the label that is presented to the user.

This change makes the Select widget search by the value (label) of the options.