### PR TITLE
Allow to change additionalProperties to falsy values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fix for clearing errors after updating and submitting form (https://github.com/rjsf-team/react-jsonschema-form/pull/2536)
 - bootstrap-4 TextWidget wrappers now pull from registry, add rootSchema to Registry, fix FieldProps.onFocus type to match WidgetProps (https://github.com/rjsf-team/react-jsonschema-form/pull/2519)
 - Added global `readonly` flag to the `Form` (https://github.com/rjsf-team/react-jsonschema-form/pull/2554)
+- Fix to allow changing `additionalProperties` to falsy values (https://github.com/rjsf-team/react-jsonschema-form/pull/2540)
 
 ## @rjsf/bootstrap-4
 - bootstrap-4 TextWidget wrappers now pull from registry, add rootSchema to Registry, fix FieldProps.onFocus type to match WidgetProps (https://github.com/rjsf-team/react-jsonschema-form/pull/2519)

--- a/packages/core/src/components/fields/ObjectField.js
+++ b/packages/core/src/components/fields/ObjectField.js
@@ -66,7 +66,7 @@ class ObjectField extends Component {
 
   onPropertyChange = (name, addedByAdditionalProperties = false) => {
     return (value, errorSchema) => {
-      if (!value && addedByAdditionalProperties) {
+      if (value === undefined && addedByAdditionalProperties) {
         // Don't set value = undefined for fields added by
         // additionalProperties. Doing so removes them from the
         // formData, which causes them to completely disappear

--- a/packages/core/test/ObjectField_test.js
+++ b/packages/core/test/ObjectField_test.js
@@ -866,5 +866,56 @@ describe("ObjectField", () => {
         formData: { first: "" },
       });
     });
+
+    it("should change content of value input to boolean false", () => {
+      const { node, onChange } = createFormComponent({
+        schema: {
+          ...schema,
+          additionalProperties: true,
+        },
+        formData: { first: true },
+      });
+
+      Simulate.change(node.querySelector("#root_first"), {
+        target: { checked: false },
+      });
+
+      sinon.assert.calledWithMatch(onChange.lastCall, {
+        formData: { first: false },
+      });
+    });
+
+    it("should change content of value input to number 0", () => {
+      const { node, onChange } = createFormComponent({
+        schema: {
+          ...schema,
+          additionalProperties: true,
+        },
+        formData: { first: 1 },
+      });
+
+      Simulate.change(node.querySelector("#root_first"), {
+        target: { value: 0 },
+      });
+
+      sinon.assert.calledWithMatch(onChange.lastCall, {
+        formData: { first: 0 },
+      });
+    });
+
+    it("should change content of value input to null", () => {
+      const { node, onChange } = createFormComponent({
+        schema,
+        formData: { first: "str" },
+      });
+
+      Simulate.change(node.querySelector("#root_first"), {
+        target: { value: null },
+      });
+
+      sinon.assert.calledWithMatch(onChange.lastCall, {
+        formData: { first: null },
+      });
+    });
   });
 });


### PR DESCRIPTION
### Reasons for making this change

fixes #2462

Changing of additionalProperties to any falsy value (false, 0, null) leads to its unexpected conversion to an empty string.

Similar change is proposed here - #2463, but it requires tests and the PR has been stall for a little while. Feel free to cancel current PR, if the other one gets finished faster.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

