### PR TITLE
Add `ui:DuplicateKeySuffixSeparator`

### DIFF
--- a/docs/api-reference/uiSchema.md
+++ b/docs/api-reference/uiSchema.md
@@ -218,5 +218,18 @@ const uiSchema = {
   "ui:title": "Your password"
 };
 ```
+
+## Duplicate Key Suffix Separator
+
+When using `additionalProperties`, key collision is prevented by appending a unique suffix to the duplicate key. For example, when you add a key named `myKey` to a form where `myKey` is already described, then your new key will become `myKey-1`.
+
+With `ui:DuplicateKeySuffixSeparator`, you can change the `"-"` to a string of your choice, such as an underscore (`"_"`), or the empty string (`""`).
+
+```js
+const uiSchema = {
+  "ui:DuplicateKeySuffixSeparator": "_",
+};
+```
+
 ## Theme Options
 [Semantic UI](themes/semantic-ui/uiSchema.md)

--- a/packages/core/src/components/fields/ObjectField.js
+++ b/packages/core/src/components/fields/ObjectField.js
@@ -98,11 +98,11 @@ class ObjectField extends Component {
     };
   };
 
-  getAvailableKey = (preferredKey, formData) => {
+  getAvailableKey = (preferredKey, formData, separator = "-") => {
     var index = 0;
     var newKey = preferredKey;
     while (formData.hasOwnProperty(newKey)) {
-      newKey = `${preferredKey}-${++index}`;
+      newKey = `${preferredKey}${separator}${++index}`;
     }
     return newKey;
   };
@@ -113,7 +113,11 @@ class ObjectField extends Component {
         return;
       }
 
-      value = this.getAvailableKey(value, this.props.formData);
+      value = this.getAvailableKey(
+        value,
+        this.props.formData,
+        this.props.uiSchema["ui:DuplicateKeySuffixSeparator"]
+      );
       const newFormData = { ...this.props.formData };
       const newKeys = { [oldValue]: value };
       const keyValues = Object.keys(newFormData).map(key => {
@@ -171,7 +175,11 @@ class ObjectField extends Component {
     }
 
     newFormData[
-      this.getAvailableKey("newKey", newFormData)
+      this.getAvailableKey(
+        "newKey",
+        newFormData,
+        this.props.uiSchema["ui:DuplicateKeySuffixSeparator"]
+      )
     ] = this.getDefaultValue(type);
 
     this.props.onChange(newFormData);
@@ -202,6 +210,17 @@ class ObjectField extends Component {
     let orderedProperties;
     try {
       const properties = Object.keys(schema.properties || {});
+      // Order properties so additional properties are always last
+      // There may be an issue that our conditional logic is causing that this fixes, so this may need to be rolled back
+      // const properties = [
+      //   ...Object.keys(schema.properties || {}).filter(
+      //     key => !schema.properties[key][ADDITIONAL_PROPERTY_FLAG]
+      //   ),
+      //   ...Object.keys(schema.properties || {}).filter(
+      //     key => schema.properties[key][ADDITIONAL_PROPERTY_FLAG]
+      //   ),
+      // ];
+
       orderedProperties = orderProperties(properties, uiSchema["ui:order"]);
     } catch (err) {
       return (

--- a/packages/core/test/ObjectField_test.js
+++ b/packages/core/test/ObjectField_test.js
@@ -658,6 +658,29 @@ describe("ObjectField", () => {
       });
     });
 
+    it("uses a custom separator between the duplicate key name and the suffix", () => {
+      const formData = {
+        first: 1,
+        second: 2,
+      };
+      const { node, onChange } = createFormComponent({
+        schema,
+        formData,
+        uiSchema: {
+          "ui:DuplicateKeySuffixSeparator": "_",
+        },
+      });
+
+      const textNode = node.querySelector("#root_first-key");
+      Simulate.blur(textNode, {
+        target: { value: "second" },
+      });
+
+      sinon.assert.calledWithMatch(onChange.lastCall, {
+        formData: { second: 2, second_1: 1 },
+      });
+    });
+
     it("should not attach suffix when input is only clicked", () => {
       const formData = {
         first: 1,


### PR DESCRIPTION
### Reasons for making this change

For my own use case, I needed to change the separator from `-` to `_` between a duplicate key and its unique suffix when using `additionalProperties`.

To accomplish this, I added a new field to the uiSchema called `ui:DuplicateKeySuffixSeparator`, which can be used to override the separator with any string.

If the property is undefined, `-` is used, so the default behavior is unchanged.

### Checklist

* [X] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests
  - [X] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [X] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

