### PR TITLE
Fix 2749 by using webpack magic comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/material-ui
 - Remove `console.log()` of the import error in `MaterialUIContext` and `Mui5Context`
 - Export the `MaterialComponentContext` (#2724)
+- Use component-level `require()` along with webpack magic comment to support tree-shaking again
 
 ## Dev / docs / playground
 - Added documentation for the new `ui:hideError` feature

--- a/packages/material-ui/src/Theme/MaterialUIContext.tsx
+++ b/packages/material-ui/src/Theme/MaterialUIContext.tsx
@@ -2,14 +2,46 @@ import React from 'react';
 import MaterialUIContextProps from './MaterialUIContextProps';
 
 /** Use require for loading these libraries in case they are not available in order to perform a useful fallback
+ * We are explicitly loading each component with the `#__PURE__` webpack magic comment so that tree-shaking works.
  */
 let mui;
 let icons;
 try {
-  mui = require('@material-ui/core');
-  icons = require('@material-ui/icons');
+  mui = {
+    Box: /*#__PURE__*/require('@material-ui/core/Box').default,
+    Button: /*#__PURE__*/require('@material-ui/core/Button').default,
+    Checkbox: /*#__PURE__*/require('@material-ui/core/Checkbox').default,
+    Divider: /*#__PURE__*/require('@material-ui/core/Divider').default,
+    FormControl: /*#__PURE__*/require('@material-ui/core/FormControl').default,
+    FormControlLabel: /*#__PURE__*/require('@material-ui/core/FormControlLabel').default,
+    FormHelperText: /*#__PURE__*/require('@material-ui/core/FormHelperText').default,
+    FormGroup: /*#__PURE__*/require('@material-ui/core/FormGroup').default,
+    FormLabel: /*#__PURE__*/require('@material-ui/core/FormLabel').default,
+    Grid: /*#__PURE__*/require('@material-ui/core/Grid').default,
+    IconButton: /*#__PURE__*/require('@material-ui/core/IconButton').default,
+    Input: /*#__PURE__*/require('@material-ui/core/Input').default,
+    InputLabel: /*#__PURE__*/require('@material-ui/core/InputLabel').default,
+    List: /*#__PURE__*/require('@material-ui/core/List').default,
+    ListItem: /*#__PURE__*/require('@material-ui/core/ListItem').default,
+    ListItemIcon: /*#__PURE__*/require('@material-ui/core/ListItemIcon').default,
+    ListItemText: /*#__PURE__*/require('@material-ui/core/ListItemText').default,
+    MenuItem: /*#__PURE__*/require('@material-ui/core/MenuItem').default,
+    Paper: /*#__PURE__*/require('@material-ui/core/Paper').default,
+    Radio: /*#__PURE__*/require('@material-ui/core/Radio').default,
+    RadioGroup: /*#__PURE__*/require('@material-ui/core/RadioGroup').default,
+    Slider: /*#__PURE__*/require('@material-ui/core/Slider').default,
+    TextField: /*#__PURE__*/require('@material-ui/core/TextField').default,
+    Typography: /*#__PURE__*/require('@material-ui/core/Typography').default,
+  };
+  icons = {
+    Add: /*#__PURE__*/require('@material-ui/icons/Add').default,
+    ArrowUpward: /*#__PURE__*/require('@material-ui/icons/ArrowUpward').default,
+    ArrowDownward: /*#__PURE__*/require('@material-ui/icons/ArrowDownward').default,
+    Error: /*#__PURE__*/require('@material-ui/icons/Error').default,
+    Remove: /*#__PURE__*/require('@material-ui/icons/Remove').default
+  };
 } catch (err) {
-  // purposely a no-op. If it is not here, don't make noise like we used to
+  // purposely a no-op
 }
 
 export let MaterialUIContext: MaterialUIContextProps;

--- a/packages/material-ui/src/Theme/MaterialUIContextProps.ts
+++ b/packages/material-ui/src/Theme/MaterialUIContextProps.ts
@@ -2,7 +2,33 @@
  */
 let mui = {};
 try {
-  mui = require('@material-ui/core');
+  mui = {
+    Box: /*#__PURE__*/require('@material-ui/core/Box').default,
+    Button: /*#__PURE__*/require('@material-ui/core/Button').default,
+    Checkbox: /*#__PURE__*/require('@material-ui/core/Checkbox').default,
+    Divider: /*#__PURE__*/require('@material-ui/core/Divider').default,
+    FormControl: /*#__PURE__*/require('@material-ui/core/FormControl').default,
+    FormControlLabel: /*#__PURE__*/require('@material-ui/core/FormControlLabel').default,
+    FormHelperText: /*#__PURE__*/require('@material-ui/core/FormHelperText').default,
+    FormGroup: /*#__PURE__*/require('@material-ui/core/FormGroup').default,
+    FormLabel: /*#__PURE__*/require('@material-ui/core/FormLabel').default,
+    Grid: /*#__PURE__*/require('@material-ui/core/Grid').default,
+    IconButton: /*#__PURE__*/require('@material-ui/core/IconButton').default,
+    Input: /*#__PURE__*/require('@material-ui/core/Input').default,
+    InputLabel: /*#__PURE__*/require('@material-ui/core/InputLabel').default,
+    List: /*#__PURE__*/require('@material-ui/core/List').default,
+    ListItem: /*#__PURE__*/require('@material-ui/core/ListItem').default,
+    ListItemIcon: /*#__PURE__*/require('@material-ui/core/ListItemIcon').default,
+    ListItemText: /*#__PURE__*/require('@material-ui/core/ListItemText').default,
+    MenuItem: /*#__PURE__*/require('@material-ui/core/MenuItem').default,
+    Paper: /*#__PURE__*/require('@material-ui/core/Paper').default,
+    Radio: /*#__PURE__*/require('@material-ui/core/Radio').default,
+    RadioGroup: /*#__PURE__*/require('@material-ui/core/RadioGroup').default,
+    Slider: /*#__PURE__*/require('@material-ui/core/Slider').default,
+    SvgIcon: /*#__PURE__*/require('@material-ui/core/SvgIcon').default,
+    TextField: /*#__PURE__*/require('@material-ui/core/TextField').default,
+    Typography: /*#__PURE__*/require('@material-ui/core/Typography').default,
+  };
 } catch (err) {
   // purposely a no-op
 }

--- a/packages/material-ui/src/Theme5/Mui5Context.tsx
+++ b/packages/material-ui/src/Theme5/Mui5Context.tsx
@@ -3,12 +3,44 @@ import React from 'react';
 import Mui5ContextProps from './Mui5ContextProps';
 
 /** Use require for loading these libraries in case they are not available in order to perform a useful fallback
+ * We are explicitly loading each component with the `#__PURE__` webpack magic comment so that tree-shaking works.
  */
 let mui;
 let icons;
 try {
-  mui = require('@mui/material');
-  icons = require('@mui/icons-material');
+  mui = {
+    Box: /*#__PURE__*/require('@mui/material/Box').default,
+    Button: /*#__PURE__*/require('@mui/material/Button').default,
+    Checkbox: /*#__PURE__*/require('@mui/material/Checkbox').default,
+    Divider: /*#__PURE__*/require('@mui/material/Divider').default,
+    FormControl: /*#__PURE__*/require('@mui/material/FormControl').default,
+    FormControlLabel: /*#__PURE__*/require('@mui/material/FormControlLabel').default,
+    FormHelperText: /*#__PURE__*/require('@mui/material/FormHelperText').default,
+    FormGroup: /*#__PURE__*/require('@mui/material/FormGroup').default,
+    FormLabel: /*#__PURE__*/require('@mui/material/FormLabel').default,
+    Grid: /*#__PURE__*/require('@mui/material/Grid').default,
+    IconButton: /*#__PURE__*/require('@mui/material/IconButton').default,
+    InputLabel: /*#__PURE__*/require('@mui/material/InputLabel').default,
+    List: /*#__PURE__*/require('@mui/material/List').default,
+    ListItem: /*#__PURE__*/require('@mui/material/ListItem').default,
+    ListItemIcon: /*#__PURE__*/require('@mui/material/ListItemIcon').default,
+    ListItemText: /*#__PURE__*/require('@mui/material/ListItemText').default,
+    MenuItem: /*#__PURE__*/require('@mui/material/MenuItem').default,
+    OutlinedInput: /*#__PURE__*/require('@mui/material/OutlinedInput').default,
+    Paper: /*#__PURE__*/require('@mui/material/Paper').default,
+    Radio: /*#__PURE__*/require('@mui/material/Radio').default,
+    RadioGroup: /*#__PURE__*/require('@mui/material/RadioGroup').default,
+    Slider: /*#__PURE__*/require('@mui/material/Slider').default,
+    TextField: /*#__PURE__*/require('@mui/material/TextField').default,
+    Typography: /*#__PURE__*/require('@mui/material/Typography').default,
+  };
+  icons = {
+    Add: /*#__PURE__*/require('@mui/icons-material/Add').default,
+    ArrowUpward: /*#__PURE__*/require('@mui/icons-material/ArrowUpward').default,
+    ArrowDownward: /*#__PURE__*/require('@mui/icons-material/ArrowDownward').default,
+    Error: /*#__PURE__*/require('@mui/icons-material/Error').default,
+    Remove: /*#__PURE__*/require('@mui/icons-material/Remove').default
+  };
 } catch (err) {
   // purposely a no-op
 }

--- a/packages/material-ui/src/Theme5/Mui5ContextProps.ts
+++ b/packages/material-ui/src/Theme5/Mui5ContextProps.ts
@@ -2,7 +2,33 @@
  */
 let mui = {};
 try {
-  mui = require('@mui/material');
+  mui = {
+    Box: /*#__PURE__*/require('@mui/material/Box').default,
+    Button: /*#__PURE__*/require('@mui/material/Button').default,
+    Checkbox: /*#__PURE__*/require('@mui/material/Checkbox').default,
+    Divider: /*#__PURE__*/require('@mui/material/Divider').default,
+    FormControl: /*#__PURE__*/require('@mui/material/FormControl').default,
+    FormControlLabel: /*#__PURE__*/require('@mui/material/FormControlLabel').default,
+    FormHelperText: /*#__PURE__*/require('@mui/material/FormHelperText').default,
+    FormGroup: /*#__PURE__*/require('@mui/material/FormGroup').default,
+    FormLabel: /*#__PURE__*/require('@mui/material/FormLabel').default,
+    Grid: /*#__PURE__*/require('@mui/material/Grid').default,
+    IconButton: /*#__PURE__*/require('@mui/material/IconButton').default,
+    InputLabel: /*#__PURE__*/require('@mui/material/InputLabel').default,
+    List: /*#__PURE__*/require('@mui/material/List').default,
+    ListItem: /*#__PURE__*/require('@mui/material/ListItem').default,
+    ListItemIcon: /*#__PURE__*/require('@mui/material/ListItemIcon').default,
+    ListItemText: /*#__PURE__*/require('@mui/material/ListItemText').default,
+    MenuItem: /*#__PURE__*/require('@mui/material/MenuItem').default,
+    OutlinedInput: /*#__PURE__*/require('@mui/material/OutlinedInput').default,
+    Paper: /*#__PURE__*/require('@mui/material/Paper').default,
+    Radio: /*#__PURE__*/require('@mui/material/Radio').default,
+    RadioGroup: /*#__PURE__*/require('@mui/material/RadioGroup').default,
+    Slider: /*#__PURE__*/require('@mui/material/Slider').default,
+    SvgIcon: /*#__PURE__*/require('@mui/material/SvgIcon').default,
+    TextField: /*#__PURE__*/require('@mui/material/TextField').default,
+    Typography: /*#__PURE__*/require('@mui/material/Typography').default,
+  };
 } catch (err) {
   // purposely a no-op
 }


### PR DESCRIPTION
### Reasons for making this change
Fix #2749 by using component-level `require()` with the `#__PURE_` magic comment for webpack

- Updated the `MaterialUIContext` and `MaterialUIContextProps` to import all Material-UI 4 components individually using `require()` and magic comments
- Updated the `Mui5Context` and `Mui5ContextProps` to import all Material-UI 5 components individually using `require()` and magic comments
- Updated the `CHANGELOG` to add fix note

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
