### PR TITLE
Deploy canary builds to npm from master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,10 @@ jobs:
     name: Deploy canary version of packages to npm
     needs: [build]
     steps:
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 14.x
       - run: npm i -g lerna@3.18.4
       - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,11 +89,11 @@ jobs:
         uses: actions/setup-node@v2.1.5
         with:
           node-version: 14.x
-      - run: npm i -g lerna@3.18.4
+      - run: npm i lerna@3.18.4
       - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: lerna publish from-package --yes --no-verify-access --canary
+      - run: npx lerna publish from-package --yes --no-verify-access --canary
       - if: always()
         run: rm .npmrc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   
+  deploy_canary:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    name: Deploy canary version of packages to npm
+    needs: [build]
+    steps:
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm i -g lerna@3.18.4
+      - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: lerna publish from-package --yes --no-verify-access --canary
+      - if: always()
+        run: rm .npmrc
+
   docs:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Reasons for making this change

Deploy canary builds to npm from master. This way, anyone can use the latest rjsf packages from master without having to wait for a new release.