### PR TITLE
add event bubbling to submit event (fix for React 17 and up)

### DIFF
--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -408,6 +408,7 @@ export default class Form extends Component {
       this.formElement.dispatchEvent(
         new CustomEvent("submit", {
           cancelable: true,
+          bubbles: true,
         })
       );
     }


### PR DESCRIPTION
### Reasons for making this change

Programmatic submittng does not work for React 17+, due to changes in event delegation in React 17.

linked issue - #2551 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

