### PR TITLE
Add null check to componentDidUpdate

### DIFF
--- a/packages/core/src/components/widgets/AltDateWidget.js
+++ b/packages/core/src/components/widgets/AltDateWidget.js
@@ -65,6 +65,7 @@ class AltDateWidget extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     if (
+      prevProps.value &&
       prevProps.value !== parseDateString(this.props.value, this.props.time)
     ) {
       this.setState(parseDateString(this.props.value, this.props.time));

--- a/packages/core/test/StringField_test.js
+++ b/packages/core/test/StringField_test.js
@@ -1171,7 +1171,7 @@ describe("StringField", () => {
       });
     });
 
-    it("should reflect the change into the dom", () => {
+    it("should call the provided onChange function once all values are filled", () => {
       const { node, onChange } = createFormComponent({
         schema: {
           type: "string",
@@ -1194,6 +1194,29 @@ describe("StringField", () => {
       sinon.assert.calledWithMatch(onChange.lastCall, {
         formData: "2012-10-02",
       });
+    });
+
+    it("should reflect the change into the dom, even when not all values are filled", () => {
+      const { node, onChange } = createFormComponent({
+        schema: {
+          type: "string",
+          format: "date",
+        },
+        uiSchema,
+      });
+
+      act(() => {
+        Simulate.change(node.querySelector("#root_year"), {
+          target: { value: 2012 },
+        });
+        Simulate.change(node.querySelector("#root_month"), {
+          target: { value: 10 },
+        });
+      });
+      expect(node.querySelector("#root_year").value).eql("2012");
+      expect(node.querySelector("#root_month").value).eql("10");
+      expect(node.querySelector("#root_day").value).eql("");
+      sinon.assert.notCalled(onChange);
     });
 
     it("should fill field with data", () => {


### PR DESCRIPTION
### Reasons for making this change

Fixes https://github.com/rjsf-team/react-jsonschema-form/issues/2440#issue-930943828

setState was mistakenly called in componentDidUpdate when no value was passed to the prop.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

