### PR TITLE
fix: use ui:title in BooleanField

### DIFF
--- a/packages/core/src/components/fields/BooleanField.js
+++ b/packages/core/src/components/fields/BooleanField.js
@@ -25,9 +25,9 @@ function BooleanField(props) {
     onBlur,
     rawErrors,
   } = props;
-  const { title } = schema;
   const { widgets, formContext, fields } = registry;
   const { widget = "checkbox", ...options } = getUiOptions(uiSchema);
+  const title = options.title || schema.title;
   const Widget = getWidget(schema, widget, widgets);
 
   let enumOptions;


### PR DESCRIPTION
### Reasons for making this change

Fixes #827

### Checklist

* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
