### PR TITLE
Hide grid for hidden fields (material-ui, bootstrap-4, fluent-ui); pass hidden prop to ObjectFieldTemplate

### DIFF
--- a/docs/advanced-customization/custom-templates.md
+++ b/docs/advanced-customization/custom-templates.md
@@ -219,5 +219,6 @@ The following props are part of each element in `properties`:
 - `name`: A string representing the property name.
 - `disabled`: A boolean value stating if the object property is disabled.
 - `readonly`: A boolean value stating if the property is read-only.
+- `hidden`: A boolean value stating if the property should be hidden.
 
 > Note: Array and object field templates are always rendered inside of the FieldTemplate. To fully customize an object field template, you may need to specify both `ui:FieldTemplate` and `ui:ObjectFieldTemplate`.

--- a/packages/antd/src/templates/ObjectFieldTemplate/index.js
+++ b/packages/antd/src/templates/ObjectFieldTemplate/index.js
@@ -75,9 +75,6 @@ const ObjectFieldTemplate = ({
     return defaultColSpan;
   };
 
-  const filterHidden = (element) =>
-    element.content.props.uiSchema['ui:widget'] !== 'hidden';
-
   return (
     <fieldset id={idSchema.$id}>
       <Row gutter={rowGutter}>
@@ -99,7 +96,7 @@ const ObjectFieldTemplate = ({
               />
             </Col>
           )}
-        {properties.filter(filterHidden).map((element) => (
+        {properties.filter((e) => !e.hidden).map((element) => (
           <Col key={element.name} span={calculateColSpan(element)}>
             {element.content}
           </Col>

--- a/packages/antd/test/Form.test.js
+++ b/packages/antd/test/Form.test.js
@@ -80,10 +80,17 @@ describe("single fields", () => {
   });
   test("hidden field", () => {
     const schema = {
-      type: "string",
+      type: "object",
+      properties: {
+        "my-field": {
+          type: "string",
+        },
+      },
     };
     const uiSchema = {
-      "ui:widget": "hidden",
+      "my-field": {
+        "ui:widget": "hidden",
+      },
     };
     const tree = renderer
       .create(<Form schema={schema} uiSchema={uiSchema} />)

--- a/packages/antd/test/Form.test.js
+++ b/packages/antd/test/Form.test.js
@@ -78,4 +78,16 @@ describe("single fields", () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+  test("hidden field", () => {
+    const schema = {
+      type: "string",
+    };
+    const uiSchema = {
+      "ui:widget": "hidden",
+    };
+    const tree = renderer
+      .create(<Form schema={schema} uiSchema={uiSchema} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/antd/test/__snapshots__/Form.test.js.snap
+++ b/packages/antd/test/__snapshots__/Form.test.js.snap
@@ -7,13 +7,21 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-hidden"
+    className="form-group field field-object"
   >
-    <input
+    <fieldset
       id="root"
-      type="hidden"
-      value=""
-    />
+    >
+      <div
+        className="ant-row"
+        style={
+          Object {
+            "marginLeft": -12,
+            "marginRight": -12,
+          }
+        }
+      />
+    </fieldset>
   </div>
   <div>
     <button

--- a/packages/antd/test/__snapshots__/Form.test.js.snap
+++ b/packages/antd/test/__snapshots__/Form.test.js.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`single fields hidden field 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="field-hidden"
+  >
+    <input
+      id="root"
+      type="hidden"
+      value=""
+    />
+  </div>
+  <div>
+    <button
+      className="btn btn-info"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields null field 1`] = `
 <form
   className="rjsf"

--- a/packages/bootstrap-4/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/bootstrap-4/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -33,7 +33,10 @@ const ObjectFieldTemplate = ({
       )}
       <Container fluid className="p-0">
         {properties.map((element: any, index: number) => (
-          <Row key={index} style={{ marginBottom: "10px" }}>
+          <Row
+            key={index}
+            style={{ marginBottom: "10px" }}
+            className={element.hidden ? "d-none" : undefined}>
             <Col xs={12}> {element.content}</Col>
           </Row>
         ))}

--- a/packages/bootstrap-4/test/Form.test.tsx
+++ b/packages/bootstrap-4/test/Form.test.tsx
@@ -197,4 +197,23 @@ describe("single fields", () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+  test("hidden field", () => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      properties: {
+        "my-field": {
+          type: "string",
+        },
+      },
+    };
+    const uiSchema: UiSchema = {
+      "my-field": {
+        "ui:widget": "hidden",
+      },
+    };
+    const tree = renderer
+      .create(<Form schema={schema} uiSchema={uiSchema} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
@@ -346,6 +346,55 @@ exports[`single fields format datetime 1`] = `
 </form>
 `;
 
+exports[`single fields hidden field 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group"
+  >
+    <div
+      className="p-0 container-fluid"
+    >
+      <div
+        className="d-none row"
+        style={
+          Object {
+            "marginBottom": "10px",
+          }
+        }
+      >
+        <div
+          className="col-12"
+        >
+           
+          <div
+            className="form-group"
+          >
+            <input
+              id="root_my-field"
+              type="hidden"
+              value=""
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields null field 1`] = `
 <form
   className="rjsf"

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -215,6 +215,7 @@ declare module '@rjsf/core' {
             name: string;
             disabled: boolean;
             readonly: boolean;
+            hidden: boolean;
         }[];
         onAddClick: (schema: JSONSchema7) => () => void;
         readonly: boolean;

--- a/packages/core/src/components/fields/ObjectField.js
+++ b/packages/core/src/components/fields/ObjectField.js
@@ -229,6 +229,11 @@ class ObjectField extends Component {
         const addedByAdditionalProperties = schema.properties[
           name
         ].hasOwnProperty(ADDITIONAL_PROPERTY_FLAG);
+        const fieldUiSchema = addedByAdditionalProperties
+          ? uiSchema.additionalProperties
+          : uiSchema[name];
+        const hidden = fieldUiSchema && fieldUiSchema["ui:widget"] === "hidden";
+
         return {
           content: (
             <SchemaField
@@ -236,11 +241,7 @@ class ObjectField extends Component {
               name={name}
               required={this.isRequired(name)}
               schema={schema.properties[name]}
-              uiSchema={
-                addedByAdditionalProperties
-                  ? uiSchema.additionalProperties
-                  : uiSchema[name]
-              }
+              uiSchema={fieldUiSchema}
               errorSchema={errorSchema[name]}
               idSchema={idSchema[name]}
               idPrefix={idPrefix}
@@ -263,6 +264,7 @@ class ObjectField extends Component {
           readonly,
           disabled,
           required,
+          hidden,
         };
       }),
       readonly,

--- a/packages/fluent-ui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/fluent-ui/src/FieldTemplate/FieldTemplate.tsx
@@ -20,12 +20,15 @@ const FieldTemplate = ({
   rawDescription,
   classNames,
   label,
-  required
+  required,
+  hidden,
 }: FieldTemplateProps) => {
   // TODO: do this better by not returning the form-group class from master.
   classNames = "ms-Grid-col ms-sm12 " + classNames.replace("form-group", "");
   return (
-    <div className={classNames} style={{marginBottom: 15}}>
+    <div
+      className={classNames}
+      style={{ marginBottom: 15, display: hidden ? "none" : undefined }}>
       {children}
       {/* {displayLabel && <Label>
         {label}

--- a/packages/fluent-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/fluent-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -29,7 +29,7 @@ const ObjectFieldTemplate = ({
 
       <div className="ms-Grid" dir="ltr">
         <div className="ms-Grid-row">
-          {properties.map((element: any) => element.content)}
+          {properties.map((element) => element.content)}
         </div>
       </div>
     </>

--- a/packages/fluent-ui/test/Form.test.tsx
+++ b/packages/fluent-ui/test/Form.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Form from "../src/index";
 import { JSONSchema7 } from "json-schema";
 import renderer from "react-test-renderer";
+import { UiSchema } from '@rjsf/core';
 
 describe("single fields", () => {
   describe("string field", () => {
@@ -69,6 +70,25 @@ describe("single fields", () => {
     };
     const tree = renderer
       .create(<Form schema={schema} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+  test("hidden field", () => {
+    const schema: JSONSchema7 = {
+      type: "object",
+      properties: {
+        "my-field": {
+          type: "string",
+        },
+      },
+    };
+    const uiSchema: UiSchema = {
+      "my-field": {
+        "ui:widget": "hidden",
+      },
+    };
+    const tree = renderer
+      .create(<Form schema={schema} uiSchema={uiSchema} />)
       .toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/fluent-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Array.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`array fields array 1`] = `
     className="ms-Grid-col ms-sm12  field field-array"
     style={
       Object {
+        "display": undefined,
         "marginBottom": 15,
       }
     }
@@ -115,6 +116,7 @@ exports[`array fields checkboxes 1`] = `
     className="ms-Grid-col ms-sm12  field field-array"
     style={
       Object {
+        "display": undefined,
         "marginBottom": 15,
       }
     }
@@ -211,6 +213,7 @@ exports[`array fields fixed array 1`] = `
     className="ms-Grid-col ms-sm12  field field-array"
     style={
       Object {
+        "display": undefined,
         "marginBottom": 15,
       }
     }
@@ -232,6 +235,7 @@ exports[`array fields fixed array 1`] = `
               className="ms-Grid-col ms-sm12  field field-string"
               style={
                 Object {
+                  "display": undefined,
                   "marginBottom": 15,
                 }
               }
@@ -389,6 +393,7 @@ exports[`array fields fixed array 1`] = `
               className="ms-Grid-col ms-sm12  field field-number"
               style={
                 Object {
+                  "display": undefined,
                   "marginBottom": 15,
                 }
               }

--- a/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
@@ -1,5 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`single fields hidden field 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="ms-Grid-col ms-sm12  field field-object"
+    style={
+      Object {
+        "display": undefined,
+        "marginBottom": 15,
+      }
+    }
+  >
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
+      <div
+        className="ms-Grid-row"
+      >
+        <div
+          className="ms-Grid-col ms-sm12  field field-string"
+          style={
+            Object {
+              "display": "none",
+              "marginBottom": 15,
+            }
+          }
+        >
+          <input
+            id="root_my-field"
+            type="hidden"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <br />
+    <div
+      className="ms-Grid-col ms-sm12"
+    >
+      <button
+        className="ms-Button ms-Button--primary root-50"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="submit"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-51"
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className="ms-Button-textContainer textContainer-52"
+          >
+            <span
+              className="ms-Button-label label-54"
+              id="id__34"
+            >
+              Submit
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</form>
+`;
+
 exports[`single fields null field 1`] = `
 <form
   className="rjsf"
@@ -10,6 +87,7 @@ exports[`single fields null field 1`] = `
     className="ms-Grid-col ms-sm12  field field-null"
     style={
       Object {
+        "display": undefined,
         "marginBottom": 15,
       }
     }
@@ -61,6 +139,7 @@ exports[`single fields number field 1`] = `
     className="ms-Grid-col ms-sm12  field field-number"
     style={
       Object {
+        "display": undefined,
         "marginBottom": 15,
       }
     }
@@ -140,6 +219,7 @@ exports[`single fields string field format data-url 1`] = `
     className="ms-Grid-col ms-sm12  field field-string"
     style={
       Object {
+        "display": undefined,
         "marginBottom": 15,
       }
     }
@@ -204,6 +284,7 @@ exports[`single fields string field format email 1`] = `
     className="ms-Grid-col ms-sm12  field field-string"
     style={
       Object {
+        "display": undefined,
         "marginBottom": 15,
       }
     }
@@ -283,6 +364,7 @@ exports[`single fields string field format uri 1`] = `
     className="ms-Grid-col ms-sm12  field field-string"
     style={
       Object {
+        "display": undefined,
         "marginBottom": 15,
       }
     }
@@ -362,6 +444,7 @@ exports[`single fields string field regular 1`] = `
     className="ms-Grid-col ms-sm12  field field-string"
     style={
       Object {
+        "display": undefined,
         "marginBottom": 15,
       }
     }
@@ -441,6 +524,7 @@ exports[`single fields unsupported field 1`] = `
     className="ms-Grid-col ms-sm12  field field-undefined"
     style={
       Object {
+        "display": undefined,
         "marginBottom": 15,
       }
     }

--- a/packages/fluent-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Object.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`object fields object 1`] = `
     className="ms-Grid-col ms-sm12  field field-object"
     style={
       Object {
+        "display": undefined,
         "marginBottom": 15,
       }
     }
@@ -25,6 +26,7 @@ exports[`object fields object 1`] = `
           className="ms-Grid-col ms-sm12  field field-string"
           style={
             Object {
+              "display": undefined,
               "marginBottom": 15,
             }
           }
@@ -70,6 +72,7 @@ exports[`object fields object 1`] = `
           className="ms-Grid-col ms-sm12  field field-number"
           style={
             Object {
+              "display": undefined,
               "marginBottom": 15,
             }
           }

--- a/packages/material-ui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/material-ui/src/FieldTemplate/FieldTemplate.tsx
@@ -16,6 +16,7 @@ const FieldTemplate = ({
   classNames,
   disabled,
   displayLabel,
+  hidden,
   label,
   onDropPropertyClick,
   onKeyChange,
@@ -26,6 +27,10 @@ const FieldTemplate = ({
   rawDescription,
   schema,
 }: FieldTemplateProps) => {
+  if (hidden) {
+    return children;
+  }
+
   return (
     <WrapIfAdditional
       classNames={classNames}

--- a/packages/material-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/material-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -53,6 +53,8 @@ const ObjectFieldTemplate = ({
       )}
       <Grid container={true} spacing={2} className={classes.root}>
         {properties.map((element: any, index: number) =>
+          // Remove the <Grid> if the inner element is hidden as the <Grid>
+          // itself would otherwise still take up space.
           isHidden(element) ? (
             element.content
           ) : (

--- a/packages/material-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/material-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -33,6 +33,9 @@ const ObjectFieldTemplate = ({
 }: ObjectFieldTemplateProps) => {
   const classes = useStyles();
 
+  const isHidden = (element: any): boolean =>
+    element.content.props.uiSchema["ui:widget"] === "hidden";
+
   return (
     <>
       {(uiSchema['ui:title'] || title) && (
@@ -49,16 +52,19 @@ const ObjectFieldTemplate = ({
         />
       )}
       <Grid container={true} spacing={2} className={classes.root}>
-        {properties.map((element: any, index: number) => (
-          <Grid
-            item={true}
-            xs={12}
-            key={index}
-            style={{ marginBottom: '10px' }}
-          >
-            {element.content}
-          </Grid>
-        ))}
+        {properties.map((element: any, index: number) =>
+          isHidden(element) ? (
+            element.content
+          ) : (
+            <Grid
+              item={true}
+              xs={12}
+              key={index}
+              style={{ marginBottom: "10px" }}>
+              {element.content}
+            </Grid>
+          )
+        )}
         {canExpand(schema, uiSchema, formData) && (
           <Grid container justify='flex-end'>
             <Grid item={true}>

--- a/packages/material-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/material-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -33,9 +33,6 @@ const ObjectFieldTemplate = ({
 }: ObjectFieldTemplateProps) => {
   const classes = useStyles();
 
-  const isHidden = (element: any): boolean =>
-    element.content.props.uiSchema["ui:widget"] === "hidden";
-
   return (
     <>
       {(uiSchema['ui:title'] || title) && (
@@ -52,10 +49,10 @@ const ObjectFieldTemplate = ({
         />
       )}
       <Grid container={true} spacing={2} className={classes.root}>
-        {properties.map((element: any, index: number) =>
+        {properties.map((element, index) =>
           // Remove the <Grid> if the inner element is hidden as the <Grid>
           // itself would otherwise still take up space.
-          isHidden(element) ? (
+          element.hidden ? (
             element.content
           ) : (
             <Grid

--- a/packages/material-ui/test/Form.test.tsx
+++ b/packages/material-ui/test/Form.test.tsx
@@ -197,6 +197,18 @@ describe("single fields", () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+  test("hidden field", () => {
+    const schema: JSONSchema7 = {
+      type: "string",
+    };
+    const uiSchema: UiSchema = {
+      "ui:widget": "hidden",
+    };
+    const tree = renderer
+      .create(<Form schema={schema} uiSchema={uiSchema} />)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
   test("hidden label", () => {
     const schema: JSONSchema7 = {
       type: "string",

--- a/packages/material-ui/test/Form.test.tsx
+++ b/packages/material-ui/test/Form.test.tsx
@@ -199,10 +199,17 @@ describe("single fields", () => {
   });
   test("hidden field", () => {
     const schema: JSONSchema7 = {
-      type: "string",
+      type: "object",
+      properties: {
+        "my-field": {
+          type: "string",
+        },
+      },
     };
     const uiSchema: UiSchema = {
-      "ui:widget": "hidden",
+      "my-field": {
+        "ui:widget": "hidden",
+      },
     };
     const tree = renderer
       .create(<Form schema={schema} uiSchema={uiSchema} />)

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -801,13 +801,21 @@ exports[`single fields hidden field 1`] = `
   noValidate={false}
   onSubmit={[Function]}
 >
-  <input
-    id="root"
-    type="hidden"
-    value=""
-  />
   <div
-    className="MuiBox-root MuiBox-root-194"
+    className="MuiFormControl-root MuiFormControl-fullWidth"
+  >
+    <div
+      className="MuiGrid-root makeStyles-root-194 MuiGrid-container MuiGrid-spacing-xs-2"
+    >
+      <input
+        id="root_my-field"
+        type="hidden"
+        value=""
+      />
+    </div>
+  </div>
+  <div
+    className="MuiBox-root MuiBox-root-298"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -921,7 +929,7 @@ exports[`single fields hidden label 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-195"
+    className="MuiBox-root MuiBox-root-299"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -795,6 +795,50 @@ exports[`single fields format datetime 1`] = `
 </form>
 `;
 
+exports[`single fields hidden field 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <input
+    id="root"
+    type="hidden"
+    value=""
+  />
+  <div
+    className="MuiBox-root MuiBox-root-194"
+  >
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+      disabled={false}
+      onBlur={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="submit"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        Submit
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields hidden label 1`] = `
 <form
   className="rjsf"

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -921,7 +921,7 @@ exports[`single fields hidden label 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-194"
+    className="MuiBox-root MuiBox-root-195"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -945,9 +945,6 @@ exports[`single fields hidden label 1`] = `
       >
         Submit
       </span>
-      <span
-        className="MuiTouchRipple-root"
-      />
     </button>
   </div>
 </form>


### PR DESCRIPTION
### Reasons for making this change

`hidden` fields aren't hidden for material-ui as the grid around them is still displayed. This hides the grid for hidden fields.
Implementations follows the one that already exists for ant design.

**Before** (note the space before the disabled example)

<img width="500" alt="Bildschirmfoto 2021-05-27 um 11 17 55" src="https://user-images.githubusercontent.com/648527/119801837-556a9e80-bede-11eb-8f98-a70f5fb85182.png">

**After**

<img width="500" alt="Bildschirmfoto 2021-05-27 um 11 20 59" src="https://user-images.githubusercontent.com/648527/119801879-5dc2d980-bede-11eb-9953-49395c6e3d24.png">

Closes #1974
Fixes https://github.com/rjsf-team/react-jsonschema-form/issues/1683

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

### Deploy preview

Once CI finishes, you should be able to view a deploy preview of the playground from this PR at this link: https://deploy-preview-[PR_NUMBER]--rjsf.netlify.app/