### PR TITLE
fix(@rjsf/antd): make FieldTemplate response correctly to empty description

### DIFF
--- a/packages/antd/src/templates/FieldTemplate/index.js
+++ b/packages/antd/src/templates/FieldTemplate/index.js
@@ -27,6 +27,7 @@ const FieldTemplate = ({
   readonly,
   required,
   schema,
+  rawDescription,
   // uiSchema,
 }) => {
   const {
@@ -44,7 +45,6 @@ const FieldTemplate = ({
     [...new Set(rawErrors)].map((error) => (
       <div key={`field-${id}-error-${error}`}>{error}</div>
     ));
-
   return (
     <WrapIfAdditional
       classNames={classNames}
@@ -63,7 +63,7 @@ const FieldTemplate = ({
       ) : (
         <Form.Item
           colon={colon}
-          extra={description}
+          extra={rawDescription&&description}
           hasFeedback={schema.type !== 'array' && schema.type !== 'object'}
           help={(!!rawHelp && help) || (!!rawErrors && renderFieldErrors())}
           htmlFor={id}

--- a/packages/antd/test/__snapshots__/Array.test.js.snap
+++ b/packages/antd/test/__snapshots__/Array.test.js.snap
@@ -281,13 +281,6 @@ exports[`array fields fixed array 1`] = `
                         />
                       </div>
                     </div>
-                    <div
-                      className="ant-form-item-extra"
-                    >
-                      <span
-                        id="root_0__description"
-                      />
-                    </div>
                   </div>
                 </div>
               </div>
@@ -438,13 +431,6 @@ exports[`array fields fixed array 1`] = `
                           </div>
                         </div>
                       </div>
-                    </div>
-                    <div
-                      className="ant-form-item-extra"
-                    >
-                      <span
-                        id="root_1__description"
-                      />
                     </div>
                   </div>
                 </div>

--- a/packages/antd/test/__snapshots__/Object.test.js.snap
+++ b/packages/antd/test/__snapshots__/Object.test.js.snap
@@ -79,13 +79,6 @@ exports[`object fields object 1`] = `
                     />
                   </div>
                 </div>
-                <div
-                  className="ant-form-item-extra"
-                >
-                  <span
-                    id="root_a__description"
-                  />
-                </div>
               </div>
             </div>
           </div>
@@ -237,13 +230,6 @@ exports[`object fields object 1`] = `
                       </div>
                     </div>
                   </div>
-                </div>
-                <div
-                  className="ant-form-item-extra"
-                >
-                  <span
-                    id="root_b__description"
-                  />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### Reasons for making this change

As is shown [below,](https://rjsf-team.github.io/react-jsonschema-form/) antd theme template has a bug, when description is empty, it will still recogonize it as truthy so it add a block there, which is not as we expected.
<img width="458" alt="image" src="https://user-images.githubusercontent.com/8097465/159900203-0425cad5-f7b9-43e9-86ff-c7f8eb4ac393.png">

The bottom logic in antd `Form.item` is as shown below:
<img width="825" alt="image" src="https://user-images.githubusercontent.com/8097465/159901809-7580679d-7550-4c71-95ea-eebf9bf878fc.png">

Then we go a level up in the theme antd's`FieldTemplate'
<img width="733" alt="image" src="https://user-images.githubusercontent.com/8097465/159916637-b1cbea19-305e-4efc-9916-49d3bda1b9e8.png">


Then our core package in `SchemaField`, there are two data source of description,`description` is a React.FC, while `rawDescription` is a string.
<img width="643" alt="image" src="https://user-images.githubusercontent.com/8097465/159916936-8c01e2c4-afd2-473e-b284-ff443ed0f871.png">



The solution to fix this is to tell from rawDescription whether it is empty, then if it's not empty we pass the description(React component) to it.



### Checklist

* [ ] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [x] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
