### PR TITLE
Fix for ui:options label & description

### DIFF
--- a/packages/core/src/components/fields/ArrayField.js
+++ b/packages/core/src/components/fields/ArrayField.js
@@ -113,18 +113,17 @@ function DefaultFixedArrayFieldTemplate(props) {
           key={`array-field-title-${props.idSchema.$id}`}
           TitleField={props.TitleField}
           idSchema={props.idSchema}
-          title={props.uiSchema["ui:title"] || props.title}
+          title={uiOptions.title || props.title}
           required={props.required}
         />
       )}
-      {displayLabel &&
-        (props.uiSchema["ui:description"] || props.schema.description) && (
-          <div
-            className="field-description"
-            key={`field-description-${props.idSchema.$id}`}>
-            {props.uiSchema["ui:description"] || props.schema.description}
-          </div>
-        )}
+      {displayLabel && (uiOptions.description || props.schema.description) && (
+        <div
+          className="field-description"
+          key={`field-description-${props.idSchema.$id}`}>
+          {uiOptions.description || props.schema.description}
+        </div>
+      )}
 
       <div
         className="row array-item-list"
@@ -154,22 +153,19 @@ function DefaultNormalArrayFieldTemplate(props) {
           key={`array-field-title-${props.idSchema.$id}`}
           TitleField={props.TitleField}
           idSchema={props.idSchema}
-          title={props.uiSchema["ui:title"] || props.title}
+          title={uiOptions.title || props.title}
           required={props.required}
         />
       )}
 
-      {displayLabel &&
-        (props.uiSchema["ui:description"] || props.schema.description) && (
-          <ArrayFieldDescription
-            key={`array-field-description-${props.idSchema.$id}`}
-            DescriptionField={props.DescriptionField}
-            idSchema={props.idSchema}
-            description={
-              props.uiSchema["ui:description"] || props.schema.description
-            }
-          />
-        )}
+      {displayLabel && (uiOptions.description || props.schema.description) && (
+        <ArrayFieldDescription
+          key={`array-field-description-${props.idSchema.$id}`}
+          DescriptionField={props.DescriptionField}
+          idSchema={props.idSchema}
+          description={uiOptions.description || props.schema.description}
+        />
+      )}
 
       <div
         className="row array-item-list"

