### PR TITLE
To improve performance, skip validating subschemas in oneOf / anyOf if formData is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 # v4.0.2 (upcoming)
 
+## @rjsf/core
+
+- For performance, skip validating subschemas if formData is undefined (#2676)
+
 # v4.0.1
 
 - Bumped the peer dependencies of `@rjsf/core` to `^4.0.0` for all of themes in `package.json`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 
-- For performance, skip validating subschemas if formData is undefined (#2676)
+- To improve performance, skip validating subschemas in oneOf / anyOf if formData is undefined (#2676)
 
 # v4.0.1
 

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1296,7 +1296,6 @@ export function getMatchingOption(formData, options, rootSchema) {
       if (isValid(augmentedSchema, formData, rootSchema)) {
         return i;
       }
-    
     } else if (isValid(option, formData, rootSchema)) {
       return i;
     }

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1291,7 +1291,7 @@ export function getMatchingOption(formData, options, rootSchema) {
       if (formData && isValid(augmentedSchema, formData, rootSchema)) {
         return i;
       }
-      return i;
+    
     } else if (formData && isValid(option, formData, rootSchema)) {
       return i;
     }

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1288,10 +1288,11 @@ export function getMatchingOption(formData, options, rootSchema) {
       // been filled in yet, which will mean that the schema is not valid
       delete augmentedSchema.required;
 
-      if (isValid(augmentedSchema, formData, rootSchema)) {
+      if (formData && isValid(augmentedSchema, formData, rootSchema)) {
         return i;
       }
-    } else if (isValid(option, formData, rootSchema)) {
+      return i;
+    } else if (formData && isValid(option, formData, rootSchema)) {
       return i;
     }
   }

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1244,6 +1244,11 @@ export function rangeSpec(schema) {
 }
 
 export function getMatchingOption(formData, options, rootSchema) {
+  // For performance, skip validating subschemas if formData is undefined. We just
+  // want to get the first option in that case.
+  if (formData === undefined) {
+    return 0;
+  }
   for (let i = 0; i < options.length; i++) {
     const option = options[i];
 
@@ -1288,11 +1293,11 @@ export function getMatchingOption(formData, options, rootSchema) {
       // been filled in yet, which will mean that the schema is not valid
       delete augmentedSchema.required;
 
-      if (formData && isValid(augmentedSchema, formData, rootSchema)) {
+      if (isValid(augmentedSchema, formData, rootSchema)) {
         return i;
       }
     
-    } else if (formData && isValid(option, formData, rootSchema)) {
+    } else if (isValid(option, formData, rootSchema)) {
       return i;
     }
   }

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -4227,6 +4227,24 @@ describe("utils", () => {
       ];
       expect(getMatchingOption(undefined, options, rootSchema)).eql(0);
     });
+    it("should infer correct anyOf schema based on data if passing null and option 2 is {type: null}", () => {
+      const rootSchema = {
+        defs: {
+          a: { type: "object", properties: { id: { enum: ["a"] } } },
+          nested: {
+            type: "object",
+            properties: {
+              id: { enum: ["nested"] },
+              child: { $ref: "#/defs/any" },
+            },
+          },
+          any: { anyOf: [{ $ref: "#/defs/a" }, { $ref: "#/defs/nested" }] },
+        },
+        $ref: "#/defs/any",
+      };
+      const options = [{type: "string"}, {type: "string"}, {type: "null"}];
+      expect(getMatchingOption(null, options, rootSchema)).eql(2);
+    });
     it("should infer correct anyOf schema based on data", () => {
       const rootSchema = {
         defs: {

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -4242,7 +4242,11 @@ describe("utils", () => {
         },
         $ref: "#/defs/any",
       };
-      const options = [{type: "string"}, {type: "string"}, {type: "null"}];
+      const options = [
+        { type: "string" },
+        { type: "string" },
+        { type: "null" },
+      ];
       expect(getMatchingOption(null, options, rootSchema)).eql(2);
     });
     it("should infer correct anyOf schema based on data", () => {

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -4200,6 +4200,33 @@ describe("utils", () => {
         }))
       );
     });
+    it("should infer correct anyOf schema based on data if passing undefined", () => {
+      const rootSchema = {
+        defs: {
+          a: { type: "object", properties: { id: { enum: ["a"] } } },
+          nested: {
+            type: "object",
+            properties: {
+              id: { enum: ["nested"] },
+              child: { $ref: "#/defs/any" },
+            },
+          },
+          any: { anyOf: [{ $ref: "#/defs/a" }, { $ref: "#/defs/nested" }] },
+        },
+        $ref: "#/defs/any",
+      };
+      const options = [
+        { type: "object", properties: { id: { enum: ["a"] } } },
+        {
+          type: "object",
+          properties: {
+            id: { enum: ["nested"] },
+            child: { $ref: "#/defs/any" },
+          },
+        },
+      ];
+      expect(getMatchingOption(undefined, options, rootSchema)).eql(0);
+    });
     it("should infer correct anyOf schema based on data", () => {
       const rootSchema = {
         defs: {


### PR DESCRIPTION
Fixing getMatchingOption in the case of oneOf/anyOf by validating schema only when formData is available

### Reasons for making this change

When there is a property with oneOf/anyOf - schema gets validated when there is not formData provided which leads to lot of load time. This fix will improves speed and performance.

