### PR TITLE
Add 'list' as an allowed proprty to fluent-ui TextWidget

### DIFF
--- a/packages/fluent-ui/src/TextWidget/TextWidget.tsx
+++ b/packages/fluent-ui/src/TextWidget/TextWidget.tsx
@@ -41,7 +41,7 @@ const allowedProps = [
   "maskChar",
   "maskFormat",
   "type",
-  "list"
+  "list",
 ];
 
 const TextWidget = ({

--- a/packages/fluent-ui/src/TextWidget/TextWidget.tsx
+++ b/packages/fluent-ui/src/TextWidget/TextWidget.tsx
@@ -41,6 +41,7 @@ const allowedProps = [
   "maskChar",
   "maskFormat",
   "type",
+  "list"
 ];
 
 const TextWidget = ({


### PR DESCRIPTION
### Reasons for making this change

It's helpful to use the `list` attribute for text input [datalists](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist). This adds the `list` attribute as allowed in the `fluent-ui` component.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

[Note: did not see relevant documentation to update; may have missed something.]
