### PR TITLE
made statelessComponent to FunctionComponent cause stateless is depre…

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -12,7 +12,7 @@ declare module '@rjsf/core' {
         acceptcharset?: string;
         action?: string;
         additionalMetaSchemas?: ReadonlyArray<object>;
-        ArrayFieldTemplate?: React.StatelessComponent<ArrayFieldTemplateProps>;
+        ArrayFieldTemplate?: React.FunctionComponent<ArrayFieldTemplateProps>;
         autoComplete?: string;
         autocomplete?: string; // deprecated
         children?: React.ReactNode;
@@ -23,9 +23,9 @@ declare module '@rjsf/core' {
         hideError?: boolean;
         enctype?: string;
         extraErrors?: any;
-        ErrorList?: React.StatelessComponent<ErrorListProps>;
+        ErrorList?: React.FunctionComponent<ErrorListProps>;
         fields?: { [name: string]: Field };
-        FieldTemplate?: React.StatelessComponent<FieldTemplateProps>;
+        FieldTemplate?: React.FunctionComponent<FieldTemplateProps>;
         formContext?: any;
         formData?: T;
         id?: string;
@@ -37,7 +37,7 @@ declare module '@rjsf/core' {
         name?: string;
         noHtml5Validate?: boolean;
         noValidate?: boolean;
-        ObjectFieldTemplate?: React.StatelessComponent<ObjectFieldTemplateProps>;
+        ObjectFieldTemplate?: React.FunctionComponent<ObjectFieldTemplateProps>;
         omitExtraData?: boolean;
         onBlur?: (id: string, value: any) => void;
         onChange?: (e: IChangeEvent<T>, es?: ErrorSchema) => any;
@@ -86,9 +86,9 @@ declare module '@rjsf/core' {
         'ui:widget'?: Widget | string;
         'ui:options'?: { [key: string]: boolean | number | string | object | any[] | null };
         'ui:order'?: string[];
-        'ui:FieldTemplate'?: React.StatelessComponent<FieldTemplateProps>;
-        'ui:ArrayFieldTemplate'?: React.StatelessComponent<ArrayFieldTemplateProps>;
-        'ui:ObjectFieldTemplate'?: React.StatelessComponent<ObjectFieldTemplateProps>;
+        'ui:FieldTemplate'?: React.FunctionComponent<FieldTemplateProps>;
+        'ui:ArrayFieldTemplate'?: React.FunctionComponent<ArrayFieldTemplateProps>;
+        'ui:ObjectFieldTemplate'?: React.FunctionComponent<ObjectFieldTemplateProps>;
         [name: string]: any;
         'ui:submitButtonOptions'?: UISchemaSubmitButtonOptions;
     };
@@ -137,7 +137,7 @@ declare module '@rjsf/core' {
         [prop: string]: any; // Allow for other props
     }
 
-    export type Widget = React.StatelessComponent<WidgetProps> | React.ComponentClass<WidgetProps>;
+    export type Widget = React.FunctionComponent<WidgetProps> | React.ComponentClass<WidgetProps>;
 
     export interface Registry {
         fields: { [name: string]: Field };
@@ -167,7 +167,7 @@ declare module '@rjsf/core' {
         [prop: string]: any; // Allow for other props
     }
 
-    export type Field = React.StatelessComponent<FieldProps> | React.ComponentClass<FieldProps>;
+    export type Field = React.FunctionComponent<FieldProps> | React.ComponentClass<FieldProps>;
 
     export type FieldTemplateProps<T = any> = {
         id: string;
@@ -197,8 +197,8 @@ declare module '@rjsf/core' {
     };
 
     export type ArrayFieldTemplateProps<T = any> = {
-        DescriptionField: React.StatelessComponent<{ id: string; description: string | React.ReactElement }>;
-        TitleField: React.StatelessComponent<{ id: string; title: string; required: boolean }>;
+        DescriptionField: React.FunctionComponent<{ id: string; description: string | React.ReactElement }>;
+        TitleField: React.FunctionComponent<{ id: string; title: string; required: boolean }>;
         canAdd: boolean;
         className: string;
         disabled: boolean;
@@ -230,8 +230,8 @@ declare module '@rjsf/core' {
     };
 
     export type ObjectFieldTemplateProps<T = any> = {
-        DescriptionField: React.StatelessComponent<{ id: string; description: string | React.ReactElement }>;
-        TitleField: React.StatelessComponent<{ id: string; title: string; required: boolean }>;
+        DescriptionField: React.FunctionComponent<{ id: string; description: string | React.ReactElement }>;
+        TitleField: React.FunctionComponent<{ id: string; title: string; required: boolean }>;
         title: string;
         description: string;
         disabled: boolean;
@@ -301,7 +301,7 @@ declare module '@rjsf/core' {
 
     export function withTheme<T = any>(
         themeProps: ThemeProps<T>,
-    ): React.ComponentClass<FormProps<T>> | React.StatelessComponent<FormProps<T>>;
+    ): React.ComponentClass<FormProps<T>> | React.FunctionComponent<FormProps<T>>;
 
     export type AddButtonProps = {
         className: string;


### PR DESCRIPTION
made statelessComponent to FunctionComponent cause stateless is deprecated

### Reasons for making this change

### made statelessComponent to FunctionComponent cause stateless is deprecated

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

If your PR is non-trivial and you'd like to schedule a synchronous review, please add it to the weekly meeting agenda: https://docs.google.com/document/d/12PjTvv21k6LIky6bNQVnsplMLLnmEuypTLQF8a-8Wss/edit

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
