### PR TITLE
fix(@rjsf/core): use name for additional properties

### DIFF
--- a/packages/core/src/components/fields/SchemaField.js
+++ b/packages/core/src/components/fields/SchemaField.js
@@ -302,7 +302,9 @@ function SchemaFieldRender(props) {
   if (wasPropertyKeyModified) {
     label = name;
   } else {
-    label = uiSchema["ui:title"] || props.schema.title || schema.title || name;
+    label = schema.hasOwnProperty(ADDITIONAL_PROPERTY_FLAG)
+      ? name
+      : uiSchema["ui:title"] || props.schema.title || schema.title || name;
   }
 
   const description =


### PR DESCRIPTION
### Reasons for making this change

When rendering additional properties with title, the key of all properties appears to be the title of the property instead of the actual value of the key. Instead, we should first take the key in this case

<img width="537" alt="image" src="https://user-images.githubusercontent.com/17147717/172781803-228b4af4-45b0-4ad0-92c8-e92c5f18ca62.png">

Is there a reason to add a test for this?

Playground (demo)[https://rjsf-team.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6eyJmaXJzdE5hbWUiOiJDaHVjayIsImxhc3ROYW1lIjoiTm9ycmlzIiwiaGVsbG8iOnsiZnNkZiI6eyJmaXJzdE5hbWUiOiJoZXkifX19LCJzY2hlbWEiOnsidGl0bGUiOiJBIGN1c3RvbWl6YWJsZSByZWdpc3RyYXRpb24gZm9ybSIsImRlc2NyaXB0aW9uIjoiQSBzaW1wbGUgZm9ybSB3aXRoIGFkZGl0aW9uYWwgcHJvcGVydGllcyBleGFtcGxlLiIsInR5cGUiOiJvYmplY3QiLCJyZXF1aXJlZCI6WyJmaXJzdE5hbWUiLCJsYXN0TmFtZSJdLCJwcm9wZXJ0aWVzIjp7ImZpcnN0TmFtZSI6eyJ0eXBlIjoic3RyaW5nIiwidGl0bGUiOiJGaXJzdCBuYW1lIn0sImxhc3ROYW1lIjp7InR5cGUiOiJzdHJpbmciLCJ0aXRsZSI6Ikxhc3QgbmFtZSJ9LCJoZWxsbyI6eyJ0eXBlIjoib2JqZWN0IiwicHJvcGVydGllcyI6e30sImFkZGl0aW9uYWxQcm9wZXJ0aWVzIjp7IiRyZWYiOiIjLyRkZWZzL2JsYSJ9fX0sIiRkZWZzIjp7ImJsYSI6eyJ0eXBlIjoib2JqZWN0IiwidGl0bGUiOiJwcm9wVGl0bGUiLCJwcm9wZXJ0aWVzIjp7ImZpcnN0TmFtZSI6eyJ0eXBlIjoic3RyaW5nIiwidGl0bGUiOiJGaXJzdCBuYW1lIn0sImxhc3ROYW1lIjp7InR5cGUiOiJzdHJpbmciLCJ0aXRsZSI6Ikxhc3QgbmFtZSJ9fX19fSwidWlTY2hlbWEiOnsiZmlyc3ROYW1lIjp7InVpOmF1dG9mb2N1cyI6dHJ1ZSwidWk6ZW1wdHlWYWx1ZSI6IiIsInVpOmF1dG9jb21wbGV0ZSI6ImZhbWlseS1uYW1lIn0sImxhc3ROYW1lIjp7InVpOmVtcHR5VmFsdWUiOiIiLCJ1aTphdXRvY29tcGxldGUiOiJnaXZlbi1uYW1lIn0sImFnZSI6eyJ1aTp3aWRnZXQiOiJ1cGRvd24iLCJ1aTp0aXRsZSI6IkFnZSBvZiBwZXJzb24iLCJ1aTpkZXNjcmlwdGlvbiI6IihlYXJ0aGlhbiB5ZWFyKSJ9LCJiaW8iOnsidWk6d2lkZ2V0IjoidGV4dGFyZWEifSwicGFzc3dvcmQiOnsidWk6d2lkZ2V0IjoicGFzc3dvcmQiLCJ1aTpoZWxwIjoiSGludDogTWFrZSBpdCBzdHJvbmchIn0sImRhdGUiOnsidWk6d2lkZ2V0IjoiYWx0LWRhdGV0aW1lIn0sInRlbGVwaG9uZSI6eyJ1aTpvcHRpb25zIjp7ImlucHV0VHlwZSI6InRlbCJ9fX0sInRoZW1lIjoiZGVmYXVsdCIsImxpdmVTZXR0aW5ncyI6eyJ2YWxpZGF0ZSI6ZmFsc2UsImRpc2FibGUiOmZhbHNlLCJyZWFkb25seSI6ZmFsc2UsIm9taXRFeHRyYURhdGEiOmZhbHNlLCJsaXZlT21pdCI6ZmFsc2V9fQ==]