--- a/packages/core/src/components/fields/ArrayField.js
+++ b/packages/core/src/components/fields/ArrayField.js
@@ -103,23 +103,28 @@ function DefaultArrayItem(props) {
 }
 
 function DefaultFixedArrayFieldTemplate(props) {
+  const uiOptions = getUiOptions(props.uiSchema);
+  let { label: displayLabel = true } = uiOptions;
+
   return (
     <fieldset className={props.className} id={props.idSchema.$id}>
-      <ArrayFieldTitle
-        key={`array-field-title-${props.idSchema.$id}`}
-        TitleField={props.TitleField}
-        idSchema={props.idSchema}
-        title={props.uiSchema["ui:title"] || props.title}
-        required={props.required}
-      />
-
-      {(props.uiSchema["ui:description"] || props.schema.description) && (
-        <div
-          className="field-description"
-          key={`field-description-${props.idSchema.$id}`}>
-          {props.uiSchema["ui:description"] || props.schema.description}
-        </div>
+      {displayLabel && (
+        <ArrayFieldTitle
+          key={`array-field-title-${props.idSchema.$id}`}
+          TitleField={props.TitleField}
+          idSchema={props.idSchema}
+          title={props.uiSchema["ui:title"] || props.title}
+          required={props.required}
+        />
       )}
+      {displayLabel &&
+        (props.uiSchema["ui:description"] || props.schema.description) && (
+          <div
+            className="field-description"
+            key={`field-description-${props.idSchema.$id}`}>
+            {props.uiSchema["ui:description"] || props.schema.description}
+          </div>
+        )}
 
       <div
         className="row array-item-list"
@@ -139,26 +144,32 @@ function DefaultFixedArrayFieldTemplate(props) {
 }
 
 function DefaultNormalArrayFieldTemplate(props) {
+  const uiOptions = getUiOptions(props.uiSchema);
+  let { label: displayLabel = true } = uiOptions;
+
   return (
     <fieldset className={props.className} id={props.idSchema.$id}>
-      <ArrayFieldTitle
-        key={`array-field-title-${props.idSchema.$id}`}
-        TitleField={props.TitleField}
-        idSchema={props.idSchema}
-        title={props.uiSchema["ui:title"] || props.title}
-        required={props.required}
-      />
-
-      {(props.uiSchema["ui:description"] || props.schema.description) && (
-        <ArrayFieldDescription
-          key={`array-field-description-${props.idSchema.$id}`}
-          DescriptionField={props.DescriptionField}
+      {displayLabel && (
+        <ArrayFieldTitle
+          key={`array-field-title-${props.idSchema.$id}`}
+          TitleField={props.TitleField}
           idSchema={props.idSchema}
-          description={
-            props.uiSchema["ui:description"] || props.schema.description
-          }
+          title={props.uiSchema["ui:title"] || props.title}
+          required={props.required}
         />
       )}
+
+      {displayLabel &&
+        (props.uiSchema["ui:description"] || props.schema.description) && (
+          <ArrayFieldDescription
+            key={`array-field-description-${props.idSchema.$id}`}
+            DescriptionField={props.DescriptionField}
+            idSchema={props.idSchema}
+            description={
+              props.uiSchema["ui:description"] || props.schema.description
+            }
+          />
+        )}
 
       <div
         className="row array-item-list"

--- a/packages/core/src/components/fields/ObjectField.js
+++ b/packages/core/src/components/fields/ObjectField.js
@@ -8,13 +8,17 @@ import {
   getDefaultRegistry,
   canExpand,
   ADDITIONAL_PROPERTY_FLAG,
+  getUiOptions,
 } from "../../utils";
 
 function DefaultObjectFieldTemplate(props) {
   const { TitleField, DescriptionField } = props;
+  const uiOptions = getUiOptions(props.uiSchema);
+  let { label: displayLabel = true } = uiOptions;
+
   return (
     <fieldset id={props.idSchema.$id}>
-      {(props.uiSchema["ui:title"] || props.title) && (
+      {displayLabel && (props.uiSchema["ui:title"] || props.title) && (
         <TitleField
           id={`${props.idSchema.$id}__title`}
           title={props.title || props.uiSchema["ui:title"]}
@@ -22,7 +26,7 @@ function DefaultObjectFieldTemplate(props) {
           formContext={props.formContext}
         />
       )}
-      {props.description && (
+      {displayLabel && props.description && (
         <DescriptionField
           id={`${props.idSchema.$id}__description`}
           description={props.description}

--- a/packages/core/src/components/fields/ObjectField.js
+++ b/packages/core/src/components/fields/ObjectField.js
@@ -18,10 +18,10 @@ function DefaultObjectFieldTemplate(props) {
 
   return (
     <fieldset id={props.idSchema.$id}>
-      {displayLabel && (props.uiSchema["ui:title"] || props.title) && (
+      {displayLabel && props.title && (
         <TitleField
           id={`${props.idSchema.$id}__title`}
-          title={props.title || props.uiSchema["ui:title"]}
+          title={props.title}
           required={props.required}
           formContext={props.formContext}
         />
@@ -201,8 +201,10 @@ class ObjectField extends Component {
     const { SchemaField, TitleField, DescriptionField } = fields;
     const schema = retrieveSchema(this.props.schema, rootSchema, formData);
 
-    const title = schema.title === undefined ? name : schema.title;
-    const description = uiSchema["ui:description"] || schema.description;
+    const uiOptions = getUiOptions(uiSchema);
+    const title = uiOptions.title || schema.title || name;
+    const description = uiOptions.description || schema.description;
+
     let orderedProperties;
     try {
       const properties = Object.keys(schema.properties || {});

--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -13,6 +13,7 @@ import {
   deepEquals,
   getSchemaType,
   getDisplayLabel,
+  getUiOptions,
 } from "../../utils";
 
 const REQUIRED_FIELD_SYMBOL = "*";
@@ -289,19 +290,18 @@ function SchemaFieldRender(props) {
   );
 
   const id = idSchema.$id;
+  const uiOptions = getUiOptions(uiSchema);
 
   // If this schema has a title defined, but the user has set a new key/label, retain their input.
   let label;
   if (wasPropertyKeyModified) {
     label = name;
   } else {
-    label = uiSchema["ui:title"] || props.schema.title || schema.title || name;
+    label = uiOptions.title || props.schema.title || schema.title || name;
   }
 
   const description =
-    uiSchema["ui:description"] ||
-    props.schema.description ||
-    schema.description;
+    uiOptions.description || props.schema.description || schema.description;
   const errors = __errors;
   const help = uiSchema["ui:help"];
   const hidden = uiSchema["ui:widget"] === "hidden";

--- a/packages/core/test/ArrayFieldTemplate_test.js
+++ b/packages/core/test/ArrayFieldTemplate_test.js
@@ -387,3 +387,121 @@ describe("ArrayFieldTemplate with hidden label", () => {
     expect(node.querySelectorAll("legend")).to.have.length.of(0);
   });
 });
+
+describe("Normal ArrayFieldTemplate with label & description from uiSchema", () => {
+  const schema = {
+    type: "array",
+    title: "Array Label",
+    description: "Array description",
+    items: { type: "string" },
+  };
+  const uiSchema = {
+    "ui:title": "Replace title",
+    "ui:description": "Replace description",
+    "ui:options": {
+      title: "Override title",
+      description: "Override description",
+    },
+  };
+  const { node: normalArrayNodeWithUiOptions } = createFormComponent({
+    schema: schema,
+    uiSchema: uiSchema,
+    formData: ["a", "b"],
+  });
+
+  it("should use label from ui:options", () => {
+    const foundNodes = normalArrayNodeWithUiOptions.querySelectorAll(
+      "#root__title"
+    );
+    expect(foundNodes).to.have.length.of(1);
+    expect(foundNodes[0].firstChild.data).to.be.equal("Override title");
+  });
+
+  it("should use description from ui:options", () => {
+    const foundNodes = normalArrayNodeWithUiOptions.querySelectorAll(
+      "#root__description"
+    );
+    expect(foundNodes).to.have.length.of(1);
+    expect(foundNodes[0].firstChild.data).to.be.equal("Override description");
+  });
+
+  // create a form with ui:title and ui:description
+  const modifiedUiSchema = {
+    "ui:title": "Replace title",
+    "ui:description": "Replace description",
+  };
+  const { node: newNode } = createFormComponent({
+    schema: schema,
+    uiSchema: modifiedUiSchema,
+    formData: ["a", "b"],
+  });
+
+  it("should use label from ui:title", () => {
+    const foundNodes = newNode.querySelectorAll("#root__title");
+    expect(foundNodes).to.have.length.of(1);
+    expect(foundNodes[0].firstChild.data).to.be.equal("Replace title");
+  });
+
+  it("should use description from ui:description", () => {
+    const foundNodes = newNode.querySelectorAll("#root__description");
+    expect(foundNodes).to.have.length.of(1);
+    expect(foundNodes[0].firstChild.data).to.be.equal("Replace description");
+  });
+});
+
+describe("Fixed ArrayFieldTemplate with label & description from uiSchema", () => {
+  const schema = {
+    type: "array",
+    title: "Array Label",
+    description: "Array description",
+    items: [{ type: "string" }],
+  };
+  const uiSchema = {
+    "ui:title": "Replace title",
+    "ui:description": "Replace description",
+    "ui:options": {
+      title: "Override title",
+      description: "Override description",
+    },
+  };
+  const { node: nodeWithUiOptions } = createFormComponent({
+    schema: schema,
+    uiSchema: uiSchema,
+    formData: ["a", "b"],
+  });
+
+  it("should use label from ui:options", () => {
+    const foundNodes = nodeWithUiOptions.querySelectorAll("#root__title");
+    expect(foundNodes).to.have.length.of(1);
+    expect(foundNodes[0].firstChild.data).to.be.equal("Override title");
+  });
+
+  it("should use description from ui:options", () => {
+    const foundNodes = nodeWithUiOptions.querySelectorAll(".field-description");
+    expect(foundNodes).to.have.length.of(1);
+    expect(foundNodes[0].firstChild.data).to.be.equal("Override description");
+  });
+
+  // create a form with ui:title and ui:description
+  const modifiedUiSchema = {
+    "ui:title": "Replace title",
+    "ui:description": "Replace description",
+  };
+  const { node: newNode } = createFormComponent({
+    schema: schema,
+    uiSchema: modifiedUiSchema,
+    formData: ["a", "b"],
+  });
+
+  it("should use label from ui:title", () => {
+    const foundNodes = newNode.querySelectorAll("#root__title");
+    expect(foundNodes).to.have.length.of(1);
+    expect(foundNodes[0].firstChild.data).to.be.equal("Replace title");
+  });
+
+  it("should use description from ui:description", () => {
+    const foundNodes = newNode.querySelectorAll(".field-description");
+    expect(foundNodes).to.have.length.of(1);
+    expect(foundNodes[0].firstChild.data).to.be.equal("Replace description");
+  });
+});

--- a/packages/core/test/ArrayFieldTemplate_test.js
+++ b/packages/core/test/ArrayFieldTemplate_test.js
@@ -350,3 +350,40 @@ describe("ArrayFieldTemplate", () => {
     });
   });
 });
+
+describe("ArrayFieldTemplate with hidden label", () => {
+  const schema = {
+    type: "array",
+    title: "Example array label",
+    description: "Example array description",
+    items: { type: "string" },
+  };
+  const uiSchema = {
+    "ui:options": { label: false },
+  };
+
+  it("normal array should not generate label and description", () => {
+    const { node } = createFormComponent({
+      schema: schema,
+      uiSchema: uiSchema,
+      formData: ["a", "b"],
+    });
+
+    expect(node.querySelectorAll("legend")).to.have.length.of(0);
+  });
+
+  it("fixed array should not generate label and description", () => {
+    const fixedArraySchema = {
+      ...schema,
+      items: [{ type: "string" }],
+    };
+
+    const { node } = createFormComponent({
+      schema: fixedArraySchema,
+      uiSchema: uiSchema,
+      formData: ["a", "b"],
+    });
+
+    expect(node.querySelectorAll("legend")).to.have.length.of(0);
+  });
+});

--- a/packages/core/test/FieldTemplate_test.js
+++ b/packages/core/test/FieldTemplate_test.js
@@ -121,4 +121,62 @@ describe("FieldTemplate", () => {
       );
     });
   });
+
+  describe("FieldTemplate should use label & description from uiSchema", () => {
+    const schema = {
+      type: "string",
+      title: "Example Title",
+      description: "Example description",
+    };
+    const uiSchemaWithUiOptions = {
+      "ui:title": "Replace Title",
+      "ui:description": "Replace description",
+      "ui:options": {
+        title: "Override Title",
+        description: "Override description",
+      },
+    };
+    const { node: nodeWithUiOptions } = createFormComponent({
+      schema: schema,
+      uiSchema: uiSchemaWithUiOptions,
+      formData: "test string",
+    });
+
+    it("should use label from ui:options", () => {
+      const foundNodes = nodeWithUiOptions.querySelectorAll("label");
+      expect(foundNodes).to.have.length.of(1);
+      expect(foundNodes[0].firstChild.data).to.equal("Override Title");
+    });
+
+    it("should use description from ui:options", () => {
+      const foundNodes = nodeWithUiOptions.querySelectorAll(
+        "#root__description"
+      );
+      expect(foundNodes).to.have.length.of(1);
+      expect(foundNodes[0].firstChild.data).to.equal("Override description");
+    });
+
+    // use ui:title and ui:description
+    const uiSchema = {
+      "ui:title": "Replace Title",
+      "ui:description": "Replace description",
+    };
+    const { node } = createFormComponent({
+      schema: schema,
+      uiSchema: uiSchema,
+      formData: "test string",
+    });
+
+    it("should use label from ui:options", () => {
+      const foundNodes = node.querySelectorAll("label");
+      expect(foundNodes).to.have.length.of(1);
+      expect(foundNodes[0].firstChild.data).to.equal("Replace Title");
+    });
+
+    it("should use description from ui:options", () => {
+      const foundNodes = node.querySelectorAll("#root__description");
+      expect(foundNodes).to.have.length.of(1);
+      expect(foundNodes[0].firstChild.data).to.equal("Replace description");
+    });
+  });
 });

--- a/packages/core/test/ObjectFieldTemplate_test.js
+++ b/packages/core/test/ObjectFieldTemplate_test.js
@@ -142,3 +142,62 @@ describe("ObjectFieldTemplate with hidden label", () => {
     expect(node.querySelectorAll("legend")).to.have.length.of(0);
   });
 });
+
+describe("ObjectFieldTemplate with labels & description from uiSchema", () => {
+  const schema = {
+    type: "object",
+    title: "Object Label",
+    description: "Object Description",
+    properties: {
+      name: { type: "string" },
+    },
+  };
+  const uiSchema = {
+    "ui:title": "Replace title",
+    "ui:description": "Replace description",
+    "ui:options": {
+      title: "Override title",
+      description: "Override description",
+    },
+  };
+  const { node } = createFormComponent({
+    schema: schema,
+    uiSchema: uiSchema,
+    formData: { name: "test object " },
+  });
+
+  it("should use label from ui:options", () => {
+    const foundNodes = node.querySelectorAll("#root__title");
+    expect(foundNodes).to.have.length.of(1);
+    expect(foundNodes[0].firstChild.data).to.be.equal("Override title");
+  });
+
+  it("should use description from ui:options", () => {
+    const foundNodes = node.querySelectorAll("#root__description");
+    expect(foundNodes).to.have.length.of(1);
+    expect(foundNodes[0].firstChild.data).to.be.equal("Override description");
+  });
+
+  // create a form with ui:title and ui:description
+  const modifiedUiSchema = {
+    "ui:title": "Replace title",
+    "ui:description": "Replace description",
+  };
+  const { node: newNode } = createFormComponent({
+    schema: schema,
+    uiSchema: modifiedUiSchema,
+    formData: { name: "test object " },
+  });
+
+  it("should use label from ui:title", () => {
+    const foundNodes = newNode.querySelectorAll("#root__title");
+    expect(foundNodes).to.have.length.of(1);
+    expect(foundNodes[0].firstChild.data).to.be.equal("Replace title");
+  });
+
+  it("should use description from ui:description", () => {
+    const foundNodes = newNode.querySelectorAll("#root__description");
+    expect(foundNodes).to.have.length.of(1);
+    expect(foundNodes[0].firstChild.data).to.be.equal("Replace description");
+  });
+});

--- a/packages/core/test/ObjectFieldTemplate_test.js
+++ b/packages/core/test/ObjectFieldTemplate_test.js
@@ -118,3 +118,27 @@ describe("ObjectFieldTemplate", () => {
     });
   }
 });
+
+describe("ObjectFieldTemplate with hidden label", () => {
+  const schema = {
+    type: "object",
+    title: "Example object label",
+    description: "Example object description",
+    properties: {
+      name: { type: "string" },
+    },
+  };
+  const uiSchema = {
+    "ui:options": { label: false },
+  };
+
+  it("should not generate label and description", () => {
+    const { node } = createFormComponent({
+      schema: schema,
+      uiSchema: uiSchema,
+      formData: { name: "test object " },
+    });
+
+    expect(node.querySelectorAll("legend")).to.have.length.of(0);
+  });
+});


### PR DESCRIPTION
### Reasons for making this change

There are many bugs describing the problem with the current code ignoring some settings from uiSchema; namely
 - ui:title,
 - ui:description
 - ui:options
   - label: <boolean>
   - title: <string>
   - description: <string>

This changeset fixes above problems for all fields, array fields and object fields. Labels are hidden when the ui:options {label: false} is provided as well as title and description fields from ui:options are applied as per the documentation.

If this is related to existing tickets, include links to them as well. Use the syntax fixes #2535 .

### Checklist

* [ ] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

### Note

- No documentation updates are required as this is a bug fix and aligns the expected behavior with documented behavior.

### Screenshots

<img width="962" alt="uiOptions" src="https://user-images.githubusercontent.com/42853152/132069822-8dedf688-ed58-441d-bf69-945afe21d721.png">

<img width="1078" alt="uiTitle" src="https://user-images.githubusercontent.com/42853152/132069831-767339f5-e307-4b64-ac48-d9f255076bea.png">

#### Tests passing after the code change
![uiSchema Tests Passing](https://user-images.githubusercontent.com/42853152/132070261-ad57ce93-11c9-4deb-8e00-75e7ae669bed.png)

#### Tests failing before code change
https://pastebin.com/QE2a9jqv
