### PR TITLE
Fix baseURL location in tsconfig adjustment

### DIFF
--- a/packages/material-ui/README.md
+++ b/packages/material-ui/README.md
@@ -123,8 +123,8 @@ If you are experiencing an error that is similar to `TS2307: Cannot find module 
   ...
   "compilerOptions": {
     ...
+    "baseUrl": ".",
     "paths": {
-      "baseUrl": ".",
       "@rjsf/material-ui/*": ["node_modules/@rjsf/material-ui/dist/*"]
     }
   }
@@ -173,8 +173,8 @@ If you are experiencing an error that is similar to `TS2307: Cannot find module 
   ...
   "compilerOptions": {
     ...
+    "baseUrl": ".",
     "paths": {
-      "baseUrl": ".",
       "@rjsf/material-ui/*": ["node_modules/@rjsf/material-ui/dist/*"]
     }
   }


### PR DESCRIPTION
As per [tsconfig reference](https://www.typescriptlang.org/tsconfig#baseUrl), the baseURL parameter is located outside of the paths object. Failure to put it there will result in a failed path resolution. 

Source: Ran onto the issue myself and that was the fix

### Reasons for making this change

The Typescript compiler will fail to resolve the material-ui form (either v4 or v5) when the baseURL is not set. This fixes the tsconfig adjustment proposal. 

### Checklist

* [X] **I'm updating documentation**
  - [X] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
