### PR TITLE
fix(utils): omit computedDefault of empty objects

### DIFF
--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -180,7 +180,13 @@ export function computeDefaults<T = any>(
             get(formData, [key]),
             includeUndefinedValues
           );
-          if (includeUndefinedValues || computedDefault !== undefined) {
+          if (typeof computedDefault === "object") {
+            // Store computedDefault if it's a non-empty object (e.g. not {})
+            if (includeUndefinedValues && !isEmpty(computedDefault)) {
+              acc[key] = computedDefault;
+            }
+          } else if (computedDefault !== undefined) {
+            // Store computedDefault if it's a defined primitive (e.g. true)
             acc[key] = computedDefault;
           }
           return acc;

--- a/packages/validator-ajv6/src/validator.ts
+++ b/packages/validator-ajv6/src/validator.ts
@@ -234,19 +234,9 @@ export default class AJV6Validator<T = any> implements ValidatorType<T> {
     customValidate?: CustomValidator<T>,
     transformErrors?: ErrorTransformer
   ): ValidationData<T> {
-    // Include form data with undefined values, which is required for validation.
-    const rootSchema = schema;
-    const newFormData = getDefaultFormState<T>(
-      this,
-      schema,
-      formData,
-      rootSchema,
-      true
-    ) as T;
-
     let validationError: Error | null = null;
     try {
-      this.ajv.validate(schema, newFormData);
+      this.ajv.validate(schema, formData);
     } catch (err) {
       validationError = err as Error;
     }
@@ -285,6 +275,16 @@ export default class AJV6Validator<T = any> implements ValidatorType<T> {
     if (typeof customValidate !== "function") {
       return { errors, errorSchema };
     }
+
+    // Include form data with undefined values, which is required for custom validation.
+    const rootSchema = schema;
+    const newFormData = getDefaultFormState<T>(
+      this,
+      schema,
+      formData,
+      rootSchema,
+      true
+    ) as T;
 
     const errorHandler = customValidate(
       newFormData,


### PR DESCRIPTION
### Reasons for making this change

Fixes #2150 and #2708. 
See this [playground](https://rjsf-team.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6e30sInNjaGVtYSI6eyJ0eXBlIjoib2JqZWN0IiwicmVxdWlyZWQiOltdLCJwcm9wZXJ0aWVzIjp7ImQwNDM0YWFjLTg1ZTYtNGVmYy05N2M3LTY0NmFiZTlhYWZhYyI6eyJ0aXRsZSI6InBlcnNvbiBmaWVsZCIsInR5cGUiOiJvYmplY3QiLCJkZXNjcmlwdGlvbiI6InNvbWUgdGV4dCIsInJlcXVpcmVkIjpbImIzZGUyNjdiLTUwNzMtNGM1MC1hYWE2LTAwY2RiMTM4OTgxZCJdLCJwcm9wZXJ0aWVzIjp7ImIzZGUyNjdiLTUwNzMtNGM1MC1hYWE2LTAwY2RiMTM4OTgxZCI6eyJ0aXRsZSI6IkVNQUlMIiwidHlwZSI6InN0cmluZyJ9LCI4ZDVhMmYzNy01NTAyLTRjZGEtOTVhOS04M2JjODYwMjg3NWIiOnsidGl0bGUiOiJGSVJTVF9OQU1FIiwidHlwZSI6InN0cmluZyJ9LCI0YTVmYjUwOC0xMGRhLTQ4ODgtOGY5Mi0zMjE3MGE5MzliZjkiOnsidGl0bGUiOiJMQVNUX05BTUUiLCJ0eXBlIjoic3RyaW5nIn19fX19LCJ1aVNjaGVtYSI6eyJmaXJzdE5hbWUiOnsidWk6YXV0b2ZvY3VzIjp0cnVlLCJ1aTplbXB0eVZhbHVlIjoiIiwidWk6YXV0b2NvbXBsZXRlIjoiZmFtaWx5LW5hbWUifSwibGFzdE5hbWUiOnsidWk6ZW1wdHlWYWx1ZSI6IiIsInVpOmF1dG9jb21wbGV0ZSI6ImdpdmVuLW5hbWUifSwiYWdlIjp7InVpOndpZGdldCI6InVwZG93biIsInVpOnRpdGxlIjoiQWdlIG9mIHBlcnNvbiIsInVpOmRlc2NyaXB0aW9uIjoiKGVhcnRoaWFuIHllYXIpIn0sImJpbyI6eyJ1aTp3aWRnZXQiOiJ0ZXh0YXJlYSJ9LCJwYXNzd29yZCI6eyJ1aTp3aWRnZXQiOiJwYXNzd29yZCIsInVpOmhlbHAiOiJIaW50OiBNYWtlIGl0IHN0cm9uZyEifSwiZGF0ZSI6eyJ1aTp3aWRnZXQiOiJhbHQtZGF0ZXRpbWUifSwidGVsZXBob25lIjp7InVpOm9wdGlvbnMiOnsiaW5wdXRUeXBlIjoidGVsIn19fSwidGhlbWUiOiJkZWZhdWx0IiwibGl2ZVNldHRpbmdzIjp7InZhbGlkYXRlIjp0cnVlLCJkaXNhYmxlIjpmYWxzZSwib21pdEV4dHJhRGF0YSI6ZmFsc2UsImxpdmVPbWl0IjpmYWxzZX19) 

If there are no defaults, `computedDefault` will still create an empty object [here](https://github.com/rjsf-team/react-jsonschema-form/blob/57f00cb522c698a2a201c7204d78dfc6323ac6f6/packages/core/src/utils.js#L240). As a result, ajv assumes that the field should exist and is failing the validation if it has any required fields. 
