### PR TITLE
Make material-ui and fluent-ui pull TextWidget from the registry; remove registry prop from <div> in TextWidget

### DIFF
--- a/packages/bootstrap-4/test/helpers/createMocks.ts
+++ b/packages/bootstrap-4/test/helpers/createMocks.ts
@@ -31,6 +31,12 @@ export function makeWidgetMockProps(
     formContext: {},
     id: "_id",
     placeholder: "",
+    registry: {
+      fields: {},
+      widgets: {},
+      formContext: {},
+      definitions: {},
+    },
     ...props,
   };
 }

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -114,9 +114,17 @@ declare module '@rjsf/core' {
         label: string;
         multiple: boolean;
         rawErrors: string[];
+        registry: Registry;
     }
 
     export type Widget = React.StatelessComponent<WidgetProps> | React.ComponentClass<WidgetProps>;
+
+    export interface Registry {
+      fields: { [name: string]: Field };
+      widgets: { [name: string]: Widget };
+      definitions: { [name: string]: any };
+      formContext: any;
+    }
 
     export interface FieldProps<T = any>
         extends Pick<React.HTMLAttributes<HTMLElement>, Exclude<keyof React.HTMLAttributes<HTMLElement>, 'onBlur'>> {
@@ -127,12 +135,7 @@ declare module '@rjsf/core' {
         errorSchema: ErrorSchema;
         onChange: (e: IChangeEvent<T> | any, es?: ErrorSchema) => any;
         onBlur: (id: string, value: any) => void;
-        registry: {
-            fields: { [name: string]: Field };
-            widgets: { [name: string]: Widget };
-            definitions: { [name: string]: any };
-            formContext: any;
-        };
+        registry: Registry;
         formContext: any;
         autofocus: boolean;
         disabled: boolean;

--- a/packages/fluent-ui/src/AltDateTimeWidget/AltDateTimeWidget.tsx
+++ b/packages/fluent-ui/src/AltDateTimeWidget/AltDateTimeWidget.tsx
@@ -1,5 +1,12 @@
 import React from "react";
 import { WidgetProps } from "@rjsf/core";
-import TextWidget from '../TextWidget';
 
-export default (props: WidgetProps) => <TextWidget {...props} />;
+const AltDateTimeWidget = (props: WidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
+  return (
+    <TextWidget {...props} />
+  );
+};
+
+export default AltDateTimeWidget;

--- a/packages/fluent-ui/src/AltDateWidget/AltDateWidget.tsx
+++ b/packages/fluent-ui/src/AltDateWidget/AltDateWidget.tsx
@@ -1,5 +1,12 @@
 import React from "react";
 import { WidgetProps } from "@rjsf/core";
-import TextWidget from '../TextWidget';
 
-export default (props: WidgetProps) => <TextWidget {...props} />;
+const AltDateWidget = (props: WidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
+  return (
+    <TextWidget {...props} />
+  );
+};
+
+export default AltDateWidget;

--- a/packages/fluent-ui/src/DateTimeWidget/DateTimeWidget.tsx
+++ b/packages/fluent-ui/src/DateTimeWidget/DateTimeWidget.tsx
@@ -2,12 +2,12 @@ import React from "react";
 
 import { WidgetProps, utils } from "@rjsf/core";
 
-import TextWidget from "../TextWidget";
-
 const { localToUTC, utcToLocal } = utils;
 
 
 const DateTimeWidget = (props: WidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
   const uiProps: any = props.options["props"] || {};
 
   const value = utcToLocal(props.value);

--- a/packages/fluent-ui/src/EmailWidget/EmailWidget.tsx
+++ b/packages/fluent-ui/src/EmailWidget/EmailWidget.tsx
@@ -2,9 +2,9 @@ import React from "react";
 
 import { WidgetProps } from "@rjsf/core";
 
-import TextWidget from "../TextWidget";
-
 const EmailWidget = (props: WidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
   const uiProps: any = props.options["props"] || {};
   let options = {
     ...props.options,

--- a/packages/fluent-ui/src/PasswordWidget/PasswordWidget.tsx
+++ b/packages/fluent-ui/src/PasswordWidget/PasswordWidget.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 
-import { WidgetProps, utils } from "@rjsf/core";
-
-import TextWidget from "../TextWidget";
+import { WidgetProps } from "@rjsf/core";
 
 const PasswordWidget = (props: WidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
   const uiProps: any = props.options["props"] || {};
   let options = {
     ...props.options,

--- a/packages/fluent-ui/src/TextareaWidget/TextareaWidget.tsx
+++ b/packages/fluent-ui/src/TextareaWidget/TextareaWidget.tsx
@@ -2,9 +2,9 @@ import React from "react";
 
 import { WidgetProps } from "@rjsf/core";
 
-import TextWidget from '../TextWidget';
-
 const TextareaWidget = (props: WidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
   const uiProps: any = props.options["props"] || {};
   let options = {
     ...props.options,

--- a/packages/fluent-ui/src/URLWidget/URLWidget.tsx
+++ b/packages/fluent-ui/src/URLWidget/URLWidget.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 
-import { WidgetProps, utils } from "@rjsf/core";
-
-import TextWidget from "../TextWidget";
+import { WidgetProps } from "@rjsf/core";
 
 const URLWidget = (props: WidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
   const uiProps: any = props.options["props"] || {};
   let options = {
     ...props.options,

--- a/packages/material-ui/src/ColorWidget/ColorWidget.tsx
+++ b/packages/material-ui/src/ColorWidget/ColorWidget.tsx
@@ -1,7 +1,9 @@
 import React from "react";
-import TextWidget, { TextWidgetProps } from "../TextWidget";
+import { TextWidgetProps } from "../TextWidget";
 
 const ColorWidget = (props: TextWidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
   return <TextWidget type="color" {...props} />;
 };
 

--- a/packages/material-ui/src/DateTimeWidget/DateTimeWidget.tsx
+++ b/packages/material-ui/src/DateTimeWidget/DateTimeWidget.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { utils } from "@rjsf/core";
-import TextWidget, { TextWidgetProps } from "../TextWidget";
+import { TextWidgetProps } from "../TextWidget";
 
 const { localToUTC, utcToLocal } = utils;
 
 const DateTimeWidget = (props: TextWidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
   const value = utcToLocal(props.value);
   const onChange = (value: any) => {
     props.onChange(localToUTC(value));

--- a/packages/material-ui/src/DateWidget/DateWidget.tsx
+++ b/packages/material-ui/src/DateWidget/DateWidget.tsx
@@ -1,7 +1,9 @@
 import React from "react";
-import TextWidget, { TextWidgetProps } from "../TextWidget";
+import { TextWidgetProps } from "../TextWidget";
 
 const DateWidget = (props: TextWidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
   return (
     <TextWidget
       type="date"

--- a/packages/material-ui/src/EmailWidget/EmailWidget.tsx
+++ b/packages/material-ui/src/EmailWidget/EmailWidget.tsx
@@ -1,7 +1,9 @@
 import React from "react";
-import TextWidget, { TextWidgetProps } from "../TextWidget";
+import { TextWidgetProps } from "../TextWidget";
 
 const EmailWidget = (props: TextWidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
   return <TextWidget type="email" {...props} />;
 };
 

--- a/packages/material-ui/src/PasswordWidget/PasswordWidget.tsx
+++ b/packages/material-ui/src/PasswordWidget/PasswordWidget.tsx
@@ -1,49 +1,11 @@
 import React from "react";
 
-import TextField from "@material-ui/core/TextField";
+import { TextWidgetProps } from "../TextWidget";
 
-import { WidgetProps } from "@rjsf/core";
-
-const PasswordWidget = ({
-  id,
-  required,
-  readonly,
-  disabled,
-  value,
-  label,
-  onFocus,
-  onBlur,
-  onChange,
-  options,
-  autofocus,
-  schema,
-  rawErrors = [],
-}: WidgetProps) => {
-  const _onChange = ({
-    target: { value },
-  }: React.ChangeEvent<HTMLInputElement>) =>
-    onChange(value === "" ? options.emptyValue : value);
-  const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
-    onBlur(id, value);
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLInputElement>) => onFocus(id, value);
-
-  return (
-    <TextField
-      id={id}
-      label={label || schema.title}
-      autoFocus={autofocus}
-      required={required}
-      disabled={disabled || readonly}
-      type="password"
-      value={value ? value : ""}
-      error={rawErrors.length > 0}
-      onFocus={_onFocus}
-      onBlur={_onBlur}
-      onChange={_onChange}
-    />
-  );
+const PasswordWidget = (props: TextWidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
+  return <TextWidget type="password" {...props} />;
 };
 
 export default PasswordWidget;

--- a/packages/material-ui/src/TextWidget/TextWidget.tsx
+++ b/packages/material-ui/src/TextWidget/TextWidget.tsx
@@ -28,6 +28,7 @@ const TextWidget = ({
   uiSchema,
   rawErrors = [],
   formContext,
+  registry, // pull out the registry so it doesn't end up in the textFieldProps
   ...textFieldProps
 }: TextWidgetProps) => {
   const _onChange = ({

--- a/packages/material-ui/src/URLWidget/URLWidget.tsx
+++ b/packages/material-ui/src/URLWidget/URLWidget.tsx
@@ -1,7 +1,9 @@
 import React from "react";
-import TextWidget, { TextWidgetProps } from "../TextWidget";
+import { TextWidgetProps } from "../TextWidget";
 
 const URLWidget = (props: TextWidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
   return <TextWidget type="url" {...props} />;
 };
 

--- a/packages/material-ui/test/UpDownWidget.test.tsx
+++ b/packages/material-ui/test/UpDownWidget.test.tsx
@@ -33,6 +33,12 @@ describe("UpDownWidget", () => {
       id: "_id",
       placeholder: "",
       value: 0,
+      registry: {
+        fields: {},
+        widgets: {},
+        definitions: {},
+        formContext: {},
+      }
     };
     const tree = renderer.create(<UpDownWidget {...props} />).toJSON();
     expect(tree).toMatchSnapshot();

--- a/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
@@ -142,56 +142,6 @@ exports[`array fields array icons 1`] = `
                     >
                       <div
                         className="MuiFormControl-root MuiTextField-root"
-                        registry={
-                          Object {
-                            "ArrayFieldTemplate": [Function],
-                            "FieldTemplate": [Function],
-                            "ObjectFieldTemplate": [Function],
-                            "definitions": Object {},
-                            "fields": Object {
-                              "AnyOfField": [Function],
-                              "ArrayField": [Function],
-                              "BooleanField": [Function],
-                              "DescriptionField": [Function],
-                              "NullField": [Function],
-                              "NumberField": [Function],
-                              "ObjectField": [Function],
-                              "OneOfField": [Function],
-                              "SchemaField": [Function],
-                              "StringField": [Function],
-                              "TitleField": [Function],
-                              "UnsupportedField": [Function],
-                            },
-                            "formContext": Object {},
-                            "rootSchema": Object {
-                              "items": Object {
-                                "type": "string",
-                              },
-                              "type": "array",
-                            },
-                            "widgets": Object {
-                              "AltDateTimeWidget": [Function],
-                              "AltDateWidget": [Function],
-                              "BaseInput": [Function],
-                              "CheckboxWidget": [Function],
-                              "CheckboxesWidget": [Function],
-                              "ColorWidget": [Function],
-                              "DateTimeWidget": [Function],
-                              "DateWidget": [Function],
-                              "EmailWidget": [Function],
-                              "FileWidget": [Function],
-                              "HiddenWidget": [Function],
-                              "PasswordWidget": [Function],
-                              "RadioWidget": [Function],
-                              "RangeWidget": [Function],
-                              "SelectWidget": [Function],
-                              "TextWidget": [Function],
-                              "TextareaWidget": [Function],
-                              "URLWidget": [Function],
-                              "UpDownWidget": [Function],
-                            },
-                          }
-                        }
                       >
                         <div
                           className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -384,56 +334,6 @@ exports[`array fields array icons 1`] = `
                     >
                       <div
                         className="MuiFormControl-root MuiTextField-root"
-                        registry={
-                          Object {
-                            "ArrayFieldTemplate": [Function],
-                            "FieldTemplate": [Function],
-                            "ObjectFieldTemplate": [Function],
-                            "definitions": Object {},
-                            "fields": Object {
-                              "AnyOfField": [Function],
-                              "ArrayField": [Function],
-                              "BooleanField": [Function],
-                              "DescriptionField": [Function],
-                              "NullField": [Function],
-                              "NumberField": [Function],
-                              "ObjectField": [Function],
-                              "OneOfField": [Function],
-                              "SchemaField": [Function],
-                              "StringField": [Function],
-                              "TitleField": [Function],
-                              "UnsupportedField": [Function],
-                            },
-                            "formContext": Object {},
-                            "rootSchema": Object {
-                              "items": Object {
-                                "type": "string",
-                              },
-                              "type": "array",
-                            },
-                            "widgets": Object {
-                              "AltDateTimeWidget": [Function],
-                              "AltDateWidget": [Function],
-                              "BaseInput": [Function],
-                              "CheckboxWidget": [Function],
-                              "CheckboxesWidget": [Function],
-                              "ColorWidget": [Function],
-                              "DateTimeWidget": [Function],
-                              "DateWidget": [Function],
-                              "EmailWidget": [Function],
-                              "FileWidget": [Function],
-                              "HiddenWidget": [Function],
-                              "PasswordWidget": [Function],
-                              "RadioWidget": [Function],
-                              "RangeWidget": [Function],
-                              "SelectWidget": [Function],
-                              "TextWidget": [Function],
-                              "TextareaWidget": [Function],
-                              "URLWidget": [Function],
-                              "UpDownWidget": [Function],
-                            },
-                          }
-                        }
                       >
                         <div
                           className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -817,61 +717,6 @@ exports[`array fields fixed array 1`] = `
                     >
                       <div
                         className="MuiFormControl-root MuiTextField-root"
-                        registry={
-                          Object {
-                            "ArrayFieldTemplate": [Function],
-                            "FieldTemplate": [Function],
-                            "ObjectFieldTemplate": [Function],
-                            "definitions": Object {},
-                            "fields": Object {
-                              "AnyOfField": [Function],
-                              "ArrayField": [Function],
-                              "BooleanField": [Function],
-                              "DescriptionField": [Function],
-                              "NullField": [Function],
-                              "NumberField": [Function],
-                              "ObjectField": [Function],
-                              "OneOfField": [Function],
-                              "SchemaField": [Function],
-                              "StringField": [Function],
-                              "TitleField": [Function],
-                              "UnsupportedField": [Function],
-                            },
-                            "formContext": Object {},
-                            "rootSchema": Object {
-                              "items": Array [
-                                Object {
-                                  "type": "string",
-                                },
-                                Object {
-                                  "type": "number",
-                                },
-                              ],
-                              "type": "array",
-                            },
-                            "widgets": Object {
-                              "AltDateTimeWidget": [Function],
-                              "AltDateWidget": [Function],
-                              "BaseInput": [Function],
-                              "CheckboxWidget": [Function],
-                              "CheckboxesWidget": [Function],
-                              "ColorWidget": [Function],
-                              "DateTimeWidget": [Function],
-                              "DateWidget": [Function],
-                              "EmailWidget": [Function],
-                              "FileWidget": [Function],
-                              "HiddenWidget": [Function],
-                              "PasswordWidget": [Function],
-                              "RadioWidget": [Function],
-                              "RangeWidget": [Function],
-                              "SelectWidget": [Function],
-                              "TextWidget": [Function],
-                              "TextareaWidget": [Function],
-                              "URLWidget": [Function],
-                              "UpDownWidget": [Function],
-                            },
-                          }
-                        }
                       >
                         <div
                           className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -925,61 +770,6 @@ exports[`array fields fixed array 1`] = `
                     >
                       <div
                         className="MuiFormControl-root MuiTextField-root"
-                        registry={
-                          Object {
-                            "ArrayFieldTemplate": [Function],
-                            "FieldTemplate": [Function],
-                            "ObjectFieldTemplate": [Function],
-                            "definitions": Object {},
-                            "fields": Object {
-                              "AnyOfField": [Function],
-                              "ArrayField": [Function],
-                              "BooleanField": [Function],
-                              "DescriptionField": [Function],
-                              "NullField": [Function],
-                              "NumberField": [Function],
-                              "ObjectField": [Function],
-                              "OneOfField": [Function],
-                              "SchemaField": [Function],
-                              "StringField": [Function],
-                              "TitleField": [Function],
-                              "UnsupportedField": [Function],
-                            },
-                            "formContext": Object {},
-                            "rootSchema": Object {
-                              "items": Array [
-                                Object {
-                                  "type": "string",
-                                },
-                                Object {
-                                  "type": "number",
-                                },
-                              ],
-                              "type": "array",
-                            },
-                            "widgets": Object {
-                              "AltDateTimeWidget": [Function],
-                              "AltDateWidget": [Function],
-                              "BaseInput": [Function],
-                              "CheckboxWidget": [Function],
-                              "CheckboxesWidget": [Function],
-                              "ColorWidget": [Function],
-                              "DateTimeWidget": [Function],
-                              "DateWidget": [Function],
-                              "EmailWidget": [Function],
-                              "FileWidget": [Function],
-                              "HiddenWidget": [Function],
-                              "PasswordWidget": [Function],
-                              "RadioWidget": [Function],
-                              "RangeWidget": [Function],
-                              "SelectWidget": [Function],
-                              "TextWidget": [Function],
-                              "TextareaWidget": [Function],
-                              "URLWidget": [Function],
-                              "UpDownWidget": [Function],
-                            },
-                          }
-                        }
                       >
                         <div
                           className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -464,54 +464,6 @@ exports[`single fields format color 1`] = `
   >
     <div
       className="MuiFormControl-root MuiTextField-root"
-      registry={
-        Object {
-          "ArrayFieldTemplate": [Function],
-          "FieldTemplate": [Function],
-          "ObjectFieldTemplate": [Function],
-          "definitions": Object {},
-          "fields": Object {
-            "AnyOfField": [Function],
-            "ArrayField": [Function],
-            "BooleanField": [Function],
-            "DescriptionField": [Function],
-            "NullField": [Function],
-            "NumberField": [Function],
-            "ObjectField": [Function],
-            "OneOfField": [Function],
-            "SchemaField": [Function],
-            "StringField": [Function],
-            "TitleField": [Function],
-            "UnsupportedField": [Function],
-          },
-          "formContext": Object {},
-          "rootSchema": Object {
-            "format": "color",
-            "type": "string",
-          },
-          "widgets": Object {
-            "AltDateTimeWidget": [Function],
-            "AltDateWidget": [Function],
-            "BaseInput": [Function],
-            "CheckboxWidget": [Function],
-            "CheckboxesWidget": [Function],
-            "ColorWidget": [Function],
-            "DateTimeWidget": [Function],
-            "DateWidget": [Function],
-            "EmailWidget": [Function],
-            "FileWidget": [Function],
-            "HiddenWidget": [Function],
-            "PasswordWidget": [Function],
-            "RadioWidget": [Function],
-            "RangeWidget": [Function],
-            "SelectWidget": [Function],
-            "TextWidget": [Function],
-            "TextareaWidget": [Function],
-            "URLWidget": [Function],
-            "UpDownWidget": [Function],
-          },
-        }
-      }
     >
       <div
         className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -579,54 +531,6 @@ exports[`single fields format date 1`] = `
   >
     <div
       className="MuiFormControl-root MuiTextField-root"
-      registry={
-        Object {
-          "ArrayFieldTemplate": [Function],
-          "FieldTemplate": [Function],
-          "ObjectFieldTemplate": [Function],
-          "definitions": Object {},
-          "fields": Object {
-            "AnyOfField": [Function],
-            "ArrayField": [Function],
-            "BooleanField": [Function],
-            "DescriptionField": [Function],
-            "NullField": [Function],
-            "NumberField": [Function],
-            "ObjectField": [Function],
-            "OneOfField": [Function],
-            "SchemaField": [Function],
-            "StringField": [Function],
-            "TitleField": [Function],
-            "UnsupportedField": [Function],
-          },
-          "formContext": Object {},
-          "rootSchema": Object {
-            "format": "date",
-            "type": "string",
-          },
-          "widgets": Object {
-            "AltDateTimeWidget": [Function],
-            "AltDateWidget": [Function],
-            "BaseInput": [Function],
-            "CheckboxWidget": [Function],
-            "CheckboxesWidget": [Function],
-            "ColorWidget": [Function],
-            "DateTimeWidget": [Function],
-            "DateWidget": [Function],
-            "EmailWidget": [Function],
-            "FileWidget": [Function],
-            "HiddenWidget": [Function],
-            "PasswordWidget": [Function],
-            "RadioWidget": [Function],
-            "RangeWidget": [Function],
-            "SelectWidget": [Function],
-            "TextWidget": [Function],
-            "TextareaWidget": [Function],
-            "URLWidget": [Function],
-            "UpDownWidget": [Function],
-          },
-        }
-      }
     >
       <div
         className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -691,54 +595,6 @@ exports[`single fields format datetime 1`] = `
   >
     <div
       className="MuiFormControl-root MuiTextField-root"
-      registry={
-        Object {
-          "ArrayFieldTemplate": [Function],
-          "FieldTemplate": [Function],
-          "ObjectFieldTemplate": [Function],
-          "definitions": Object {},
-          "fields": Object {
-            "AnyOfField": [Function],
-            "ArrayField": [Function],
-            "BooleanField": [Function],
-            "DescriptionField": [Function],
-            "NullField": [Function],
-            "NumberField": [Function],
-            "ObjectField": [Function],
-            "OneOfField": [Function],
-            "SchemaField": [Function],
-            "StringField": [Function],
-            "TitleField": [Function],
-            "UnsupportedField": [Function],
-          },
-          "formContext": Object {},
-          "rootSchema": Object {
-            "format": "datetime",
-            "type": "string",
-          },
-          "widgets": Object {
-            "AltDateTimeWidget": [Function],
-            "AltDateWidget": [Function],
-            "BaseInput": [Function],
-            "CheckboxWidget": [Function],
-            "CheckboxesWidget": [Function],
-            "ColorWidget": [Function],
-            "DateTimeWidget": [Function],
-            "DateWidget": [Function],
-            "EmailWidget": [Function],
-            "FileWidget": [Function],
-            "HiddenWidget": [Function],
-            "PasswordWidget": [Function],
-            "RadioWidget": [Function],
-            "RangeWidget": [Function],
-            "SelectWidget": [Function],
-            "TextWidget": [Function],
-            "TextareaWidget": [Function],
-            "URLWidget": [Function],
-            "UpDownWidget": [Function],
-          },
-        }
-      }
     >
       <div
         className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -858,53 +714,6 @@ exports[`single fields hidden label 1`] = `
   >
     <div
       className="MuiFormControl-root MuiTextField-root"
-      registry={
-        Object {
-          "ArrayFieldTemplate": [Function],
-          "FieldTemplate": [Function],
-          "ObjectFieldTemplate": [Function],
-          "definitions": Object {},
-          "fields": Object {
-            "AnyOfField": [Function],
-            "ArrayField": [Function],
-            "BooleanField": [Function],
-            "DescriptionField": [Function],
-            "NullField": [Function],
-            "NumberField": [Function],
-            "ObjectField": [Function],
-            "OneOfField": [Function],
-            "SchemaField": [Function],
-            "StringField": [Function],
-            "TitleField": [Function],
-            "UnsupportedField": [Function],
-          },
-          "formContext": Object {},
-          "rootSchema": Object {
-            "type": "string",
-          },
-          "widgets": Object {
-            "AltDateTimeWidget": [Function],
-            "AltDateWidget": [Function],
-            "BaseInput": [Function],
-            "CheckboxWidget": [Function],
-            "CheckboxesWidget": [Function],
-            "ColorWidget": [Function],
-            "DateTimeWidget": [Function],
-            "DateWidget": [Function],
-            "EmailWidget": [Function],
-            "FileWidget": [Function],
-            "HiddenWidget": [Function],
-            "PasswordWidget": [Function],
-            "RadioWidget": [Function],
-            "RangeWidget": [Function],
-            "SelectWidget": [Function],
-            "TextWidget": [Function],
-            "TextareaWidget": [Function],
-            "URLWidget": [Function],
-            "UpDownWidget": [Function],
-          },
-        }
-      }
     >
       <div
         className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -1011,53 +820,6 @@ exports[`single fields number field 0 1`] = `
   >
     <div
       className="MuiFormControl-root MuiTextField-root"
-      registry={
-        Object {
-          "ArrayFieldTemplate": [Function],
-          "FieldTemplate": [Function],
-          "ObjectFieldTemplate": [Function],
-          "definitions": Object {},
-          "fields": Object {
-            "AnyOfField": [Function],
-            "ArrayField": [Function],
-            "BooleanField": [Function],
-            "DescriptionField": [Function],
-            "NullField": [Function],
-            "NumberField": [Function],
-            "ObjectField": [Function],
-            "OneOfField": [Function],
-            "SchemaField": [Function],
-            "StringField": [Function],
-            "TitleField": [Function],
-            "UnsupportedField": [Function],
-          },
-          "formContext": Object {},
-          "rootSchema": Object {
-            "type": "number",
-          },
-          "widgets": Object {
-            "AltDateTimeWidget": [Function],
-            "AltDateWidget": [Function],
-            "BaseInput": [Function],
-            "CheckboxWidget": [Function],
-            "CheckboxesWidget": [Function],
-            "ColorWidget": [Function],
-            "DateTimeWidget": [Function],
-            "DateWidget": [Function],
-            "EmailWidget": [Function],
-            "FileWidget": [Function],
-            "HiddenWidget": [Function],
-            "PasswordWidget": [Function],
-            "RadioWidget": [Function],
-            "RangeWidget": [Function],
-            "SelectWidget": [Function],
-            "TextWidget": [Function],
-            "TextareaWidget": [Function],
-            "URLWidget": [Function],
-            "UpDownWidget": [Function],
-          },
-        }
-      }
     >
       <div
         className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -1122,53 +884,6 @@ exports[`single fields number field 1`] = `
   >
     <div
       className="MuiFormControl-root MuiTextField-root"
-      registry={
-        Object {
-          "ArrayFieldTemplate": [Function],
-          "FieldTemplate": [Function],
-          "ObjectFieldTemplate": [Function],
-          "definitions": Object {},
-          "fields": Object {
-            "AnyOfField": [Function],
-            "ArrayField": [Function],
-            "BooleanField": [Function],
-            "DescriptionField": [Function],
-            "NullField": [Function],
-            "NumberField": [Function],
-            "ObjectField": [Function],
-            "OneOfField": [Function],
-            "SchemaField": [Function],
-            "StringField": [Function],
-            "TitleField": [Function],
-            "UnsupportedField": [Function],
-          },
-          "formContext": Object {},
-          "rootSchema": Object {
-            "type": "number",
-          },
-          "widgets": Object {
-            "AltDateTimeWidget": [Function],
-            "AltDateWidget": [Function],
-            "BaseInput": [Function],
-            "CheckboxWidget": [Function],
-            "CheckboxesWidget": [Function],
-            "ColorWidget": [Function],
-            "DateTimeWidget": [Function],
-            "DateWidget": [Function],
-            "EmailWidget": [Function],
-            "FileWidget": [Function],
-            "HiddenWidget": [Function],
-            "PasswordWidget": [Function],
-            "RadioWidget": [Function],
-            "RangeWidget": [Function],
-            "SelectWidget": [Function],
-            "TextWidget": [Function],
-            "TextareaWidget": [Function],
-            "URLWidget": [Function],
-            "UpDownWidget": [Function],
-          },
-        }
-      }
     >
       <div
         className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -1236,53 +951,6 @@ exports[`single fields password field 1`] = `
   >
     <div
       className="MuiFormControl-root MuiTextField-root"
-      registry={
-        Object {
-          "ArrayFieldTemplate": [Function],
-          "FieldTemplate": [Function],
-          "ObjectFieldTemplate": [Function],
-          "definitions": Object {},
-          "fields": Object {
-            "AnyOfField": [Function],
-            "ArrayField": [Function],
-            "BooleanField": [Function],
-            "DescriptionField": [Function],
-            "NullField": [Function],
-            "NumberField": [Function],
-            "ObjectField": [Function],
-            "OneOfField": [Function],
-            "SchemaField": [Function],
-            "StringField": [Function],
-            "TitleField": [Function],
-            "UnsupportedField": [Function],
-          },
-          "formContext": Object {},
-          "rootSchema": Object {
-            "type": "string",
-          },
-          "widgets": Object {
-            "AltDateTimeWidget": [Function],
-            "AltDateWidget": [Function],
-            "BaseInput": [Function],
-            "CheckboxWidget": [Function],
-            "CheckboxesWidget": [Function],
-            "ColorWidget": [Function],
-            "DateTimeWidget": [Function],
-            "DateWidget": [Function],
-            "EmailWidget": [Function],
-            "FileWidget": [Function],
-            "HiddenWidget": [Function],
-            "PasswordWidget": [Function],
-            "RadioWidget": [Function],
-            "RangeWidget": [Function],
-            "SelectWidget": [Function],
-            "TextWidget": [Function],
-            "TextareaWidget": [Function],
-            "URLWidget": [Function],
-            "UpDownWidget": [Function],
-          },
-        }
-      }
     >
       <div
         className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -1667,54 +1335,6 @@ exports[`single fields string field format email 1`] = `
   >
     <div
       className="MuiFormControl-root MuiTextField-root"
-      registry={
-        Object {
-          "ArrayFieldTemplate": [Function],
-          "FieldTemplate": [Function],
-          "ObjectFieldTemplate": [Function],
-          "definitions": Object {},
-          "fields": Object {
-            "AnyOfField": [Function],
-            "ArrayField": [Function],
-            "BooleanField": [Function],
-            "DescriptionField": [Function],
-            "NullField": [Function],
-            "NumberField": [Function],
-            "ObjectField": [Function],
-            "OneOfField": [Function],
-            "SchemaField": [Function],
-            "StringField": [Function],
-            "TitleField": [Function],
-            "UnsupportedField": [Function],
-          },
-          "formContext": Object {},
-          "rootSchema": Object {
-            "format": "email",
-            "type": "string",
-          },
-          "widgets": Object {
-            "AltDateTimeWidget": [Function],
-            "AltDateWidget": [Function],
-            "BaseInput": [Function],
-            "CheckboxWidget": [Function],
-            "CheckboxesWidget": [Function],
-            "ColorWidget": [Function],
-            "DateTimeWidget": [Function],
-            "DateWidget": [Function],
-            "EmailWidget": [Function],
-            "FileWidget": [Function],
-            "HiddenWidget": [Function],
-            "PasswordWidget": [Function],
-            "RadioWidget": [Function],
-            "RangeWidget": [Function],
-            "SelectWidget": [Function],
-            "TextWidget": [Function],
-            "TextareaWidget": [Function],
-            "URLWidget": [Function],
-            "UpDownWidget": [Function],
-          },
-        }
-      }
     >
       <div
         className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -1782,54 +1402,6 @@ exports[`single fields string field format uri 1`] = `
   >
     <div
       className="MuiFormControl-root MuiTextField-root"
-      registry={
-        Object {
-          "ArrayFieldTemplate": [Function],
-          "FieldTemplate": [Function],
-          "ObjectFieldTemplate": [Function],
-          "definitions": Object {},
-          "fields": Object {
-            "AnyOfField": [Function],
-            "ArrayField": [Function],
-            "BooleanField": [Function],
-            "DescriptionField": [Function],
-            "NullField": [Function],
-            "NumberField": [Function],
-            "ObjectField": [Function],
-            "OneOfField": [Function],
-            "SchemaField": [Function],
-            "StringField": [Function],
-            "TitleField": [Function],
-            "UnsupportedField": [Function],
-          },
-          "formContext": Object {},
-          "rootSchema": Object {
-            "format": "uri",
-            "type": "string",
-          },
-          "widgets": Object {
-            "AltDateTimeWidget": [Function],
-            "AltDateWidget": [Function],
-            "BaseInput": [Function],
-            "CheckboxWidget": [Function],
-            "CheckboxesWidget": [Function],
-            "ColorWidget": [Function],
-            "DateTimeWidget": [Function],
-            "DateWidget": [Function],
-            "EmailWidget": [Function],
-            "FileWidget": [Function],
-            "HiddenWidget": [Function],
-            "PasswordWidget": [Function],
-            "RadioWidget": [Function],
-            "RangeWidget": [Function],
-            "SelectWidget": [Function],
-            "TextWidget": [Function],
-            "TextareaWidget": [Function],
-            "URLWidget": [Function],
-            "UpDownWidget": [Function],
-          },
-        }
-      }
     >
       <div
         className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -1894,53 +1466,6 @@ exports[`single fields string field regular 1`] = `
   >
     <div
       className="MuiFormControl-root MuiTextField-root"
-      registry={
-        Object {
-          "ArrayFieldTemplate": [Function],
-          "FieldTemplate": [Function],
-          "ObjectFieldTemplate": [Function],
-          "definitions": Object {},
-          "fields": Object {
-            "AnyOfField": [Function],
-            "ArrayField": [Function],
-            "BooleanField": [Function],
-            "DescriptionField": [Function],
-            "NullField": [Function],
-            "NumberField": [Function],
-            "ObjectField": [Function],
-            "OneOfField": [Function],
-            "SchemaField": [Function],
-            "StringField": [Function],
-            "TitleField": [Function],
-            "UnsupportedField": [Function],
-          },
-          "formContext": Object {},
-          "rootSchema": Object {
-            "type": "string",
-          },
-          "widgets": Object {
-            "AltDateTimeWidget": [Function],
-            "AltDateWidget": [Function],
-            "BaseInput": [Function],
-            "CheckboxWidget": [Function],
-            "CheckboxesWidget": [Function],
-            "ColorWidget": [Function],
-            "DateTimeWidget": [Function],
-            "DateWidget": [Function],
-            "EmailWidget": [Function],
-            "FileWidget": [Function],
-            "HiddenWidget": [Function],
-            "PasswordWidget": [Function],
-            "RadioWidget": [Function],
-            "RangeWidget": [Function],
-            "SelectWidget": [Function],
-            "TextWidget": [Function],
-            "TextareaWidget": [Function],
-            "URLWidget": [Function],
-            "UpDownWidget": [Function],
-          },
-        }
-      }
     >
       <div
         className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -2005,53 +1530,6 @@ exports[`single fields string field with placeholder 1`] = `
   >
     <div
       className="MuiFormControl-root MuiTextField-root"
-      registry={
-        Object {
-          "ArrayFieldTemplate": [Function],
-          "FieldTemplate": [Function],
-          "ObjectFieldTemplate": [Function],
-          "definitions": Object {},
-          "fields": Object {
-            "AnyOfField": [Function],
-            "ArrayField": [Function],
-            "BooleanField": [Function],
-            "DescriptionField": [Function],
-            "NullField": [Function],
-            "NumberField": [Function],
-            "ObjectField": [Function],
-            "OneOfField": [Function],
-            "SchemaField": [Function],
-            "StringField": [Function],
-            "TitleField": [Function],
-            "UnsupportedField": [Function],
-          },
-          "formContext": Object {},
-          "rootSchema": Object {
-            "type": "string",
-          },
-          "widgets": Object {
-            "AltDateTimeWidget": [Function],
-            "AltDateWidget": [Function],
-            "BaseInput": [Function],
-            "CheckboxWidget": [Function],
-            "CheckboxesWidget": [Function],
-            "ColorWidget": [Function],
-            "DateTimeWidget": [Function],
-            "DateWidget": [Function],
-            "EmailWidget": [Function],
-            "FileWidget": [Function],
-            "HiddenWidget": [Function],
-            "PasswordWidget": [Function],
-            "RadioWidget": [Function],
-            "RangeWidget": [Function],
-            "SelectWidget": [Function],
-            "TextWidget": [Function],
-            "TextareaWidget": [Function],
-            "URLWidget": [Function],
-            "UpDownWidget": [Function],
-          },
-        }
-      }
     >
       <div
         className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -1236,6 +1236,53 @@ exports[`single fields password field 1`] = `
   >
     <div
       className="MuiFormControl-root MuiTextField-root"
+      registry={
+        Object {
+          "ArrayFieldTemplate": [Function],
+          "FieldTemplate": [Function],
+          "ObjectFieldTemplate": [Function],
+          "definitions": Object {},
+          "fields": Object {
+            "AnyOfField": [Function],
+            "ArrayField": [Function],
+            "BooleanField": [Function],
+            "DescriptionField": [Function],
+            "NullField": [Function],
+            "NumberField": [Function],
+            "ObjectField": [Function],
+            "OneOfField": [Function],
+            "SchemaField": [Function],
+            "StringField": [Function],
+            "TitleField": [Function],
+            "UnsupportedField": [Function],
+          },
+          "formContext": Object {},
+          "rootSchema": Object {
+            "type": "string",
+          },
+          "widgets": Object {
+            "AltDateTimeWidget": [Function],
+            "AltDateWidget": [Function],
+            "BaseInput": [Function],
+            "CheckboxWidget": [Function],
+            "CheckboxesWidget": [Function],
+            "ColorWidget": [Function],
+            "DateTimeWidget": [Function],
+            "DateWidget": [Function],
+            "EmailWidget": [Function],
+            "FileWidget": [Function],
+            "HiddenWidget": [Function],
+            "PasswordWidget": [Function],
+            "RadioWidget": [Function],
+            "RangeWidget": [Function],
+            "SelectWidget": [Function],
+            "TextWidget": [Function],
+            "TextareaWidget": [Function],
+            "URLWidget": [Function],
+            "UpDownWidget": [Function],
+          },
+        }
+      }
     >
       <div
         className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -1251,6 +1298,7 @@ exports[`single fields password field 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
+          placeholder=""
           required={false}
           type="password"
           value=""

--- a/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
@@ -64,54 +64,6 @@ exports[`object fields additionalProperties 1`] = `
             >
               <div
                 className="MuiFormControl-root MuiTextField-root"
-                registry={
-                  Object {
-                    "ArrayFieldTemplate": [Function],
-                    "FieldTemplate": [Function],
-                    "ObjectFieldTemplate": [Function],
-                    "definitions": Object {},
-                    "fields": Object {
-                      "AnyOfField": [Function],
-                      "ArrayField": [Function],
-                      "BooleanField": [Function],
-                      "DescriptionField": [Function],
-                      "NullField": [Function],
-                      "NumberField": [Function],
-                      "ObjectField": [Function],
-                      "OneOfField": [Function],
-                      "SchemaField": [Function],
-                      "StringField": [Function],
-                      "TitleField": [Function],
-                      "UnsupportedField": [Function],
-                    },
-                    "formContext": Object {},
-                    "rootSchema": Object {
-                      "additionalProperties": true,
-                      "type": "object",
-                    },
-                    "widgets": Object {
-                      "AltDateTimeWidget": [Function],
-                      "AltDateWidget": [Function],
-                      "BaseInput": [Function],
-                      "CheckboxWidget": [Function],
-                      "CheckboxesWidget": [Function],
-                      "ColorWidget": [Function],
-                      "DateTimeWidget": [Function],
-                      "DateWidget": [Function],
-                      "EmailWidget": [Function],
-                      "FileWidget": [Function],
-                      "HiddenWidget": [Function],
-                      "PasswordWidget": [Function],
-                      "RadioWidget": [Function],
-                      "RangeWidget": [Function],
-                      "SelectWidget": [Function],
-                      "TextWidget": [Function],
-                      "TextareaWidget": [Function],
-                      "URLWidget": [Function],
-                      "UpDownWidget": [Function],
-                    },
-                  }
-                }
               >
                 <label
                   className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
@@ -301,61 +253,6 @@ exports[`object fields object 1`] = `
         >
           <div
             className="MuiFormControl-root MuiTextField-root"
-            registry={
-              Object {
-                "ArrayFieldTemplate": [Function],
-                "FieldTemplate": [Function],
-                "ObjectFieldTemplate": [Function],
-                "definitions": Object {},
-                "fields": Object {
-                  "AnyOfField": [Function],
-                  "ArrayField": [Function],
-                  "BooleanField": [Function],
-                  "DescriptionField": [Function],
-                  "NullField": [Function],
-                  "NumberField": [Function],
-                  "ObjectField": [Function],
-                  "OneOfField": [Function],
-                  "SchemaField": [Function],
-                  "StringField": [Function],
-                  "TitleField": [Function],
-                  "UnsupportedField": [Function],
-                },
-                "formContext": Object {},
-                "rootSchema": Object {
-                  "properties": Object {
-                    "a": Object {
-                      "type": "string",
-                    },
-                    "b": Object {
-                      "type": "number",
-                    },
-                  },
-                  "type": "object",
-                },
-                "widgets": Object {
-                  "AltDateTimeWidget": [Function],
-                  "AltDateWidget": [Function],
-                  "BaseInput": [Function],
-                  "CheckboxWidget": [Function],
-                  "CheckboxesWidget": [Function],
-                  "ColorWidget": [Function],
-                  "DateTimeWidget": [Function],
-                  "DateWidget": [Function],
-                  "EmailWidget": [Function],
-                  "FileWidget": [Function],
-                  "HiddenWidget": [Function],
-                  "PasswordWidget": [Function],
-                  "RadioWidget": [Function],
-                  "RangeWidget": [Function],
-                  "SelectWidget": [Function],
-                  "TextWidget": [Function],
-                  "TextareaWidget": [Function],
-                  "URLWidget": [Function],
-                  "UpDownWidget": [Function],
-                },
-              }
-            }
           >
             <label
               className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
@@ -401,61 +298,6 @@ exports[`object fields object 1`] = `
         >
           <div
             className="MuiFormControl-root MuiTextField-root"
-            registry={
-              Object {
-                "ArrayFieldTemplate": [Function],
-                "FieldTemplate": [Function],
-                "ObjectFieldTemplate": [Function],
-                "definitions": Object {},
-                "fields": Object {
-                  "AnyOfField": [Function],
-                  "ArrayField": [Function],
-                  "BooleanField": [Function],
-                  "DescriptionField": [Function],
-                  "NullField": [Function],
-                  "NumberField": [Function],
-                  "ObjectField": [Function],
-                  "OneOfField": [Function],
-                  "SchemaField": [Function],
-                  "StringField": [Function],
-                  "TitleField": [Function],
-                  "UnsupportedField": [Function],
-                },
-                "formContext": Object {},
-                "rootSchema": Object {
-                  "properties": Object {
-                    "a": Object {
-                      "type": "string",
-                    },
-                    "b": Object {
-                      "type": "number",
-                    },
-                  },
-                  "type": "object",
-                },
-                "widgets": Object {
-                  "AltDateTimeWidget": [Function],
-                  "AltDateWidget": [Function],
-                  "BaseInput": [Function],
-                  "CheckboxWidget": [Function],
-                  "CheckboxesWidget": [Function],
-                  "ColorWidget": [Function],
-                  "DateTimeWidget": [Function],
-                  "DateWidget": [Function],
-                  "EmailWidget": [Function],
-                  "FileWidget": [Function],
-                  "HiddenWidget": [Function],
-                  "PasswordWidget": [Function],
-                  "RadioWidget": [Function],
-                  "RangeWidget": [Function],
-                  "SelectWidget": [Function],
-                  "TextWidget": [Function],
-                  "TextareaWidget": [Function],
-                  "URLWidget": [Function],
-                  "UpDownWidget": [Function],
-                },
-              }
-            }
           >
             <label
               className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"


### PR DESCRIPTION
### Reasons for making this change

In all the `TextWidget` wrappers, rather than directly import `TextWidget` from the source hierarchy, instead pull from the `registry.widgets`

- These changes allow all of these `TextWidget` wrappers (like `EmailWidget`, etc...) to immediately use a custom `TextWidget` class
- Added a new `Registry` type in the `core/index.d.ts` file, refactoring it from `FieldProps`, and adding it to `WidgetProps` as well
- Updated all of the `material-ui` and `fluent-ui` widgets to use `TextWidget` from the registry
  - Converted the `material-ui` `PasswordWidget` to simply use `TextWidget` in a manner similar the other `material-ui` wrappers
    - `fluent-ui` simply wraps `TextWidget` and it seemed like doing so here made sense as well
- Updated material-ui `TextWidget` to declare `registry` in the props so it doesn't get collected into the `textFieldProps`
- Needed to updated the snapshots for the `material-ui` tests since `registry` is no longer part of the snapshots
  - The only non-registry change was adding `placeholder=''` to the `PasswordWidget`, since password inputs are allowed to have them in [html 5](https://www.w3schools.com/jsref/prop_password_placeholder.asp) it seems like a small bug fix
- Also needed to update `UpDownWidget.test.tsx` to add a mock `registry`
- Updated `packages/bootstrap-4/test/helpers/createMocks.ts` to add a mock `registry`

fixes #2512 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

