### PR TITLE
Fix #1935 add new `ui:hideError` flag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed the `toIdSchema()` typescript definition to add new `idSeparator` prop along with the spelling of `idPrefix`
   - Also passed the new `idSeparator` prop through to the `AnyOfField` and `OneOfField` inside of `SchemaField` 
   - Updated `ArrayField` in `@rjsf/core` to pass `idSeparator` and `idPrefix` through to `SchemaField`, fixing a small bug
-- Added support for the new `ui:hideError` feature
+- Added support for the new `ui:hideError` feature, which allows you to hide errors at a field level
 
 ## @rjsf/material-ui
 - Remove `console.log()` the import error in `MaterialUIContext` and `Mui5Context`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # v5.0.0 (coming soon)
 
-# v4.0.3 (upcoming)
+# v4.1.1 (upcoming)
 
-# v4.0.2
+# v4.1.0
 
 ## @rjsf/core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Added support for the new `ui:hideError` feature, which allows you to hide errors at a field level
 
 ## @rjsf/material-ui
-- Remove `console.log()` the import error in `MaterialUIContext` and `Mui5Context`
+- Remove `console.log()` of the import error in `MaterialUIContext` and `Mui5Context`
 - Export the `MaterialComponentContext` (#2724)
 
 ## Dev / docs / playground

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,14 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed the `toIdSchema()` typescript definition to add new `idSeparator` prop along with the spelling of `idPrefix`
   - Also passed the new `idSeparator` prop through to the `AnyOfField` and `OneOfField` inside of `SchemaField` 
   - Updated `ArrayField` in `@rjsf/core` to pass `idSeparator` and `idPrefix` through to `SchemaField`, fixing a small bug
+- Added support for the new `ui:hideError` feature
 
 ## @rjsf/material-ui
 - Remove `console.log()` the import error in `MaterialUIContext` and `Mui5Context`
 - Export the `MaterialComponentContext` (#2724)
+
+## Dev / docs / playground
+- Added documentation for the new `ui:hideError` feature
 
 # v4.0.1
 

--- a/docs/advanced-customization/custom-templates.md
+++ b/docs/advanced-customization/custom-templates.md
@@ -141,6 +141,7 @@ The following props are passed to a custom field template component:
 - `hidden`: A boolean value stating if the field should be hidden.
 - `required`: A boolean value stating if the field is required.
 - `readonly`: A boolean value stating if the field is read-only.
+- `hideError`: A boolean value stating if the field is hiding its errors
 - `disabled`: A boolean value stating if the field is disabled.
 - `displayLabel`: A boolean value stating if the label should be rendered or not. This is useful for nested fields in arrays where you don't want to clutter the UI.
 - `fields`: An array containing all Form's fields including your [custom fields](#custom-field-components) and the built-in fields.

--- a/docs/api-reference/uiSchema.md
+++ b/docs/api-reference/uiSchema.md
@@ -109,6 +109,14 @@ const uiSchema = {
 
 Help texts work for any kind of field at any level, and will always be rendered immediately below the field component widget(s) (after contextualized errors, if any).
 
+## hideError
+
+The `ui:hideError` uiSchema directive will, if set to `true`, hide the default error display provided by the `FieldTemplate` for the given field AND all of its child fields in the hierarchy.
+
+If you need to enable the default error display of a child in the hierarchy after setting `hideError: true` on the parent field, simply set `hideError: false` on the child.
+
+This is useful when you have a custom field or widget that utilizes either the `rawErrors` or the `errorSchema` to manipulate and/or show the error(s) for the field/widget itself.
+
 ## inputType
 
 To change the input type (for example, `tel` or `email`) you can specify the `inputType` in the `ui:options` uiSchema directive.

--- a/docs/api-reference/uiSchema.md
+++ b/docs/api-reference/uiSchema.md
@@ -111,7 +111,7 @@ Help texts work for any kind of field at any level, and will always be rendered 
 
 ## hideError
 
-The `ui:hideError` uiSchema directive will, if set to `true`, hide the default error display provided by the `FieldTemplate` for the given field AND all of its child fields in the hierarchy.
+The `ui:hideError` uiSchema directive will, if set to `true`, hide the default error display for the given field AND all of its child fields in the hierarchy.
 
 If you need to enable the default error display of a child in the hierarchy after setting `hideError: true` on the parent field, simply set `hideError: false` on the child.
 

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -20,6 +20,7 @@ declare module '@rjsf/core' {
         customFormats?: { [k: string]: string | RegExp | ((data: string) => boolean) };
         disabled?: boolean;
         readonly?: boolean;
+        hideError?: boolean;
         enctype?: string;
         extraErrors?: any;
         ErrorList?: React.StatelessComponent<ErrorListProps>;

--- a/packages/core/src/components/fields/ArrayField.js
+++ b/packages/core/src/components/fields/ArrayField.js
@@ -469,6 +469,7 @@ class ArrayField extends Component {
       required,
       disabled,
       readonly,
+      hideError,
       autofocus,
       registry = getDefaultRegistry(),
       onBlur,
@@ -519,6 +520,7 @@ class ArrayField extends Component {
       uiSchema,
       onAddClick: this.onAddClick,
       readonly,
+      hideError,
       required,
       schema,
       title,
@@ -544,6 +546,7 @@ class ArrayField extends Component {
       uiSchema,
       disabled,
       readonly,
+      hideError,
       required,
       placeholder,
       autofocus,
@@ -574,6 +577,7 @@ class ArrayField extends Component {
         value={items}
         disabled={disabled}
         readonly={readonly}
+        hideError={hideError}
         required={required}
         label={title}
         placeholder={placeholder}
@@ -829,6 +833,7 @@ class ArrayField extends Component {
           registry={this.props.registry}
           disabled={this.props.disabled}
           readonly={this.props.readonly}
+          hideError={this.props.hideError}
           autofocus={autofocus}
           rawErrors={rawErrors}
         />

--- a/packages/core/src/components/fields/MultiSchemaField.js
+++ b/packages/core/src/components/fields/MultiSchemaField.js
@@ -101,6 +101,8 @@ class AnyOfField extends Component {
     const {
       baseType,
       disabled,
+      readonly,
+      hideError,
       errorSchema,
       formData,
       idPrefix,
@@ -168,6 +170,8 @@ class AnyOfField extends Component {
             onFocus={onFocus}
             registry={registry}
             disabled={disabled}
+            readonly={readonly}
+            hideError={hideError}
           />
         )}
       </div>
@@ -177,6 +181,8 @@ class AnyOfField extends Component {
 
 AnyOfField.defaultProps = {
   disabled: false,
+  readonly: false,
+  hideError: false,
   errorSchema: {},
   idSchema: {},
   uiSchema: {},

--- a/packages/core/src/components/fields/ObjectField.js
+++ b/packages/core/src/components/fields/ObjectField.js
@@ -187,6 +187,7 @@ class ObjectField extends Component {
       required,
       disabled,
       readonly,
+      hideError,
       idPrefix,
       idSeparator,
       onBlur,
@@ -259,6 +260,7 @@ class ObjectField extends Component {
               registry={registry}
               disabled={disabled}
               readonly={readonly}
+              hideError={hideError}
               onDropPropertyClick={this.onDropPropertyClick}
             />
           ),

--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -264,6 +264,12 @@ function SchemaFieldRender(props) {
       props.schema.readOnly ||
       schema.readOnly
   );
+  const uiSchemaHideError = uiSchema["ui:hideError"];
+  // Set hideError to the value provided in the uiSchema, otherwise stick with the prop to propagate to children
+  const hideError =
+    uiSchemaHideError === undefined
+      ? props.hideError
+      : Boolean(uiSchemaHideError);
   const autofocus = Boolean(props.autofocus || uiSchema["ui:autofocus"]);
   if (Object.keys(schema).length === 0) {
     return null;
@@ -282,6 +288,7 @@ function SchemaFieldRender(props) {
       uiSchema={{ ...uiSchema, classNames: undefined }}
       disabled={disabled}
       readonly={readonly}
+      hideError={hideError}
       autofocus={autofocus}
       errorSchema={fieldErrorSchema}
       formContext={formContext}
@@ -306,15 +313,13 @@ function SchemaFieldRender(props) {
   const errors = __errors;
   const help = uiSchema["ui:help"];
   const hidden = uiSchema["ui:widget"] === "hidden";
-  const classNames = [
-    "form-group",
-    "field",
-    `field-${schema.type}`,
-    errors && errors.length > 0 ? "field-error has-error has-danger" : "",
-    uiSchema.classNames,
-  ]
-    .join(" ")
-    .trim();
+
+  let classNames = ["form-group", "field", `field-${schema.type}`];
+  if (!hideError && errors && errors.length > 0) {
+    classNames.push("field-error has-error has-danger");
+  }
+  classNames.push(uiSchema.classNames);
+  classNames = classNames.join(" ").trim();
 
   const fieldProps = {
     description: (
@@ -327,8 +332,8 @@ function SchemaFieldRender(props) {
     rawDescription: description,
     help: <Help id={id + "__help"} help={help} />,
     rawHelp: typeof help === "string" ? help : undefined,
-    errors: <ErrorList errors={errors} />,
-    rawErrors: errors,
+    errors: hideError ? undefined : <ErrorList errors={errors} />,
+    rawErrors: hideError ? undefined : errors,
     id,
     label,
     hidden,
@@ -338,6 +343,7 @@ function SchemaFieldRender(props) {
     required,
     disabled,
     readonly,
+    hideError,
     displayLabel,
     classNames,
     formContext,
@@ -364,6 +370,8 @@ function SchemaFieldRender(props) {
         {schema.anyOf && !isSelect(schema) && (
           <_AnyOfField
             disabled={disabled}
+            readonly={readonly}
+            hideError={hideError}
             errorSchema={errorSchema}
             formData={formData}
             idPrefix={idPrefix}
@@ -385,6 +393,8 @@ function SchemaFieldRender(props) {
         {schema.oneOf && !isSelect(schema) && (
           <_OneOfField
             disabled={disabled}
+            readonly={readonly}
+            hideError={hideError}
             errorSchema={errorSchema}
             formData={formData}
             idPrefix={idPrefix}
@@ -424,6 +434,7 @@ SchemaField.defaultProps = {
   disabled: false,
   readonly: false,
   autofocus: false,
+  hideError: false,
 };
 
 if (process.env.NODE_ENV !== "production") {

--- a/packages/core/test/ArrayField_test.js
+++ b/packages/core/test/ArrayField_test.js
@@ -1943,4 +1943,62 @@ describe("ArrayField", () => {
       expect(inputs[3].id).eql("base/foo_1/baz");
     });
   });
+
+  describe("should handle nested 'hideError: true' uiSchema value", () => {
+    const complexSchema = {
+      type: "object",
+      properties: {
+        foo: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              bar: { type: "string" },
+            },
+          },
+        },
+      },
+    };
+    function validate(formData, errors) {
+      errors.foo[0].bar.addError("test");
+      errors.foo[1].bar.addError("test");
+      return errors;
+    }
+
+    it("should render nested error decorated input widgets with the expected ids", () => {
+      const { node } = createFormComponent({
+        schema: complexSchema,
+        formData: {
+          foo: [{ bar: "bar1" }, { bar: "bar2" }],
+        },
+        validate,
+      });
+      Simulate.submit(node);
+
+      const inputs = node.querySelectorAll(
+        ".form-group.field-error input[type=text]"
+      );
+      expect(inputs[0].id).eql("root_foo_0_bar");
+      expect(inputs[1].id).eql("root_foo_1_bar");
+    });
+    it("should NOT render nested error decorated input widgets", () => {
+      const { node } = createFormComponent({
+        schema: complexSchema,
+        uiSchema: {
+          "ui:hideError": true,
+        },
+        formData: {
+          foo: [{ bar: "bar1" }, { bar: "bar2" }],
+        },
+        validate,
+        showErrorList: false,
+      });
+      Simulate.submit(node);
+
+      const inputsNoError = node.querySelectorAll(
+        ".form-group.field-error input[type=text]"
+      );
+      expect(inputsNoError.length).eql(0);
+    });
+  });
 });

--- a/packages/core/test/ArrayField_test.js
+++ b/packages/core/test/ArrayField_test.js
@@ -1998,7 +1998,7 @@ describe("ArrayField", () => {
       const inputsNoError = node.querySelectorAll(
         ".form-group.field-error input[type=text]"
       );
-      expect(inputsNoError.length).eql(0);
+      expect(inputsNoError).to.have.length.of(0);
     });
   });
 });

--- a/packages/core/test/SchemaField_test.js
+++ b/packages/core/test/SchemaField_test.js
@@ -482,7 +482,7 @@ describe("SchemaField", () => {
         });
       });
     });
-    describe("hideError flag false for child and has errors", () => {
+    describe("hideError flag false for child should show errors", () => {
       const hideUiSchema = {
         "ui:hideError": true,
         "ui:field": props => {

--- a/packages/core/test/SchemaField_test.js
+++ b/packages/core/test/SchemaField_test.js
@@ -427,129 +427,101 @@ describe("SchemaField", () => {
         expect(matches[0].textContent).to.eql("test");
       });
     });
-  });
-  describe("hideError flag and errors", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        foo: { type: "string" },
-      },
-    };
 
-    const uiSchema = {
-      "ui:hideError": true,
-      "ui:field": props => {
-        const { uiSchema, ...fieldProps } = props; //eslint-disable-line
-        return <SchemaField {...fieldProps} />;
-      },
-    };
-
-    function validate(formData, errors) {
-      errors.addError("container");
-      errors.foo.addError("test");
-      return errors;
-    }
-
-    it("should not render its own default errors", () => {
-      const { node } = createFormComponent({
-        schema,
-        uiSchema,
-        validate,
-      });
-      Simulate.submit(node);
-
-      const matches = node.querySelectorAll(
-        "form > .form-group > div > .error-detail .text-danger"
-      );
-      expect(matches).to.have.length.of(0);
-    });
-
-    it("should not show default errors in child component", () => {
-      const { node } = createFormComponent({
-        schema,
-        uiSchema,
-        validate,
-      });
-      Simulate.submit(node);
-
-      const matches = node.querySelectorAll(
-        "form .form-group .form-group .text-danger"
-      );
-      expect(matches).to.have.length.of(0);
-    });
-
-    describe("Custom error rendering", () => {
-      const customStringWidget = props => {
-        return <div className="custom-text-widget">{props.rawErrors}</div>;
+    describe("hideError flag and errors", () => {
+      const hideUiSchema = {
+        "ui:hideError": true,
+        ...uiSchema,
       };
 
-      it("should pass rawErrors down to custom widgets and render them", () => {
+      it("should not render its own default errors", () => {
         const { node } = createFormComponent({
           schema,
-          uiSchema,
+          uiSchema: hideUiSchema,
           validate,
-          widgets: { BaseInput: customStringWidget },
         });
         Simulate.submit(node);
 
-        const matches = node.querySelectorAll(".custom-text-widget");
-        expect(matches).to.have.length.of(1);
-        expect(matches[0].textContent).to.eql("test");
-      });
-    });
-  });
-  describe("hideError flag false for child and has errors", () => {
-    const schema = {
-      type: "object",
-      properties: {
-        foo: { type: "string" },
-      },
-    };
-
-    const uiSchema = {
-      "ui:hideError": true,
-      "ui:field": props => {
-        const { uiSchema, ...fieldProps } = props; //eslint-disable-line
-        // Pass the children schema in after removing the global one
-        return (
-          <SchemaField {...fieldProps} uiSchema={{ "ui:hideError": false }} />
+        const matches = node.querySelectorAll(
+          "form > .form-group > div > .error-detail .text-danger"
         );
-      },
-    };
-
-    function validate(formData, errors) {
-      errors.addError("container");
-      errors.foo.addError("test");
-      return errors;
-    }
-
-    it("should not render its own errors", () => {
-      const { node } = createFormComponent({
-        schema,
-        uiSchema,
-        validate,
+        expect(matches).to.have.length.of(0);
       });
-      Simulate.submit(node);
 
-      const matches = node.querySelectorAll(
-        "form > .form-group > div > .error-detail .text-danger"
-      );
-      expect(matches).to.have.length.of(0);
+      it("should not show default errors in child component", () => {
+        const { node } = createFormComponent({
+          schema,
+          uiSchema: hideUiSchema,
+          validate,
+        });
+        Simulate.submit(node);
+
+        const matches = node.querySelectorAll(
+          "form .form-group .form-group .text-danger"
+        );
+        expect(matches).to.have.length.of(0);
+      });
+
+      describe("Custom error rendering", () => {
+        const customStringWidget = props => {
+          return <div className="custom-text-widget">{props.rawErrors}</div>;
+        };
+
+        it("should pass rawErrors down to custom widgets and render them", () => {
+          const { node } = createFormComponent({
+            schema,
+            uiSchema: hideUiSchema,
+            validate,
+            widgets: { BaseInput: customStringWidget },
+          });
+          Simulate.submit(node);
+
+          const matches = node.querySelectorAll(".custom-text-widget");
+          expect(matches).to.have.length.of(1);
+          expect(matches[0].textContent).to.eql("test");
+        });
+      });
     });
+    describe("hideError flag false for child and has errors", () => {
+      const hideUiSchema = {
+        "ui:hideError": true,
+        "ui:field": props => {
+          const { uiSchema, ...fieldProps } = props; //eslint-disable-line
+          // Pass the children schema in after removing the global one
+          return (
+            <SchemaField {...fieldProps} uiSchema={{ "ui:hideError": false }} />
+          );
+        },
+      };
 
-    it("should show errors on child component", () => {
-      const { node } = createFormComponent({
-        schema,
-        uiSchema,
-        validate,
+      it("should not render its own default errors", () => {
+        const { node } = createFormComponent({
+          schema,
+          uiSchema: hideUiSchema,
+          validate,
+        });
+        Simulate.submit(node);
+
+        const matches = node.querySelectorAll(
+          "form > .form-group > div > .error-detail .text-danger"
+        );
+        expect(matches).to.have.length.of(0);
       });
-      Simulate.submit(node);
 
-      const matches = node.querySelectorAll(
-        "form .form-group .form-group .text-danger"
-      );
-      expect(matches).to.have.length.of(1);
-      expect(matches[0].textContent).to.contain("test");
+      it("should show errors on child component", () => {
+        const { node } = createFormComponent({
+          schema,
+          uiSchema: hideUiSchema,
+          validate,
+        });
+        Simulate.submit(node);
+
+        const matches = node.querySelectorAll(
+          "form .form-group .form-group .text-danger"
+        );
+        expect(matches).to.have.length.of(1);
+        expect(matches[0].textContent).to.contain("test");
+      });
     });
   });
 });

--- a/packages/core/test/anyOf_test.js
+++ b/packages/core/test/anyOf_test.js
@@ -1084,4 +1084,93 @@ describe("anyOf", () => {
       expect(idSelects[3].value).eql("to_absolute");
     });
   });
+  describe("hideError works with anyOf", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        userId: {
+          anyOf: [
+            {
+              type: "number",
+            },
+            {
+              type: "string",
+            },
+          ],
+        },
+      },
+    };
+    function validate(formData, errors) {
+      errors.userId.addError("test");
+      return errors;
+    }
+
+    it("should show error on options with different types", () => {
+      const { node } = createFormComponent({
+        schema,
+        validate,
+      });
+
+      Simulate.change(node.querySelector("input#root_userId"), {
+        target: { value: 12345 },
+      });
+      Simulate.submit(node);
+
+      let inputs = node.querySelectorAll(
+        ".form-group.field-error input[type=number]"
+      );
+      expect(inputs[0].id).eql("root_userId");
+
+      const $select = node.querySelector("select");
+
+      Simulate.change($select, {
+        target: { value: $select.options[1].value },
+      });
+
+      Simulate.change(node.querySelector("input#root_userId"), {
+        target: { value: "Lorem ipsum dolor sit amet" },
+      });
+      Simulate.submit(node);
+
+      inputs = node.querySelectorAll(
+        ".form-group.field-error input[type=text]"
+      );
+      expect(inputs[0].id).eql("root_userId");
+    });
+    it("should NOT show error on options with different types when hideError: true", () => {
+      const { node } = createFormComponent({
+        schema,
+        uiSchema: {
+          "ui:hideError": true,
+        },
+        validate,
+      });
+
+      Simulate.change(node.querySelector("input#root_userId"), {
+        target: { value: 12345 },
+      });
+      Simulate.submit(node);
+
+      let inputs = node.querySelectorAll(
+        ".form-group.field-error input[type=number]"
+      );
+      expect(inputs.length).eql(0);
+
+      const $select = node.querySelector("select");
+
+      Simulate.change($select, {
+        target: { value: $select.options[1].value },
+      });
+
+      Simulate.change(node.querySelector("input#root_userId"), {
+        target: { value: "Lorem ipsum dolor sit amet" },
+      });
+      Simulate.submit(node);
+
+      inputs = node.querySelectorAll(
+        ".form-group.field-error input[type=text]"
+      );
+      expect(inputs.length).eql(0);
+    });
+  });
 });

--- a/packages/core/test/anyOf_test.js
+++ b/packages/core/test/anyOf_test.js
@@ -1154,7 +1154,7 @@ describe("anyOf", () => {
       let inputs = node.querySelectorAll(
         ".form-group.field-error input[type=number]"
       );
-      expect(inputs.length).eql(0);
+      expect(inputs).to.have.length.of(0);
 
       const $select = node.querySelector("select");
 
@@ -1170,7 +1170,7 @@ describe("anyOf", () => {
       inputs = node.querySelectorAll(
         ".form-group.field-error input[type=text]"
       );
-      expect(inputs.length).eql(0);
+      expect(inputs).to.have.length.of(0);
     });
   });
 });


### PR DESCRIPTION
### Reasons for making this change
Added support for a new `ui:hideError` flag in the `uiSchema` that will recursively hide the default errors displayed to `FieldTemplate` when true
- Updated the documentation for the new `uiSchema` flag
- Updated the `custom-templates.md` documentation to add `hideError` flag description
- Updated the `FormProps` to add a new, optional `hideError` boolean prop
- Updated `SchemaField` to derive the `hideError` prop from `uiSchema['ui:hideError]` dealing with turning it on and off
  - Used `hideError`, when true, to not output error classes AND pass `errors` and `rawErrors` down to the `FieldTemplate`
  - Also forwarded `hideError` to the `FormComponent` and the `AnyOfField` and/or `OneOfField`
- Updated `ArrayField` to forward the `hideError` prop down to the `SchemaField` of each item
- Updated `MultiSchemaField` to forward `hideError` prop down to the inner `SchemaField`
  - Also fixed a small bug to forward `readonly` prop down as well
- Updated `ObjectField` to forward `hideError` prop down to the inner `SchemaField`
- Updated tests for `SchemaField`, `ArrayField` and `anyOf` to validate that `hideError` works
  - NOTE: `ObjectField` tests were not explicitly updated because the code is exercised in the other three updated tests
- Updated the CHANGELOG

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
