### PR TITLE
Add predictable ID for help fields, aria describedby attributes

### DIFF
--- a/packages/antd/src/templates/ArrayFieldTemplate/NormalArrayFieldTemplate.js
+++ b/packages/antd/src/templates/ArrayFieldTemplate/NormalArrayFieldTemplate.js
@@ -6,6 +6,7 @@ import Col from 'antd/lib/col';
 import Row from 'antd/lib/row';
 import { withConfigConsumer } from 'antd/lib/config-provider/context';
 import PlusCircleOutlined from '@ant-design/icons/PlusCircleOutlined';
+import { utils } from '@rjsf/core';
 
 import ArrayFieldTemplateItem from './ArrayFieldTemplateItem';
 
@@ -59,7 +60,7 @@ const NormalArrayFieldTemplate = ({
           <Col span={24} style={DESCRIPTION_COL_STYLE}>
             <DescriptionField
               description={uiSchema['ui:description'] || schema.description}
-              id={`${idSchema.$id}__description`}
+              id={utils.descriptionId(idSchema.$id)}
               key={`array-field-description-${idSchema.$id}`}
             />
           </Col>

--- a/packages/bootstrap-4/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/bootstrap-4/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -57,7 +57,7 @@ const ArrayFieldDescription = ({
     return null;
   }
 
-  const id = `${idSchema.$id}__description`;
+  const id = utils.descriptionId(idSchema.$id);
   return <DescriptionField id={id} description={description} />;
 };
 

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -433,6 +433,12 @@ declare module '@rjsf/core' {
         ): number;
 
         export function schemaRequiresTrueValue(schema: JSONSchema7): boolean;
+
+        export function descriptionId(id: string): string;
+
+        export function helpId(id: string): string;
+
+        export function ariaDescribedBy(id: string): { 'aria-describedby': string };
     }
 }
 

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -440,7 +440,7 @@ declare module '@rjsf/core' {
 
         export function errorsId(id: string): string;
 
-        export function ariaDescribedBy(id: string): { 'aria-describedby': string };
+        export function ariaDescribedBy(id: string): string;
     }
 }
 

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -438,6 +438,8 @@ declare module '@rjsf/core' {
 
         export function helpId(id: string): string;
 
+        export function errorsId(id: string): string;
+
         export function ariaDescribedBy(id: string): { 'aria-describedby': string };
     }
 }

--- a/packages/core/src/components/fields/ArrayField.js
+++ b/packages/core/src/components/fields/ArrayField.js
@@ -16,6 +16,7 @@ import {
   retrieveSchema,
   toIdSchema,
   getDefaultRegistry,
+  descriptionId,
 } from "../../utils";
 import shortid from "shortid";
 
@@ -31,7 +32,7 @@ function ArrayFieldDescription({ DescriptionField, idSchema, description }) {
   if (!description) {
     return null;
   }
-  const id = `${idSchema.$id}__description`;
+  const id = descriptionId(idSchema.$id);
   return <DescriptionField id={id} description={description} />;
 }
 

