### PR TITLE
Don't crash when non-object formData is passed in to a schema item with additionalProperties

### DIFF
--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -634,6 +634,9 @@ export function stubExistingAdditionalProperties(
     properties: { ...schema.properties },
   };
 
+  // handle null formData
+  formData = formData || {};
+
   Object.keys(formData).forEach(key => {
     if (schema.properties.hasOwnProperty(key)) {
       // No need to stub, our schema already has the property

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -634,8 +634,8 @@ export function stubExistingAdditionalProperties(
     properties: { ...schema.properties },
   };
 
-  // handle null formData
-  formData = formData || {};
+  // make sure formData is an object
+  formData = isObject(formData) ? formData : {};
 
   Object.keys(formData).forEach(key => {
     if (schema.properties.hasOwnProperty(key)) {

--- a/packages/core/test/Form_test.js
+++ b/packages/core/test/Form_test.js
@@ -46,7 +46,7 @@ describeRepeated("Form common", createFormComponent => {
         <Form {...props}>
           <button type="submit">Submit</button>
           <button type="submit">Another submit</button>
-        </Form>,
+        </Form>
       );
       const node = findDOMNode(comp);
       expect(node.querySelectorAll("button[type=submit]")).to.have.length.of(2);
@@ -73,11 +73,11 @@ describeRepeated("Form common", createFormComponent => {
       const comp = renderIntoDocument(
         <Form {...props}>
           <button type="submit">Submit</button>
-        </Form>,
+        </Form>
       );
       const node = findDOMNode(comp);
       expect(node.querySelector(".unsupported-field").textContent).to.contain(
-        "Unknown field type undefined",
+        "Unknown field type undefined"
       );
     });
   });
@@ -92,7 +92,7 @@ describeRepeated("Form common", createFormComponent => {
         <Form schema={schema} onChange={onChangeProp} formData={formData}>
           <button type="submit">Submit</button>
           <button type="submit">Another submit</button>
-        </Form>,
+        </Form>
       );
     }
 
@@ -336,22 +336,22 @@ describeRepeated("Form common", createFormComponent => {
 
     it("should use the provided template for labels", () => {
       expect(node.querySelector(".my-template > label").textContent).eql(
-        "root object",
+        "root object"
       );
       expect(
-        node.querySelector(".my-template .field-string > label").textContent,
+        node.querySelector(".my-template .field-string > label").textContent
       ).eql("foo*");
     });
 
     it("should pass description as the provided React element", () => {
       expect(node.querySelector("#root_foo__description").textContent).eql(
-        "this is description",
+        "this is description"
       );
     });
 
     it("should pass rawDescription as a string", () => {
       expect(node.querySelector(".raw-description").textContent).eql(
-        "this is description rendered from the raw format",
+        "this is description rendered from the raw format"
       );
     });
 
@@ -369,7 +369,7 @@ describeRepeated("Form common", createFormComponent => {
 
     it("should pass rawHelp as a string", () => {
       expect(node.querySelector(".raw-help").textContent).eql(
-        "this is help rendered from the raw format",
+        "this is help rendered from the raw format"
       );
     });
   });
@@ -400,7 +400,7 @@ describeRepeated("Form common", createFormComponent => {
           <button type="submit" value="Submit button" />
           <button type="submit" value="Another submit button" />
         </Form>,
-        domNode,
+        domNode
       );
       const node = findDOMNode(comp);
       const buttons = node.querySelectorAll("button[type=submit]");
@@ -552,7 +552,7 @@ describeRepeated("Form common", createFormComponent => {
         schema,
         formData: {
           data1: 123,
-          data2: ["one","two","three"]
+          data2: ["one", "two", "three"],
         },
       });
 
@@ -569,7 +569,7 @@ describeRepeated("Form common", createFormComponent => {
 
       expect(() => createFormComponent({ schema })).to.Throw(
         Error,
-        /#\/definitions\/nonexistent/,
+        /#\/definitions\/nonexistent/
       );
     });
 
@@ -1040,7 +1040,7 @@ describeRepeated("Form common", createFormComponent => {
         setProps(comp, {
           ...formProps,
           formData: null,
-        }),
+        })
       );
 
       it("should call onChange", () => {
@@ -1069,7 +1069,7 @@ describeRepeated("Form common", createFormComponent => {
           ...formProps,
           schema: newSchema,
           formData: "some value",
-        }),
+        })
       );
 
       it("should not call onChange", () => {
@@ -1088,7 +1088,7 @@ describeRepeated("Form common", createFormComponent => {
           ...formProps,
           schema: newSchema,
           formData: "something else",
-        }),
+        })
       );
 
       it("should not call onChange", () => {
@@ -1107,7 +1107,7 @@ describeRepeated("Form common", createFormComponent => {
           ...formProps,
           schema: newSchema,
           formData: null,
-        }),
+        })
       );
 
       it("should call onChange", () => {
@@ -1481,7 +1481,7 @@ describeRepeated("Form common", createFormComponent => {
 
           expect(node.querySelectorAll(".field-error")).to.have.length.of(1);
           expect(
-            node.querySelector(".field-string .error-detail").textContent,
+            node.querySelector(".field-string .error-detail").textContent
           ).eql("should NOT be shorter than 8 characters");
         });
       });
@@ -1545,7 +1545,7 @@ describeRepeated("Form common", createFormComponent => {
               value.length === 1 &&
               value[0].message === "should NOT be shorter than 8 characters"
             );
-          }),
+          })
         );
       });
 
