### PR TITLE
Fixed (#2831) by removing special DefaultChildren

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # v5.0.0 (coming soon)
 
+# 4.2.1 (upcoming)
+
 # 4.2.0
 
 ## @rjsf/core
@@ -32,6 +34,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed bundler warning issue (#2762) by exporting a `@rjsf/material-ui/v4` and `@rjsf/material-ui/v5` sub-package
   - NOTE: `@rjsf/material-ui` was retained to avoid a breaking change, but using it will continue to cause bundler warnings
   - See the `README.md` for the `@rjsf/material-ui` package for updated usage information
+- Fixed (#2831) for `material-ui` by removing the `DefaultChildren` passed into the themes
   
 ## @rjsf/bootstrap-4
 - SubmitButton widget to use new ui:submitButtonOptions on the submit button for forms (https://github.com/rjsf-team/react-jsonschema-form/pull/2640)

--- a/packages/material-ui/src/Theme/MaterialUIContext.tsx
+++ b/packages/material-ui/src/Theme/MaterialUIContext.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import MaterialUIContextProps from './MaterialUIContextProps';
 
 /** Use require for loading these libraries in case they are not available in order to perform a useful fallback */
@@ -107,17 +106,3 @@ if (Box && AddIcon) {
     RemoveIcon,
   };
 }
-
-export const DefaultChildren = () => {
-  if (MaterialUIContext.Box && MaterialUIContext.Button && MaterialUIContext.AddIcon) {
-    return (
-      <MaterialUIContext.Box marginTop={3}>
-        <MaterialUIContext.Button type="submit" variant="contained" color="primary">
-          Submit
-        </MaterialUIContext.Button>
-      </MaterialUIContext.Box>
-    );
-  }
-
-  return <div>@material-ui not available</div>;
-};

--- a/packages/material-ui/src/Theme/Theme.tsx
+++ b/packages/material-ui/src/Theme/Theme.tsx
@@ -3,7 +3,7 @@ import { ThemeProps } from '@rjsf/core';
 
 import MuiComponentContext from '../MuiComponentContext';
 import ThemeCommon from '../ThemeCommon';
-import { MaterialUIContext, DefaultChildren } from './MaterialUIContext';
+import { MaterialUIContext } from './MaterialUIContext';
 
 /** Create a component that will wrap a ref-able HTML "form" with a `MuiComponentContext.Provider` so that all of the
  * `@material-ui` fields, widgets and helpers will be rendered using the Material UI version 4 components. If the
@@ -24,11 +24,10 @@ const Mui4FormWrapper = React.forwardRef(
   }
 );
 
-/** The Material UI 4 theme, with the `Mui4FormWrapper` and `DefaultChildren`
+/** The Material UI 4 theme, with the `Mui4FormWrapper`
  */
 const Theme: ThemeProps = {
   _internalFormWrapper: Mui4FormWrapper,
-  children: <DefaultChildren />,
   ...ThemeCommon,
 };
 

--- a/packages/material-ui/src/Theme5/Mui5Context.tsx
+++ b/packages/material-ui/src/Theme5/Mui5Context.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Mui5ContextProps from './Mui5ContextProps';
 
 /** Use require for loading these libraries in case they are not available in order to perform a useful fallback */
@@ -107,17 +106,3 @@ if (Box && AddIcon) {
     RemoveIcon,
   };
 }
-
-export let DefaultChildren = () => {
-  if (Mui5Context.Box && Mui5Context.Button && Mui5Context.AddIcon) {
-    return (
-      <Mui5Context.Box marginTop={3}>
-        <Mui5Context.Button type="submit" variant="contained" color="primary">
-          Submit
-        </Mui5Context.Button>
-      </Mui5Context.Box>
-    );
-  }
-
-  return <div>@mui not available</div>;
-};

--- a/packages/material-ui/src/Theme5/Theme5.tsx
+++ b/packages/material-ui/src/Theme5/Theme5.tsx
@@ -3,7 +3,7 @@ import { ThemeProps } from '@rjsf/core';
 
 import MuiComponentContext from '../MuiComponentContext';
 import ThemeCommon from '../ThemeCommon';
-import { Mui5Context, DefaultChildren } from './Mui5Context';
+import { Mui5Context } from './Mui5Context';
 
 /** Create a component that will wrap a ref-able HTML "form" with a `MuiComponentContext.Provider` so that all of the
  * `@mui` fields, widgets and helpers will be rendered using the Material UI version 5 components. If the `Mui5Context`
@@ -24,11 +24,10 @@ const Mui5FormWrapper = React.forwardRef(
   }
 );
 
-/** The Material UI 5 theme, with the `Mui5FormWrapper` and `DefaultChildren`
+/** The Material UI 5 theme, with the `Mui5FormWrapper
  */
 const Theme5: ThemeProps = {
   _internalFormWrapper: Mui5FormWrapper,
-  children: <DefaultChildren />,
   ...ThemeCommon,
 };
 


### PR DESCRIPTION
### Reasons for making this change

Fixed (#2831) for Material-ui

- Updated the `Theme` and `Theme5` themes to no longer include special `DefaultChildren` since no children is rendered when the context is missing anyway
### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
