### PR TITLE
fix: allow UISchemaSubmitButtonOptions properties to be undefined

### DIFF
--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -72,9 +72,9 @@ declare module '@rjsf/core' {
     }
 
     export type UISchemaSubmitButtonOptions = {
-      submitText: string;
-      norender: boolean;
-      props: {
+      submitText?: string;
+      norender?: boolean;
+      props?: {
         disabled?:boolean;
         className?:string;
         [name: string]: any;


### PR DESCRIPTION
### Reasons for making this change

How to reproduce:

In a TS context, when you create a form like the following:

```ts
const uiSchema: UiSchema = {
  'ui:submitButtonOptions': {
    submitText: 'Save and next',
    // norender: false,
    // props: {},
  },
};

function Part2(): JSX.Element {

  return (
    <Form
      className="Ssa-Part2"
      schema={whatever}
      uiSchema={uiSchema}
    />
  );
}
``` 

TS will complain because `props` and `norender` are needed. We have to add them with the default values. Since these 3 props don't seem to be interconnected, I'd suggest making the 3 optional.

Regarding the checklog, do I need to update the changelog?


Have a nice day :)

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
