### PR TITLE
Fix for clearing errors after updating and submitting form

### DIFF
--- a/packages/antd/package-lock.json
+++ b/packages/antd/package-lock.json
@@ -3842,9 +3842,9 @@
 			}
 		},
 		"@rjsf/core": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@rjsf/core/-/core-3.0.2.tgz",
-			"integrity": "sha512-6hqXS3zbEF9OdHzPs/otFP3bh3GWYQXYmzCrebZ80SRkdMRjVJaH0+X9XFqndI/nRLH1v/bFUrLc9Rcyzy3S9g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@rjsf/core/-/core-3.1.0.tgz",
+			"integrity": "sha512-EwM2juiQxEdXzFy9rIIsDr6/e+FYeR1cKx0/no8ASEuXZ1p+/nf/CxKGobzD6UhpRip7JK9PhhuHFEFBIjHFJA==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.7",
@@ -9597,9 +9597,9 @@
 			"optional": true
 		},
 		"nanoid": {
-			"version": "3.1.23",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-			"integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+			"version": "3.1.25",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+			"integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
 			"dev": true
 		},
 		"nanomatch": {
@@ -12123,9 +12123,9 @@
 			"dev": true
 		},
 		"tar": {
-			"version": "4.4.16",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.16.tgz",
-			"integrity": "sha512-gOVUT/KWPkGFZQmCRDVFNUWBl7niIo/PRR7lzrIqtZpit+st54lGROuVjc6zEQM9FhH+dJfQIl+9F0k8GNXg5g==",
+			"version": "4.4.19",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+			"integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
 			"dev": true,
 			"optional": true,
 			"requires": {

--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -364,6 +364,8 @@ export default class Form extends Component {
       }
     }
 
+    // There are no errors generated through schema validation.
+    // Check for user provided errors and update state accordingly.
     let errorSchema;
     let errors;
     if (this.props.extraErrors) {

--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -375,7 +375,13 @@ export default class Form extends Component {
     }
 
     this.setState(
-      { formData: newFormData, errors: errors, errorSchema: errorSchema },
+      {
+        formData: newFormData,
+        errors: errors,
+        errorSchema: errorSchema,
+        schemaValidationErrors: [],
+        schemaValidationErrorSchema: {},
+      },
       () => {
         if (this.props.onSubmit) {
           this.props.onSubmit(

--- a/packages/core/test/Form_test.js
+++ b/packages/core/test/Form_test.js
@@ -1531,6 +1531,31 @@ describeRepeated("Form common", createFormComponent => {
           schemaValidationErrorSchema: {},
         });
       });
+
+      it("should reset errors from UI after correction and resubmission", () => {
+        const { node } = createFormComponent({
+          schema,
+        });
+
+        Simulate.change(node.querySelector("input[type=text]"), {
+          target: { value: "short" },
+        });
+        Simulate.submit(node);
+
+        const errorListHTML =
+          '<li class="text-danger">should NOT be shorter than 8 characters</li>';
+        const errors = node.querySelectorAll(".error-detail");
+        // Check for errors attached to the field
+        expect(errors).to.have.lengthOf(1);
+        expect(errors[0]).to.have.property("innerHTML");
+        expect(errors[0].innerHTML).to.be.eql(errorListHTML);
+
+        Simulate.change(node.querySelector("input[type=text]"), {
+          target: { value: "long enough" },
+        });
+        Simulate.submit(node);
+        expect(node.querySelectorAll(".error-detail")).to.have.lengthOf(0);
+      });
     });
 
     describe("root level", () => {

--- a/packages/core/test/Form_test.js
+++ b/packages/core/test/Form_test.js
@@ -1497,7 +1497,7 @@ describeRepeated("Form common", createFormComponent => {
       });
 
       it("should reset errors and errorSchema state to initial state after correction and resubmission", () => {
-        const { node, onError } = createFormComponent({
+        const { node, onError, onSubmit } = createFormComponent({
           schema,
         });
 
@@ -1524,6 +1524,12 @@ describeRepeated("Form common", createFormComponent => {
         });
         Simulate.submit(node);
         sinon.assert.notCalled(onError);
+        sinon.assert.calledWithMatch(onSubmit.lastCall, {
+          errors: [],
+          errorSchema: {},
+          schemaValidationErrors: [],
+          schemaValidationErrorSchema: {},
+        });
       });
     });
 


### PR DESCRIPTION
### Reasons for making this change
There is a bug in the core form (and other variations) where by the form continues to render errors even after the user has fixed them and submitted the form.

The reason this happens is as follows, when the user submits the form, [onSubmit handler](https://github.com/rjsf-team/react-jsonschema-form/blob/d889f071aa9823bae92d8ea048ce1db0c59e75e9/packages/core/src/components/Form.js#L306) is called. If validation is enabled then, the handler [runs validation functions to check for errors](https://github.com/rjsf-team/react-jsonschema-form/blob/d889f071aa9823bae92d8ea048ce1db0c59e75e9/packages/core/src/components/Form.js#L333), 
```
      let schemaValidation = this.validate(newFormData);
      let errors = schemaValidation.errors;
      let errorSchema = schemaValidation.errorSchema;
      const schemaValidationErrors = errors;
      const schemaValidationErrorSchema = errorSchema;
```
If errors are generated then the form State is [updated with the new errors](https://github.com/rjsf-team/react-jsonschema-form/blob/d889f071aa9823bae92d8ea048ce1db0c59e75e9/packages/core/src/components/Form.js#L348)
```
        this.setState(
          {
            errors,
            errorSchema,
            schemaValidationErrors,
            schemaValidationErrorSchema,
          },
```

If errors are not generated then the [state is updated as follows](https://github.com/rjsf-team/react-jsonschema-form/blob/d889f071aa9823bae92d8ea048ce1db0c59e75e9/packages/core/src/components/Form.js#L377)
```
    this.setState(
      { formData: newFormData, errors: errors, errorSchema: errorSchema },
```
**As we see in the later state update `schemaValidationErrors` and `schemaValidationErrorSchema` are not being updated.**

This creates a problem because the state for the form is derived using the above values as [seen here](https://github.com/rjsf-team/react-jsonschema-form/blob/d889f071aa9823bae92d8ea048ce1db0c59e75e9/packages/core/src/components/Form.js#L73)

```
    const getCurrentErrors = () => {
      if (props.noValidate) {
        return { errors: [], errorSchema: {} };
      } else if (!props.liveValidate) {
        return {
          errors: state.schemaValidationErrors || [],
          errorSchema: state.schemaValidationErrorSchema || {},
        };
      }
      return {
        errors: state.errors || [],
        errorSchema: state.errorSchema || {},
      };
    };
```

What this does is that when the last error is fixed on re-submission of the form, the state is calculated from the stale values of schemaValidationErrors & schemaValidationErrorSchema

We fix this by updating the schemaValidationErrors & schemaValidationErrorSchema in the state when form is submitted with errors fixed.


If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

### Checklist

* [ ] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

### Tests

#### Failing test due to this bug
![Test Fail](https://user-images.githubusercontent.com/42853152/131912193-25692a41-2166-4e49-a9f6-d798fc490b15.png)

#### Passing test after fix
![Tests Passing](https://user-images.githubusercontent.com/42853152/131912211-05df5739-e7d9-4149-b720-91de68f0fd7d.png)