@@ -1596,7 +1596,7 @@ describeRepeated("Form common", createFormComponent => {
         Simulate.submit(node);
 
         const errorListHTML =
-          "<li class=\"text-danger\">should NOT be shorter than 8 characters</li>";
+          '<li class="text-danger">should NOT be shorter than 8 characters</li>';
         const errors = node.querySelectorAll(".error-detail");
         // Check for errors attached to the field
         expect(errors).to.have.lengthOf(1);
@@ -1641,7 +1641,7 @@ describeRepeated("Form common", createFormComponent => {
 
         expect(node.querySelectorAll(".field-error")).to.have.length.of(1);
         expect(
-          node.querySelector(".field-string .error-detail").textContent,
+          node.querySelector(".field-string .error-detail").textContent
         ).eql("should NOT be shorter than 8 characters");
       });
     });
@@ -1670,12 +1670,12 @@ describeRepeated("Form common", createFormComponent => {
             stack: "should NOT be shorter than 8 characters",
           },
           {
-            message: "should match pattern \"d+\"",
+            message: 'should match pattern "d+"',
             name: "pattern",
             params: { pattern: "d+" },
             property: "",
             schemaPath: "#/pattern",
-            stack: "should match pattern \"d+\"",
+            stack: 'should match pattern "d+"',
           },
         ]);
       });
@@ -1688,7 +1688,7 @@ describeRepeated("Form common", createFormComponent => {
 
         expect(errors).eql([
           "should NOT be shorter than 8 characters",
-          "should match pattern \"d+\"",
+          'should match pattern "d+"',
         ]);
       });
     });
@@ -1738,12 +1738,12 @@ describeRepeated("Form common", createFormComponent => {
       it("should denote the error in the field", () => {
         const { node } = createFormComponent(formProps);
         const errorDetail = node.querySelector(
-          ".field-object .field-string .error-detail",
+          ".field-object .field-string .error-detail"
         );
 
         expect(node.querySelectorAll(".field-error")).to.have.length.of(1);
         expect(errorDetail.textContent).eql(
-          "should NOT be shorter than 8 characters",
+          "should NOT be shorter than 8 characters"
         );
       });
     });
