### PR TITLE
Take into account implicitly defined types when rendering labels for fields

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -389,15 +389,17 @@ export function getUiOptions(uiSchema) {
 export function getDisplayLabel(schema, uiSchema, rootSchema) {
   const uiOptions = getUiOptions(uiSchema);
   let { label: displayLabel = true } = uiOptions;
-  if (schema.type === "array") {
+  const schemaType = getSchemaType(schema);
+
+  if (schemaType === "array") {
     displayLabel =
       isMultiSelect(schema, rootSchema) ||
       isFilesArray(schema, uiSchema, rootSchema);
   }
-  if (schema.type === "object") {
+  if (schemaType === "object") {
     displayLabel = false;
   }
-  if (schema.type === "boolean" && !uiSchema["ui:widget"]) {
+  if (schemaType === "boolean" && !uiSchema["ui:widget"]) {
     displayLabel = false;
   }
   if (uiSchema["ui:field"]) {

--- a/packages/core/test/SchemaField_test.js
+++ b/packages/core/test/SchemaField_test.js
@@ -279,6 +279,17 @@ describe("SchemaField", () => {
       const { node } = createFormComponent({ schema, uiSchema });
       expect(node.querySelectorAll("label")).to.have.length.of(0);
     });
+
+    it("should render label even when type object is missing", () => {
+      const schema = {
+        title: "test",
+        properties: {
+          foo: { type: "string" },
+        },
+      };
+      const { node } = createFormComponent({ schema });
+      expect(node.querySelectorAll("label")).to.have.length.of(1);
+    });
   });
 
   describe("description support", () => {


### PR DESCRIPTION
`getSchemaType` is clever enough to figure out that a schema with
`properties` or `additionalProperties` has `type` "object", even if the
type is not explicitly defined, but `getDisplayLabel` does not have the
same logic, which results in displaying the label twice in cases where
the schema was guessed to be object.

Using `getSchemaType` as well in `getDisplayLabel` bring consistent
behavior and the label is rendered only once in that case.

### Reasons for making this change

fixes #2501

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

