### PR TITLE
fix(@rjsf/chakra-ui): performance issues with array fields

### DIFF
--- a/packages/chakra-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/chakra-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 
 import { utils } from "@rjsf/core";
 
@@ -62,42 +62,51 @@ const ArrayFieldDescription = ({
 };
 
 // Used in the two templates
-const DefaultArrayItem = (props: any) => {
+const DefaultArrayItem = ({
+  index, readonly, disabled, children, hasToolbar, hasRemove, hasMoveUp, hasMoveDown, onReorderClick, onDropIndexClick
+}: any) => {
+
+  const onRemoveClick = useMemo(() => onDropIndexClick(index), [index, onDropIndexClick]);
+
+  const onArrowUpClick = useMemo(() => onReorderClick(index, index - 1), [index, onReorderClick]);
+
+  const onArrowDownClick = useMemo(() => onReorderClick(index, index + 1), [index, onReorderClick]);
+
   return (
-    <HStack key={props.key} alignItems={"flex-end"} py={1}>
+    <HStack alignItems={"flex-end"} py={1}>
       <Box w="100%">
-        {props.children}
+        {children}
       </Box>
 
-      {props.hasToolbar && (
+      {hasToolbar && (
         <Box>
           <ButtonGroup isAttached mb={1}>
-            {(props.hasMoveUp || props.hasMoveDown) && (
+            {(hasMoveUp || hasMoveDown) && (
               <IconButton
                 icon="arrow-up"
                 tabIndex={-1}
-                disabled={props.disabled || props.readonly || !props.hasMoveUp}
-                onClick={props.onReorderClick(props.index, props.index - 1)}
+                disabled={disabled || readonly || !hasMoveUp}
+                onClick={onArrowUpClick}
               />
             )}
 
-            {(props.hasMoveUp || props.hasMoveDown) && (
+            {(hasMoveUp || hasMoveDown) && (
               <IconButton
                 icon="arrow-down"
                 tabIndex={-1}
                 disabled={
-                  props.disabled || props.readonly || !props.hasMoveDown
+                  disabled || readonly || !hasMoveDown
                 }
-                onClick={props.onReorderClick(props.index, props.index + 1)}
+                onClick={onArrowDownClick}
               />
             )}
 
-            {props.hasRemove && (
+            {hasRemove && (
               <IconButton
                 icon="remove"
                 tabIndex={-1}
-                disabled={props.disabled || props.readonly}
-                onClick={props.onDropIndexClick(props.index)}
+                disabled={disabled || readonly}
+                onClick={onRemoveClick}
               />
             )}
           </ButtonGroup>
@@ -131,7 +140,10 @@ const DefaultFixedArrayFieldTemplate = (props: ArrayFieldTemplateProps) => (
       className="row array-item-list"
       key={`array-item-list-${props.idSchema.$id}`}
     >
-      {props.items && props.items.map(DefaultArrayItem)}
+      {props.items && props.items.map((p) => {
+        const { key, ...itemProps } = p;
+        return <DefaultArrayItem key={key} {...itemProps}></DefaultArrayItem>;
+      })}
     </div>
 
     {props.canAdd && (
@@ -168,7 +180,10 @@ const DefaultNormalArrayFieldTemplate = (props: ArrayFieldTemplateProps) => (
 
     <Grid key={`array-item-list-${props.idSchema.$id}`}>
       <GridItem>
-        {props.items.length > 0 && props.items.map(p => DefaultArrayItem(p))}
+        {props.items.length > 0 && props.items.map((p) => {
+          const { key, ...itemProps } = p;
+          return <DefaultArrayItem key={key} {...itemProps}></DefaultArrayItem>;
+        })}
       </GridItem>
       {props.canAdd && (
         <GridItem justifySelf={"flex-end"}>

--- a/packages/chakra-ui/src/IconButton/IconButton.tsx
+++ b/packages/chakra-ui/src/IconButton/IconButton.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 import {
   IconButton,
   IconButtonProps as ChakraIconButtonProps,
@@ -26,9 +26,11 @@ type IconButtonProps = Omit<ChakraIconButtonProps, "aria-label" | "icon"> & {
  * props used in Template:
  * icon, tabIndex, disabled, onClick
  */
-const ChakraIconButton = (props: IconButtonProps) => {
+const ChakraIconButton = memo((props: IconButtonProps) => {
   const { icon, ...otherProps } = props;
   return <IconButton {...otherProps} icon={mappings[icon]} aria-label={icon} />;
-};
+});
+
+ChakraIconButton.displayName = 'ChakraIconButton';
 
 export default ChakraIconButton;


### PR DESCRIPTION
### Reasons for making this change

I found an input lag issue when we have an array type in schema with hundreds to thousands of items in formData. You could feel the latency when you input in the following example: [playground with 1000 items](https://rjsf-team.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6eyJsaXN0T2ZTdHJpbmdzIjpbImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyIsImZvbyJdLCJtdWx0aXBsZUNob2ljZXNMaXN0IjpbImZvbyIsImJhciJdLCJmaXhlZEl0ZW1zTGlzdCI6WyJTb21lIHRleHQiLHRydWUsMTIzXSwibWluSXRlbXNMaXN0IjpbeyJuYW1lIjoiRGVmYXVsdCBuYW1lIn0seyJuYW1lIjoiRGVmYXVsdCBuYW1lIn0seyJuYW1lIjoiRGVmYXVsdCBuYW1lIn1dLCJkZWZhdWx0c0FuZE1pbkl0ZW1zIjpbImNhcnAiLCJ0cm91dCIsImJyZWFtIiwidW5pZGVudGlmaWVkIiwidW5pZGVudGlmaWVkIl0sIm5lc3RlZExpc3QiOltbImxvcmVtIiwiaXBzdW0iXSxbImRvbG9yIl1dLCJ1bm9yZGVyYWJsZSI6WyJvbmUiLCJ0d28iXSwidW5yZW1vdmFibGUiOlsib25lIiwidHdvIl0sIm5vVG9vbGJhciI6WyJvbmUiLCJ0d28iXSwiZml4ZWROb1Rvb2xiYXIiOls0Mix0cnVlLCJhZGRpdGlvbmFsIGl0ZW0gb25lIiwiYWRkaXRpb25hbCBpdGVtIHR3byJdfSwic2NoZW1hIjp7ImRlZmluaXRpb25zIjp7IlRoaW5nIjp7InR5cGUiOiJvYmplY3QiLCJwcm9wZXJ0aWVzIjp7Im5hbWUiOnsidHlwZSI6InN0cmluZyIsImRlZmF1bHQiOiJEZWZhdWx0IG5hbWUifX19fSwidHlwZSI6Im9iamVjdCIsInByb3BlcnRpZXMiOnsibGlzdE9mU3RyaW5ncyI6eyJ0eXBlIjoiYXJyYXkiLCJ0aXRsZSI6IkEgbGlzdCBvZiBzdHJpbmdzIiwiaXRlbXMiOnsidHlwZSI6InN0cmluZyIsImRlZmF1bHQiOiJiYXppbmdhIn19LCJtdWx0aXBsZUNob2ljZXNMaXN0Ijp7InR5cGUiOiJhcnJheSIsInRpdGxlIjoiQSBtdWx0aXBsZSBjaG9pY2VzIGxpc3QiLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIiwiZW51bSI6WyJmb28iLCJiYXIiLCJmdXp6IiwicXV4Il19LCJ1bmlxdWVJdGVtcyI6dHJ1ZX0sImZpeGVkSXRlbXNMaXN0Ijp7InR5cGUiOiJhcnJheSIsInRpdGxlIjoiQSBsaXN0IG9mIGZpeGVkIGl0ZW1zIiwiaXRlbXMiOlt7InRpdGxlIjoiQSBzdHJpbmcgdmFsdWUiLCJ0eXBlIjoic3RyaW5nIiwiZGVmYXVsdCI6ImxvcmVtIGlwc3VtIn0seyJ0aXRsZSI6ImEgYm9vbGVhbiB2YWx1ZSIsInR5cGUiOiJib29sZWFuIn1dLCJhZGRpdGlvbmFsSXRlbXMiOnsidGl0bGUiOiJBZGRpdGlvbmFsIGl0ZW0iLCJ0eXBlIjoibnVtYmVyIn19LCJtaW5JdGVtc0xpc3QiOnsidHlwZSI6ImFycmF5IiwidGl0bGUiOiJBIGxpc3Qgd2l0aCBhIG1pbmltYWwgbnVtYmVyIG9mIGl0ZW1zIiwibWluSXRlbXMiOjMsIml0ZW1zIjp7IiRyZWYiOiIjL2RlZmluaXRpb25zL1RoaW5nIn19LCJkZWZhdWx0c0FuZE1pbkl0ZW1zIjp7InR5cGUiOiJhcnJheSIsInRpdGxlIjoiTGlzdCBhbmQgaXRlbSBsZXZlbCBkZWZhdWx0cyIsIm1pbkl0ZW1zIjo1LCJkZWZhdWx0IjpbImNhcnAiLCJ0cm91dCIsImJyZWFtIl0sIml0ZW1zIjp7InR5cGUiOiJzdHJpbmciLCJkZWZhdWx0IjoidW5pZGVudGlmaWVkIn19LCJuZXN0ZWRMaXN0Ijp7InR5cGUiOiJhcnJheSIsInRpdGxlIjoiTmVzdGVkIGxpc3QiLCJpdGVtcyI6eyJ0eXBlIjoiYXJyYXkiLCJ0aXRsZSI6IklubmVyIGxpc3QiLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIiwiZGVmYXVsdCI6ImxvcmVtIGlwc3VtIn19fSwidW5vcmRlcmFibGUiOnsidGl0bGUiOiJVbm9yZGVyYWJsZSBpdGVtcyIsInR5cGUiOiJhcnJheSIsIml0ZW1zIjp7InR5cGUiOiJzdHJpbmciLCJkZWZhdWx0IjoibG9yZW0gaXBzdW0ifX0sInVucmVtb3ZhYmxlIjp7InRpdGxlIjoiVW5yZW1vdmFibGUgaXRlbXMiLCJ0eXBlIjoiYXJyYXkiLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIiwiZGVmYXVsdCI6ImxvcmVtIGlwc3VtIn19LCJub1Rvb2xiYXIiOnsidGl0bGUiOiJObyBhZGQsIHJlbW92ZSBhbmQgb3JkZXIgYnV0dG9ucyIsInR5cGUiOiJhcnJheSIsIml0ZW1zIjp7InR5cGUiOiJzdHJpbmciLCJkZWZhdWx0IjoibG9yZW0gaXBzdW0ifX0sImZpeGVkTm9Ub29sYmFyIjp7InRpdGxlIjoiRml4ZWQgYXJyYXkgd2l0aG91dCBidXR0b25zIiwidHlwZSI6ImFycmF5IiwiaXRlbXMiOlt7InRpdGxlIjoiQSBudW1iZXIiLCJ0eXBlIjoibnVtYmVyIiwiZGVmYXVsdCI6NDJ9LHsidGl0bGUiOiJBIGJvb2xlYW4iLCJ0eXBlIjoiYm9vbGVhbiIsImRlZmF1bHQiOmZhbHNlfV0sImFkZGl0aW9uYWxJdGVtcyI6eyJ0aXRsZSI6IkEgc3RyaW5nIiwidHlwZSI6InN0cmluZyIsImRlZmF1bHQiOiJsb3JlbSBpcHN1bSJ9fX19LCJ1aVNjaGVtYSI6eyJsaXN0T2ZTdHJpbmdzIjp7Iml0ZW1zIjp7InVpOmVtcHR5VmFsdWUiOiIifX0sIm11bHRpcGxlQ2hvaWNlc0xpc3QiOnsidWk6d2lkZ2V0IjoiY2hlY2tib3hlcyJ9LCJmaXhlZEl0ZW1zTGlzdCI6eyJpdGVtcyI6W3sidWk6d2lkZ2V0IjoidGV4dGFyZWEifSx7InVpOndpZGdldCI6InNlbGVjdCJ9XSwiYWRkaXRpb25hbEl0ZW1zIjp7InVpOndpZGdldCI6InVwZG93biJ9fSwidW5vcmRlcmFibGUiOnsidWk6b3B0aW9ucyI6eyJvcmRlcmFibGUiOmZhbHNlfX0sInVucmVtb3ZhYmxlIjp7InVpOm9wdGlvbnMiOnsicmVtb3ZhYmxlIjpmYWxzZX19LCJub1Rvb2xiYXIiOnsidWk6b3B0aW9ucyI6eyJhZGRhYmxlIjpmYWxzZSwib3JkZXJhYmxlIjpmYWxzZSwicmVtb3ZhYmxlIjpmYWxzZX19LCJmaXhlZE5vVG9vbGJhciI6eyJ1aTpvcHRpb25zIjp7ImFkZGFibGUiOmZhbHNlLCJvcmRlcmFibGUiOmZhbHNlLCJyZW1vdmFibGUiOmZhbHNlfX19LCJ0aGVtZSI6ImNoYWtyYS11aSIsImxpdmVTZXR0aW5ncyI6eyJ2YWxpZGF0ZSI6ZmFsc2UsImRpc2FibGUiOmZhbHNlLCJyZWFkb25seSI6ZmFsc2UsIm9taXRFeHRyYURhdGEiOmZhbHNlLCJsaXZlT21pdCI6ZmFsc2V9fQ==)

By making a record in React Profiler, you'll notice that it takes 800ms (nearly a second) for a letter to appear on the screen from the key stroke.

<img width="1171" alt="image" src="https://user-images.githubusercontent.com/6823107/161918811-e14a47fd-2ead-46c1-a009-e29f1b937530.png">

The reason for that is although only one item value has changed, all the other items have been re-rendered, because the svg buttons next to the input(up, down, delete) were re-rendered.

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/6823107/161919505-a26ba1d2-db2b-4999-95dc-9d84fafe6a2a.png">

### Solution
This PR added memos for `onClick` functions and `ChakraIconButton` component to prevent unnecessary re-renders.

The result is that the render time is reduced to around 170ms from 830ms on my mac, and the icon buttons will not be re-rendered.

<img width="1112" alt="image" src="https://user-images.githubusercontent.com/6823107/161922144-c17851e2-e522-4c70-b6ce-50a657b80399.png">

<img width="810" alt="image" src="https://user-images.githubusercontent.com/6823107/161922328-8eee8413-74f0-47c1-a635-9e46cef14ec5.png">

https://user-images.githubusercontent.com/6823107/161929368-3c9daf1a-7f3d-4b87-9243-34821cf24c94.mp4


### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
