### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,8 @@
 
 If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).
 
+If your PR is non-trivial and you'd like to schedule a synchronous review, please add it to the weekly meeting agenda: https://docs.google.com/document/d/12PjTvv21k6LIky6bNQVnsplMLLnmEuypTLQF8a-8Wss/edit
+
 ### Checklist
 
 * [ ] **I'm updating documentation**


### PR DESCRIPTION
### Reasons for making this change

Make it clear that people can request a synchronous review by adding their PR to the meeting agenda.