### PR TITLE
fluent-ui: Allow value of 0 in TextWidget

### DIFF
--- a/packages/fluent-ui/src/TextWidget/TextWidget.tsx
+++ b/packages/fluent-ui/src/TextWidget/TextWidget.tsx
@@ -84,7 +84,7 @@ const TextWidget = ({
       // TODO: once fluent-ui supports the name prop, we can add it back in here.
       // name={name}
       type={inputType as string}
-      value={typeof value === "undefined" || value === null ?  "" : value}
+      value={value || value === 0 ? value : ""}
       onChange={_onChange as any}
       onBlur={_onBlur}
       onFocus={_onFocus}

--- a/packages/fluent-ui/src/TextWidget/TextWidget.tsx
+++ b/packages/fluent-ui/src/TextWidget/TextWidget.tsx
@@ -84,7 +84,7 @@ const TextWidget = ({
       // TODO: once fluent-ui supports the name prop, we can add it back in here.
       // name={name}
       type={inputType as string}
-      value={value ? value : ""}
+      value={typeof value === "undefined" || value === null ?  "" : value}
       onChange={_onChange as any}
       onBlur={_onBlur}
       onFocus={_onFocus}


### PR DESCRIPTION
Fixes proper undefined/null check and not falsy check.  when value is 0 its changed to "" instead of "0"

### Reasons for making this change

[Please describe them here]

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

