### PR TITLE
fix(ts): expose ObjectField component types

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -477,6 +477,14 @@ declare module '@rjsf/core/lib/components/fields/SchemaField' {
     export default class SchemaField extends React.Component<SchemaFieldProps> {}
 }
 
+declare module '@rjsf/core/lib/components/fields/ObjectField' {
+  import { FieldProps } from '@rjsf/core';
+
+  export type ObjectFieldProps<T = any> = FieldProps<T>;
+
+  export default class ObjectField extends React.Component<ObjectFieldProps> {}
+}
+
 declare module '@rjsf/core/lib/validate' {
     import { JSONSchema7Definition } from 'json-schema';
     import { AjvError, ErrorSchema, FormProps } from '@rjsf/core';


### PR DESCRIPTION
### Reasons for making this change

The `ObjectField` type is currently not exposed and therefore we need to add `// @ts-ignore` if we need to reuse an `ObjectField` component in the implementation of `ui:field`. It's already exported by the packaged and the only missing piece is to declare the module. 