### PR TITLE
Load 3.0 codepen examples in documentation once more

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -12,7 +12,7 @@ $(".language-jsx").each(function() {
     var prefill = {
         "title":"RJSF example",
         "tags":[],
-        "scripts":["https://cdnjs.cloudflare.com/ajax/libs/react/17.0.2/umd/react.production.min.js","https://cdnjs.cloudflare.com/ajax/libs/react-dom/17.0.2/umd/react-dom.production.min.js","https://unpkg.com/@rjsf/core@3.0.1/dist/react-jsonschema-form.js"],
+        "scripts":["https://cdnjs.cloudflare.com/ajax/libs/react/17.0.2/umd/react.production.min.js","https://cdnjs.cloudflare.com/ajax/libs/react-dom/17.0.2/umd/react-dom.production.min.js","https://unpkg.com/@rjsf/core/dist/react-jsonschema-form.js"],
         "stylesheets":["//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"]
     };
     var div = $("<div><div class=\"codepen\" data-height=\"400\" data-theme-id=\"light\" data-default-tab=\"js,result\" data-prefill='" + JSON.stringify(prefill) + " '>\"<pre data-lang=\"html\">\n&lt;div id=\"app\">&lt;/div></pre><pre data-lang=\"babel\">" + text + "</pre></div></div>").css("margin", "30px 0px");

--- a/docs/main.js
+++ b/docs/main.js
@@ -12,7 +12,7 @@ $(".language-jsx").each(function() {
     var prefill = {
         "title":"RJSF example",
         "tags":[],
-        "scripts":["https://cdnjs.cloudflare.com/ajax/libs/react/16.13.1/umd/react.production.min.js","https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.13.1/umd/react-dom.production.min.js","https://unpkg.com/@rjsf/core@2.5.1/dist/react-jsonschema-form.js"],
+        "scripts":["https://cdnjs.cloudflare.com/ajax/libs/react/17.0.2/umd/react.production.min.js","https://cdnjs.cloudflare.com/ajax/libs/react-dom/17.0.2/umd/react-dom.production.min.js","https://unpkg.com/@rjsf/core@3.0.1/dist/react-jsonschema-form.js"],
         "stylesheets":["//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"]
     };
     var div = $("<div><div class=\"codepen\" data-height=\"400\" data-theme-id=\"light\" data-default-tab=\"js,result\" data-prefill='" + JSON.stringify(prefill) + " '>\"<pre data-lang=\"html\">\n&lt;div id=\"app\">&lt;/div></pre><pre data-lang=\"babel\">" + text + "</pre></div></div>").css("margin", "30px 0px");

--- a/packages/core/webpack.config.dist.js
+++ b/packages/core/webpack.config.dist.js
@@ -1,6 +1,5 @@
 var path = require("path");
 var webpack = require("webpack");
-const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 
 module.exports = {
   mode: "production",
@@ -15,9 +14,6 @@ module.exports = {
     libraryTarget: "umd"
   },
   plugins: [
-    new MonacoWebpackPlugin({
-      languages: ['json']
-    }),
     new webpack.DefinePlugin({
       "process.env": {
         NODE_ENV: JSON.stringify("production")
@@ -25,10 +21,21 @@ module.exports = {
     })
   ],
   devtool: "source-map",
-  externals: [
-    'react',
-    'react-dom'
-  ],
+  externals: {
+    react: {
+      root: "React",
+      commonjs: "react",
+      commonjs2: "react",
+      amd: "react"
+    },
+    'react-dom': {
+      root: "ReactDOM",
+      commonjs2: 'react-dom',
+      commonjs: 'react-dom',
+      amd: 'react-dom',
+      umd: 'react-dom',
+    }
+  },
   module: {
     rules: [
       {

--- a/packages/core/webpack.config.dist.js
+++ b/packages/core/webpack.config.dist.js
@@ -1,5 +1,6 @@
 var path = require("path");
 var webpack = require("webpack");
+const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 
 module.exports = {
   mode: "production",
@@ -14,6 +15,9 @@ module.exports = {
     libraryTarget: "umd"
   },
   plugins: [
+    new MonacoWebpackPlugin({
+      languages: ['json']
+    }),
     new webpack.DefinePlugin({
       "process.env": {
         NODE_ENV: JSON.stringify("production")


### PR DESCRIPTION
### Reasons for making this change

The React module's Component property wasn't defined in the 3.0 UMD bundle for some reason in codepen. Use ESM @rjsf/core bundle instead.

fixes #2447 

### Checklist

* [x] **I'm updating documentation**
  - [x] I've checked the rendering of the Markdown text I've added
  <img width="1440" alt="Screen Shot 2021-07-14 at 18 29 29" src="https://user-images.githubusercontent.com/5156873/125701178-9f3bf283-2763-4b16-b96b-cefa6df3dc42.png">
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

