### PR TITLE
Update SelectWidget.tsx

### DIFF
--- a/packages/fluent-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/fluent-ui/src/SelectWidget/SelectWidget.tsx
@@ -97,7 +97,7 @@ const SelectWidget = ({
   const uiProps = _pick(options.props || {}, allowedProps);
   return (
     <>
-      <Label>{label || schema.title}</Label>
+      {typeof uiProps.onRenderLabel === "undefined" && <Label>{label || schema.title}</Label>}
       <Dropdown
         multiSelect={multiple}
         defaultSelectedKey={value}


### PR DESCRIPTION
If onRenderLabel is provided then Dropdown will render using that and the label is shown twice, this fixes it.
 
