### PR TITLE
prevent reference from losing local properties on nested references, …

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -597,7 +597,8 @@ export function findSchemaDefinition($ref, rootSchema = {}) {
     throw new Error(`Could not find a definition for ${origRef}.`);
   }
   if (current.hasOwnProperty("$ref")) {
-    return findSchemaDefinition(current.$ref, rootSchema);
+    const { $ref, ...currentSchema } = current;
+    return { ...findSchemaDefinition($ref, rootSchema), ...currentSchema };
   }
   return current;
 }

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -1651,6 +1651,33 @@ describe("utils", () => {
 
       expect(retrieveSchema(schema, { definitions })).eql(address);
     });
+    it("should 'resolve' a schema which contains definitions from combined with another reference in `#/definitions`", () => {
+      const expectedPhone = {
+        maximum: 12,
+        minLength: 10,
+        type: "string",
+        title: "Cellphone number",
+      };
+      const schema = {
+        maximum: 12,
+        $ref: "#/definitions/cellphone",
+      };
+      const basePhone = {
+        type: "string",
+        minLength: 10,
+      };
+      const cellphone = {
+        $ref: "#/definitions/basePhone",
+        title: "Cellphone number",
+      };
+      const alternativeCellphone = {
+        $ref: "#/definitions/basePhone",
+        title: "Alternative Cellphone number",
+        description: "Not applied to all",
+      };
+      const definitions = { basePhone, cellphone, alternativeCellphone };
+      expect(retrieveSchema(schema, { definitions })).eql(expectedPhone);
+    });
 
     it("should 'resolve' a schema which contains definitions not in `#/definitions`", () => {
       const address = {


### PR DESCRIPTION
prevent reference from losing local properties on nested references, using the same behaviour as `resolveReference()`

### Reasons for making this change

using the following schema: 

```
{
  definitions: {
    basePhone: {
      type: "string",
      minLength: 10,
    },
    cellphone: {
      $ref: "#/definitions/basePhone",
      title: "Cellphone number",
    },
    alternativeCellphone: {
      $ref: "#/definitions/basePhone",
      title: "Alternative Cellphone number",
      description: "Not applied to all",
    }
  },
  maximum: 12,
  $ref: "#/definitions/cellphone"
}

```
I'm pointing to the definition #/definitions/cellphone that points to #/definitions/basePhone.

the expected result was to have the properties from each reference resulting in:

```
{
  maximum: 12,
  minLength: 10,
  type: "string",
  title: "Cellphone number"
}
```

the result retrieving the schema was:
```
{
  maximum: 12,
  minLength: 10,
  type: "string",
}

```
ignoring the properties from the 1st reference.
The function `resolveReference()` is prepared get the local properties by merging the result, but on `findSchemaDefinition()` it isn't, resulting in the schema above.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