@@ -1784,7 +1784,7 @@ describeRepeated("Form common", createFormComponent => {
         const fieldNodes = node.querySelectorAll(".field-string");
 
         const liNodes = fieldNodes[1].querySelectorAll(
-          ".field-string .error-detail li",
+          ".field-string .error-detail li"
         );
         const errors = [].map.call(liNodes, li => li.textContent);
 
@@ -1965,7 +1965,7 @@ describeRepeated("Form common", createFormComponent => {
         const fieldNodes = node.querySelectorAll(".field-string");
 
         const liNodes = fieldNodes[1].querySelectorAll(
-          ".field-string .error-detail li",
+          ".field-string .error-detail li"
         );
         const errors = [].map.call(liNodes, li => li.textContent);
 
@@ -2386,8 +2386,8 @@ describeRepeated("Form common", createFormComponent => {
       });
       expect(
         console.warn.calledWithMatch(
-          /Using autocomplete property of Form is deprecated/,
-        ),
+          /Using autocomplete property of Form is deprecated/
+        )
       ).to.be.true;
     });
 
@@ -2444,12 +2444,12 @@ describeRepeated("Form common", createFormComponent => {
       submitForm(node);
       sinon.assert.calledWithMatch(onError.lastCall, [
         {
-          message: "should match format \"area-code\"",
+          message: 'should match format "area-code"',
           name: "format",
           params: { format: "area-code" },
           property: ".areaCode",
           schemaPath: "#/properties/areaCode/format",
-          stack: ".areaCode should match format \"area-code\"",
+          stack: '.areaCode should match format "area-code"',
         },
       ]);
     });
@@ -2474,7 +2474,7 @@ describeRepeated("Form common", createFormComponent => {
       sinon.assert.calledWithMatch(onError.lastCall, [
         {
           stack:
-            "no schema with key or ref \"http://json-schema.org/draft-04/schema#\"",
+            'no schema with key or ref "http://json-schema.org/draft-04/schema#"',
         },
       ]);
 
@@ -2497,12 +2497,12 @@ describeRepeated("Form common", createFormComponent => {
           stack: "should NOT be shorter than 8 characters",
         },
         {
-          message: "should match pattern \"d+\"",
+          message: 'should match pattern "d+"',
           name: "pattern",
           params: { pattern: "d+" },
           property: "",
           schemaPath: "#/pattern",
-          stack: "should match pattern \"d+\"",
+          stack: 'should match pattern "d+"',
         },
       ]);
 
@@ -2512,7 +2512,7 @@ describeRepeated("Form common", createFormComponent => {
       sinon.assert.calledWithMatch(onError.lastCall, [
         {
           stack:
-            "no schema with key or ref \"http://json-schema.org/draft-04/schema#\"",
+            'no schema with key or ref "http://json-schema.org/draft-04/schema#"',
         },
       ]);
     });
@@ -2934,7 +2934,7 @@ describe("Form omitExtraData and liveOmit", () => {
           "level1.level2",
           "level1.anotherThing.anotherThingNested",
           "level1.anotherThing.anotherThingNested2",
-        ].sort(),
+        ].sort()
       );
     });
 
@@ -2981,7 +2981,7 @@ describe("Form omitExtraData and liveOmit", () => {
 
       const fieldNames = comp.getFieldNames(pathSchema, formData);
       expect(fieldNames.sort()).eql(
-        ["level1a", "level1.level2", "level1.mixedMap"].sort(),
+        ["level1a", "level1.level2", "level1.mixedMap"].sort()
       );
     });
 
@@ -3049,7 +3049,7 @@ describe("Form omitExtraData and liveOmit", () => {
           "address_list.1.city",
           "address_list.1.state",
           "address_list.1.street_address",
-        ].sort(),
+        ].sort()
       );
     });
   });
@@ -3206,7 +3206,7 @@ describe("Form omitExtraData and liveOmit", () => {
         },
         formData: { nested: { key1: "value" } },
       },
-      { omitExtraData: true, liveOmit: true },
+      { omitExtraData: true, liveOmit: true }
     );
 
     const textNode = node.querySelector("#root-key");

--- a/packages/core/test/Form_test.js
+++ b/packages/core/test/Form_test.js
@@ -46,7 +46,7 @@ describeRepeated("Form common", createFormComponent => {
         <Form {...props}>
           <button type="submit">Submit</button>
           <button type="submit">Another submit</button>
-        </Form>
+        </Form>,
       );
       const node = findDOMNode(comp);
       expect(node.querySelectorAll("button[type=submit]")).to.have.length.of(2);
@@ -73,11 +73,11 @@ describeRepeated("Form common", createFormComponent => {
       const comp = renderIntoDocument(
         <Form {...props}>
           <button type="submit">Submit</button>
-        </Form>
+        </Form>,
       );
       const node = findDOMNode(comp);
       expect(node.querySelector(".unsupported-field").textContent).to.contain(
-        "Unknown field type undefined"
+        "Unknown field type undefined",
       );
     });
   });
@@ -92,7 +92,7 @@ describeRepeated("Form common", createFormComponent => {
         <Form schema={schema} onChange={onChangeProp} formData={formData}>
           <button type="submit">Submit</button>
           <button type="submit">Another submit</button>
-        </Form>
+        </Form>,
       );
     }
 
@@ -336,22 +336,22 @@ describeRepeated("Form common", createFormComponent => {
 
     it("should use the provided template for labels", () => {
       expect(node.querySelector(".my-template > label").textContent).eql(
-        "root object"
+        "root object",
       );
       expect(
-        node.querySelector(".my-template .field-string > label").textContent
+        node.querySelector(".my-template .field-string > label").textContent,
       ).eql("foo*");
     });
 
     it("should pass description as the provided React element", () => {
       expect(node.querySelector("#root_foo__description").textContent).eql(
-        "this is description"
+        "this is description",
       );
     });
 
     it("should pass rawDescription as a string", () => {
       expect(node.querySelector(".raw-description").textContent).eql(
-        "this is description rendered from the raw format"
+        "this is description rendered from the raw format",
       );
     });
 
@@ -369,7 +369,7 @@ describeRepeated("Form common", createFormComponent => {
 
     it("should pass rawHelp as a string", () => {
       expect(node.querySelector(".raw-help").textContent).eql(
-        "this is help rendered from the raw format"
+        "this is help rendered from the raw format",
       );
     });
   });
@@ -400,7 +400,7 @@ describeRepeated("Form common", createFormComponent => {
           <button type="submit" value="Submit button" />
           <button type="submit" value="Another submit button" />
         </Form>,
-        domNode
+        domNode,
       );
       const node = findDOMNode(comp);
       const buttons = node.querySelectorAll("button[type=submit]");
@@ -506,6 +506,29 @@ describeRepeated("Form common", createFormComponent => {
       expect(node.querySelectorAll("input[type=text]")).to.have.length.of(1);
     });
 
+    it("should handle null values for property with additionalProperties", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          data: {
+            additionalProperties: {
+              type: "string",
+            },
+            type: "object",
+          },
+        },
+      };
+
+      const { node } = createFormComponent({
+        schema,
+        formData: {
+          data: null,
+        },
+      });
+
+      expect(node).to.not.be.null;
+    });
+
     it("should raise for non-existent definitions referenced", () => {
       const schema = {
         type: "object",
@@ -516,7 +539,7 @@ describeRepeated("Form common", createFormComponent => {
 
       expect(() => createFormComponent({ schema })).to.Throw(
         Error,
-        /#\/definitions\/nonexistent/
+        /#\/definitions\/nonexistent/,
       );
     });
 
@@ -987,7 +1010,7 @@ describeRepeated("Form common", createFormComponent => {
         setProps(comp, {
           ...formProps,
           formData: null,
-        })
+        }),
       );
 
       it("should call onChange", () => {
@@ -1016,7 +1039,7 @@ describeRepeated("Form common", createFormComponent => {
           ...formProps,
           schema: newSchema,
           formData: "some value",
-        })
+        }),
       );
 
       it("should not call onChange", () => {
@@ -1035,7 +1058,7 @@ describeRepeated("Form common", createFormComponent => {
           ...formProps,
           schema: newSchema,
           formData: "something else",
-        })
+        }),
       );
 
       it("should not call onChange", () => {
@@ -1054,7 +1077,7 @@ describeRepeated("Form common", createFormComponent => {
           ...formProps,
           schema: newSchema,
           formData: null,
-        })
+        }),
       );
 
       it("should call onChange", () => {
@@ -1428,7 +1451,7 @@ describeRepeated("Form common", createFormComponent => {
 
           expect(node.querySelectorAll(".field-error")).to.have.length.of(1);
           expect(
-            node.querySelector(".field-string .error-detail").textContent
+            node.querySelector(".field-string .error-detail").textContent,
           ).eql("should NOT be shorter than 8 characters");
         });
       });
@@ -1492,7 +1515,7 @@ describeRepeated("Form common", createFormComponent => {
               value.length === 1 &&
               value[0].message === "should NOT be shorter than 8 characters"
             );
-          })
+          }),
         );
       });
 
@@ -1543,7 +1566,7 @@ describeRepeated("Form common", createFormComponent => {
         Simulate.submit(node);
 
         const errorListHTML =
-          '<li class="text-danger">should NOT be shorter than 8 characters</li>';
+          "<li class=\"text-danger\">should NOT be shorter than 8 characters</li>";
         const errors = node.querySelectorAll(".error-detail");
         // Check for errors attached to the field
         expect(errors).to.have.lengthOf(1);
@@ -1588,7 +1611,7 @@ describeRepeated("Form common", createFormComponent => {
 
         expect(node.querySelectorAll(".field-error")).to.have.length.of(1);
         expect(
-          node.querySelector(".field-string .error-detail").textContent
+          node.querySelector(".field-string .error-detail").textContent,
         ).eql("should NOT be shorter than 8 characters");
       });
     });
@@ -1617,12 +1640,12 @@ describeRepeated("Form common", createFormComponent => {
             stack: "should NOT be shorter than 8 characters",
           },
           {
-            message: 'should match pattern "d+"',
+            message: "should match pattern \"d+\"",
             name: "pattern",
             params: { pattern: "d+" },
             property: "",
             schemaPath: "#/pattern",
-            stack: 'should match pattern "d+"',
+            stack: "should match pattern \"d+\"",
           },
         ]);
       });
@@ -1635,7 +1658,7 @@ describeRepeated("Form common", createFormComponent => {
 
         expect(errors).eql([
           "should NOT be shorter than 8 characters",
-          'should match pattern "d+"',
+          "should match pattern \"d+\"",
         ]);
       });
     });
@@ -1685,12 +1708,12 @@ describeRepeated("Form common", createFormComponent => {
       it("should denote the error in the field", () => {
         const { node } = createFormComponent(formProps);
         const errorDetail = node.querySelector(
-          ".field-object .field-string .error-detail"
+          ".field-object .field-string .error-detail",
         );
 
         expect(node.querySelectorAll(".field-error")).to.have.length.of(1);
         expect(errorDetail.textContent).eql(
-          "should NOT be shorter than 8 characters"
+          "should NOT be shorter than 8 characters",
         );
       });
     });
@@ -1731,7 +1754,7 @@ describeRepeated("Form common", createFormComponent => {
         const fieldNodes = node.querySelectorAll(".field-string");
 
         const liNodes = fieldNodes[1].querySelectorAll(
-          ".field-string .error-detail li"
+          ".field-string .error-detail li",
         );
         const errors = [].map.call(liNodes, li => li.textContent);
 
@@ -1912,7 +1935,7 @@ describeRepeated("Form common", createFormComponent => {
         const fieldNodes = node.querySelectorAll(".field-string");
 
         const liNodes = fieldNodes[1].querySelectorAll(
-          ".field-string .error-detail li"
+          ".field-string .error-detail li",
         );
         const errors = [].map.call(liNodes, li => li.textContent);
 
@@ -2333,8 +2356,8 @@ describeRepeated("Form common", createFormComponent => {
       });
       expect(
         console.warn.calledWithMatch(
-          /Using autocomplete property of Form is deprecated/
-        )
+          /Using autocomplete property of Form is deprecated/,
+        ),
       ).to.be.true;
     });
 
@@ -2391,12 +2414,12 @@ describeRepeated("Form common", createFormComponent => {
       submitForm(node);
       sinon.assert.calledWithMatch(onError.lastCall, [
         {
-          message: 'should match format "area-code"',
+          message: "should match format \"area-code\"",
           name: "format",
           params: { format: "area-code" },
           property: ".areaCode",
           schemaPath: "#/properties/areaCode/format",
-          stack: '.areaCode should match format "area-code"',
+          stack: ".areaCode should match format \"area-code\"",
         },
       ]);
     });
@@ -2421,7 +2444,7 @@ describeRepeated("Form common", createFormComponent => {
       sinon.assert.calledWithMatch(onError.lastCall, [
         {
           stack:
-            'no schema with key or ref "http://json-schema.org/draft-04/schema#"',
+            "no schema with key or ref \"http://json-schema.org/draft-04/schema#\"",
         },
       ]);
 
@@ -2444,12 +2467,12 @@ describeRepeated("Form common", createFormComponent => {
           stack: "should NOT be shorter than 8 characters",
         },
         {
-          message: 'should match pattern "d+"',
+          message: "should match pattern \"d+\"",
           name: "pattern",
           params: { pattern: "d+" },
           property: "",
           schemaPath: "#/pattern",
-          stack: 'should match pattern "d+"',
+          stack: "should match pattern \"d+\"",
         },
       ]);
 
@@ -2459,7 +2482,7 @@ describeRepeated("Form common", createFormComponent => {
       sinon.assert.calledWithMatch(onError.lastCall, [
         {
           stack:
-            'no schema with key or ref "http://json-schema.org/draft-04/schema#"',
+            "no schema with key or ref \"http://json-schema.org/draft-04/schema#\"",
         },
       ]);
     });
@@ -2881,7 +2904,7 @@ describe("Form omitExtraData and liveOmit", () => {
           "level1.level2",
           "level1.anotherThing.anotherThingNested",
           "level1.anotherThing.anotherThingNested2",
-        ].sort()
+        ].sort(),
       );
     });
 
