### PR TITLE
Add React 17 "Programmatic submit" support

### DIFF
--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -408,6 +408,7 @@ export default class Form extends Component {
       this.formElement.dispatchEvent(
         new CustomEvent("submit", {
           cancelable: true,
+          bubbles: true
         })
       );
     }


### PR DESCRIPTION
Add bubbles to Event in submit method

### Reasons for making this change

Programmatic Submission does not work after upgrading to React 17.
https://github.com/facebook/react/issues/20151#issuecomment-721000418


fixes https://github.com/rjsf-team/react-jsonschema-form/issues/2104

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