--- a/packages/core/src/components/fields/ObjectField.js
+++ b/packages/core/src/components/fields/ObjectField.js
@@ -8,6 +8,7 @@ import {
   getDefaultRegistry,
   canExpand,
   ADDITIONAL_PROPERTY_FLAG,
+  descriptionId,
 } from "../../utils";
 
 function DefaultObjectFieldTemplate(props) {
@@ -24,7 +25,7 @@ function DefaultObjectFieldTemplate(props) {
       )}
       {props.description && (
         <DescriptionField
-          id={`${props.idSchema.$id}__description`}
+          id={descriptionId(props.idSchema.$id)}
           description={props.description}
           formContext={props.formContext}
         />

--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -116,7 +116,7 @@ function ErrorList(props) {
 
   return (
     <div>
-      <ul className="error-detail bs-callout bs-callout-info" id={errorsId(id)}>
+      <ul className="error-detail bs-callout bs-callout-info" id={id}>
         {errors
           .filter(elem => !!elem)
           .map((error, index) => {
@@ -331,7 +331,7 @@ function SchemaFieldRender(props) {
     rawDescription: description,
     help: <Help id={helpId(id)} help={help} />,
     rawHelp: typeof help === "string" ? help : undefined,
-    errors: <ErrorList errors={errors} id={id} />,
+    errors: <ErrorList id={errorsId(id)} errors={errors} />,
     rawErrors: errors,
     id,
     label,

--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -13,6 +13,9 @@ import {
   deepEquals,
   getSchemaType,
   getDisplayLabel,
+  ariaDescribedBy,
+  helpId,
+  descriptionId,
 } from "../../utils";
 
 const REQUIRED_FIELD_SYMBOL = "*";
@@ -64,7 +67,7 @@ function Label(props) {
     return null;
   }
   return (
-    <label className="control-label" htmlFor={id}>
+    <label className="control-label" htmlFor={id} {...ariaDescribedBy(id)}>
       {label}
       {required && <span className="required">{REQUIRED_FIELD_SYMBOL}</span>}
     </label>
@@ -80,6 +83,7 @@ function LabelInput(props) {
       id={id}
       onBlur={event => onChange(event.target.value)}
       defaultValue={label}
+      {...ariaDescribedBy(id)}
     />
   );
 }
@@ -91,7 +95,7 @@ function Help(props) {
   }
   if (typeof help === "string") {
     return (
-      <p id={id} className="help-block">
+      <p className="help-block" id={helpId(id)}>
         {help}
       </p>
     );
@@ -318,13 +322,13 @@ function SchemaFieldRender(props) {
   const fieldProps = {
     description: (
       <DescriptionField
-        id={id + "__description"}
+        id={descriptionId(id)}
         description={description}
         formContext={formContext}
       />
     ),
     rawDescription: description,
-    help: <Help id={id + "__help"} help={help} />,
+    help: <Help help={help} id={id} />,
     rawHelp: typeof help === "string" ? help : undefined,
     errors: <ErrorList errors={errors} />,
     rawErrors: errors,

--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -16,6 +16,7 @@ import {
   ariaDescribedBy,
   helpId,
   descriptionId,
+  errorsId,
 } from "../../utils";
 
 const REQUIRED_FIELD_SYMBOL = "*";
@@ -108,14 +109,14 @@ function Help(props) {
 }
 
 function ErrorList(props) {
-  const { errors = [] } = props;
+  const { errors = [], id } = props;
   if (errors.length === 0) {
     return null;
   }
 
   return (
     <div>
-      <ul className="error-detail bs-callout bs-callout-info">
+      <ul className="error-detail bs-callout bs-callout-info" id={errorsId(id)}>
         {errors
           .filter(elem => !!elem)
           .map((error, index) => {
@@ -330,7 +331,7 @@ function SchemaFieldRender(props) {
     rawDescription: description,
     help: <Help help={help} id={id} />,
     rawHelp: typeof help === "string" ? help : undefined,
-    errors: <ErrorList errors={errors} />,
+    errors: <ErrorList errors={errors} id={id} />,
     rawErrors: errors,
     id,
     label,

--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -96,7 +96,7 @@ function Help(props) {
   }
   if (typeof help === "string") {
     return (
-      <p className="help-block" id={helpId(id)}>
+      <p id={id} className="help-block">
         {help}
       </p>
     );
@@ -329,7 +329,7 @@ function SchemaFieldRender(props) {
       />
     ),
     rawDescription: description,
-    help: <Help help={help} id={id} />,
+    help: <Help id={helpId(id)} help={help} />,
     rawHelp: typeof help === "string" ? help : undefined,
     errors: <ErrorList errors={errors} id={id} />,
     rawErrors: errors,

--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -68,7 +68,10 @@ function Label(props) {
     return null;
   }
   return (
-    <label className="control-label" htmlFor={id} {...ariaDescribedBy(id)}>
+    <label
+      className="control-label"
+      htmlFor={id}
+      aria-describedby={ariaDescribedBy(id)}>
       {label}
       {required && <span className="required">{REQUIRED_FIELD_SYMBOL}</span>}
     </label>
@@ -84,7 +87,7 @@ function LabelInput(props) {
       id={id}
       onBlur={event => onChange(event.target.value)}
       defaultValue={label}
-      {...ariaDescribedBy(id)}
+      aria-describedby={ariaDescribedBy(id)}
     />
   );
 }

--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -68,10 +68,7 @@ function Label(props) {
     return null;
   }
   return (
-    <label
-      className="control-label"
-      htmlFor={id}
-      aria-describedby={ariaDescribedBy(id)}>
+    <label className="control-label" htmlFor={id}>
       {label}
       {required && <span className="required">{REQUIRED_FIELD_SYMBOL}</span>}
     </label>

--- a/packages/core/src/components/widgets/BaseInput.js
+++ b/packages/core/src/components/widgets/BaseInput.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import { ariaDescribedBy } from "../../utils";
 
 function BaseInput(props) {
   // Note: since React 15.2.0 we can't forward unknown element attributes, so we
@@ -79,6 +80,7 @@ function BaseInput(props) {
       onChange={_onChange}
       onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}
       onFocus={onFocus && (event => onFocus(inputProps.id, event.target.value))}
+      {...ariaDescribedBy(inputProps.id)}
     />,
     schema.examples ? (
       <datalist id={`examples_${inputProps.id}`}>

--- a/packages/core/src/components/widgets/BaseInput.js
+++ b/packages/core/src/components/widgets/BaseInput.js
@@ -80,7 +80,7 @@ function BaseInput(props) {
       onChange={_onChange}
       onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}
       onFocus={onFocus && (event => onFocus(inputProps.id, event.target.value))}
-      {...ariaDescribedBy(inputProps.id)}
+      aria-describedby={ariaDescribedBy(inputProps.id)}
     />,
     schema.examples ? (
       <datalist id={`examples_${inputProps.id}`}>

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1265,3 +1265,11 @@ export function schemaRequiresTrueValue(schema) {
 
   return false;
 }
+
+export const descriptionId = id => `${id}__description`;
+
+export const helpId = id => `${id}__help`;
+
+export const ariaDescribedBy = id => ({
+  "aria-describedby": `${descriptionId(id)} ${helpId(id)}`,
+});

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1270,6 +1270,8 @@ export const descriptionId = id => `${id}__description`;
 
 export const helpId = id => `${id}__help`;
 
+export const errorsId = id => `${id}__errors`;
+
 export const ariaDescribedBy = id => ({
-  "aria-describedby": `${descriptionId(id)} ${helpId(id)}`,
+  "aria-describedby": `${errorsId(id)} ${descriptionId(id)} ${helpId(id)}`,
 });

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1266,11 +1266,16 @@ export function schemaRequiresTrueValue(schema) {
   return false;
 }
 
+// Create a consistent id for the field description element
 export const descriptionId = id => `${id}__description`;
 
+// Create a consistent id for the field help element
 export const helpId = id => `${id}__help`;
 
+// Create a consistent id for the field errors element
 export const errorsId = id => `${id}__errors`;
 
+// Create a list of element ids that contain additional information about the
+// field
 export const ariaDescribedBy = id =>
   `${errorsId(id)} ${descriptionId(id)} ${helpId(id)}`;

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1272,6 +1272,5 @@ export const helpId = id => `${id}__help`;
 
 export const errorsId = id => `${id}__errors`;
 
-export const ariaDescribedBy = id => ({
-  "aria-describedby": `${errorsId(id)} ${descriptionId(id)} ${helpId(id)}`,
-});
+export const ariaDescribedBy = id =>
+  `${errorsId(id)} ${descriptionId(id)} ${helpId(id)}`;

--- a/packages/fluent-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/fluent-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -60,7 +60,7 @@ const ArrayFieldDescription = ({
     return null;
   }
 
-  const id = `${idSchema.$id}__description`;
+  const id = utils.descriptionId(idSchema.$id);
   return <DescriptionField id={id} description={description} />;
 };
 

--- a/packages/material-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/material-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -63,7 +63,7 @@ const ArrayFieldDescription = ({
     return null;
   }
 
-  const id = `${idSchema.$id}__description`;
+  const id = utils.descriptionId(idSchema.$id);
   return <DescriptionField id={id} description={description} />;
 };
 

--- a/packages/material-ui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/material-ui/src/FieldTemplate/FieldTemplate.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { FieldTemplateProps } from "@rjsf/core";
+import { FieldTemplateProps, utils } from "@rjsf/core";
 
 import FormControl from "@material-ui/core/FormControl";
 import FormHelperText from "@material-ui/core/FormHelperText";
@@ -43,22 +43,27 @@ const FieldTemplate = ({
         required={required}>
         {children}
         {displayLabel && rawDescription ? (
-          <Typography variant="caption" color="textSecondary">
+          <Typography
+            id={utils.descriptionId(id)}
+            variant="caption"
+            color="textSecondary">
             {rawDescription}
           </Typography>
         ) : null}
         {rawErrors.length > 0 && (
-          <List dense={true} disablePadding={true}>
+          <List id={utils.errorsId(id)} dense={true} disablePadding={true}>
             {rawErrors.map((error, i: number) => {
               return (
                 <ListItem key={i} disableGutters={true}>
-                  <FormHelperText id={id}>{error}</FormHelperText>
+                  <FormHelperText>{error}</FormHelperText>
                 </ListItem>
               );
             })}
           </List>
         )}
-        {rawHelp && <FormHelperText id={id}>{rawHelp}</FormHelperText>}
+        {rawHelp && (
+          <FormHelperText id={utils.helpId(id)}>{rawHelp}</FormHelperText>
+        )}
       </FormControl>
     </WrapIfAdditional>
   );

--- a/packages/material-ui/src/FieldTemplate/WrapIfAdditional.tsx
+++ b/packages/material-ui/src/FieldTemplate/WrapIfAdditional.tsx
@@ -64,6 +64,7 @@ const WrapIfAdditional = ({
             name={`${id}-key`}
             onBlur={!readonly ? handleBlur : undefined}
             type="text"
+            {...utils.ariaDescribedBy(id)}
           />
         </FormControl>
       </Grid>

--- a/packages/material-ui/src/FieldTemplate/WrapIfAdditional.tsx
+++ b/packages/material-ui/src/FieldTemplate/WrapIfAdditional.tsx
@@ -64,7 +64,7 @@ const WrapIfAdditional = ({
             name={`${id}-key`}
             onBlur={!readonly ? handleBlur : undefined}
             type="text"
-            {...utils.ariaDescribedBy(id)}
+            aria-describedby={utils.ariaDescribedBy(id)}
           />
         </FormControl>
       </Grid>

--- a/packages/material-ui/src/PasswordWidget/PasswordWidget.tsx
+++ b/packages/material-ui/src/PasswordWidget/PasswordWidget.tsx
@@ -42,7 +42,7 @@ const PasswordWidget = ({
       onFocus={_onFocus}
       onBlur={_onBlur}
       onChange={_onChange}
-      InputProps={utils.ariaDescribedBy(id)}
+      InputProps={{ "aria-describedby": utils.ariaDescribedBy(id) }}
     />
   );
 };

--- a/packages/material-ui/src/PasswordWidget/PasswordWidget.tsx
+++ b/packages/material-ui/src/PasswordWidget/PasswordWidget.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import TextField from "@material-ui/core/TextField";
 
-import { WidgetProps } from "@rjsf/core";
+import { utils, WidgetProps } from "@rjsf/core";
 
 const PasswordWidget = ({
   id,
@@ -42,6 +42,7 @@ const PasswordWidget = ({
       onFocus={_onFocus}
       onBlur={_onBlur}
       onChange={_onChange}
+      InputProps={utils.ariaDescribedBy(id)}
     />
   );
 };

--- a/packages/material-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/material-ui/src/SelectWidget/SelectWidget.tsx
@@ -3,8 +3,7 @@ import React from "react";
 import MenuItem from "@material-ui/core/MenuItem";
 import TextField from "@material-ui/core/TextField";
 
-import { WidgetProps } from "@rjsf/core";
-import { utils } from "@rjsf/core";
+import { utils, WidgetProps } from "@rjsf/core";
 
 const { asNumber, guessType } = utils;
 
@@ -89,6 +88,7 @@ const SelectWidget = ({
       }}
       SelectProps={{
         multiple: typeof multiple === "undefined" ? false : multiple,
+        ...utils.ariaDescribedBy(id),
       }}>
       {(enumOptions as any).map(({ value, label }: any, i: number) => {
         const disabled: any =

--- a/packages/material-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/material-ui/src/SelectWidget/SelectWidget.tsx
@@ -88,7 +88,7 @@ const SelectWidget = ({
       }}
       SelectProps={{
         multiple: typeof multiple === "undefined" ? false : multiple,
-        ...utils.ariaDescribedBy(id),
+        "aria-describedby": utils.ariaDescribedBy(id),
       }}>
       {(enumOptions as any).map(({ value, label }: any, i: number) => {
         const disabled: any =

--- a/packages/material-ui/src/TextWidget/TextWidget.tsx
+++ b/packages/material-ui/src/TextWidget/TextWidget.tsx
@@ -61,7 +61,7 @@ const TextWidget = ({
       onChange={_onChange}
       onBlur={_onBlur}
       onFocus={_onFocus}
-      InputProps={utils.ariaDescribedBy(id)}
+      InputProps={{ "aria-describedby": utils.ariaDescribedBy(id) }}
       {...(textFieldProps as TextFieldProps)}
     />
   );

--- a/packages/material-ui/src/TextWidget/TextWidget.tsx
+++ b/packages/material-ui/src/TextWidget/TextWidget.tsx
@@ -61,6 +61,7 @@ const TextWidget = ({
       onChange={_onChange}
       onBlur={_onBlur}
       onFocus={_onFocus}
+      InputProps={utils.ariaDescribedBy(id)}
       {...(textFieldProps as TextFieldProps)}
     />
   );

--- a/packages/material-ui/src/TextareaWidget/TextareaWidget.tsx
+++ b/packages/material-ui/src/TextareaWidget/TextareaWidget.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { WidgetProps } from "@rjsf/core";
+import { utils, WidgetProps } from "@rjsf/core";
 
 import TextField from "@material-ui/core/TextField";
 
@@ -49,6 +49,7 @@ const TextareaWidget = ({
       onChange={_onChange}
       onBlur={_onBlur}
       onFocus={_onFocus}
+      InputProps={utils.ariaDescribedBy(id)}
     />
   );
 };

--- a/packages/material-ui/src/TextareaWidget/TextareaWidget.tsx
+++ b/packages/material-ui/src/TextareaWidget/TextareaWidget.tsx
@@ -49,7 +49,7 @@ const TextareaWidget = ({
       onChange={_onChange}
       onBlur={_onBlur}
       onFocus={_onFocus}
-      InputProps={utils.ariaDescribedBy(id)}
+      InputProps={{ "aria-describedby": utils.ariaDescribedBy(id) }}
     />
   );
 };

--- a/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
@@ -198,6 +198,7 @@ exports[`array fields array icons 1`] = `
                           onClick={[Function]}
                         >
                           <input
+                            aria-describedby="root_0__errors root_0__description root_0__help"
                             aria-invalid={false}
                             autoFocus={false}
                             className="MuiInputBase-input MuiInput-input"
@@ -440,6 +441,7 @@ exports[`array fields array icons 1`] = `
                           onClick={[Function]}
                         >
                           <input
+                            aria-describedby="root_1__errors root_1__description root_1__help"
                             aria-invalid={false}
                             autoFocus={false}
                             className="MuiInputBase-input MuiInput-input"
@@ -725,6 +727,7 @@ exports[`array fields checkboxes 1`] = `
           />
         </div>
         <input
+          aria-describedby="root__errors root__description root__help"
           autoFocus={false}
           onAnimationStart={[Function]}
           type="hidden"
@@ -878,6 +881,7 @@ exports[`array fields fixed array 1`] = `
                           onClick={[Function]}
                         >
                           <input
+                            aria-describedby="root_0__errors root_0__description root_0__help"
                             aria-invalid={false}
                             autoFocus={false}
                             className="MuiInputBase-input MuiInput-input"
@@ -986,6 +990,7 @@ exports[`array fields fixed array 1`] = `
                           onClick={[Function]}
                         >
                           <input
+                            aria-describedby="root_1__errors root_1__description root_1__help"
                             aria-invalid={false}
                             autoFocus={false}
                             className="MuiInputBase-input MuiInput-input"

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -518,6 +518,7 @@ exports[`single fields format color 1`] = `
         onClick={[Function]}
       >
         <input
+          aria-describedby="root__errors root__description root__help"
           aria-invalid={false}
           autoFocus={false}
           className="MuiInputBase-input MuiInput-input"
@@ -633,6 +634,7 @@ exports[`single fields format date 1`] = `
         onClick={[Function]}
       >
         <input
+          aria-describedby="root__errors root__description root__help"
           aria-invalid={false}
           autoFocus={false}
           className="MuiInputBase-input MuiInput-input"
@@ -745,6 +747,7 @@ exports[`single fields format datetime 1`] = `
         onClick={[Function]}
       >
         <input
+          aria-describedby="root__errors root__description root__help"
           aria-invalid={false}
           autoFocus={false}
           className="MuiInputBase-input MuiInput-input"
@@ -859,6 +862,7 @@ exports[`single fields hidden label 1`] = `
         onClick={[Function]}
       >
         <input
+          aria-describedby="root__errors root__description root__help"
           aria-invalid={false}
           autoFocus={false}
           className="MuiInputBase-input MuiInput-input"
@@ -1015,6 +1019,7 @@ exports[`single fields number field 0 1`] = `
         onClick={[Function]}
       >
         <input
+          aria-describedby="root__errors root__description root__help"
           aria-invalid={false}
           autoFocus={false}
           className="MuiInputBase-input MuiInput-input"
@@ -1126,6 +1131,7 @@ exports[`single fields number field 1`] = `
         onClick={[Function]}
       >
         <input
+          aria-describedby="root__errors root__description root__help"
           aria-invalid={false}
           autoFocus={false}
           className="MuiInputBase-input MuiInput-input"
@@ -1193,6 +1199,7 @@ exports[`single fields password field 1`] = `
         onClick={[Function]}
       >
         <input
+          aria-describedby="root__errors root__description root__help"
           aria-invalid={false}
           autoFocus={false}
           className="MuiInputBase-input MuiInput-input"
@@ -1455,6 +1462,7 @@ exports[`single fields select field 1`] = `
           />
         </div>
         <input
+          aria-describedby="root__errors root__description root__help"
           autoFocus={false}
           onAnimationStart={[Function]}
           type="hidden"
@@ -1624,6 +1632,7 @@ exports[`single fields string field format email 1`] = `
         onClick={[Function]}
       >
         <input
+          aria-describedby="root__errors root__description root__help"
           aria-invalid={false}
           autoFocus={false}
           className="MuiInputBase-input MuiInput-input"
@@ -1739,6 +1748,7 @@ exports[`single fields string field format uri 1`] = `
         onClick={[Function]}
       >
         <input
+          aria-describedby="root__errors root__description root__help"
           aria-invalid={false}
           autoFocus={false}
           className="MuiInputBase-input MuiInput-input"
@@ -1850,6 +1860,7 @@ exports[`single fields string field regular 1`] = `
         onClick={[Function]}
       >
         <input
+          aria-describedby="root__errors root__description root__help"
           aria-invalid={false}
           autoFocus={false}
           className="MuiInputBase-input MuiInput-input"
@@ -1961,6 +1972,7 @@ exports[`single fields string field with placeholder 1`] = `
         onClick={[Function]}
       >
         <input
+          aria-describedby="root__errors root__description root__help"
           aria-invalid={false}
           autoFocus={false}
           className="MuiInputBase-input MuiInput-input"
@@ -2025,6 +2037,7 @@ exports[`single fields textarea field 1`] = `
         onClick={[Function]}
       >
         <textarea
+          aria-describedby="root__errors root__description root__help"
           aria-invalid={false}
           autoFocus={false}
           className="MuiInputBase-input MuiInput-input MuiInputBase-inputMultiline MuiInput-inputMultiline"

--- a/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
@@ -40,6 +40,7 @@ exports[`object fields additionalProperties 1`] = `
                 onClick={[Function]}
               >
                 <input
+                  aria-describedby="root_foo__errors root_foo__description root_foo__help"
                   aria-invalid={false}
                   className="MuiInputBase-input MuiInput-input"
                   defaultValue="foo"
@@ -126,6 +127,7 @@ exports[`object fields additionalProperties 1`] = `
                   onClick={[Function]}
                 >
                   <input
+                    aria-describedby="root_foo__errors root_foo__description root_foo__help"
                     aria-invalid={false}
                     autoFocus={false}
                     className="MuiInputBase-input MuiInput-input"
@@ -370,6 +372,7 @@ exports[`object fields object 1`] = `
               onClick={[Function]}
             >
               <input
+                aria-describedby="root_a__errors root_a__description root_a__help"
                 aria-invalid={false}
                 autoFocus={false}
                 className="MuiInputBase-input MuiInput-input"
@@ -470,6 +473,7 @@ exports[`object fields object 1`] = `
               onClick={[Function]}
             >
               <input
+                aria-describedby="root_b__errors root_b__description root_b__help"
                 aria-invalid={false}
                 autoFocus={false}
                 className="MuiInputBase-input MuiInput-input"

--- a/packages/semantic-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.js
+++ b/packages/semantic-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.js
@@ -22,7 +22,7 @@ function ArrayFieldDescription({ DescriptionField, idSchema, description }) {
     // See #312: Ensure compatibility with old versions of React.
     return null;
   }
-  const id = `${idSchema.$id}__description`;
+  const id = utils.descriptionId(idSchema.$id);
   return <DescriptionField id={id} description={description} />;
 }
 

--- a/packages/semantic-ui/src/FieldTemplate/FieldTemplate.js
+++ b/packages/semantic-ui/src/FieldTemplate/FieldTemplate.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { Form } from "semantic-ui-react";
+import { utils } from "@rjsf/core";
 import DescriptionField from "../DescriptionField";
 import HelpField from "../HelpField";
 import RawErrors from "../RawErrors";
@@ -31,7 +32,7 @@ function FieldTemplate({
             )}
           </MaybeWrap>
         )}
-        <HelpField helpText={rawHelp} id={id + "__help"} />
+        <HelpField helpText={rawHelp} id={utils.helpId(id)} />
         <RawErrors errors={rawErrors} options={errorOptions} />
       </MaybeWrap>
     </Form.Group>

--- a/packages/semantic-ui/test/__snapshots__/Form.test.js.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.js.snap
@@ -103,6 +103,7 @@ exports[`single fields string field format email 1`] = `
     className="grouped equal width fields"
   >
     <input
+      aria-describedby="root__errors root__description root__help"
       autoFocus={false}
       className="form-control"
       disabled={false}
@@ -139,6 +140,7 @@ exports[`single fields string field format uri 1`] = `
     className="grouped equal width fields"
   >
     <input
+      aria-describedby="root__errors root__description root__help"
       autoFocus={false}
       className="form-control"
       disabled={false}


### PR DESCRIPTION
### Reasons for making this change

Make screen reader read field errors, description and help text.

Fixes #959

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

### Deploy preview

Once CI finishes, you should be able to view a deploy preview of the playground from this PR at this link: https://deploy-preview-[PR_NUMBER]--rjsf.netlify.app/