### PR TITLE
fix(bootstrap-4): double margin above select widget help text

### DIFF
--- a/packages/bootstrap-4/src/SelectWidget/SelectWidget.tsx
+++ b/packages/bootstrap-4/src/SelectWidget/SelectWidget.tsx
@@ -75,7 +75,7 @@ const SelectWidget = ({
   }
 
   return (
-    <Form.Group>
+    <Form.Group className="mb-0">
       <Form.Label className={rawErrors.length > 0 ? "text-danger" : ""}>
         {label || schema.title}
         {(label || schema.title) && required ? "*" : null}


### PR DESCRIPTION
### Reasons for making this change

The `SelectWidget` has a double margin above the help text. Have added `mb-0` like on the `TextWidget`.
