### PR TITLE
Fix canary builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
   
   deploy_canary:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+#     if: github.ref == 'refs/heads/master'
     name: Deploy canary version of packages to npm
     needs: [build]
     steps:
@@ -94,7 +94,7 @@ jobs:
       - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: npx lerna publish from-package --yes --no-verify-access --canary
+      - run: npx lerna publish --yes --no-verify-access --canary
       - if: always()
         run: rm .npmrc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
     name: Deploy canary version of packages to npm
     needs: [build]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
       - name: Use Node.js 14.x
         uses: actions/setup-node@v2.1.5
         with:


### PR DESCRIPTION
Fix canary builds by not including `from-package` (earlier, it wouldn't publish canaries at all due to the presence of this argument).