### PR TITLE
[updated] trim empty objects to allow correct validation of optional objects with mandatory fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 4.2.1 (upcoming)
 
+## @rjsf/core
+- Optional object with empty values are now trimmed to avoid "required" errors (#675)
+
 # 4.2.0
 
 ## @rjsf/core

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1365,9 +1365,9 @@ export function schemaRequiresTrueValue(schema) {
   return false;
 }
 
-function trimObject(object) {
-  return Object.entries(object).reduce((acc, [key, value]) => {
-    const trimmed = trimEmptyValues(value);
+function trimObject(schema, object) {
+  return Object.entries(schema.properties).reduce((acc, [key, value]) => {
+    const trimmed = trimEmptyValues(value, object[key]);
     if (trimmed || trimmed === false) {
       if (!acc) {
         acc = {};
@@ -1378,9 +1378,9 @@ function trimObject(object) {
   }, undefined);
 }
 
-function trimArray(array) {
+function trimArray(schema, array) {
   return array.reduce((acc, value) => {
-    const trimmed = trimEmptyValues(value);
+    const trimmed = trimEmptyValues(schema.items, value);
     if (trimmed || trimmed === false) {
       acc.push(trimmed);
     }
@@ -1388,10 +1388,10 @@ function trimArray(array) {
   }, []);
 }
 
-export function trimEmptyValues(value) {
-  return Array.isArray(value)
-    ? trimArray(value) || []
-    : typeof value === "object"
-    ? trimObject(value) || {}
+export function trimEmptyValues(schema, value) {
+  return schema.type === "array"
+    ? trimArray(schema, value) || []
+    : schema.type === "object"
+    ? trimObject(schema, value) || {}
     : value;
 }

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1390,8 +1390,8 @@ function trimArray(array) {
 
 export function trimEmptyValues(value) {
   return Array.isArray(value)
-    ? trimArray(value)
+    ? trimArray(value) || []
     : typeof value === "object"
-    ? trimObject(value)
+    ? trimObject(value) || {}
     : value;
 }

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1364,3 +1364,34 @@ export function schemaRequiresTrueValue(schema) {
 
   return false;
 }
+
+function trimObject(object) {
+  return Object.entries(object).reduce((acc, [key, value]) => {
+    const trimmed = trimEmptyValues(value);
+    if (trimmed) {
+      if (!acc) {
+        acc = {};
+      }
+      acc[key] = trimmed;
+    }
+    return acc;
+  }, undefined);
+}
+
+function trimArray(array) {
+  return array.reduce((acc, value) => {
+    const trimmed = trimEmptyValues(value);
+    if (trimmed) {
+      acc.push(trimmed);
+    }
+    return acc;
+  }, []);
+}
+
+export function trimEmptyValues(value) {
+  return Array.isArray(value)
+    ? trimArray(value)
+    : typeof value === "object"
+    ? trimObject(value)
+    : value;
+}

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -1368,7 +1368,7 @@ export function schemaRequiresTrueValue(schema) {
 function trimObject(object) {
   return Object.entries(object).reduce((acc, [key, value]) => {
     const trimmed = trimEmptyValues(value);
-    if (trimmed) {
+    if (trimmed || trimmed === false) {
       if (!acc) {
         acc = {};
       }
@@ -1381,7 +1381,7 @@ function trimObject(object) {
 function trimArray(array) {
   return array.reduce((acc, value) => {
     const trimmed = trimEmptyValues(value);
-    if (trimmed) {
+    if (trimmed || trimmed === false) {
       acc.push(trimmed);
     }
     return acc;

--- a/packages/core/src/validate.js
+++ b/packages/core/src/validate.js
@@ -206,7 +206,7 @@ export default function validateFormData(
   let validationError = null;
   try {
     // 675 - deal with optional objects with required values
-    const trimmedData = trimEmptyValues(formData);
+    const trimmedData = trimEmptyValues(schema, formData);
     ajv.validate(schema, trimmedData);
   } catch (err) {
     validationError = err;
@@ -303,7 +303,7 @@ export function withIdRefPrefix(schemaNode) {
 export function isValid(schema, data, rootSchema) {
   try {
     // 675 - deal with optional objects with required values
-    const trimmedData = trimEmptyValues(data);
+    const trimmedData = trimEmptyValues(schema, data);
 
     // add the rootSchema ROOT_SCHEMA_PREFIX as id.
     // then rewrite the schema ref's to point to the rootSchema

--- a/packages/core/src/validate.js
+++ b/packages/core/src/validate.js
@@ -7,7 +7,7 @@ let formerCustomFormats = null;
 let formerMetaSchema = null;
 const ROOT_SCHEMA_PREFIX = "__rjsf_rootSchema";
 
-import { isObject, mergeObjects } from "./utils";
+import { isObject, mergeObjects, trimEmptyValues } from "./utils";
 
 function createAjvInstance() {
   const ajv = new Ajv({
@@ -205,7 +205,9 @@ export default function validateFormData(
 
   let validationError = null;
   try {
-    ajv.validate(schema, formData);
+    // 675 - deal with optional objects with required values
+    const trimmedData = trimEmptyValues(formData);
+    ajv.validate(schema, trimmedData);
   } catch (err) {
     validationError = err;
   }
@@ -300,13 +302,16 @@ export function withIdRefPrefix(schemaNode) {
  */
 export function isValid(schema, data, rootSchema) {
   try {
+    // 675 - deal with optional objects with required values
+    const trimmedData = trimEmptyValues(data);
+
     // add the rootSchema ROOT_SCHEMA_PREFIX as id.
     // then rewrite the schema ref's to point to the rootSchema
     // this accounts for the case where schema have references to models
     // that lives in the rootSchema but not in the schema in question.
     return ajv
       .addSchema(rootSchema, ROOT_SCHEMA_PREFIX)
-      .validate(withIdRefPrefix(schema), data);
+      .validate(withIdRefPrefix(schema), trimmedData);
   } catch (e) {
     return false;
   } finally {

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -32,6 +32,7 @@ import {
   isCustomWidget,
   getMatchingOption,
   getSubmitButtonOptions,
+  trimEmptyValues,
 } from "../src/utils";
 import { createSandbox } from "./test_utils";
 
@@ -4497,5 +4498,142 @@ describe("utils", () => {
       };
       expect(getMatchingOption(formData, options, rootSchema)).eql(1);
     });
-  });
+  }),
+    describe("trimEmptyValues", () => {
+      it("empty object", () => {
+        const input = {};
+        const expected = undefined;
+        expect(trimEmptyValues(input)).to.eql(expected);
+      });
+      it("flat populated object", () => {
+        const input = { a: "value", b: 3 };
+        const expected = { a: "value", b: 3 };
+        expect(trimEmptyValues(input)).to.eql(expected);
+      });
+      it("flat populated object with boolean values", () => {
+        const input = { a: true, b: false };
+        const expected = { a: true, b: false };
+        expect(trimEmptyValues(input)).to.eql(expected);
+      });
+      it("flat partially populated object", () => {
+        const input = { a: "value", b: undefined };
+        const expected = { a: "value" };
+        expect(trimEmptyValues(input)).to.eql(expected);
+      });
+      it("flat unpopulated object", () => {
+        const input = { a: undefined, b: undefined };
+        const expected = undefined;
+        expect(trimEmptyValues(input)).to.eql(expected);
+      });
+      it("nested populated object", () => {
+        const input = { a: "value", b: 3, c: { c1: "nested value" } };
+        const expected = { a: "value", b: 3, c: { c1: "nested value" } };
+        expect(trimEmptyValues(input)).to.eql(expected);
+      });
+      it("nested partially populated object", () => {
+        const input = { a: "value", b: undefined, c: { c1: "nested value" } };
+        const expected = { a: "value", c: { c1: "nested value" } };
+        expect(trimEmptyValues(input)).to.eql(expected);
+      });
+      it("unpopulated nested object", () => {
+        const input = { a: "value", b: 3, c: { c1: undefined } };
+        const expected = { a: "value", b: 3 };
+        expect(trimEmptyValues(input)).to.eql(expected);
+      });
+      it("partially populated nested object", () => {
+        const input = {
+          a: "value",
+          b: 3,
+          c: { c1: undefined, c2: "nested value" },
+        };
+        const expected = { a: "value", b: 3, c: { c2: "nested value" } };
+        expect(trimEmptyValues(input)).to.eql(expected);
+      });
+      it("partially populated deeply nested object", () => {
+        const input = {
+          a: "value",
+          b: undefined,
+          c: {
+            c1: undefined,
+            c2: "nested value",
+            c3: {
+              c31: undefined,
+              c32: {
+                c321: undefined,
+                c322: undefined,
+                c323: false,
+              },
+              c33: {
+                c331: "nested value",
+                c332: undefined,
+              },
+            },
+          },
+        };
+        const expected = {
+          a: "value",
+          c: {
+            c2: "nested value",
+            c3: {
+              c32: {
+                c323: false,
+              },
+              c33: {
+                c331: "nested value",
+              },
+            },
+          },
+        };
+        expect(trimEmptyValues(input)).to.eql(expected);
+      });
+      it("empty array is kept", () => {
+        const input = { a: [] };
+        const expected = { a: [] };
+        expect(trimEmptyValues(input)).to.eql(expected);
+      });
+      it("populated array is kept", () => {
+        const input = { a: [{ b: "value" }] };
+        const expected = { a: [{ b: "value" }] };
+        expect(trimEmptyValues(input)).to.eql(expected);
+      });
+      it("partially populated deeply nested object with arrays", () => {
+        const input = {
+          a: "value",
+          b: undefined,
+          c: {
+            c1: [],
+            c2: "nested value",
+            c3: {
+              c31: undefined,
+              c32: {
+                c321: undefined,
+                c322: undefined,
+                c323: false,
+              },
+              c33: {
+                c331: "nested value",
+                c332: [{ a: undefined, b: { c: undefined } }, { b: "value" }],
+              },
+            },
+          },
+        };
+        const expected = {
+          a: "value",
+          c: {
+            c1: [],
+            c2: "nested value",
+            c3: {
+              c32: {
+                c323: false,
+              },
+              c33: {
+                c331: "nested value",
+                c332: [{ b: "value" }],
+              },
+            },
+          },
+        };
+        expect(trimEmptyValues(input)).to.eql(expected);
+      });
+    });
 });


### PR DESCRIPTION
### Reasons for making this change

This is a rebase and fix of #1228, which is stale. See also #675, #682

I've kept the change exactly the same (trusting @numical's work there), beyond rebasing I merely added b9f462e2176b4471ca24e60b92f43c455069ed6e which fixes the tests. I don't know if it makes sense to also edit the documentation beyond the changelog, or if this should be implicit behavior?

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
