### PR TITLE
Fix incorrect react syntax inside MUI ArrayFieldTemplate (broken hook order)

### DIFF
--- a/packages/material-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/material-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -49,7 +49,7 @@ const ArrayFieldDescription = ({ DescriptionField, idSchema, description }: Arra
 };
 
 // Used in the two templates
-const DefaultArrayItem = (props: any) => {
+const DefaultArrayItem = (props: { extra: any }) => {
   const { ArrowDownwardIcon, ArrowUpwardIcon, Box, Grid, IconButton, Paper, RemoveIcon } = useMuiComponent();
   const btnStyle = {
     flex: 1,
@@ -59,49 +59,49 @@ const DefaultArrayItem = (props: any) => {
     minWidth: 0,
   };
   return (
-    <Grid container={true} key={props.key} alignItems="center">
+    <Grid container={true} key={props.extra.key} alignItems="center">
       <Grid item={true} xs style={{ overflow: 'auto' }}>
         <Box mb={2}>
           <Paper elevation={2}>
-            <Box p={2}>{props.children}</Box>
+            <Box p={2}>{props.extra.children}</Box>
           </Paper>
         </Box>
       </Grid>
 
-      {props.hasToolbar && (
+      {props.extra.hasToolbar && (
         <Grid item={true}>
-          {(props.hasMoveUp || props.hasMoveDown) && (
+          {(props.extra.hasMoveUp || props.extra.hasMoveDown) && (
             <IconButton
               size="small"
               className="array-item-move-up"
               tabIndex={-1}
               style={btnStyle as any}
-              disabled={props.disabled || props.readonly || !props.hasMoveUp}
-              onClick={props.onReorderClick(props.index, props.index - 1)}
+              disabled={props.extra.disabled || props.extra.readonly || !props.extra.hasMoveUp}
+              onClick={props.extra.onReorderClick(props.extra.index, props.extra.index - 1)}
             >
               <ArrowUpwardIcon fontSize="small" />
             </IconButton>
           )}
 
-          {(props.hasMoveUp || props.hasMoveDown) && (
+          {(props.extra.hasMoveUp || props.extra.hasMoveDown) && (
             <IconButton
               size="small"
               tabIndex={-1}
               style={btnStyle as any}
-              disabled={props.disabled || props.readonly || !props.hasMoveDown}
-              onClick={props.onReorderClick(props.index, props.index + 1)}
+              disabled={props.extra.disabled || props.extra.readonly || !props.extra.hasMoveDown}
+              onClick={props.extra.onReorderClick(props.extra.index, props.extra.index + 1)}
             >
               <ArrowDownwardIcon fontSize="small" />
             </IconButton>
           )}
 
-          {props.hasRemove && (
+          {props.extra.hasRemove && (
             <IconButton
               size="small"
               tabIndex={-1}
               style={btnStyle as any}
-              disabled={props.disabled || props.readonly}
-              onClick={props.onDropIndexClick(props.index)}
+              disabled={props.extra.disabled || props.extra.readonly}
+              onClick={props.extra.onDropIndexClick(props.extra.index)}
             >
               <RemoveIcon fontSize="small" />
             </IconButton>
@@ -130,7 +130,7 @@ const DefaultFixedArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
       )}
 
       <div className="row array-item-list" key={`array-item-list-${props.idSchema.$id}`}>
-        {props.items && props.items.map(DefaultArrayItem)}
+        {props.items && props.items.map((p) => <DefaultArrayItem extra={p} key={p.key} />)}
       </div>
 
       {props.canAdd && (
@@ -167,7 +167,7 @@ const DefaultNormalArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
         )}
 
         <Grid container={true} key={`array-item-list-${props.idSchema.$id}`}>
-          {props.items && props.items.map(p => DefaultArrayItem(p))}
+          {props.items && props.items.map(p => <DefaultArrayItem extra={p} key={p.key} />)}
 
           {props.canAdd && (
             <Grid container justifyContent="flex-end">


### PR DESCRIPTION
### Reasons for making this change

Misuse of functional react is causing following console error in my application (which I'm trying to avoid). 
![image](https://user-images.githubusercontent.com/52047345/177992898-6bead375-eed4-412d-bd4c-1ced70ae0d88.png)
After investigation, I notice that `DefaultArrayItem` is invoked as a function, not as a JSX.Element. Inside of `DefaultArrayItem` a hook is called, and since the component is called conditionally (as callback to `.map`) and not as an JSX.Element but a function, this plays out as broken hook order.

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).
Could not find if this is related to any existing tickets

Please double check PR and let me know how I can get this merged, thanks.

### Checklist

* [X] **I'm adding or updating code**
  - [X] Fix error by invoking local component as a JSX component, instead of function
  - [X] Pass key to JSX component so that there is no console.error about not using key

