### PR TITLE
(Hopefully) Fixed the issues described in #2721

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,19 +15,24 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# v5.0.0 (coming soon)
+
 # v4.0.2 (upcoming)
 
 # v4.0.1
 
+- Bumped the peer dependencies of `@rjsf/core` to `^4.0.0` for all of themes in `package.json`
+- Also, added tests to all themes to verify that the `tagName` prop works as expected
+
 ## @rjsf/core
-- Added new `_internalFormWrapper` prop to `Form` that supports the `semantic-ui` and `material-ui` themes to work when `tagName` is provided
+- Updated `Form` to support the `semantic-ui` and `material-ui` themes to allow them work when `tagName` is provided
 
 ## @rjsf/material-ui
-- Fixed up the `Theme` and `Theme5` implementation to use `_internalFormWrapper` rather than `tagName` for the themes to pass their form wrapper implementations
-- Only `console.log()` the import error in `MaterialUIContext` and `Mui5Context` when not in `production` to eliminate ton's of warnings for released code
+- Fixed up the `Theme` and `Theme5` implementations to deal with a regression in which adding `tagName` caused the 2 themes to not work
+- Only `console.log()` the import error in `MaterialUIContext` and `Mui5Context` when not in `production` to eliminate tons of warnings for released code
 
 ## @rjsf/semantic-ui
-- Fixed up the `Theme` implementation to use `_internalFormWrapper` rather than `tagName` for the theme to pass its form wrapper implementation
+- Fixed up the `Theme` implementation to deal with a regression in which adding `tagName` caused the theme to not work
 
 # v4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,19 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
-# v4.0.1 (upcoming)
+# v4.0.2 (upcoming)
+
+# v4.0.1
+
+## @rjsf/core
+- Added new `_internalFormWrapper` prop to `Form` that supports the `semantic-ui` and `material-ui` themes to work when `tagName` is provided
+
+## @rjsf/material-ui
+- Fixed up the `Theme` and `Theme5` implementation to use `_internalFormWrapper` rather than `tagName` for the themes to pass their form wrapper implementations
+- Only `console.log()` the import error in `MaterialUIContext` and `Mui5Context` when not in `production` to eliminate ton's of warnings for released code
+
+## @rjsf/semantic-ui
+- Fixed up the `Theme` implementation to use `_internalFormWrapper` rather than `tagName` for the theme to pass its form wrapper implementation
 
 # v4.0.0
 

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "@ant-design/icons": "^4.0.0",
-    "@rjsf/core": "^3.0.0",
+    "@rjsf/core": "^4.0.0",
     "antd": "^4.0.0",
     "antd-dayjs-webpack-plugin": "1.0.0",
     "dayjs": "^1.8.0",

--- a/packages/antd/test/Form.test.js
+++ b/packages/antd/test/Form.test.js
@@ -129,4 +129,13 @@ describe("single fields", () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+  test("using custom tagName", () => {
+    const schema = {
+      type: "string"
+    };
+    const tree = renderer
+      .create(<Form schema={schema} tagName="div"/>)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/antd/test/__snapshots__/Form.test.js.snap
+++ b/packages/antd/test/__snapshots__/Form.test.js.snap
@@ -587,3 +587,42 @@ exports[`single fields unsupported field 1`] = `
   </div>
 </form>
 `;
+
+exports[`single fields using custom tagName 1`] = `
+<div
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <input
+      className="ant-input"
+      disabled={false}
+      id="root"
+      name="root"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      placeholder=""
+      style={
+        Object {
+          "width": "100%",
+        }
+      }
+      type="text"
+      value=""
+    />
+  </div>
+  <div>
+    <button
+      className="btn btn-info"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;

--- a/packages/bootstrap-4/package.json
+++ b/packages/bootstrap-4/package.json
@@ -18,7 +18,7 @@
     "test": "tsdx test"
   },
   "peerDependencies": {
-    "@rjsf/core": "^3.0.0",
+    "@rjsf/core": "^4.0.0",
     "react": ">=16",
     "react-bootstrap": "^1.0.1"
   },

--- a/packages/bootstrap-4/test/Form.test.tsx
+++ b/packages/bootstrap-4/test/Form.test.tsx
@@ -236,4 +236,13 @@ describe("single fields", () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+  test("using custom tagName", () => {
+    const schema: JSONSchema7 = {
+      type: "string"
+    };
+    const tree = renderer
+      .create(<Form schema={schema} tagName="div"/>)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
@@ -1052,3 +1052,45 @@ exports[`single fields unsupported field 1`] = `
   </div>
 </form>
 `;
+
+exports[`single fields using custom tagName 1`] = `
+<div
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group"
+  >
+    <div
+      className="mb-0 form-group"
+    >
+      <label
+        className="form-label"
+      />
+      <input
+        autoFocus={false}
+        className="form-control"
+        disabled={false}
+        id="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        type="text"
+        value=""
+      />
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;

--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "@chakra-ui/icons": ">=1.1.1",
     "@chakra-ui/react": ">=1.7.3",
-    "@rjsf/core": "^3.0.0",
+    "@rjsf/core": "^4.0.0",
     "framer-motion": ">=5.5.5",
     "react": ">=16"
   },

--- a/packages/chakra-ui/test/Form.test.tsx
+++ b/packages/chakra-ui/test/Form.test.tsx
@@ -79,4 +79,13 @@ describe("single fields", () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+  test("using custom tagName", () => {
+    const schema: JSONSchema7 = {
+      type: "string"
+    };
+    const tree = renderer
+      .create(<Form schema={schema} tagName="div"/>)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
@@ -599,3 +599,84 @@ exports[`single fields unsupported field 1`] = `
   </div>
 </form>
 `;
+
+exports[`single fields using custom tagName 1`] = `
+.emotion-1 {
+  margin-bottom: 1px;
+}
+
+.emotion-3 {
+  margin-top: 3px;
+}
+
+.emotion-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  position: relative;
+  white-space: nowrap;
+  vertical-align: middle;
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  width: auto;
+}
+
+<div
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="chakra-form-control emotion-0"
+    role="group"
+  >
+    <div
+      className="chakra-form-control emotion-1"
+      role="group"
+    >
+      <input
+        autoFocus={false}
+        className="chakra-input emotion-0"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        required={false}
+        type="text"
+        value=""
+      />
+    </div>
+  </div>
+  <div
+    className="emotion-3"
+  >
+    <button
+      className="chakra-button emotion-4"
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -51,7 +51,10 @@ declare module '@rjsf/core' {
         uiSchema?: UiSchema;
         validate?: (formData: T, errors: FormValidation) => FormValidation;
         widgets?: { [name: string]: Widget };
-        /** WARNING: This exists for internal react-jsonschema-form purposes only. Use ONLY if you know what you are doing */
+        /**
+         * WARNING: This exists for internal react-jsonschema-form purposes only. No guarantees of backwards
+         * compatibility. Use ONLY if you know what you are doing
+         */
         _internalFormWrapper?: React.ElementType;
     }
 

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -51,7 +51,7 @@ declare module '@rjsf/core' {
         uiSchema?: UiSchema;
         validate?: (formData: T, errors: FormValidation) => FormValidation;
         widgets?: { [name: string]: Widget };
-        // WARNING: This exists for internal react-jsonschema-form purposes only. Use ONLY if you know what you are doing
+        /** WARNING: This exists for internal react-jsonschema-form purposes only. Use ONLY if you know what you are doing */
         _internalFormWrapper?: React.ElementType;
     }
 

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -51,6 +51,8 @@ declare module '@rjsf/core' {
         uiSchema?: UiSchema;
         validate?: (formData: T, errors: FormValidation) => FormValidation;
         widgets?: { [name: string]: Widget };
+        // WARNING: This exists for internal react-jsonschema-form purposes only. Use ONLY if you know what you are doing
+        _internalFormWrapper?: React.ElementType;
     }
 
     export default class Form<T> extends React.Component<FormProps<T>> {

--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -443,6 +443,19 @@ export default class Form extends Component {
       disabled,
       readonly,
       formContext,
+      /**
+       * _internalFormWrapper is currently used by the material-ui and semantic-ui themes to provide a custom wrapper
+       * around the `form` that supports the proper rendering of those themes. To use this prop, one must pass a
+       * component that takes two props: `children` and `as`. That component, at minimum, will render the `children`
+       * inside of a <form /> tag unless `as` is provided, in which case, use the `as` prop in place of the `form`.
+       * i.e.:
+       * ```
+       * export default function InternalForm({ children, as}) {
+       *   const FormTag = as || 'form';
+       *   return <FormTag>{children}</FormTag>;
+       * }
+       * ```
+       */
       _internalFormWrapper,
     } = this.props;
 

--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -443,12 +443,17 @@ export default class Form extends Component {
       disabled,
       readonly,
       formContext,
+      _internalFormWrapper,
     } = this.props;
 
     const { schema, uiSchema, formData, errorSchema, idSchema } = this.state;
     const registry = this.getRegistry();
     const _SchemaField = registry.fields.SchemaField;
-    const FormTag = tagName ? tagName : "form";
+    // The `semantic-ui` and `material-ui` themes have `_internalFormWrappers` that take an `as` prop that is the
+    // PropTypes.elementType to use for the inner tag so we'll need to pass `tagName` along if it is provided.
+    // NOTE, the `as` prop is native to `semantic-ui` and is emulated in the `material-ui` theme
+    const as = _internalFormWrapper ? tagName : undefined;
+    const FormTag = _internalFormWrapper || tagName || "form";
     if (deprecatedAutocomplete) {
       console.warn(
         "Using autocomplete property of Form is deprecated, use autoComplete instead."
@@ -471,6 +476,7 @@ export default class Form extends Component {
         acceptCharset={acceptcharset}
         noValidate={noHtml5Validate}
         onSubmit={this.onSubmit}
+        as={as}
         ref={form => {
           this.formElement = form;
         }}>
@@ -527,6 +533,7 @@ if (process.env.NODE_ENV !== "production") {
     id: PropTypes.string,
     className: PropTypes.string,
     tagName: PropTypes.elementType,
+    _internalFormWrapper: PropTypes.elementType,
     name: PropTypes.string,
     method: PropTypes.string,
     target: PropTypes.string,

--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -445,9 +445,9 @@ export default class Form extends Component {
       formContext,
       /**
        * _internalFormWrapper is currently used by the material-ui and semantic-ui themes to provide a custom wrapper
-       * around the `form` that supports the proper rendering of those themes. To use this prop, one must pass a
-       * component that takes two props: `children` and `as`. That component, at minimum, will render the `children`
-       * inside of a <form /> tag unless `as` is provided, in which case, use the `as` prop in place of the `form`.
+       * around `<Form />` that supports the proper rendering of those themes. To use this prop, one must pass a
+       * component that takes two props: `children` and `as`. That component, at minimum, should render the `children`
+       * inside of a <form /> tag unless `as` is provided, in which case, use the `as` prop in place of `<form />`.
        * i.e.:
        * ```
        * export default function InternalForm({ children, as}) {

--- a/packages/core/src/components/Form.js
+++ b/packages/core/src/components/Form.js
@@ -449,7 +449,7 @@ export default class Form extends Component {
     const { schema, uiSchema, formData, errorSchema, idSchema } = this.state;
     const registry = this.getRegistry();
     const _SchemaField = registry.fields.SchemaField;
-    // The `semantic-ui` and `material-ui` themes have `_internalFormWrappers` that take an `as` prop that is the
+    // The `semantic-ui` and `material-ui` themes have `_internalFormWrapper`s that take an `as` prop that is the
     // PropTypes.elementType to use for the inner tag so we'll need to pass `tagName` along if it is provided.
     // NOTE, the `as` prop is native to `semantic-ui` and is emulated in the `material-ui` theme
     const as = _internalFormWrapper ? tagName : undefined;

--- a/packages/fluent-ui/package.json
+++ b/packages/fluent-ui/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "@fluentui/react": "^7.114.2",
-    "@rjsf/core": "^3.0.0",
+    "@rjsf/core": "^4.0.0",
     "react": ">=16"
   },
   "devDependencies": {

--- a/packages/fluent-ui/test/Form.test.tsx
+++ b/packages/fluent-ui/test/Form.test.tsx
@@ -92,4 +92,13 @@ describe("single fields", () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+  test("using custom tagName", () => {
+    const schema: JSONSchema7 = {
+      type: "string"
+    };
+    const tree = renderer
+      .create(<Form schema={schema} tagName="div"/>)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
@@ -588,3 +588,83 @@ exports[`single fields unsupported field 1`] = `
   </div>
 </form>
 `;
+
+exports[`single fields using custom tagName 1`] = `
+<div
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="ms-Grid-col ms-sm12  field field-string"
+    style={
+      Object {
+        "display": undefined,
+        "marginBottom": 15,
+      }
+    }
+  >
+    <div
+      className="ms-TextField root-42"
+    >
+      <div
+        className="ms-TextField-wrapper"
+      >
+        <div
+          className="ms-TextField-fieldGroup fieldGroup-43"
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="ms-TextField-field field-44"
+            disabled={false}
+            id="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            placeholder=""
+            readOnly={false}
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <br />
+    <div
+      className="ms-Grid-col ms-sm12"
+    >
+      <button
+        className="ms-Button ms-Button--primary root-50"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="submit"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-51"
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className="ms-Button-textContainer textContainer-52"
+          >
+            <span
+              className="ms-Button-label label-54"
+              id="id__40"
+            >
+              Submit
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -20,7 +20,7 @@
     "@material-ui/icons": "^4.11.2",
     "@mui/icons-material": "^5.2.0",
     "@mui/material": "^5.2.2",
-    "@rjsf/core": "^3.0.0",
+    "@rjsf/core": "^4.0.0",
     "@types/react": "^16.8.6 || ^17.0.0",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"

--- a/packages/material-ui/src/Theme/MaterialUIContext.tsx
+++ b/packages/material-ui/src/Theme/MaterialUIContext.tsx
@@ -9,7 +9,9 @@ try {
   mui = require('@material-ui/core');
   icons = require('@material-ui/icons');
 } catch (err) {
-  console.log(err);
+  if (process.env.NODE_ENV !== 'PRODUCTION') {
+    console.log(err);
+  }
 }
 
 export let MaterialUIContext: MaterialUIContextProps;

--- a/packages/material-ui/src/Theme/Theme.tsx
+++ b/packages/material-ui/src/Theme/Theme.tsx
@@ -5,28 +5,29 @@ import MuiComponentContext from '../MuiComponentContext';
 import ThemeCommon from '../ThemeCommon';
 import { MaterialUIContext, DefaultChildren } from './MaterialUIContext';
 
-/** Create a component that will wrap a ref-able HTML `form` with a `MuiComponentContext.Provider` so that all of the
+/** Create a component that will wrap a ref-able HTML "form" with a `MuiComponentContext.Provider` so that all of the
  * `@material-ui` fields, widgets and helpers will be rendered using the Material UI version 4 components. If the
  * `MaterialUIContext` does not exist, then the form will contain a simple warning that `@material-ui` is not available.
+ * If the `as` prop is passed in then use that as the `FormTag` for the ref otherwise `form`.
  */
-const Mui4TagName = React.forwardRef(
+const Mui4FormWrapper = React.forwardRef(
   function Mui4TagName(props: Omit<PropsWithChildren<HTMLFormElement>, 'contentEditable'>,
-                       ref: Ref<HTMLFormElement>) {
-    const { children, ...rest } = props;
+                       ref: Ref<HTMLBaseElement>) {
+    const { children, as: FormTag = 'form', ...rest } = props;
     return (
       <MuiComponentContext.Provider value={MaterialUIContext || {}}>
-        <form ref={ref} {...rest}>
+        <FormTag ref={ref} {...rest}>
           {MaterialUIContext ? children : <div>WARNING: @material-ui/core or @material-ui/icons is not available</div>}
-        </form>
+        </FormTag>
       </MuiComponentContext.Provider>
     );
   }
 );
 
-/** The Material UI 4 theme, with the `Mui4TagName` and `DefaultChildren`
+/** The Material UI 4 theme, with the `Mui4FormWrapper` and `DefaultChildren`
  */
 const Theme: ThemeProps = {
-  tagName: Mui4TagName,
+  _internalFormWrapper: Mui4FormWrapper,
   children: <DefaultChildren />,
   ...ThemeCommon,
 };

--- a/packages/material-ui/src/Theme5/Mui5Context.tsx
+++ b/packages/material-ui/src/Theme5/Mui5Context.tsx
@@ -10,7 +10,9 @@ try {
   mui = require('@mui/material');
   icons = require('@mui/icons-material');
 } catch (err) {
-  console.log(err);
+  if (process.env.NODE_ENV !== 'PRODUCTION') {
+    console.log(err);
+  }
 }
 
 export let Mui5Context: Mui5ContextProps;

--- a/packages/material-ui/src/Theme5/Theme5.tsx
+++ b/packages/material-ui/src/Theme5/Theme5.tsx
@@ -5,28 +5,29 @@ import MuiComponentContext from '../MuiComponentContext';
 import ThemeCommon from '../ThemeCommon';
 import { Mui5Context, DefaultChildren } from './Mui5Context';
 
-/** Create a component that will wrap a ref-able HTML `form` with a `MuiComponentContext.Provider` so that all of the
+/** Create a component that will wrap a ref-able HTML "form" with a `MuiComponentContext.Provider` so that all of the
  * `@mui` fields, widgets and helpers will be rendered using the Material UI version 5 components. If the `Mui5Context`
- * does not exist, then the form will contain a simple warning that `@mui` is not available.
+ * does not exist, then the form will contain a simple warning that `@mui` is not available. If the `as` prop is passed
+ * in then use that as the `FormTag` for the ref otherwise `form`.
  */
-const Mui5TagName = React.forwardRef(
+const Mui5FormWrapper = React.forwardRef(
   function Mui5TagName(props: Omit<PropsWithChildren<HTMLFormElement>, 'contentEditable'>,
-                       ref: Ref<HTMLFormElement>) {
-    const { children, ...rest } = props;
+                       ref: Ref<HTMLBaseElement>) {
+    const { children, as: FormTag = 'form', ...rest } = props;
     return (
       <MuiComponentContext.Provider value={Mui5Context || {}}>
-        <form ref={ref} {...rest}>
+        <FormTag ref={ref} {...rest}>
           {Mui5Context ? children : <div>WARNING: @mui/material or @mui/icons-material is not available</div>}
-        </form>
+        </FormTag>
       </MuiComponentContext.Provider>
     );
   }
 );
 
-/** The Material UI 5 theme, with the `Mui5TagName` and `DefaultChildren`
+/** The Material UI 5 theme, with the `Mui5FormWrapper` and `DefaultChildren`
  */
 const Theme5: ThemeProps = {
-  tagName: Mui5TagName,
+  _internalFormWrapper: Mui5FormWrapper,
   children: <DefaultChildren />,
   ...ThemeCommon,
 };

--- a/packages/material-ui/test/Form.test.tsx
+++ b/packages/material-ui/test/Form.test.tsx
@@ -230,4 +230,11 @@ describe("single fields", () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+  test("using custom tagName", () => {
+    const schema: JSONSchema7 = {
+      type: "string",
+    };
+    const tree = renderer.create(<Form schema={schema} tagName="div" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -1714,3 +1714,70 @@ exports[`single fields unsupported field 1`] = `
   </div>
 </form>
 `;
+
+exports[`single fields using custom tagName 1`] = `
+<div
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="MuiFormControl-root MuiFormControl-fullWidth"
+  >
+    <div
+      className="MuiFormControl-root MuiTextField-root"
+    >
+      <div
+        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+        onClick={[Function]}
+      >
+        <input
+          aria-invalid={false}
+          autoFocus={false}
+          className="MuiInputBase-input MuiInput-input"
+          disabled={false}
+          id="root"
+          onAnimationStart={[Function]}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          required={false}
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className="MuiBox-root MuiBox-root-29"
+  >
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+      disabled={false}
+      onBlur={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="submit"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        Submit
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</div>
+`;

--- a/packages/material-ui/test/mui-5/Form.test.tsx
+++ b/packages/material-ui/test/mui-5/Form.test.tsx
@@ -232,4 +232,11 @@ describe("single fields", () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+  test("using custom tagName", () => {
+    const schema: JSONSchema7 = {
+      type: "string",
+    };
+    const tree = renderer.create(<Form schema={schema} tagName="div" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/material-ui/test/mui-5/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/mui-5/__snapshots__/Form.test.tsx.snap
@@ -1837,3 +1837,81 @@ exports[`single fields unsupported field 1`] = `
   </div>
 </form>
 `;
+
+exports[`single fields using custom tagName 1`] = `
+<div
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="MuiFormControl-root MuiFormControl-fullWidth css-q8hpuo-MuiFormControl-root"
+  >
+    <div
+      className="MuiFormControl-root MuiTextField-root css-1u3bzj6-MuiFormControl-root-MuiTextField-root"
+    >
+      <div
+        className="MuiOutlinedInput-root MuiInputBase-root MuiInputBase-colorPrimary MuiInputBase-formControl css-9ddj71-MuiInputBase-root-MuiOutlinedInput-root"
+        onClick={[Function]}
+      >
+        <input
+          aria-invalid={false}
+          autoFocus={false}
+          className="MuiOutlinedInput-input MuiInputBase-input css-1t8l2tu-MuiInputBase-input-MuiOutlinedInput-input"
+          disabled={false}
+          id="root"
+          onAnimationStart={[Function]}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          required={false}
+          type="text"
+          value=""
+        />
+        <fieldset
+          aria-hidden={true}
+          className="MuiOutlinedInput-notchedOutline css-1d3z3hw-MuiOutlinedInput-notchedOutline"
+        >
+          <legend
+            className="css-nnbavb"
+          >
+            <span
+              className="notranslate"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "&#8203;",
+                }
+              }
+            />
+          </legend>
+        </fieldset>
+      </div>
+    </div>
+  </div>
+  <div
+    className="MuiBox-root css-178yklu"
+  >
+    <button
+      className="MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButtonBase-root  css-sghohy-MuiButtonBase-root-MuiButton-root"
+      disabled={false}
+      onBlur={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</div>
+`;

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -26,7 +26,7 @@
     "test": "cross-env NODE_ENV=test BABEL_ENV=test jest"
   },
   "peerDependencies": {
-    "@rjsf/core": "^3.0.0",
+    "@rjsf/core": "^4.0.0",
     "lodash": "^4.17.15",
     "nanoid": "^3.1.23",
     "react": ">=16",

--- a/packages/semantic-ui/src/Theme/Theme.js
+++ b/packages/semantic-ui/src/Theme/Theme.js
@@ -17,7 +17,7 @@ const Theme = {
   fields: { ...fields, ...Fields },
   FieldTemplate,
   ObjectFieldTemplate,
-  tagName: SuiForm,
+  _internalFormWrapper: SuiForm,
   widgets: { ...widgets, ...Widgets },
   children: React.createElement(SubmitButton)
 };

--- a/packages/semantic-ui/test/Form.test.js
+++ b/packages/semantic-ui/test/Form.test.js
@@ -105,5 +105,14 @@ describe("single fields", () => {
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
+  test("testing with tagName", () => {
+    const schema = {
+      type: "string"
+    };
+    const tree = renderer
+      .create(<Form schema={schema} tagName="div"/>)
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
 });

--- a/packages/semantic-ui/test/__snapshots__/Form.test.js.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.js.snap
@@ -209,6 +209,46 @@ exports[`single fields string field regular 1`] = `
 </form>
 `;
 
+exports[`single fields testing with tagName 1`] = `
+<div
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="grouped equal width fields"
+  >
+    <div
+      className="field"
+    >
+      <div
+        className="ui fluid input"
+      >
+        <input
+          aria-describedby={null}
+          autoFocus={false}
+          disabled={false}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</div>
+`;
+
 exports[`single fields uiSchema theme props 1`] = `
 <form
   className="ui form rjsf"


### PR DESCRIPTION
### Reasons for making this change
Fix #2721 as follows:

- Manually bump `@rjsf/core` in all the `package.json` files in `peerDependencies` to `^4.0.0`
- Updated `@rjsf/core` implementation of `Form` to add a new `_internalFormWrapper` prop that is used to support the form wrapping done in the `material-ui` and `semantic-ui` themes
  - This preserves the theme functionality when a custom `tagName` is desired by the user
  - Also updated the `FormProps` in `index.d.ts`
- Updated `MaterialUIContext.tsx` and `Mui5Context.tsx` to log only for non-production builds
- Updated the `material-ui` themes, `Theme` and `Theme5` implementations to rename the `XXXTagName` to `XXXFormWrapper`, passing them into `_internalFormWrapper` rather than `tagName`
  - Updated the `XXXFormWrapper` components to accept an optional `as` prop that will be used as the `tagName`
  - Added a test to verify that this still works when `tagName` is passed and that the wrapper is given the `tagName` on the `as` prop
- Updated the `semantic-ui` theme `Theme` to pass `SuiForm` via the `_internalFormWrapper`
  - Added a test to verify that this still works when `tagName` is passed and that the wrapper is given the `tagName` on the `as` prop

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
