### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Release
 on:
   release:
     types: [published]
-  push:
-    branches: rel
 
 jobs:
   release_to_npm:


### PR DESCRIPTION
Fix typo

I think it's a test I had added earlier in which rjsf would be released if you push to the `rel` branch. It should not have been merged into the master branch. This is an issue because now anyone who has write access to the repository can now trigger a release outside the regular process of releasing a new release, just by pushing to the `rel` branch.