### PR TITLE
Fixed warnings detected in tests

### DIFF
--- a/packages/antd/test/Form.test.js
+++ b/packages/antd/test/Form.test.js
@@ -134,7 +134,7 @@ describe("single fields", () => {
       type: "string"
     };
     const tree = renderer
-      .create(<Form schema={schema} tagName="div"/>)
+      .create(<Form schema={schema} tagName="div" />)
       .toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/semantic-ui/test/Form.test.js
+++ b/packages/semantic-ui/test/Form.test.js
@@ -110,7 +110,7 @@ describe("single fields", () => {
       type: "string"
     };
     const tree = renderer
-      .create(<Form schema={schema} tagName="div"/>)
+      .create(<Form schema={schema} tagName="div" />)
       .toJSON();
     expect(tree).toMatchSnapshot();
   });


### PR DESCRIPTION
### Reasons for making this change
Follow-up fix for #2721
Fixed warnings detected in tests by adding a space between the `"` an…d `/">` in `tagName="div"/>`

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
