### PR TITLE
Follow up fix for #2722

### DIFF
--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -20,7 +20,7 @@
     "@material-ui/icons": "^4.11.2",
     "@mui/icons-material": "^5.2.0",
     "@mui/material": "^5.2.2",
-    "@rjsf/core": "^4.0.0",
+    "@rjsf/core": "^4.0.1",
     "@types/react": "^16.8.6 || ^17.0.0",
     "react": "^16.8.0 || ^17.0.0",
     "react-dom": "^16.8.0 || ^17.0.0"

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -26,7 +26,7 @@
     "test": "cross-env NODE_ENV=test BABEL_ENV=test jest"
   },
   "peerDependencies": {
-    "@rjsf/core": "^4.0.0",
+    "@rjsf/core": "^4.0.1",
     "lodash": "^4.17.15",
     "nanoid": "^3.1.23",
     "react": ">=16",


### PR DESCRIPTION
### Reasons for making this change
Follow-up for #2722
- Make `peerDependencies` for `material-ui` and `semantic-ui` be `4.0.1` to match the feature change in previous PR

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
