### PR TITLE
Pass registry to ObjectFieldTemplate

### DIFF
--- a/packages/core/src/components/fields/ObjectField.js
+++ b/packages/core/src/components/fields/ObjectField.js
@@ -273,6 +273,7 @@ class ObjectField extends Component {
       schema,
       formData,
       formContext,
+      registry,
     };
     return <Template {...templateProps} onAddClick={this.handleAddClick} />;
   }


### PR DESCRIPTION
### Reasons for making this change

`<ObjectFieldTemplate />` does not receive the `registry` prop from `<ObjectField />` even though the documentation suggests that it does/should.

https://react-jsonschema-form.readthedocs.io/en/latest/advanced-customization/custom-templates/#objectfieldtemplate

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

### Deploy preview

Once CI finishes, you should be able to view a deploy preview of the playground from this PR at this link: https://deploy-preview-[PR_NUMBER]--rjsf.netlify.app/