### PR TITLE
Set datalist key to avoid warnings when base input with examples used as sibling

### DIFF
--- a/packages/core/src/components/widgets/BaseInput.js
+++ b/packages/core/src/components/widgets/BaseInput.js
@@ -81,7 +81,9 @@ function BaseInput(props) {
       onFocus={onFocus && (event => onFocus(inputProps.id, event.target.value))}
     />,
     schema.examples ? (
-      <datalist id={`examples_${inputProps.id}`}>
+      <datalist
+        key={`datalist_${inputProps.id}`}
+        id={`examples_${inputProps.id}`}>
         {[
           ...new Set(
             schema.examples.concat(schema.default ? [schema.default] : [])


### PR DESCRIPTION
### Reasons for making this change

We use json-schema to render forms and get this warning.
`react_devtools_backend.js:2560 Warning: Each child in a list should have a unique "key" prop. 
See https://fb.me/react-warning-keys for more information.
    in BaseInput`
The options inside the datalist and the input along have a key specified, the only missing key is for the datalist.

This should break nothing but get BaseInput with examples work without warning when used as siblings inside a form.

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

### Deploy preview

Once CI finishes, you should be able to view a deploy preview of the playground from this PR at this link: https://deploy-preview-[PR_NUMBER]--rjsf.netlify.app/