### PR TITLE
Use idSeparator prop for array item ids (#2792)

### DIFF
--- a/packages/core/src/components/fields/ArrayField.js
+++ b/packages/core/src/components/fields/ArrayField.js
@@ -475,7 +475,7 @@ class ArrayField extends Component {
       onBlur,
       onFocus,
       idPrefix,
-      idSeparator,
+      idSeparator = "_",
       rawErrors,
     } = this.props;
     const title = schema.title === undefined ? name : schema.title;
@@ -489,7 +489,7 @@ class ArrayField extends Component {
         const { key, item } = keyedItem;
         const itemSchema = retrieveSchema(schema.items, rootSchema, item);
         const itemErrorSchema = errorSchema ? errorSchema[index] : undefined;
-        const itemIdPrefix = idSchema.$id + "_" + index;
+        const itemIdPrefix = idSchema.$id + idSeparator + index;
         const itemIdSchema = toIdSchema(
           itemSchema,
           itemIdPrefix,
@@ -684,7 +684,7 @@ class ArrayField extends Component {
       formData,
       errorSchema,
       idPrefix,
-      idSeparator,
+      idSeparator = "_",
       idSchema,
       name,
       required,
@@ -726,7 +726,7 @@ class ArrayField extends Component {
         const itemSchema = additional
           ? retrieveSchema(schema.additionalItems, rootSchema, item)
           : itemSchemas[index];
-        const itemIdPrefix = idSchema.$id + "_" + index;
+        const itemIdPrefix = idSchema.$id + idSeparator + index;
         const itemIdSchema = toIdSchema(
           itemSchema,
           itemIdPrefix,

--- a/packages/core/test/ArrayField_test.js
+++ b/packages/core/test/ArrayField_test.js
@@ -1937,10 +1937,10 @@ describe("ArrayField", () => {
       });
 
       const inputs = node.querySelectorAll("input[type=text]");
-      expect(inputs[0].id).eql("base/foo_0/bar");
-      expect(inputs[1].id).eql("base/foo_0/baz");
-      expect(inputs[2].id).eql("base/foo_1/bar");
-      expect(inputs[3].id).eql("base/foo_1/baz");
+      expect(inputs[0].id).eql("base/foo/0/bar");
+      expect(inputs[1].id).eql("base/foo/0/baz");
+      expect(inputs[2].id).eql("base/foo/1/bar");
+      expect(inputs[3].id).eql("base/foo/1/baz");
     });
   });
 


### PR DESCRIPTION
### Reasons for making this change

To prefix ids for items' array, underscore (ie "_0") was used in the id prefix.

This fixes #2792 


### Checklist

* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
