### PR TITLE
feat: add `readonly` property to set whole form read-only

### DIFF
--- a/docs/api-reference/form-props.md
+++ b/docs/api-reference/form-props.md
@@ -72,6 +72,23 @@ render((
 
 If you just want to disable some of the fields, see the `ui:disabled` parameter in `uiSchema`.
 
+## readonly
+
+It's possible to set the whole form read-only by setting the `readonly` prop. The `readonly` prop is then forwarded down to each field of the form.
+
+```jsx
+const schema = {
+  type: "string"
+};
+
+render((
+  <Form schema={schema}
+        readonly />
+), document.getElementById("app"));
+```
+
+If you just want to set some of the fields read-only, see the `ui:readonly` parameter in `uiSchema`.
+
 ## enctype
 
 The value of this prop will be passed to the `enctype` [HTML attribute on the form](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-enctype).

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -19,6 +19,7 @@ declare module '@rjsf/core' {
         className?: string;
         customFormats?: { [k: string]: string | RegExp | ((data: string) => boolean) };
         disabled?: boolean;
+        readonly?: boolean;
         enctype?: string;
         extraErrors?: any;
         ErrorList?: React.StatelessComponent<ErrorListProps>;

--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -24,6 +24,7 @@ export default class Form extends Component {
     noValidate: false,
     liveValidate: false,
     disabled: false,
+    readonly: false,
     noHtml5Validate: false,
     ErrorList: DefaultErrorList,
     omitExtraData: false,
@@ -430,6 +431,7 @@ export default class Form extends Component {
       acceptcharset,
       noHtml5Validate,
       disabled,
+      readonly,
       formContext,
     } = this.props;
 
@@ -476,6 +478,7 @@ export default class Form extends Component {
           onFocus={this.onFocus}
           registry={registry}
           disabled={disabled}
+          readonly={readonly}
         />
         {children ? (
           children

--- a/packages/core/test/Form_test.js
+++ b/packages/core/test/Form_test.js
@@ -2195,6 +2195,33 @@ describeRepeated("Form common", createFormComponent => {
     });
   });
 
+  describe("Form readonly prop", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        foo: { type: "string" },
+        bar: { type: "string" },
+      },
+    };
+    const formData = { foo: "foo", bar: "bar" };
+
+    it("should set all items editable", () => {
+      const { node } = createFormComponent({ schema, formData });
+
+      expect(node.querySelectorAll("input:read-only")).to.have.length.of(0);
+    });
+
+    it("should set all items read-only", () => {
+      const { node } = createFormComponent({
+        schema,
+        formData,
+        readonly: true,
+      });
+
+      expect(node.querySelectorAll("input:read-only")).to.have.length.of(2);
+    });
+  });
+
   describe("Attributes", () => {
     const formProps = {
       schema: {},

--- a/packages/playground/src/app.js
+++ b/packages/playground/src/app.js
@@ -100,6 +100,7 @@ const liveSettingsSchema = {
   properties: {
     validate: { type: "boolean", title: "Live validation" },
     disable: { type: "boolean", title: "Disable whole form" },
+    readonly: { type: "boolean", title: "Set whole form read-only" },
     omitExtraData: { type: "boolean", title: "Omit extra data" },
     liveOmit: { type: "boolean", title: "Live omit" },
   },
@@ -601,6 +602,7 @@ class Playground extends Component {
                 disabled={liveSettings.disable}
                 omitExtraData={liveSettings.omitExtraData}
                 liveOmit={liveSettings.liveOmit}
+                readonly={liveSettings.readonly}
                 schema={schema}
                 uiSchema={uiSchema}
                 formData={formData}


### PR DESCRIPTION
### Reasons for making this change

Just like existing `disabled` property, add `readonly` property to set whole form read-only.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature

### Deploy preview

Once CI finishes, you should be able to view a deploy preview of the playground from this PR at this link: https://deploy-preview-[PR_NUMBER]--rjsf.netlify.app/