### PR TITLE
material-ui: Add unique id for each field in order to allow precise css selector.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 4.2.1 (upcoming)
 
+## @rjsf/material-ui
+- Add unique id on each rendered object fields to ease specific CSS selector [#2884](https://github.com/rjsf-team/react-jsonschema-form/pull/2884)
+
 # 4.2.0
 
 ## @rjsf/core

--- a/packages/material-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/material-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -28,14 +28,14 @@ const ObjectFieldTemplate = ({
         <TitleField id={`${idSchema.$id}-title`} title={title} required={required} />
       )}
       {description && <DescriptionField id={`${idSchema.$id}-description`} description={description} />}
-      <Grid container={true} spacing={2} style={{ marginTop: '10px' }}>
+      <Grid id={idSchema.$id} container={true} spacing={2} style={{ marginTop: '10px' }}>
         {properties.map((element, index) =>
           // Remove the <Grid> if the inner element is hidden as the <Grid>
           // itself would otherwise still take up space.
           element.hidden ? (
             element.content
           ) : (
-            <Grid item={true} xs={12} key={index} style={{ marginBottom: '10px' }}>
+            <Grid id={`${idSchema.$id}-${element.name}`} item={true} xs={12} key={index} style={{ marginBottom: '10px' }}>
               {element.content}
             </Grid>
           )

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -660,6 +660,7 @@ exports[`single fields hidden field 1`] = `
   >
     <div
       className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
+      id="root"
       style={
         Object {
           "marginTop": "10px",

--- a/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`object fields additionalProperties 1`] = `
   >
     <div
       className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
+      id="root"
       style={
         Object {
           "marginTop": "10px",
@@ -19,6 +20,7 @@ exports[`object fields additionalProperties 1`] = `
     >
       <div
         className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+        id="root-foo"
         style={
           Object {
             "marginBottom": "10px",
@@ -242,6 +244,7 @@ exports[`object fields object 1`] = `
   >
     <div
       className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
+      id="root"
       style={
         Object {
           "marginTop": "10px",
@@ -250,6 +253,7 @@ exports[`object fields object 1`] = `
     >
       <div
         className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+        id="root-a"
         style={
           Object {
             "marginBottom": "10px",
@@ -295,6 +299,7 @@ exports[`object fields object 1`] = `
       </div>
       <div
         className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+        id="root-b"
         style={
           Object {
             "marginBottom": "10px",

--- a/packages/material-ui/test/mui-5/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/mui-5/__snapshots__/Form.test.tsx.snap
@@ -660,6 +660,7 @@ exports[`single fields hidden field 1`] = `
   >
     <div
       className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-mhc70k-MuiGrid-root"
+      id="root"
       style={
         Object {
           "marginTop": "10px",

--- a/packages/material-ui/test/mui-5/__snapshots__/Object.test.tsx.snap
+++ b/packages/material-ui/test/mui-5/__snapshots__/Object.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`object fields additionalProperties 1`] = `
   >
     <div
       className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-mhc70k-MuiGrid-root"
+      id="root"
       style={
         Object {
           "marginTop": "10px",
@@ -19,6 +20,7 @@ exports[`object fields additionalProperties 1`] = `
     >
       <div
         className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1idn90j-MuiGrid-root"
+        id="root-foo"
         style={
           Object {
             "marginBottom": "10px",
@@ -264,6 +266,7 @@ exports[`object fields object 1`] = `
   >
     <div
       className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-mhc70k-MuiGrid-root"
+      id="root"
       style={
         Object {
           "marginTop": "10px",
@@ -272,6 +275,7 @@ exports[`object fields object 1`] = `
     >
       <div
         className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1idn90j-MuiGrid-root"
+        id="root-a"
         style={
           Object {
             "marginBottom": "10px",
@@ -329,6 +333,7 @@ exports[`object fields object 1`] = `
       </div>
       <div
         className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-1idn90j-MuiGrid-root"
+        id="root-b"
         style={
           Object {
             "marginBottom": "10px",


### PR DESCRIPTION
### Reasons for making this change

Well, I started to work on it after checking this issue #1738 . But at the end it is not exactly solving this, but it is allowing at least a way to have a specific selector for each rendered field using the MUI theme.

Which is really important from my point of view because it allows a more complex way to style the form.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
