### PR TITLE
Update react peer dependency to be 16.8.0 so hooks can be used in this repo.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ Then import the dependency as follows:
 import Form from "@rjsf/core";
 ```
 
-Our latest version requires React 16+. You can also install `react-jsonschema-form` (the 1.x version) which works with React 15+.
+Our latest version requires React 16.8.0+. You can also install `react-jsonschema-form` (the 1.x version) which works with React 15+.
 
 ### As a script served from a CDN
 

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -33,7 +33,7 @@
     "antd-dayjs-webpack-plugin": "1.0.0",
     "dayjs": "^1.8.0",
     "lodash": "^4.17.15",
-    "react": ">=16"
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "@ant-design/icons": "^4.0.0",

--- a/packages/bootstrap-4/package.json
+++ b/packages/bootstrap-4/package.json
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "@rjsf/core": "^2.0.0-alpha.6",
-    "react": ">=16",
+    "react": ">=16.8.0",
     "react-bootstrap": "^1.0.1"
   },
   "engineStrict": false,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
     "node": ">=12"
   },
   "peerDependencies": {
-    "react": ">=16"
+    "react": ">=16.8.0"
   },
   "dependencies": {
     "@types/json-schema": "^7.0.7",

--- a/packages/fluent-ui/package.json
+++ b/packages/fluent-ui/package.json
@@ -20,7 +20,7 @@
   "peerDependencies": {
     "@fluentui/react": "^7.114.2",
     "@rjsf/core": "^2.0.0",
-    "react": ">=16"
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -17,7 +17,7 @@
     "@material-ui/core": "^4.2.0",
     "@material-ui/icons": "^4.2.1",
     "@rjsf/core": "^2.0.0",
-    "react": ">=16"
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-0",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -32,7 +32,7 @@
     "node": ">=12"
   },
   "peerDependencies": {
-    "react": ">=16"
+    "react": ">=16.8.0"
   },
   "dependencies": {
     "@ant-design/icons": "^4.2.1",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -29,7 +29,7 @@
     "@rjsf/core": "^2.0.0",
     "lodash": "^4.17.15",
     "nanoid": "^3.1.23",
-    "react": ">=16",
+    "react": ">=16.8.0",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^0.87.3"
   },


### PR DESCRIPTION
### Reasons for making this change

I am planning on making a change to fix #2449. Want to be able to use hooks in the feature I'm writing.

### Checklist

* [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [X] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed

