### PR TITLE
MUI rendered is missing any control over the fields render. Other ren…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 
 # v3.2.1 (upcoming)
+- MUI: Added ui-schema 'fieldFlexWidth' variable to override object field Flex Grid 'xs' default size '12' (https://github.com/rjsf-team/react-jsonschema-form/pull/2597)
 
 # v3.2.0
 

--- a/packages/material-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/material-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -57,7 +57,7 @@ const ObjectFieldTemplate = ({
           ) : (
             <Grid
               item={true}
-              xs={12}
+              xs={uiSchema['ui:fieldFlexWidth'] || 12}
               key={index}
               style={{ marginBottom: "10px" }}>
               {element.content}


### PR DESCRIPTION
Other renders have 'className' variable to control the style of the forms fields. Toward this end I added 'fieldFlexWidth' uiSchema varaible to control the flex grid withs in MUI ObjectFieldTemplate.tsx instead of the hard coded '12'. If variable is not the the code defaults to '12' as before and code behaves exactly as before.

### Reasons for making this change
Other renders have 'className' variable to control the style of the forms fields. MUI rendered has no way to control the style. And in order to be able to render form in multiple columns #2108 and have some responsiveness to UI. Change is minimal and non volatile. When not used it has no effect on the behavior and code defaults to previously hard coded value. 


### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature


