### PR TITLE
feat: chakra-ui adds name prop to hidden

### DIFF
--- a/packages/chakra-ui/src/HiddenWidget/HiddenWidget.tsx
+++ b/packages/chakra-ui/src/HiddenWidget/HiddenWidget.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { WidgetProps } from "@rjsf/core";
+
+const HiddenWidget = ({ id, value }: WidgetProps) => {
+  return (
+    <input
+      id={id}
+      name={id}
+      value={typeof value === "undefined" ? "" : value}
+      type="hidden"
+    />
+  );
+};
+
+export default HiddenWidget;

--- a/packages/chakra-ui/src/HiddenWidget/index.ts
+++ b/packages/chakra-ui/src/HiddenWidget/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./HiddenWidget";
+export * from "./HiddenWidget";

--- a/packages/chakra-ui/src/Widgets/Widgets.ts
+++ b/packages/chakra-ui/src/Widgets/Widgets.ts
@@ -6,6 +6,7 @@ import ColorWidget from "../ColorWidget/ColorWidget";
 import DateWidget from "../DateWidget/DateWidget";
 import DateTimeWidget from "../DateTimeWidget/DateTimeWidget";
 import EmailWidget from "../EmailWidget/EmailWidget";
+import HiddenWidget from "../HiddenWidget/HiddenWidget";
 import PasswordWidget from "../PasswordWidget/PasswordWidget";
 import RadioWidget from "../RadioWidget/RadioWidget";
 import RangeWidget from "../RangeWidget/RangeWidget";
@@ -24,6 +25,7 @@ const widgets = {
   DateWidget,
   DateTimeWidget,
   EmailWidget,
+  HiddenWidget,
   PasswordWidget,
   RadioWidget,
   RangeWidget,

--- a/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`single fields hidden field 1`] = `
     >
       <input
         id="root_my-field"
+        name="root_my-field"
         type="hidden"
         value=""
       />


### PR DESCRIPTION
### Reasons for making this change

To align with the rest of `@rjsf/chakra-ui` , have added a name prop to the hidden input. 
This is as such it could be used in tools such as Remix.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
