### PR TITLE
hide empty help label in antd form items

### DIFF
--- a/packages/antd/src/templates/FieldTemplate/index.js
+++ b/packages/antd/src/templates/FieldTemplate/index.js
@@ -65,7 +65,7 @@ const FieldTemplate = ({
           colon={colon}
           extra={description}
           hasFeedback={schema.type !== 'array' && schema.type !== 'object'}
-          help={(!!rawHelp && help) || (!!rawErrors && renderFieldErrors())}
+          help={rawHelp ? help : rawErrors ? randerFieldErrors() : undefined}
           htmlFor={id}
           label={displayLabel && label}
           labelCol={labelCol}


### PR DESCRIPTION
### Reasons for making this change

`fixes #2779`

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