@@ -2928,7 +2951,7 @@ describe("Form omitExtraData and liveOmit", () => {
 
       const fieldNames = comp.getFieldNames(pathSchema, formData);
       expect(fieldNames.sort()).eql(
-        ["level1a", "level1.level2", "level1.mixedMap"].sort()
+        ["level1a", "level1.level2", "level1.mixedMap"].sort(),
       );
     });
 
@@ -2996,7 +3019,7 @@ describe("Form omitExtraData and liveOmit", () => {
           "address_list.1.city",
           "address_list.1.state",
           "address_list.1.street_address",
-        ].sort()
+        ].sort(),
       );
     });
   });
@@ -3153,7 +3176,7 @@ describe("Form omitExtraData and liveOmit", () => {
         },
         formData: { nested: { key1: "value" } },
       },
-      { omitExtraData: true, liveOmit: true }
+      { omitExtraData: true, liveOmit: true },
     );
 
     const textNode = node.querySelector("#root-key");

--- a/packages/core/test/Form_test.js
+++ b/packages/core/test/Form_test.js
@@ -506,7 +506,7 @@ describeRepeated("Form common", createFormComponent => {
       expect(node.querySelectorAll("input[type=text]")).to.have.length.of(1);
     });
 
-    it("should handle null values for property with additionalProperties", () => {
+    it("should not crash with null values for property with additionalProperties", () => {
       const schema = {
         type: "object",
         properties: {
@@ -523,6 +523,36 @@ describeRepeated("Form common", createFormComponent => {
         schema,
         formData: {
           data: null,
+        },
+      });
+
+      expect(node).to.not.be.null;
+    });
+
+    it("should not crash with non-object values for property with additionalProperties", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          data1: {
+            additionalProperties: {
+              type: "string",
+            },
+            type: "object",
+          },
+          data2: {
+            additionalProperties: {
+              type: "string",
+            },
+            type: "object",
+          },
+        },
+      };
+
+      const { node } = createFormComponent({
+        schema,
+        formData: {
+          data1: 123,
+          data2: ["one","two","three"]
         },
       });
 

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -1770,6 +1770,21 @@ describe("utils", () => {
       });
     });
 
+    it("should handle null formData for schema which contains additionalProperties", () => {
+      const schema = {
+        additionalProperties: {
+          type: "string",
+        },
+        type: "object"
+      };
+
+      const formData = null;
+      expect( retrieveSchema(schema, {}, formData)).eql({
+        ...schema,
+        properties: {}
+      });
+    });
+
     it("should priorize local definitions over foreign ones", () => {
       const schema = {
         $ref: "#/definitions/address",

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -1775,13 +1775,13 @@ describe("utils", () => {
         additionalProperties: {
           type: "string",
         },
-        type: "object"
+        type: "object",
       };
 
       const formData = null;
-      expect( retrieveSchema(schema, {}, formData)).eql({
+      expect(retrieveSchema(schema, {}, formData)).eql({
         ...schema,
-        properties: {}
+        properties: {},
       });
     });
 


### PR DESCRIPTION
### Reasons for making this change

Fixed a crash when null formData was passed for property with additionalProperties defined in the schema

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
