### PR TITLE
Fix oneOf schema not working when omitExtraData and liveOmit is set.

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1035,6 +1035,11 @@ export function toPathSchema(schema, name = "", rootSchema, formData = {}) {
     return toPathSchema(_schema, name, rootSchema, formData);
   }
 
+  if ("oneOf" in schema) {
+    const _schema =  schema.oneOf[getMatchingOption(formData, schema.oneOf, rootSchema)];
+    return toPathSchema(_schema, name, rootSchema, formData);
+  }
+
   if (schema.hasOwnProperty("additionalProperties")) {
     pathSchema.__rjsf_additionalProperties = true;
   }

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -2884,6 +2884,39 @@ describe("utils", () => {
       });
     });
 
+    it("should return a pathSchema for a schema with oneOf", () => {
+      const schema = {
+        type: "object",
+        oneOf: [
+          {
+            properties: {
+              lorem: {
+                type: "string",
+              },
+            }
+          },
+          {
+            properties: {
+              ipsum: {
+                type: "string",
+              },
+            }
+          },
+        ],
+      };
+
+      const formData = {
+        lorem: "loremValue"
+      };
+
+      expect(toPathSchema(schema, "", schema, formData)).eql({
+        $name: "",
+        lorem: {
+          $name: "lorem",
+        }
+      });
+    });
+
     it("should return a pathSchema for a schema with references in an array item", () => {
       const schema = {
         definitions: {


### PR DESCRIPTION
### Reasons for making this change
For schema with oneOf array, setting omitExtraData and liveOmit would cause formData to be clear out on input change.  This PR fixes this issue by adding code to hand oneOf schema inside toPathSchema function.

fixes #2262
https://github.com/rjsf-team/react-jsonschema-form/issues/2262

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

@epicfaace @agustin107 this is blocking issue for our company's project, if you can take a quick look, it would be greatly appreciated.  