### PR TITLE
Fix docs codepen by reverting to 2.5.1 for now

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -12,7 +12,7 @@ $(".language-jsx").each(function() {
     var prefill = {
         "title":"RJSF example",
         "tags":[],
-        "scripts":["https://cdnjs.cloudflare.com/ajax/libs/react/16.13.1/umd/react.production.min.js","https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.13.1/umd/react-dom.production.min.js","https://unpkg.com/@rjsf/core/dist/react-jsonschema-form.js"],
+        "scripts":["https://cdnjs.cloudflare.com/ajax/libs/react/16.13.1/umd/react.production.min.js","https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.13.1/umd/react-dom.production.min.js","https://unpkg.com/@rjsf/core@2.5.1/dist/react-jsonschema-form.js"],
         "stylesheets":["//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"]
     };
     var div = $("<div><div class=\"codepen\" data-height=\"400\" data-theme-id=\"light\" data-default-tab=\"js,result\" data-prefill='" + JSON.stringify(prefill) + " '>\"<pre data-lang=\"html\">\n&lt;div id=\"app\">&lt;/div></pre><pre data-lang=\"babel\">" + text + "</pre></div></div>").css("margin", "30px 0px");


### PR DESCRIPTION
It seems like 3.0.0 doesn't work if you use the UMD bundle. Reverting it to 2.5.1 for now to address https://github.com/rjsf-team/react-jsonschema-form/issues/2447