### PR TITLE
Create changelog process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ If your PR affects multiple packages, list it multiple times under headings for 
 If it affects more general things such as dependency updates or non-package-specific changes,
 add it under a "Dev / docs / playground" section.
 
+You should also update the heading of the latest (upcoming) version if your PR change merits
+it according to semantic versioning. For example, if your PR adds a breaking change, then you
+should change the heading of the (upcoming) version to include a major version bump.
+
 -->
 
-# v3.1.0 (upcoming)
+# v3.2.0 (upcoming)
 
 ## @rjsf/core
 - Fix for clearing errors after updating and submitting form (https://github.com/rjsf-team/react-jsonschema-form/pull/2536)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+<!--
+
+INSTRUCTIONS:
+
+For each PR, add a changelog entry that describes what your PR does. Add it to the heading
+for the appropriate package it modifies and include it in this format:
+- [Description] ([Link to PR])
+
+If your PR affects multiple packages, list it multiple times under headings for each package.
+If it affects more general things such as dependency updates or non-package-specific changes,
+add it under a "Dev / docs / playground" section.
+
+-->
+
+# v3.1.0 (upcoming)
+
+## @rjsf/core
+- Fix for clearing errors after updating and submitting form (https://github.com/rjsf-team/react-jsonschema-form/pull/2536)
+- bootstrap-4 TextWidget wrappers now pull from registry, add rootSchema to Registry, fix FieldProps.onFocus type to match WidgetProps (https://github.com/rjsf-team/react-jsonschema-form/pull/2519)
+
+## @rjsf/bootstrap-4
+- bootstrap-4 TextWidget wrappers now pull from registry, add rootSchema to Registry, fix FieldProps.onFocus type to match WidgetProps (https://github.com/rjsf-team/react-jsonschema-form/pull/2519)
+
+## @rjsf/fluent-ui
+- fluent-ui: Allow value of 0 in TextWidget (https://github.com/rjsf-team/react-jsonschema-form/pull/2497)
+
+## Dev / docs / playground
+- Several dependency updates
+
+# v3.1.0
+
+## @rjsf/core
+- Properly assign label prop for MultiSelect ArrayField (https://github.com/rjsf-team/react-jsonschema-form/pull/2459)
+- Take into account implicitly defined types when rendering labels for fields (https://github.com/rjsf-team/react-jsonschema-form/pull/2502)
+
+## @rjsf/antd
+- Add default Form export to @rjsf/antd (https://github.com/rjsf-team/react-jsonschema-form/pull/2514) 
+
+## @rjsf/fluent-ui
+- Make material-ui and fluent-ui pull TextWidget from the registry; remove registry prop from <div> in TextWidget (https://github.com/rjsf-team/react-jsonschema-form/pull/2515)
+
+## @rjsf/material-ui
+- Make material-ui and fluent-ui pull TextWidget from the registry; remove registry prop from <div> in TextWidget (https://github.com/rjsf-team/react-jsonschema-form/pull/2515)
+
+## @rjsf/semantic-ui
+- Use getDisplayLabel to properly show labels for widgets (https://github.com/rjsf-team/react-jsonschema-form/pull/2225)
+- Add submit button, email, url, date widgets (https://github.com/rjsf-team/react-jsonschema-form/pull/2224)
+
+## Dev / docs / playground
+- Several dependency updates

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,6 @@ If this is related to existing tickets, include links to them as well. Use the s
 * [ ] **I'm adding or updating code**
   - [ ] I've added and/or updated tests
   - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
-  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR.
+  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
 * [ ] **I'm adding a new feature**
   - [ ] I've updated the playground with an example use of the feature

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,6 @@ If this is related to existing tickets, include links to them as well. Use the s
 * [ ] **I'm adding or updating code**
   - [ ] I've added and/or updated tests
   - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
+  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR.
 * [ ] **I'm adding a new feature**
   - [ ] I've updated the playground with an example use of the feature
-

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -49,7 +49,8 @@ lerna version
 
 Make sure you use [semver](https://semver.org/) for version numbering when selecting the version.
 The command above will create a new version tag and push it to GitHub. Then, create a release in
-the Github "Releases" tab and add a description of the changes in the new release.
+the Github "Releases" tab and add a description of the changes in the new release. You can copy
+the latest changelog entry in `CHANGELOG.md` to make the release notes, and update as necessary.
 
 This will trigger a GitHub Actions pipeline that will build and publish all packages to npm.
 


### PR DESCRIPTION
### Reasons for making this change

This will save a lot of time for maintainers to make releases. Each time someone makes a PR, they must update the changelog. This way, once the maintainer needs to make a release, they can just copy / paste from the changelog.