### PR TITLE
Added support for node 16, formatting and linting (antd)

### DIFF
--- a/packages/antd/.eslintrc
+++ b/packages/antd/.eslintrc
@@ -1,5 +1,10 @@
 {
-    "parser": "babel-eslint",
+    "parser": "@babel/eslint-parser",
+    "parserOptions": {
+        "babelOptions": {
+            "presets": ["@babel/preset-react"]
+        }
+    },
     "rules": {
         "react/jsx-uses-react": 2,
         "react/jsx-uses-vars": 2,

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -18,7 +18,8 @@
       "eslint --fix",
       "prettier --write"
     ]
-  },  "files": [
+  },
+  "files": [
     "dist"
   ],
   "engineStrict": false,

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -7,10 +7,18 @@
   "scripts": {
     "start": "tsdx watch",
     "build": "rimraf dist && tsdx build --format cjs,es,umd",
+    "cs-check": "prettier -l \"{src,test}/**/*.js\"",
+    "cs-format": "prettier \"{src,test}/**/*.js\" --write",
+    "lint": "eslint src test",
     "test": "tsdx test",
     "test:update": "tsdx test --u"
   },
-  "files": [
+  "lint-staged": {
+    "{src,test}/**/*.js": [
+      "eslint --fix",
+      "prettier --write"
+    ]
+  },  "files": [
     "dist"
   ],
   "engineStrict": false,
@@ -34,6 +42,7 @@
     "@ant-design/icons": "^4.0.0",
     "@babel/cli": "^7.18.6",
     "@babel/core": "^7.18.6",
+    "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-transform-react-jsx": "^7.18.6",
     "@babel/preset-env": "^7.18.6",
@@ -44,7 +53,6 @@
     "@rjsf/validator-ajv6": "^4.2.0",
     "antd": "^4.0.0",
     "atob": "^2.0.3",
-    "babel-eslint": "^10.0.1",
     "dayjs": "^1.11.3",
     "eslint": "^8.19.0",
     "eslint-plugin-import": "^2.26.0",

--- a/packages/antd/src/ErrorList.js
+++ b/packages/antd/src/ErrorList.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React from "react";
 
-import Alert from 'antd/lib/alert';
-import List from 'antd/lib/list';
-import Space from 'antd/lib/space';
-import ExclamationCircleOutlined from '@ant-design/icons/ExclamationCircleOutlined';
+import Alert from "antd/lib/alert";
+import List from "antd/lib/list";
+import Space from "antd/lib/space";
+import ExclamationCircleOutlined from "@ant-design/icons/ExclamationCircleOutlined";
 
 const ErrorList = ({
   // errorSchema,

--- a/packages/antd/src/components/DatePicker/index.js
+++ b/packages/antd/src/components/DatePicker/index.js
@@ -1,5 +1,5 @@
-import dayjsGenerateConfig from 'rc-picker/lib/generate/dayjs';
-import generatePicker from 'antd/lib/date-picker/generatePicker';
+import dayjsGenerateConfig from "rc-picker/lib/generate/dayjs";
+import generatePicker from "antd/lib/date-picker/generatePicker";
 
 const DatePicker = generatePicker(dayjsGenerateConfig);
 

--- a/packages/antd/src/fields/DescriptionField/index.js
+++ b/packages/antd/src/fields/DescriptionField/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 
 const DescriptionField = ({
   // autofocus,

--- a/packages/antd/src/fields/TitleField/index.js
+++ b/packages/antd/src/fields/TitleField/index.js
@@ -1,7 +1,7 @@
-import React from 'react';
-import classNames from 'classnames';
+import React from "react";
+import classNames from "classnames";
 
-import { withConfigConsumer } from 'antd/lib/config-provider/context';
+import { withConfigConsumer } from "antd/lib/config-provider/context";
 
 const TitleField = ({
   // autofocus,
@@ -24,8 +24,8 @@ const TitleField = ({
   const { colon = true } = formContext;
 
   let labelChildren = title;
-  if (colon && typeof title === 'string' && title.trim() !== '') {
-    labelChildren = title.replace(/[：:]\s*$/, '');
+  if (colon && typeof title === "string" && title.trim() !== "") {
+    labelChildren = title.replace(/[：:]\s*$/, "");
   }
 
   const labelClassName = classNames({
@@ -49,7 +49,7 @@ const TitleField = ({
       className={labelClassName}
       htmlFor={id}
       onClick={handleLabelClick}
-      title={typeof title === 'string' ? title : ''}
+      title={typeof title === "string" ? title : ""}
     >
       {labelChildren}
     </label>
@@ -60,4 +60,4 @@ TitleField.defaultProps = {
   formContext: {},
 };
 
-export default withConfigConsumer({ prefixCls: 'form' })(TitleField);
+export default withConfigConsumer({ prefixCls: "form" })(TitleField);

--- a/packages/antd/src/index.js
+++ b/packages/antd/src/index.js
@@ -1,31 +1,31 @@
-import { withTheme, getDefaultRegistry } from '@rjsf/core';
+import { withTheme, getDefaultRegistry } from "@rjsf/core";
 
-import DescriptionField from './fields/DescriptionField';
-import TitleField from './fields/TitleField';
+import DescriptionField from "./fields/DescriptionField";
+import TitleField from "./fields/TitleField";
 
-import FieldTemplate from './templates/FieldTemplate';
-import ObjectFieldTemplate from './templates/ObjectFieldTemplate';
-import ArrayFieldTemplate from './templates/ArrayFieldTemplate';
+import FieldTemplate from "./templates/FieldTemplate";
+import ObjectFieldTemplate from "./templates/ObjectFieldTemplate";
+import ArrayFieldTemplate from "./templates/ArrayFieldTemplate";
 
-import AltDateTimeWidget from './widgets/AltDateTimeWidget';
-import AltDateWidget from './widgets/AltDateWidget';
-import CheckboxesWidget from './widgets/CheckboxesWidget';
-import CheckboxWidget from './widgets/CheckboxWidget';
-import ColorWidget from './widgets/ColorWidget';
-import DateTimeWidget from './widgets/DateTimeWidget';
-import DateWidget from './widgets/DateWidget';
-import EmailWidget from './widgets/EmailWidget';
-import PasswordWidget from './widgets/PasswordWidget';
-import RadioWidget from './widgets/RadioWidget';
-import RangeWidget from './widgets/RangeWidget';
-import SelectWidget from './widgets/SelectWidget';
-import TextareaWidget from './widgets/TextareaWidget';
-import TextWidget from './widgets/TextWidget';
-import UpDownWidget from './widgets/UpDownWidget';
-import URLWidget from './widgets/URLWidget';
-import SubmitButton from './widgets/SubmitButton';
+import AltDateTimeWidget from "./widgets/AltDateTimeWidget";
+import AltDateWidget from "./widgets/AltDateWidget";
+import CheckboxesWidget from "./widgets/CheckboxesWidget";
+import CheckboxWidget from "./widgets/CheckboxWidget";
+import ColorWidget from "./widgets/ColorWidget";
+import DateTimeWidget from "./widgets/DateTimeWidget";
+import DateWidget from "./widgets/DateWidget";
+import EmailWidget from "./widgets/EmailWidget";
+import PasswordWidget from "./widgets/PasswordWidget";
+import RadioWidget from "./widgets/RadioWidget";
+import RangeWidget from "./widgets/RangeWidget";
+import SelectWidget from "./widgets/SelectWidget";
+import TextareaWidget from "./widgets/TextareaWidget";
+import TextWidget from "./widgets/TextWidget";
+import UpDownWidget from "./widgets/UpDownWidget";
+import URLWidget from "./widgets/URLWidget";
+import SubmitButton from "./widgets/SubmitButton";
 
-import ErrorList from './ErrorList';
+import ErrorList from "./ErrorList";
 
 // import './index.less';
 

--- a/packages/antd/src/templates/ArrayFieldTemplate/ArrayFieldTemplateItem.js
+++ b/packages/antd/src/templates/ArrayFieldTemplate/ArrayFieldTemplateItem.js
@@ -1,18 +1,18 @@
-import React from 'react';
+import React from "react";
 
-import Button from 'antd/lib/button';
-import Col from 'antd/lib/col';
-import Row from 'antd/lib/row';
-import ArrowDownOutlined from '@ant-design/icons/ArrowDownOutlined';
-import ArrowUpOutlined from '@ant-design/icons/ArrowUpOutlined';
-import DeleteOutlined from '@ant-design/icons/DeleteOutlined';
+import Button from "antd/lib/button";
+import Col from "antd/lib/col";
+import Row from "antd/lib/row";
+import ArrowDownOutlined from "@ant-design/icons/ArrowDownOutlined";
+import ArrowUpOutlined from "@ant-design/icons/ArrowUpOutlined";
+import DeleteOutlined from "@ant-design/icons/DeleteOutlined";
 
 const BTN_GRP_STYLE = {
-  width: '100%',
+  width: "100%",
 };
 
 const BTN_STYLE = {
-  width: 'calc(100% / 3)',
+  width: "calc(100% / 3)",
 };
 
 const ArrayFieldTemplateItem = ({
@@ -28,7 +28,7 @@ const ArrayFieldTemplateItem = ({
   onReorderClick,
   readonly,
 }) => {
-  const { rowGutter = 24, toolbarAlign = 'top' } = formContext;
+  const { rowGutter = 24, toolbarAlign = "top" } = formContext;
 
   return (
     <Row align={toolbarAlign} key={`array-item-${index}`} gutter={rowGutter}>

--- a/packages/antd/src/templates/ArrayFieldTemplate/FixedArrayFieldTemplate.js
+++ b/packages/antd/src/templates/ArrayFieldTemplate/FixedArrayFieldTemplate.js
@@ -1,16 +1,16 @@
-import React from 'react';
-import classNames from 'classnames';
+import React from "react";
+import classNames from "classnames";
 
-import Button from 'antd/lib/button';
-import Col from 'antd/lib/col';
-import Row from 'antd/lib/row';
-import { withConfigConsumer } from 'antd/lib/config-provider/context';
-import PlusCircleOutlined from '@ant-design/icons/PlusCircleOutlined';
+import Button from "antd/lib/button";
+import Col from "antd/lib/col";
+import Row from "antd/lib/row";
+import { withConfigConsumer } from "antd/lib/config-provider/context";
+import PlusCircleOutlined from "@ant-design/icons/PlusCircleOutlined";
 
-import ArrayFieldTemplateItem from './ArrayFieldTemplateItem';
+import ArrayFieldTemplateItem from "./ArrayFieldTemplateItem";
 
 const DESCRIPTION_COL_STYLE = {
-  paddingBottom: '8px',
+  paddingBottom: "8px",
 };
 
 const FixedArrayFieldTemplate = ({
@@ -32,12 +32,12 @@ const FixedArrayFieldTemplate = ({
   TitleField,
   uiSchema,
 }) => {
-  const { labelAlign = 'right', rowGutter = 24 } = formContext;
+  const { labelAlign = "right", rowGutter = 24 } = formContext;
 
   const labelClsBasic = `${prefixCls}-item-label`;
   const labelColClassName = classNames(
     labelClsBasic,
-    labelAlign === 'left' && `${labelClsBasic}-left`,
+    labelAlign === "left" && `${labelClsBasic}-left`
     // labelCol.className,
   );
 
@@ -50,25 +50,29 @@ const FixedArrayFieldTemplate = ({
               id={`${idSchema.$id}__title`}
               key={`array-field-title-${idSchema.$id}`}
               required={required}
-              title={uiSchema['ui:title'] || title}
+              title={uiSchema["ui:title"] || title}
             />
           </Col>
         )}
 
-        {(uiSchema['ui:description'] || schema.description) && (
+        {(uiSchema["ui:description"] || schema.description) && (
           <Col span={24} style={DESCRIPTION_COL_STYLE}>
             <DescriptionField
-              description={uiSchema['ui:description'] || schema.description}
+              description={uiSchema["ui:description"] || schema.description}
               id={`${idSchema.$id}-description`}
-              key={`array-field-description-${idSchema.$id}`}      
+              key={`array-field-description-${idSchema.$id}`}
             />
           </Col>
         )}
 
         <Col className="row array-item-list" span={24}>
-          {items && items.map((itemProps) => (
-            <ArrayFieldTemplateItem {...itemProps} formContext={formContext} />
-          ))}
+          {items &&
+            items.map(itemProps => (
+              <ArrayFieldTemplateItem
+                {...itemProps}
+                formContext={formContext}
+              />
+            ))}
         </Col>
 
         {canAdd && (
@@ -93,6 +97,6 @@ const FixedArrayFieldTemplate = ({
   );
 };
 
-export default withConfigConsumer({ prefixCls: 'form' })(
-  FixedArrayFieldTemplate,
+export default withConfigConsumer({ prefixCls: "form" })(
+  FixedArrayFieldTemplate
 );

--- a/packages/antd/src/templates/ArrayFieldTemplate/NormalArrayFieldTemplate.js
+++ b/packages/antd/src/templates/ArrayFieldTemplate/NormalArrayFieldTemplate.js
@@ -1,16 +1,16 @@
-import React from 'react';
-import classNames from 'classnames';
+import React from "react";
+import classNames from "classnames";
 
-import Button from 'antd/lib/button';
-import Col from 'antd/lib/col';
-import Row from 'antd/lib/row';
-import { withConfigConsumer } from 'antd/lib/config-provider/context';
-import PlusCircleOutlined from '@ant-design/icons/PlusCircleOutlined';
+import Button from "antd/lib/button";
+import Col from "antd/lib/col";
+import Row from "antd/lib/row";
+import { withConfigConsumer } from "antd/lib/config-provider/context";
+import PlusCircleOutlined from "@ant-design/icons/PlusCircleOutlined";
 
-import ArrayFieldTemplateItem from './ArrayFieldTemplateItem';
+import ArrayFieldTemplateItem from "./ArrayFieldTemplateItem";
 
 const DESCRIPTION_COL_STYLE = {
-  paddingBottom: '8px',
+  paddingBottom: "8px",
 };
 
 const NormalArrayFieldTemplate = ({
@@ -32,12 +32,12 @@ const NormalArrayFieldTemplate = ({
   TitleField,
   uiSchema,
 }) => {
-  const { labelAlign = 'right', rowGutter = 24 } = formContext;
+  const { labelAlign = "right", rowGutter = 24 } = formContext;
 
   const labelClsBasic = `${prefixCls}-item-label`;
   const labelColClassName = classNames(
     labelClsBasic,
-    labelAlign === 'left' && `${labelClsBasic}-left`,
+    labelAlign === "left" && `${labelClsBasic}-left`
     // labelCol.className,
   );
 
@@ -50,15 +50,15 @@ const NormalArrayFieldTemplate = ({
               id={`${idSchema.$id}__title`}
               key={`array-field-title-${idSchema.$id}`}
               required={required}
-              title={uiSchema['ui:title'] || title}
+              title={uiSchema["ui:title"] || title}
             />
           </Col>
         )}
 
-        {(uiSchema['ui:description'] || schema.description) && (
+        {(uiSchema["ui:description"] || schema.description) && (
           <Col span={24} style={DESCRIPTION_COL_STYLE}>
             <DescriptionField
-              description={uiSchema['ui:description'] || schema.description}
+              description={uiSchema["ui:description"] || schema.description}
               id={`${idSchema.$id}__description`}
               key={`array-field-description-${idSchema.$id}`}
             />
@@ -66,9 +66,13 @@ const NormalArrayFieldTemplate = ({
         )}
 
         <Col className="row array-item-list" span={24}>
-          {items && items.map((itemProps) => (
-            <ArrayFieldTemplateItem {...itemProps} formContext={formContext} />
-          ))}
+          {items &&
+            items.map(itemProps => (
+              <ArrayFieldTemplateItem
+                {...itemProps}
+                formContext={formContext}
+              />
+            ))}
         </Col>
 
         {canAdd && (
@@ -93,6 +97,6 @@ const NormalArrayFieldTemplate = ({
   );
 };
 
-export default withConfigConsumer({ prefixCls: 'form' })(
-  NormalArrayFieldTemplate,
+export default withConfigConsumer({ prefixCls: "form" })(
+  NormalArrayFieldTemplate
 );

--- a/packages/antd/src/templates/ArrayFieldTemplate/index.js
+++ b/packages/antd/src/templates/ArrayFieldTemplate/index.js
@@ -1,9 +1,15 @@
-import React from 'react';
+import React from "react";
 
-import { getUiOptions, getWidget, isFixedItems, optionsList, ITEMS_KEY } from '@rjsf/utils';
+import {
+  getUiOptions,
+  getWidget,
+  isFixedItems,
+  optionsList,
+  ITEMS_KEY,
+} from "@rjsf/utils";
 
-import FixedArrayFieldTemplate from './FixedArrayFieldTemplate';
-import NormalArrayFieldTemplate from './NormalArrayFieldTemplate';
+import FixedArrayFieldTemplate from "./FixedArrayFieldTemplate";
+import NormalArrayFieldTemplate from "./NormalArrayFieldTemplate";
 
 const ArrayFieldTemplate = ({
   DescriptionField,
@@ -35,7 +41,7 @@ const ArrayFieldTemplate = ({
   const { UnsupportedField } = fields;
 
   const renderFiles = () => {
-    const { widget = 'files', ...options } = getUiOptions(uiSchema);
+    const { widget = "files", ...options } = getUiOptions(uiSchema);
 
     const Widget = getWidget(schema, widget, widgets);
 
@@ -63,7 +69,7 @@ const ArrayFieldTemplate = ({
   const renderMultiSelect = () => {
     const itemsSchema = schemaUtils.retrieveSchema(schema.items, formData);
     const enumOptions = optionsList(itemsSchema);
-    const { widget = 'select', ...options } = {
+    const { widget = "select", ...options } = {
       ...getUiOptions(uiSchema),
       enumOptions,
     };

--- a/packages/antd/src/templates/FieldTemplate/WrapIfAdditional.js
+++ b/packages/antd/src/templates/FieldTemplate/WrapIfAdditional.js
@@ -1,18 +1,18 @@
-import React from 'react';
+import React from "react";
 
-import { ADDITIONAL_PROPERTY_FLAG } from '@rjsf/utils';
-import Button from 'antd/lib/button';
-import Col from 'antd/lib/col';
-import Form from 'antd/lib/form';
-import Input from 'antd/lib/input';
-import Row from 'antd/lib/row';
-import DeleteOutlined from '@ant-design/icons/DeleteOutlined';
+import { ADDITIONAL_PROPERTY_FLAG } from "@rjsf/utils";
+import Button from "antd/lib/button";
+import Col from "antd/lib/col";
+import Form from "antd/lib/form";
+import Input from "antd/lib/input";
+import Row from "antd/lib/row";
+import DeleteOutlined from "@ant-design/icons/DeleteOutlined";
 
 const VERTICAL_LABEL_COL = { span: 24 };
 const VERTICAL_WRAPPER_COL = { span: 24 };
 
 const INPUT_STYLE = {
-  width: '100%',
+  width: "100%",
 };
 
 const WrapIfAdditional = ({
@@ -33,13 +33,13 @@ const WrapIfAdditional = ({
     labelCol = VERTICAL_LABEL_COL,
     readonlyAsDisabled = true,
     rowGutter = 24,
-    toolbarAlign = 'top',
+    toolbarAlign = "top",
     wrapperCol = VERTICAL_WRAPPER_COL,
     wrapperStyle,
   } = formContext;
 
   const keyLabel = `${label} Key`; // i18n ?
-  const additional = schema.hasOwnProperty(ADDITIONAL_PROPERTY_FLAG);
+  const additional = ADDITIONAL_PROPERTY_FLAG in schema;
 
   if (!additional) {
     return <div className={classNames}>{children}</div>;

--- a/packages/antd/src/templates/FieldTemplate/index.js
+++ b/packages/antd/src/templates/FieldTemplate/index.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React from "react";
 
-import Form from 'antd/lib/form';
+import Form from "antd/lib/form";
 
-import WrapIfAdditional from './WrapIfAdditional';
+import WrapIfAdditional from "./WrapIfAdditional";
 
 const VERTICAL_LABEL_COL = { span: 24 };
 const VERTICAL_WRAPPER_COL = { span: 24 };
@@ -42,7 +42,7 @@ const FieldTemplate = ({
   }
 
   const renderFieldErrors = () =>
-    [...new Set(rawErrors)].map((error) => (
+    [...new Set(rawErrors)].map(error => (
       <div key={`field-${id}-error-${error}`}>{error}</div>
     ));
 
@@ -59,20 +59,20 @@ const FieldTemplate = ({
       required={required}
       schema={schema}
     >
-      {id === 'root' ? (
+      {id === "root" ? (
         children
       ) : (
         <Form.Item
           colon={colon}
           extra={description}
-          hasFeedback={schema.type !== 'array' && schema.type !== 'object'}
+          hasFeedback={schema.type !== "array" && schema.type !== "object"}
           help={(!!rawHelp && help) || (!!rawErrors && renderFieldErrors())}
           htmlFor={id}
           label={displayLabel && label}
           labelCol={labelCol}
           required={required}
           style={wrapperStyle}
-          validateStatus={rawErrors ? 'error' : undefined}
+          validateStatus={rawErrors ? "error" : undefined}
           wrapperCol={wrapperCol}
         >
           {children}

--- a/packages/antd/src/templates/ObjectFieldTemplate/index.js
+++ b/packages/antd/src/templates/ObjectFieldTemplate/index.js
@@ -1,16 +1,16 @@
-import React from 'react';
-import classNames from 'classnames';
-import _ from 'lodash';
+import React from "react";
+import classNames from "classnames";
+import _ from "lodash";
 
-import { canExpand } from '@rjsf/utils';
-import Button from 'antd/lib/button';
-import Col from 'antd/lib/col';
-import Row from 'antd/lib/row';
-import { withConfigConsumer } from 'antd/lib/config-provider/context';
-import PlusCircleOutlined from '@ant-design/icons/PlusCircleOutlined';
+import { canExpand } from "@rjsf/utils";
+import Button from "antd/lib/button";
+import Col from "antd/lib/col";
+import Row from "antd/lib/row";
+import { withConfigConsumer } from "antd/lib/config-provider/context";
+import PlusCircleOutlined from "@ant-design/icons/PlusCircleOutlined";
 
 const DESCRIPTION_COL_STYLE = {
-  paddingBottom: '8px',
+  paddingBottom: "8px",
 };
 
 const ObjectFieldTemplate = ({
@@ -30,35 +30,35 @@ const ObjectFieldTemplate = ({
   title,
   uiSchema,
 }) => {
-  const { colSpan = 24, labelAlign = 'right', rowGutter = 24 } = formContext;
+  const { colSpan = 24, labelAlign = "right", rowGutter = 24 } = formContext;
 
   const labelClsBasic = `${prefixCls}-item-label`;
   const labelColClassName = classNames(
     labelClsBasic,
-    labelAlign === 'left' && `${labelClsBasic}-left`,
+    labelAlign === "left" && `${labelClsBasic}-left`
     // labelCol.className,
   );
 
-  const findSchema = (element) => element.content.props.schema;
+  const findSchema = element => element.content.props.schema;
 
-  const findSchemaType = (element) => findSchema(element).type;
+  const findSchemaType = element => findSchema(element).type;
 
-  const findUiSchema = (element) => element.content.props.uiSchema;
+  const findUiSchema = element => element.content.props.uiSchema;
 
-  const findUiSchemaField = (element) => findUiSchema(element)['ui:field'];
+  const findUiSchemaField = element => findUiSchema(element)["ui:field"];
 
-  const findUiSchemaWidget = (element) => findUiSchema(element)['ui:widget'];
+  const findUiSchemaWidget = element => findUiSchema(element)["ui:widget"];
 
-  const calculateColSpan = (element) => {
+  const calculateColSpan = element => {
     const type = findSchemaType(element);
     const field = findUiSchemaField(element);
     const widget = findUiSchemaWidget(element);
 
     const defaultColSpan =
       properties.length < 2 || // Single or no field in object.
-      type === 'object' ||
-      type === 'array' ||
-      widget === 'textarea'
+      type === "object" ||
+      type === "array" ||
+      widget === "textarea"
         ? 24
         : 12;
 
@@ -76,29 +76,31 @@ const ObjectFieldTemplate = ({
   return (
     <fieldset id={idSchema.$id}>
       <Row gutter={rowGutter}>
-        {uiSchema['ui:title'] !== false && (uiSchema['ui:title'] || title) && (
+        {uiSchema["ui:title"] !== false && (uiSchema["ui:title"] || title) && (
           <Col className={labelColClassName} span={24}>
             <TitleField
               id={`${idSchema.$id}-title`}
               required={required}
-              title={uiSchema['ui:title'] || title}
+              title={uiSchema["ui:title"] || title}
             />
           </Col>
         )}
-        {uiSchema['ui:description'] !== false &&
-          (uiSchema['ui:description'] || description) && (
+        {uiSchema["ui:description"] !== false &&
+          (uiSchema["ui:description"] || description) && (
             <Col span={24} style={DESCRIPTION_COL_STYLE}>
               <DescriptionField
-                description={uiSchema['ui:description'] || description}
+                description={uiSchema["ui:description"] || description}
                 id={`${idSchema.$id}-description`}
               />
             </Col>
           )}
-        {properties.filter((e) => !e.hidden).map((element) => (
-          <Col key={element.name} span={calculateColSpan(element)}>
-            {element.content}
-          </Col>
-        ))}
+        {properties
+          .filter(e => !e.hidden)
+          .map(element => (
+            <Col key={element.name} span={calculateColSpan(element)}>
+              {element.content}
+            </Col>
+          ))}
       </Row>
 
       {canExpand(schema, uiSchema, formData) && (
@@ -122,4 +124,4 @@ const ObjectFieldTemplate = ({
   );
 };
 
-export default withConfigConsumer({ prefixCls: 'form' })(ObjectFieldTemplate);
+export default withConfigConsumer({ prefixCls: "form" })(ObjectFieldTemplate);

--- a/packages/antd/src/widgets/AltDateTimeWidget/index.js
+++ b/packages/antd/src/widgets/AltDateTimeWidget/index.js
@@ -1,9 +1,8 @@
-  
 import React from "react";
 
 import _AltDateWidget from "../AltDateWidget";
 
-const AltDateTimeWidget = (props) => {
+const AltDateTimeWidget = props => {
   const { AltDateWidget } = props.registry.widgets;
   return <AltDateWidget showTime {...props} />;
 };

--- a/packages/antd/src/widgets/AltDateWidget/index.js
+++ b/packages/antd/src/widgets/AltDateWidget/index.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from "react";
 
-import { pad, parseDateString, toDateString } from '@rjsf/utils';
-import Button from 'antd/lib/button';
-import Col from 'antd/lib/col';
-import Row from 'antd/lib/row';
+import { pad, parseDateString, toDateString } from "@rjsf/utils";
+import Button from "antd/lib/button";
+import Col from "antd/lib/col";
+import Row from "antd/lib/row";
 
 const rangeOptions = (start, stop) => {
   let options = [];
@@ -13,9 +13,9 @@ const rangeOptions = (start, stop) => {
   return options;
 };
 
-const readyForChange = (state) => {
+const readyForChange = state => {
   return Object.keys(state).every(
-    key => typeof state[key] !== "undefined" && state[key] !== -1,
+    key => typeof state[key] !== "undefined" && state[key] !== -1
   );
 };
 
@@ -55,7 +55,7 @@ const AltDateWidget = ({
     }
   };
 
-  const handleNow = (event) => {
+  const handleNow = event => {
     event.preventDefault();
     if (disabled || readonly) {
       return;
@@ -64,7 +64,7 @@ const AltDateWidget = ({
     onChange(toDateString(nextState, showTime));
   };
 
-  const handleClear = (event) => {
+  const handleClear = event => {
     event.preventDefault();
     if (disabled || readonly) {
       return;
@@ -92,14 +92,14 @@ const AltDateWidget = ({
     return data;
   };
 
-  const renderDateElement = (elemProps) => (
+  const renderDateElement = elemProps => (
     <SelectWidget
       autofocus={elemProps.autofocus}
       className="form-control"
       disabled={elemProps.disabled}
       id={elemProps.id}
       onBlur={elemProps.onBlur}
-      onChange={(elemValue) => elemProps.select(elemProps.type, elemValue)}
+      onChange={elemValue => elemProps.select(elemProps.type, elemValue)}
       onFocus={elemProps.onFocus}
       options={{
         enumOptions: rangeOptions(elemProps.range[0], elemProps.range[1]),

--- a/packages/antd/src/widgets/CheckboxWidget/index.js
+++ b/packages/antd/src/widgets/CheckboxWidget/index.js
@@ -1,6 +1,6 @@
-import React from 'react';
+import React from "react";
 
-import Checkbox from 'antd/lib/checkbox';
+import Checkbox from "antd/lib/checkbox";
 
 const CheckboxWidget = ({
   autofocus,
@@ -29,7 +29,7 @@ const CheckboxWidget = ({
   return (
     <Checkbox
       autoFocus={autofocus}
-      checked={typeof value === 'undefined' ? false : value}
+      checked={typeof value === "undefined" ? false : value}
       disabled={disabled || (readonlyAsDisabled && readonly)}
       id={id}
       name={id}

--- a/packages/antd/src/widgets/CheckboxesWidget/index.js
+++ b/packages/antd/src/widgets/CheckboxesWidget/index.js
@@ -1,7 +1,7 @@
-import React from 'react';
-import _ from 'lodash';
+import React from "react";
+import _ from "lodash";
 
-import Checkbox from 'antd/lib/checkbox';
+import Checkbox from "antd/lib/checkbox";
 
 const CheckboxesWidget = ({
   autofocus,
@@ -23,7 +23,7 @@ const CheckboxesWidget = ({
 
   const { enumOptions, enumDisabled, inline } = options;
 
-  const handleChange = (nextValue) => onChange(nextValue);
+  const handleChange = nextValue => onChange(nextValue);
 
   const handleBlur = ({ target }) => onBlur(id, target.value);
 

--- a/packages/antd/src/widgets/ColorWidget/index.js
+++ b/packages/antd/src/widgets/ColorWidget/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React from "react";
 
-import Input from 'antd/lib/checkbox';
+import Input from "antd/lib/checkbox";
 
 const INPUT_STYLE = {
-  width: '100%',
+  width: "100%",
 };
 
 const ColorWidget = ({

--- a/packages/antd/src/widgets/DateTimeWidget/index.js
+++ b/packages/antd/src/widgets/DateTimeWidget/index.js
@@ -1,10 +1,10 @@
-import React from 'react';
-import dayjs from 'dayjs';
+import React from "react";
+import dayjs from "dayjs";
 
-import DatePicker from '../../components/DatePicker';
+import DatePicker from "../../components/DatePicker";
 
 const DATE_PICKER_STYLE = {
-  width: '100%',
+  width: "100%",
 };
 
 const DateTimeWidget = ({
@@ -25,14 +25,14 @@ const DateTimeWidget = ({
 }) => {
   const { readonlyAsDisabled = true } = formContext;
 
-  const handleChange = (nextValue) =>
+  const handleChange = nextValue =>
     onChange(nextValue && nextValue.toISOString());
 
   const handleBlur = () => onBlur(id, value);
 
   const handleFocus = () => onFocus(id, value);
 
-  const getPopupContainer = (node) => node.parentNode;
+  const getPopupContainer = node => node.parentNode;
 
   return (
     <DatePicker

--- a/packages/antd/src/widgets/DateWidget/index.js
+++ b/packages/antd/src/widgets/DateWidget/index.js
@@ -1,10 +1,10 @@
-import React from 'react';
-import dayjs from 'dayjs';
+import React from "react";
+import dayjs from "dayjs";
 
-import DatePicker from '../../components/DatePicker';
+import DatePicker from "../../components/DatePicker";
 
 const DATE_PICKER_STYLE = {
-  width: '100%',
+  width: "100%",
 };
 
 const DateWidget = ({
@@ -25,14 +25,14 @@ const DateWidget = ({
 }) => {
   const { readonlyAsDisabled = true } = formContext;
 
-  const handleChange = (nextValue) =>
-    onChange(nextValue && nextValue.format('YYYY-MM-DD'));
+  const handleChange = nextValue =>
+    onChange(nextValue && nextValue.format("YYYY-MM-DD"));
 
   const handleBlur = () => onBlur(id, value);
 
   const handleFocus = () => onFocus(id, value);
 
-  const getPopupContainer = (node) => node.parentNode;
+  const getPopupContainer = node => node.parentNode;
 
   return (
     <DatePicker

--- a/packages/antd/src/widgets/EmailWidget/index.js
+++ b/packages/antd/src/widgets/EmailWidget/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React from "react";
 
-import Input from 'antd/lib/input';
+import Input from "antd/lib/input";
 
 const INPUT_STYLE = {
-  width: '100%',
+  width: "100%",
 };
 
 const EmailWidget = ({
@@ -25,7 +25,7 @@ const EmailWidget = ({
   const { readonlyAsDisabled = true } = formContext;
 
   const handleChange = ({ target }) =>
-    onChange(target.value === '' ? options.emptyValue : target.value);
+    onChange(target.value === "" ? options.emptyValue : target.value);
 
   const handleBlur = ({ target }) => onBlur(id, target.value);
 

--- a/packages/antd/src/widgets/PasswordWidget/index.js
+++ b/packages/antd/src/widgets/PasswordWidget/index.js
@@ -1,6 +1,6 @@
-import React from 'react';
+import React from "react";
 
-import Input from 'antd/lib/input';
+import Input from "antd/lib/input";
 
 const PasswordWidget = ({
   // autofocus,
@@ -20,10 +20,10 @@ const PasswordWidget = ({
 }) => {
   const { readonlyAsDisabled = true } = formContext;
 
-  const emptyValue = options.emptyValue || '';
+  const emptyValue = options.emptyValue || "";
 
   const handleChange = ({ target }) =>
-    onChange(target.value === '' ? emptyValue : target.value);
+    onChange(target.value === "" ? emptyValue : target.value);
 
   const handleBlur = ({ target }) => onBlur(id, target.value);
 
@@ -38,7 +38,7 @@ const PasswordWidget = ({
       onChange={!readonly ? handleChange : undefined}
       onFocus={!readonly ? handleFocus : undefined}
       placeholder={placeholder}
-      value={value || ''}
+      value={value || ""}
     />
   );
 };

--- a/packages/antd/src/widgets/RadioWidget/index.js
+++ b/packages/antd/src/widgets/RadioWidget/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-else-return */
-import React from 'react';
+import React from "react";
 
-import Radio from 'antd/lib/radio';
+import Radio from "antd/lib/radio";
 
 const RadioWidget = ({
   autofocus,
@@ -24,7 +24,7 @@ const RadioWidget = ({
   const { enumOptions, enumDisabled } = options;
 
   const handleChange = ({ target: { value: nextValue } }) =>
-    onChange(schema.type === 'boolean' ? nextValue !== 'false' : nextValue);
+    onChange(schema.type === "boolean" ? nextValue !== "false" : nextValue);
 
   const handleBlur = ({ target }) => onBlur(id, target.value);
 

--- a/packages/antd/src/widgets/RangeWidget/index.js
+++ b/packages/antd/src/widgets/RangeWidget/index.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-else-return */
-import React from 'react';
+import React from "react";
 
-import { rangeSpec } from '@rjsf/utils';
-import Slider from 'antd/lib/slider';
+import { rangeSpec } from "@rjsf/utils";
+import Slider from "antd/lib/slider";
 
 const RangeWidget = ({
   autofocus,
@@ -24,10 +24,10 @@ const RangeWidget = ({
 
   const { min, max, step } = rangeSpec(schema);
 
-  const emptyValue = options.emptyValue || '';
+  const emptyValue = options.emptyValue || "";
 
-  const handleChange = (nextValue) =>
-    onChange(nextValue === '' ? emptyValue : nextValue);
+  const handleChange = nextValue =>
+    onChange(nextValue === "" ? emptyValue : nextValue);
 
   const handleBlur = () => onBlur(id, value);
 

--- a/packages/antd/src/widgets/SelectWidget/index.js
+++ b/packages/antd/src/widgets/SelectWidget/index.js
@@ -1,11 +1,11 @@
 /* eslint-disable no-else-return */
-import React from 'react';
+import React from "react";
 
-import { processSelectValue } from '@rjsf/utils';
-import Select from 'antd/lib/select';
+import { processSelectValue } from "@rjsf/utils";
+import Select from "antd/lib/select";
 
 const SELECT_STYLE = {
-  width: '100%',
+  width: "100%",
 };
 
 const SelectWidget = ({
@@ -29,15 +29,16 @@ const SelectWidget = ({
 
   const { enumOptions, enumDisabled } = options;
 
-  const handleChange = (nextValue) => onChange(processSelectValue(schema, nextValue));
+  const handleChange = nextValue =>
+    onChange(processSelectValue(schema, nextValue));
 
   const handleBlur = () => onBlur(id, processSelectValue(schema, value));
 
   const handleFocus = () => onFocus(id, processSelectValue(schema, value));
 
-  const getPopupContainer = (node) => node.parentNode;
+  const getPopupContainer = node => node.parentNode;
 
-  const stringify = (currentValue) =>
+  const stringify = currentValue =>
     Array.isArray(currentValue) ? value.map(String) : String(value);
 
   return (
@@ -46,14 +47,14 @@ const SelectWidget = ({
       disabled={disabled || (readonlyAsDisabled && readonly)}
       getPopupContainer={getPopupContainer}
       id={id}
-      mode={typeof multiple !== 'undefined' ? 'multiple' : undefined}
+      mode={typeof multiple !== "undefined" ? "multiple" : undefined}
       name={id}
       onBlur={!readonly ? handleBlur : undefined}
       onChange={!readonly ? handleChange : undefined}
       onFocus={!readonly ? handleFocus : undefined}
       placeholder={placeholder}
       style={SELECT_STYLE}
-      value={typeof value !== 'undefined' ? stringify(value) : undefined}
+      value={typeof value !== "undefined" ? stringify(value) : undefined}
     >
       {enumOptions.map(({ value: optionValue, label: optionLabel }) => (
         <Select.Option

--- a/packages/antd/src/widgets/SubmitButton/SubmitButton.js
+++ b/packages/antd/src/widgets/SubmitButton/SubmitButton.js
@@ -1,12 +1,19 @@
-import { getSubmitButtonOptions } from '@rjsf/utils';
+import { getSubmitButtonOptions } from "@rjsf/utils";
 import React from "react";
-import Button from 'antd/lib/button';
+import Button from "antd/lib/button";
 
 export default ({ uiSchema }) => {
-  const { submitText, norender, props: submitButtonProps }= getSubmitButtonOptions(uiSchema);
-  if (norender) {return null;}
-  return (<Button  type="submit" {...submitButtonProps}>
-    {submitText}
-  </Button>);
+  const {
+    submitText,
+    norender,
+    props: submitButtonProps,
+  } = getSubmitButtonOptions(uiSchema);
+  if (norender) {
+    return null;
+  }
+  return (
+    <Button type="submit" {...submitButtonProps}>
+      {submitText}
+    </Button>
+  );
 };
-

--- a/packages/antd/src/widgets/SubmitButton/index.js
+++ b/packages/antd/src/widgets/SubmitButton/index.js
@@ -1,2 +1,2 @@
-export { default } from './SubmitButton';
-export * from './SubmitButton';
+export { default } from "./SubmitButton";
+export * from "./SubmitButton";

--- a/packages/antd/src/widgets/TextWidget/index.js
+++ b/packages/antd/src/widgets/TextWidget/index.js
@@ -1,10 +1,10 @@
-import React from 'react';
+import React from "react";
 
-import Input from 'antd/lib/input';
-import InputNumber from 'antd/lib/input-number';
+import Input from "antd/lib/input";
+import InputNumber from "antd/lib/input-number";
 
 const INPUT_STYLE = {
-  width: '100%',
+  width: "100%",
 };
 
 const TextWidget = ({
@@ -25,16 +25,16 @@ const TextWidget = ({
 }) => {
   const { readonlyAsDisabled = true } = formContext;
 
-  const handleNumberChange = (nextValue) => onChange(nextValue);
+  const handleNumberChange = nextValue => onChange(nextValue);
 
   const handleTextChange = ({ target }) =>
-    onChange(target.value === '' ? options.emptyValue : target.value);
+    onChange(target.value === "" ? options.emptyValue : target.value);
 
   const handleBlur = ({ target }) => onBlur(id, target.value);
 
   const handleFocus = ({ target }) => onFocus(id, target.value);
 
-  return schema.type === 'number' || schema.type === 'integer' ? (
+  return schema.type === "number" || schema.type === "integer" ? (
     <InputNumber
       disabled={disabled || (readonlyAsDisabled && readonly)}
       id={id}
@@ -57,7 +57,7 @@ const TextWidget = ({
       onFocus={!readonly ? handleFocus : undefined}
       placeholder={placeholder}
       style={INPUT_STYLE}
-      type={options.inputType || 'text'}
+      type={options.inputType || "text"}
       value={value}
     />
   );

--- a/packages/antd/src/widgets/TextareaWidget/index.js
+++ b/packages/antd/src/widgets/TextareaWidget/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React from "react";
 
-import Input from 'antd/lib/input';
+import Input from "antd/lib/input";
 
 const INPUT_STYLE = {
-  width: '100%',
+  width: "100%",
 };
 
 const TextareaWidget = ({
@@ -25,7 +25,7 @@ const TextareaWidget = ({
   const { readonlyAsDisabled = true } = formContext;
 
   const handleChange = ({ target }) =>
-    onChange(target.value === '' ? options.emptyValue : target.value);
+    onChange(target.value === "" ? options.emptyValue : target.value);
 
   const handleBlur = ({ target }) => onBlur(id, target.value);
 

--- a/packages/antd/src/widgets/URLWidget/index.js
+++ b/packages/antd/src/widgets/URLWidget/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React from "react";
 
-import Input from 'antd/lib/input';
+import Input from "antd/lib/input";
 
 const INPUT_STYLE = {
-  width: '100%',
+  width: "100%",
 };
 
 const URLWidget = ({
@@ -25,7 +25,7 @@ const URLWidget = ({
   const { readonlyAsDisabled = true } = formContext;
 
   const handleChange = ({ target }) =>
-    onChange(target.value === '' ? options.emptyValue : target.value);
+    onChange(target.value === "" ? options.emptyValue : target.value);
 
   const handleBlur = ({ target }) => onBlur(id, target.value);
 

--- a/packages/antd/src/widgets/UpDownWidget/index.js
+++ b/packages/antd/src/widgets/UpDownWidget/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React from "react";
 
-import InputNumber from 'antd/lib/input-number';
+import InputNumber from "antd/lib/input-number";
 
 const INPUT_STYLE = {
-  width: '100%',
+  width: "100%",
 };
 
 const UpDownWidget = ({
@@ -23,7 +23,7 @@ const UpDownWidget = ({
 }) => {
   const { readonlyAsDisabled = true } = formContext;
 
-  const handleChange = (nextValue) => onChange(nextValue);
+  const handleChange = nextValue => onChange(nextValue);
 
   const handleBlur = ({ target }) => onBlur(id, target.value);
 

--- a/packages/antd/test/Array.test.js
+++ b/packages/antd/test/Array.test.js
@@ -1,9 +1,9 @@
-import React from 'react';
-import renderer from 'react-test-renderer';
-import validator from '@rjsf/validator-ajv6';
+import React from "react";
+import renderer from "react-test-renderer";
+import validator from "@rjsf/validator-ajv6";
 
-import '../__mocks__/matchMedia.mock';
-import Form from '../src';
+import "../__mocks__/matchMedia.mock";
+import Form from "../src";
 
 const { describe, expect, test } = global;
 
@@ -12,8 +12,8 @@ describe("array fields", () => {
     const schema = {
       type: "array",
       items: {
-        type: "string"
-      }
+        type: "string",
+      },
     };
     const tree = renderer
       .create(<Form schema={schema} validator={validator} />)
@@ -25,12 +25,12 @@ describe("array fields", () => {
       type: "array",
       items: [
         {
-          type: "string"
+          type: "string",
         },
         {
-          type: "number"
-        }
-      ]
+          type: "number",
+        },
+      ],
     };
     const tree = renderer
       .create(<Form schema={schema} validator={validator} />)
@@ -42,9 +42,9 @@ describe("array fields", () => {
       type: "array",
       items: {
         type: "string",
-        enum: ["a", "b", "c"]
+        enum: ["a", "b", "c"],
       },
-      uniqueItems: true
+      uniqueItems: true,
     };
     const tree = renderer
       .create(<Form schema={schema} validator={validator} />)

--- a/packages/antd/test/Form.test.js
+++ b/packages/antd/test/Form.test.js
@@ -1,9 +1,9 @@
-import React from 'react';
-import renderer from 'react-test-renderer';
-import validator from '@rjsf/validator-ajv6';
+import React from "react";
+import renderer from "react-test-renderer";
+import validator from "@rjsf/validator-ajv6";
 
-import '../__mocks__/matchMedia.mock';
-import Form from '../src';
+import "../__mocks__/matchMedia.mock";
+import Form from "../src";
 
 const { describe, expect, test } = global;
 
@@ -11,7 +11,7 @@ describe("single fields", () => {
   describe("string field", () => {
     test("regular", () => {
       const schema = {
-        type: "string"
+        type: "string",
       };
       const tree = renderer
         .create(<Form schema={schema} validator={validator} />)
@@ -21,7 +21,7 @@ describe("single fields", () => {
     test("format email", () => {
       const schema = {
         type: "string",
-        format: "email"
+        format: "email",
       };
       const tree = renderer
         .create(<Form schema={schema} validator={validator} />)
@@ -31,7 +31,7 @@ describe("single fields", () => {
     test("format uri", () => {
       const schema = {
         type: "string",
-        format: "uri"
+        format: "uri",
       };
       const tree = renderer
         .create(<Form schema={schema} validator={validator} />)
@@ -51,7 +51,7 @@ describe("single fields", () => {
   });
   test("number field", () => {
     const schema = {
-      type: "number"
+      type: "number",
     };
     const tree = renderer
       .create(<Form schema={schema} validator={validator} />)
@@ -60,7 +60,7 @@ describe("single fields", () => {
   });
   test("null field", () => {
     const schema = {
-      type: "null"
+      type: "null",
     };
     const tree = renderer
       .create(<Form schema={schema} validator={validator} />)
@@ -69,7 +69,7 @@ describe("single fields", () => {
   });
   test("unsupported field", () => {
     const schema = {
-      type: undefined
+      type: undefined,
     };
     const tree = renderer
       .create(<Form schema={schema} validator={validator} />)
@@ -91,7 +91,9 @@ describe("single fields", () => {
       },
     };
     const tree = renderer
-      .create(<Form schema={schema} validator={validator} uiSchema={uiSchema} />)
+      .create(
+        <Form schema={schema} validator={validator} uiSchema={uiSchema} />
+      )
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
@@ -102,8 +104,8 @@ describe("single fields", () => {
         "my-field": {
           type: "string",
           description: "some description",
-        }
-      }
+        },
+      },
     };
     const tree = renderer
       .create(<Form schema={schema} validator={validator} />)
@@ -117,8 +119,8 @@ describe("single fields", () => {
         "my-field": {
           type: "string",
           description: "some description",
-        }
-      }
+        },
+      },
     };
     const uiSchema = {
       "my-field": {
@@ -126,13 +128,15 @@ describe("single fields", () => {
       },
     };
     const tree = renderer
-      .create(<Form schema={schema} validator={validator} uiSchema={uiSchema} />)
+      .create(
+        <Form schema={schema} validator={validator} uiSchema={uiSchema} />
+      )
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
   test("using custom tagName", () => {
     const schema = {
-      type: "string"
+      type: "string",
     };
     const tree = renderer
       .create(<Form schema={schema} validator={validator} tagName="div" />)

--- a/packages/antd/test/Object.test.js
+++ b/packages/antd/test/Object.test.js
@@ -1,9 +1,9 @@
-import React from 'react';
+import React from "react";
 import renderer from "react-test-renderer";
 import validator from "@rjsf/validator-ajv6";
 
-import '../__mocks__/matchMedia.mock';
-import Form from '../src';
+import "../__mocks__/matchMedia.mock";
+import Form from "../src";
 
 const { describe, expect, test } = global;
 
@@ -13,8 +13,8 @@ describe("object fields", () => {
       type: "object",
       properties: {
         a: { type: "string" },
-        b: { type: "number" }
-      }
+        b: { type: "number" },
+      },
     };
     const tree = renderer
       .create(<Form schema={schema} validator={validator} />)


### PR DESCRIPTION
### Reasons for making this change

- Regenerated the `package-lock.json` file with node-16
- Added the `cs-check`, `cs-format` and `lint` scripts along with `lint-staged` to the `package.json` file
  - Added `@babel/eslint-parser` and removed `babel-eslint`
- Ran `cs-format` over the `src` and `test` directories to fix the build
- Updated `.eslintrc` to switch to using the `@babel/eslint-parser` with the necessary `parserOptions`

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
