### PR TITLE
fix: Ensure errorSchema is a plain object before going deep in toErrorList

### DIFF
--- a/packages/core/src/validate.js
+++ b/packages/core/src/validate.js
@@ -131,10 +131,11 @@ function unwrapErrorHandler(errorHandler) {
   return Object.keys(errorHandler).reduce((acc, key) => {
     if (key === "addError") {
       return acc;
-    } else if (key === "__errors") {
+    } else if (isPlainObject(errorHandler[key])) {
+      return { ...acc, [key]: unwrapErrorHandler(errorHandler[key]) };
+    } else {
       return { ...acc, [key]: errorHandler[key] };
     }
-    return { ...acc, [key]: unwrapErrorHandler(errorHandler[key]) };
   }, {});
 }
 

--- a/packages/core/src/validate.js
+++ b/packages/core/src/validate.js
@@ -97,6 +97,9 @@ export function toErrorList(errorSchema, fieldName = "root") {
   }
 
   return Object.keys(errorSchema).reduce((acc, key) => {
+    // Ensure errorSchema property is an object (meaning it relates to an object property)
+    // before going deep in toErrorList to avoid exceptions,
+    // for instance if errorSchema[key] is an array used in custom field.
     if (key !== "__errors" && isPlainObject(errorSchema[key])) {
       acc = acc.concat(toErrorList(errorSchema[key], key));
     }

--- a/packages/core/src/validate.js
+++ b/packages/core/src/validate.js
@@ -1,4 +1,5 @@
 import toPath from "lodash/toPath";
+import isPlainObject from "lodash/isPlainObject";
 import Ajv from "ajv";
 let ajv = createAjvInstance();
 import { deepEquals, getDefaultFormState } from "./utils";
@@ -84,6 +85,7 @@ function toErrorSchema(errors) {
 export function toErrorList(errorSchema, fieldName = "root") {
   // XXX: We should transform fieldName as a full field path string.
   let errorList = [];
+
   if ("__errors" in errorSchema) {
     errorList = errorList.concat(
       errorSchema.__errors.map(stack => {
@@ -93,8 +95,9 @@ export function toErrorList(errorSchema, fieldName = "root") {
       })
     );
   }
+
   return Object.keys(errorSchema).reduce((acc, key) => {
-    if (key !== "__errors") {
+    if (key !== "__errors" && isPlainObject(errorSchema[key])) {
       acc = acc.concat(toErrorList(errorSchema[key], key));
     }
     return acc;

--- a/packages/core/test/Form_test.js
+++ b/packages/core/test/Form_test.js
@@ -3418,4 +3418,25 @@ describe("Form omitExtraData and liveOmit", () => {
 
     expect(node.querySelectorAll(".error-detail li")).to.have.length.of(2);
   });
+
+  it("should ignore extra array properties passed within the errorSchema", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        foo: { type: "string" },
+      },
+    };
+
+    const extraErrors = {
+      __warnings: ["a warning that should be ignored"],
+      foo: {
+        __errors: ["foo", "bar"],
+        __warnings: ["another warning"],
+      },
+    };
+
+    const { node } = createFormComponent({ schema, extraErrors });
+
+    expect(node.querySelectorAll(".error-detail li")).to.have.length.of(2);
+  });
 });

--- a/packages/core/test/Form_test.js
+++ b/packages/core/test/Form_test.js
@@ -3422,20 +3422,31 @@ describe("Form omitExtraData and liveOmit", () => {
   it("should ignore extra array properties passed within the errorSchema", () => {
     const schema = {
       type: "object",
+      required: ["foo", "bar"],
       properties: {
-        foo: { type: "string" },
+        foo: { type: "string", minLength: 10 },
+        bar: { type: "string" },
       },
     };
 
-    const extraErrors = {
-      __warnings: ["a warning that should be ignored"],
-      foo: {
-        __errors: ["foo", "bar"],
-        __warnings: ["another warning"],
-      },
+    const formData = {
+      foo: "dummy",
     };
 
-    const { node } = createFormComponent({ schema, extraErrors });
+    const validate = (formData, errors) => {
+      if (formData.foo === "dummy") {
+        errors.foo.__warnings = ["value might be too common"];
+      }
+
+      return errors;
+    };
+
+    const { node } = createFormComponent({
+      schema,
+      formData,
+      validate,
+      liveValidate: true,
+    });
 
     expect(node.querySelectorAll(".error-detail li")).to.have.length.of(2);
   });

--- a/packages/core/test/validate_test.js
+++ b/packages/core/test/validate_test.js
@@ -404,6 +404,18 @@ describe("Validation", () => {
         { stack: "c: err5" },
       ]);
     });
+
+    it("should not crash when extra properties exist in errorSchema and omit them", () => {
+      expect(
+        toErrorList({
+          __errors: ["err1", "err2"],
+          __warnings: ["warn1", "warn2"],
+          b: {
+            __warnings: ["warn3"],
+          },
+        })
+      ).eql([{ stack: "root: err1" }, { stack: "root: err2" }]);
+    });
   });
 
   describe("transformErrors", () => {


### PR DESCRIPTION
### Reasons for making this change

In our application, we also pass some "__warnings" properties within the errorSchema (warnings which are then extracted and used in a custom SchemaField). Without this change, the toErrorList function just crash when it encounter a __warnings array, as it currently assumes that anything but __errors are objects.

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
