### PR TITLE
Add file preview option on FileWidget

### DIFF
--- a/packages/core/src/components/widgets/FileWidget.js
+++ b/packages/core/src/components/widgets/FileWidget.js
@@ -28,18 +28,45 @@ function processFiles(files) {
   return Promise.all([].map.call(files, processFile));
 }
 
+function FileInfoPreview(props) {
+  const { dataURL, type } = props;
+  const onPreviewButtonClicked = () => {
+    window.location.href = dataURL;
+  };
+
+  if (type.indexOf("image") !== -1) {
+    return (
+      <img
+        src={dataURL}
+        style={{ maxWidth: "100%" }}
+        className="file-preview"
+      />
+    );
+  }
+
+  return (
+    <button onClick={onPreviewButtonClicked} className="file-preview">
+      Click to preview
+    </button>
+  );
+}
+
 function FilesInfo(props) {
-  const { filesInfo } = props;
+  const { filesInfo, fileOptions } = props;
+  const { preview } = fileOptions;
+
   if (filesInfo.length === 0) {
     return null;
   }
   return (
     <ul className="file-info">
       {filesInfo.map((fileInfo, key) => {
-        const { name, size, type } = fileInfo;
+        const { name, size, type, dataURL } = fileInfo;
         return (
           <li key={key}>
             <strong>{name}</strong> ({type}, {size} bytes)
+            <br />
+            {preview && <FileInfoPreview type={type} dataURL={dataURL} />}
           </li>
         );
       })}
@@ -107,7 +134,7 @@ class FileWidget extends Component {
             accept={options.accept}
           />
         </p>
-        <FilesInfo filesInfo={filesInfo} />
+        <FilesInfo filesInfo={filesInfo} fileOptions={options} />
       </div>
     );
   }

--- a/packages/core/src/components/widgets/FileWidget.js
+++ b/packages/core/src/components/widgets/FileWidget.js
@@ -29,10 +29,7 @@ function processFiles(files) {
 }
 
 function FileInfoPreview(props) {
-  const { dataURL, type } = props;
-  const onPreviewButtonClicked = () => {
-    window.location.href = dataURL;
-  };
+  const { dataURL, type, name } = props;
 
   if (type.indexOf("image") !== -1) {
     return (
@@ -45,9 +42,9 @@ function FileInfoPreview(props) {
   }
 
   return (
-    <button onClick={onPreviewButtonClicked} className="file-preview">
-      Click to preview
-    </button>
+    <a download={`preview-${name}`} href={dataURL}>
+      Preview
+    </a>
   );
 }
 
@@ -63,10 +60,13 @@ function FilesInfo(props) {
       {filesInfo.map((fileInfo, key) => {
         const { name, size, type, dataURL } = fileInfo;
         return (
-          <li key={key}>
-            <strong>{name}</strong> ({type}, {size} bytes)
-            <br />
-            {preview && <FileInfoPreview type={type} dataURL={dataURL} />}
+          <li key={key} style={{ marginBottom: "15px" }}>
+            <p>
+              <strong>{name}</strong> ({type}, {size} bytes)
+            </p>
+            {preview && (
+              <FileInfoPreview type={type} dataURL={dataURL} name={name} />
+            )}
           </li>
         );
       })}

--- a/packages/core/test/StringField_test.js
+++ b/packages/core/test/StringField_test.js
@@ -1943,6 +1943,21 @@ describe("StringField", () => {
 
       expect(node.querySelector("#custom")).to.exist;
     });
+
+    it("should render the file widget with preview attribute", () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: "string",
+          format: "data-url",
+        },
+        uiSchema: {
+          "ui:options": { preview: true },
+        },
+        formData: "data:text/plain;name=file1.txt;base64,x=",
+      });
+
+      expect(node.querySelector(".file-preview")).to.exist;
+    });
   });
 
   describe("UpDownWidget", () => {


### PR DESCRIPTION
### Reasons for making this change

My user needs to preview file before uploading to ensure that the correct file is inserted.

This is similar to #698, but 
- my user need to preview other file type as well (mostly .pdf and .csv)
- preview is optional, need to add `"preview": true` to the UiSchema

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
