### PR TITLE
Make `onBlur` and the `onFocus` accept `any` types for value

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -36,10 +36,10 @@ declare module '@rjsf/core' {
         noValidate?: boolean;
         ObjectFieldTemplate?: React.StatelessComponent<ObjectFieldTemplateProps>;
         omitExtraData?: boolean;
-        onBlur?: (id: string, value: boolean | number | string | null) => void;
+        onBlur?: (id: string, value: any) => void;
         onChange?: (e: IChangeEvent<T>, es?: ErrorSchema) => any;
         onError?: (e: any) => any;
-        onFocus?: (id: string, value: boolean | number | string | null) => void;
+        onFocus?: (id: string, value: any) => void;
         onSubmit?: (e: ISubmitEvent<T>) => any;
         schema: JSONSchema7;
         showErrorList?: boolean;
@@ -59,7 +59,7 @@ declare module '@rjsf/core' {
             customFormats?: FormProps<T>['customFormats'],
         ) => { errors: AjvError[]; errorSchema: ErrorSchema };
         onChange: (formData: T, newErrorSchema: ErrorSchema) => void;
-        onBlur: (id: string, value: boolean | number | string | null) => void;
+        onBlur: (id: string, value: any) => void;
         submit: () => void;
     }
 
@@ -109,8 +109,8 @@ declare module '@rjsf/core' {
         onChange: (value: any) => void;
         options: NonNullable<UiSchema['ui:options']>;
         formContext: any;
-        onBlur: (id: string, value: boolean | number | string | null) => void;
-        onFocus: (id: string, value: boolean | number | string | null) => void;
+        onBlur: (id: string, value: any) => void;
+        onFocus: (id: string, value: any) => void;
         label: string;
         multiple: boolean;
         rawErrors: string[];
@@ -126,7 +126,7 @@ declare module '@rjsf/core' {
         formData: T;
         errorSchema: ErrorSchema;
         onChange: (e: IChangeEvent<T> | any, es?: ErrorSchema) => any;
-        onBlur: (id: string, value: boolean | number | string | null) => void;
+        onBlur: (id: string, value: any) => void;
         registry: {
             fields: { [name: string]: Field };
             widgets: { [name: string]: Widget };


### PR DESCRIPTION
### Reasons for making this change

I have some custom fields that have a array of string as value (I'm thinking about multiselect or a checkbox group type of component), I can pass its value to the onChange without any issue, but the same is not true for the `onBlur` event, because their typescript definitions are not the same.

I can think some scenarios where the field could pass a object on those events so my suggestion would be to make them all equal to the `onChange` with a `any`.

### Checklist

* [-] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [-] **I'm adding a new feature**
  - [-] I've updated the playground with an example use of the feature

### Deploy preview

Once CI finishes, you should be able to view a deploy preview of the playground from this PR at this link: https://deploy-preview-[PR_NUMBER]--rjsf.netlify.app/