### PR TITLE
Fix onSubmit type

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -40,7 +40,7 @@ declare module '@rjsf/core' {
         onChange?: (e: IChangeEvent<T>, es?: ErrorSchema) => any;
         onError?: (e: any) => any;
         onFocus?: (id: string, value: any) => void;
-        onSubmit?: (e: ISubmitEvent<T>) => any;
+        onSubmit?: (e: ISubmitEvent<T>, nativeEvent: React.FormEvent<HTMLFormElement>) => any;
         schema: JSONSchema7;
         showErrorList?: boolean;
         tagName?: keyof JSX.IntrinsicElements | React.ComponentType;


### PR DESCRIPTION
Currently, the onSubmit only allows one parameter. The docs mention that
onSubmit should receive a second parameter for the native form submit
event, so the type has been updated to include it.

### Reasons for making this change

The current type for `onSubmit` is inaccurate and leads to type errors if trying to use the second parameter in your submit handler inside a TypeScript project.

### Checklist

I believe the below checklist isn't applicable for this change, so will not be updating it.

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

### Deploy preview

Once CI finishes, you should be able to view a deploy preview of the playground from this PR at this link: https://deploy-preview-2398--rjsf.netlify.app/