### PR TITLE
bootstrap-4 TextWidget wrappers now pull from registry, add rootSchema to Registry

### DIFF
--- a/packages/bootstrap-4/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/bootstrap-4/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -13,8 +13,7 @@ const { isMultiSelect, getDefaultRegistry } = utils;
 const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
   const { schema, registry = getDefaultRegistry() } = props;
 
-  // TODO: update types so we don't have to cast registry as any
-  if (isMultiSelect(schema, (registry as any).rootSchema)) {
+  if (isMultiSelect(schema, registry.rootSchema)) {
     return <DefaultFixedArrayFieldTemplate {...props} />;
   } else {
     return <DefaultNormalArrayFieldTemplate {...props} />;

--- a/packages/bootstrap-4/src/ColorWidget/ColorWidget.tsx
+++ b/packages/bootstrap-4/src/ColorWidget/ColorWidget.tsx
@@ -1,7 +1,9 @@
 import React from "react";
-import TextWidget, { TextWidgetProps } from "../TextWidget";
+import { WidgetProps } from '@rjsf/core';
 
-const ColorWidget = (props: TextWidgetProps) => {
+const ColorWidget = (props: WidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
   return <TextWidget {...props} type="color" />;
 };
 

--- a/packages/bootstrap-4/src/DateTimeWidget/DateTimeWidget.tsx
+++ b/packages/bootstrap-4/src/DateTimeWidget/DateTimeWidget.tsx
@@ -1,17 +1,18 @@
 import React from "react";
-import { utils } from "@rjsf/core";
-import TextWidget, { TextWidgetProps } from "../TextWidget";
+import { utils, WidgetProps } from "@rjsf/core";
 
 const { localToUTC, utcToLocal } = utils;
 
-const DateTimeWidget = (props: TextWidgetProps) => {
+const DateTimeWidget = (props: WidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
   const value = utcToLocal(props.value);
   const onChange = (value: any) => {
     props.onChange(localToUTC(value));
   };
 
   return (
-    <TextWidget  
+    <TextWidget
       {...props}
       type="datetime-local"
       value={value}

--- a/packages/bootstrap-4/src/DateWidget/DateWidget.tsx
+++ b/packages/bootstrap-4/src/DateWidget/DateWidget.tsx
@@ -1,10 +1,12 @@
 import React from "react";
-import TextWidget, { TextWidgetProps } from "../TextWidget";
+import { WidgetProps } from '@rjsf/core';
 
-const DateWidget = (props: TextWidgetProps) => {
+const DateWidget = (props: WidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
   return (
     <TextWidget
-      {...props}   
+      {...props}
       type="date"
     />
   );

--- a/packages/bootstrap-4/src/EmailWidget/EmailWidget.tsx
+++ b/packages/bootstrap-4/src/EmailWidget/EmailWidget.tsx
@@ -1,7 +1,9 @@
 import React from "react";
-import TextWidget, { TextWidgetProps } from "../TextWidget";
+import { WidgetProps } from '@rjsf/core';
 
-const EmailWidget = (props: TextWidgetProps) => {
+const EmailWidget = (props: WidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
   return <TextWidget {...props} type="email" />;
 };
 

--- a/packages/bootstrap-4/src/FileWidget/FileWidget.tsx
+++ b/packages/bootstrap-4/src/FileWidget/FileWidget.tsx
@@ -1,7 +1,9 @@
 import React from "react";
-import TextWidget, { TextWidgetProps } from "../TextWidget";
+import { WidgetProps } from '@rjsf/core';
 
-const FileWidget = (props: TextWidgetProps) => {
+const FileWidget = (props: WidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
   return <TextWidget {...props} type="file"/>;
 };
 

--- a/packages/bootstrap-4/src/TextWidget/TextWidget.tsx
+++ b/packages/bootstrap-4/src/TextWidget/TextWidget.tsx
@@ -4,10 +4,6 @@ import Form from "react-bootstrap/Form";
 
 import { WidgetProps } from "@rjsf/core";
 
-export interface TextWidgetProps extends WidgetProps {
-  type?: string;
-}
-
 const TextWidget = ({
   id,
   placeholder,
@@ -25,7 +21,7 @@ const TextWidget = ({
   schema,
   rawErrors = [],
 
-}: TextWidgetProps) => {
+}: WidgetProps) => {
   const _onChange = ({
     target: { value },
   }: React.ChangeEvent<HTMLInputElement>) =>
@@ -36,7 +32,7 @@ const TextWidget = ({
     target: { value },
   }: React.FocusEvent<HTMLInputElement>) => onFocus(id, value);
   const inputType = (type || schema.type) === 'string' ?  'text' : `${type || schema.type}`
-  
+
   // const classNames = [rawErrors.length > 0 ? "is-invalid" : "", type === 'file' ? 'custom-file-label': ""]
   return (
     <Form.Group className="mb-0">

--- a/packages/bootstrap-4/src/URLWidget/URLWidget.tsx
+++ b/packages/bootstrap-4/src/URLWidget/URLWidget.tsx
@@ -1,7 +1,9 @@
 import React from "react";
-import TextWidget, { TextWidgetProps } from "../TextWidget";
+import { WidgetProps } from '@rjsf/core';
 
-const URLWidget = (props: TextWidgetProps) => {
+const URLWidget = (props: WidgetProps) => {
+  const { registry } = props;
+  const { TextWidget } = registry.widgets;
   return <TextWidget {...props} type="url" />;
 };
 

--- a/packages/bootstrap-4/test/helpers/createMocks.ts
+++ b/packages/bootstrap-4/test/helpers/createMocks.ts
@@ -1,6 +1,8 @@
 import { WidgetProps } from "@rjsf/core";
 import { JSONSchema7 } from "json-schema";
 
+import TextWidget from "../../src/TextWidget/TextWidget";
+
 export const mockSchema: JSONSchema7 = {
   type: "array",
   items: {
@@ -33,9 +35,10 @@ export function makeWidgetMockProps(
     placeholder: "",
     registry: {
       fields: {},
-      widgets: {},
+      widgets: { TextWidget },
       formContext: {},
       definitions: {},
+      rootSchema: {},
     },
     ...props,
   };

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -115,6 +115,7 @@ declare module '@rjsf/core' {
         multiple: boolean;
         rawErrors: string[];
         registry: Registry;
+        type?: string; // Add the optional prop for TextWidget to simplify Typescript usage
     }
 
     export type Widget = React.StatelessComponent<WidgetProps> | React.ComponentClass<WidgetProps>;
@@ -124,6 +125,7 @@ declare module '@rjsf/core' {
       widgets: { [name: string]: Widget };
       definitions: { [name: string]: any };
       formContext: any;
+      rootSchema: JSONSchema7;
     }
 
     export interface FieldProps<T = any>

--- a/packages/fluent-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/fluent-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -16,8 +16,7 @@ const { isMultiSelect, getDefaultRegistry } = utils;
 const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
   const { schema, registry = getDefaultRegistry() } = props;
 
-  // TODO: update types so we don't have to cast registry as any
-  if (isMultiSelect(schema, (registry as any).rootSchema)) {
+  if (isMultiSelect(schema, registry.rootSchema)) {
     return <DefaultFixedArrayFieldTemplate {...props} />;
   } else {
     return <DefaultNormalArrayFieldTemplate {...props} />;

--- a/packages/material-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/material-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -19,8 +19,7 @@ const {
 const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
   const { schema, registry = getDefaultRegistry() } = props;
 
-  // TODO: update types so we don't have to cast registry as any
-  if (isMultiSelect(schema, (registry as any).rootSchema)) {
+  if (isMultiSelect(schema, registry.rootSchema)) {
     return <DefaultFixedArrayFieldTemplate {...props} />;
   } else {
     return <DefaultNormalArrayFieldTemplate {...props} />;

--- a/packages/material-ui/test/UpDownWidget.test.tsx
+++ b/packages/material-ui/test/UpDownWidget.test.tsx
@@ -38,6 +38,7 @@ describe("UpDownWidget", () => {
         widgets: {},
         definitions: {},
         formContext: {},
+        rootSchema: {},
       }
     };
     const tree = renderer.create(<UpDownWidget {...props} />).toJSON();


### PR DESCRIPTION
### Reasons for making this change
- These changes allow all of these `TextWidget` wrappers (like `EmailWidget`, etc...) to immediately use a custom `TextWidget` class
- Updated the `Registry` type in the `core/index.d.ts` file to add `rootSchema`
  - This fixed a TODO and avoids the need to cast `registry` to any in the three typescript `ArrayFieldTemplate` implementations
- Also updated `WidgetProps` to add an optional `type`
  - This eliminated the custom `TextWidgetProps` for `bootstrap-4` which prevented a previous PR from converting the `TextWidget` wrappers
- Updated all of the `bootstrap-4` widgets to use `TextWidget` from the registry, using simple `WidgetProps`
  - Updated `TextWidget` to remove `TextWidgetProps` and to simply use `WidgetProps`
- Updated the `material-ui` `UpDownWidget` tests to add a blank `rootSchema` to the `registry`
- Updated the `bootstrap-4` `createMock()` to add a blank `rootSchema` to the `registry` as well as adding `TextWidget` to the `registry.widgets`

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).
Fixes #

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

