### PR TITLE
Fix #2721 and #2724

### DIFF
--- a/packages/material-ui/src/Theme/MaterialUIContext.tsx
+++ b/packages/material-ui/src/Theme/MaterialUIContext.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import MaterialUIContextProps from 'Theme/MaterialUIContextProps';
+import MaterialUIContextProps from './MaterialUIContextProps';
 
 /** Use require for loading these libraries in case they are not available in order to perform a useful fallback
  */
@@ -9,9 +9,7 @@ try {
   mui = require('@material-ui/core');
   icons = require('@material-ui/icons');
 } catch (err) {
-  if (process.env.NODE_ENV !== 'PRODUCTION') {
-    console.log(err);
-  }
+  // purposely a no-op. If it is not here, don't make noise like we used to
 }
 
 export let MaterialUIContext: MaterialUIContextProps;

--- a/packages/material-ui/src/Theme/MaterialUIContextProps.ts
+++ b/packages/material-ui/src/Theme/MaterialUIContextProps.ts
@@ -1,4 +1,14 @@
-import {
+/** Use require for loading these libraries in case they are not available in order to perform a useful fallback
+ */
+let mui;
+try {
+  mui = require('@material-ui/core');
+} catch (err) {
+  // purposely a no-op
+}
+
+// @ts-ignore What we are doing here isn't really good Typescript, but it works
+const {
   Box,
   Button,
   Checkbox,
@@ -24,11 +34,11 @@ import {
   SvgIcon,
   TextField,
   Typography,
-} from '@material-ui/core';
+} = mui;
 
 export default interface MaterialUIContextProps {
-  Button?: Button;
   Box?: Box;
+  Button?: Button;
   Checkbox?: Checkbox;
   Divider?: Divider;
   Grid?: Grid;

--- a/packages/material-ui/src/Theme/MaterialUIContextProps.ts
+++ b/packages/material-ui/src/Theme/MaterialUIContextProps.ts
@@ -1,6 +1,6 @@
 /** Use require for loading these libraries in case they are not available in order to perform a useful fallback
  */
-let mui;
+let mui = {};
 try {
   mui = require('@material-ui/core');
 } catch (err) {

--- a/packages/material-ui/src/Theme5/Mui5Context.tsx
+++ b/packages/material-ui/src/Theme5/Mui5Context.tsx
@@ -10,9 +10,7 @@ try {
   mui = require('@mui/material');
   icons = require('@mui/icons-material');
 } catch (err) {
-  if (process.env.NODE_ENV !== 'PRODUCTION') {
-    console.log(err);
-  }
+  // purposely a no-op
 }
 
 export let Mui5Context: Mui5ContextProps;

--- a/packages/material-ui/src/Theme5/Mui5ContextProps.ts
+++ b/packages/material-ui/src/Theme5/Mui5ContextProps.ts
@@ -1,6 +1,6 @@
 /** Use require for loading these libraries in case they are not available in order to perform a useful fallback
  */
-let mui;
+let mui = {};
 try {
   mui = require('@mui/material');
 } catch (err) {

--- a/packages/material-ui/src/Theme5/Mui5ContextProps.ts
+++ b/packages/material-ui/src/Theme5/Mui5ContextProps.ts
@@ -1,4 +1,14 @@
-import {
+/** Use require for loading these libraries in case they are not available in order to perform a useful fallback
+ */
+let mui;
+try {
+  mui = require('@mui/material');
+} catch (err) {
+  // purposely a no-op
+}
+
+// @ts-ignore What we are doing here isn't really good Typescript, but it works
+const {
   Box,
   Button,
   Checkbox,
@@ -24,11 +34,11 @@ import {
   SvgIcon,
   TextField,
   Typography,
-} from '@mui/material';
+} = mui;
 
 export default interface Mui5ContextProps {
-  Button?: Button;
   Box?: Box;
+  Button?: Button;
   Checkbox?: Checkbox;
   Divider?: Divider;
   Grid?: Grid;

--- a/packages/material-ui/src/index.ts
+++ b/packages/material-ui/src/index.ts
@@ -12,5 +12,6 @@ export { default as Widgets } from './Widgets';
 
 export { default as Theme5 } from './Theme5';
 export { default as MuiForm5 } from './MuiForm5';
+export { default as MuiComponentContext } from './MuiComponentContext';
 
 export default MuiForm;


### PR DESCRIPTION
### Reasons for making this change
Fixes #2724 and (hopefully) #2721

- Updated the `MaterialUIContext` and `Mui5Context` to eliminate the `console.log()` entirely
- Updated the `MaterialUIContextProps` and `Mui5ContextProps` to use `require` to import the libraries to avoid issues with exporting the `MaterialComponentContext`
- Updated the `index.ts` to export the `MaterialComponentContext`

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
