### PR TITLE
Docs: Clarify registry object structure and that it's passed down to custom widgets

### DIFF
--- a/docs/advanced-customization/custom-widgets-fields.md
+++ b/docs/advanced-customization/custom-widgets-fields.md
@@ -138,6 +138,7 @@ The following props are passed to custom widget components:
 - `options.enumOptions`: For enum fields, this property contains the list of options for the enum as an array of { label, value } objects. If the enum is defined using the oneOf/anyOf syntax, the entire schema object for each option is appended onto the { schema, label, value } object.
 - `formContext`: The `formContext` object that you passed to Form.
 - `rawErrors`: An array of strings listing all generated error messages from encountered errors for this widget.
+ - `registry`: A [registry](#the-registry-object) object (read next).
 
 ### Custom component registration
 
@@ -296,13 +297,13 @@ A field component will always be passed the following props:
 
 The `registry` is an object containing the registered custom fields and widgets as well as the root schema definitions.
 
- - `fields`: The [custom registered fields](#custom-field-components). By default this object contains the standard `SchemaField`, `TitleField` and `DescriptionField` components;
- - `widgets`: The [custom registered widgets](#custom-widget-components), if any;
+ - `fields`: All fields, including [custom registered fields](#custom-field-components), if any;
+ - `widgets`: All widgets, including, [custom registered widgets](#custom-widget-components), if any;
  - `rootSchema`: The root schema, which can contain referenced [definitions](#schema-definitions-and-references);
  - `formContext`: The [formContext](#the-formcontext-object) object;
  - `definitions` (deprecated since v2): Equal to `rootSchema.definitions`.
 
-The registry is passed down the component tree, so you can access it from your custom field and `SchemaField` components.
+The registry is passed down the component tree, so you can access it from your custom field, custom widget, and `SchemaField` components.
 
 ### Custom SchemaField
 


### PR DESCRIPTION
Also see: https://github.com/rjsf-team/react-jsonschema-form/blob/724fb0bc3f1ae5d1d9b761b2bff7cf5c64fd7459/packages/core/src/defaultRegistry.js