### PR TITLE
Bumping dependencies for utils

### DIFF
--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -22,20 +22,18 @@
 				"@babel/plugin-transform-react-jsx": "^7.18.6",
 				"@babel/preset-env": "^7.18.9",
 				"@babel/preset-react": "^7.18.6",
-				"@types/jest": "^27.5.2",
 				"@types/jest-expect-message": "^1.0.4",
 				"@types/json-schema": "^7.0.9",
 				"@types/json-schema-merge-allof": "^0.6.1",
 				"@types/lodash": "^4.14.182",
-				"@types/react": "^16.14.25",
+				"@types/react": "^17.0.48",
 				"@types/react-is": "^17.0.3",
-				"@types/react-test-renderer": "^16.9.5",
+				"@types/react-test-renderer": "^17.0.2",
 				"dts-cli": "^1.5.2",
-				"eslint": "^8.19.0",
+				"eslint": "^8.20.0",
 				"jest-expect-message": "^1.0.2",
-				"react": "^16.14.0",
-				"react-dom": "^16.14.0",
-				"react-test-renderer": "^16.14.0",
+				"react": "^17.0.2",
+				"react-test-renderer": "^17.0.2",
 				"rimraf": "^3.0.2"
 			},
 			"engines": {
@@ -2494,9 +2492,10 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
-			"version": "16.14.25",
+			"version": "17.0.48",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.48.tgz",
+			"integrity": "sha512-zJ6IYlJ8cYYxiJfUaZOQee4lh99mFihBoqkOSEGV+dFi9leROW6+PgstzQ+w3gWTnUfskALtQPGHK6dYmPj+2A==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "*",
@@ -2512,11 +2511,12 @@
 			}
 		},
 		"node_modules/@types/react-test-renderer": {
-			"version": "16.9.5",
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+			"integrity": "sha512-+F1KONQTBHDBBhbHuT2GNydeMpPuviduXIVJRB7Y4nma4NR5DrTJfMMZ+jbhEHbpwL+Uqhs1WXh4KHiyrtYTPg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
-				"@types/react": "^16"
+				"@types/react": "^17"
 			}
 		},
 		"node_modules/@types/resolve": {
@@ -9028,54 +9028,65 @@
 			}
 		},
 		"node_modules/react": {
-			"version": "16.14.0",
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+			"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2"
+				"object-assign": "^4.1.1"
 			},
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/react-dom": {
-			"version": "16.14.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2",
-				"scheduler": "^0.19.1"
-			},
-			"peerDependencies": {
-				"react": "^16.14.0"
 			}
 		},
 		"node_modules/react-is": {
 			"version": "18.2.0",
 			"license": "MIT"
 		},
-		"node_modules/react-test-renderer": {
-			"version": "16.14.0",
+		"node_modules/react-shallow-renderer": {
+			"version": "16.15.0",
+			"resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+			"integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2",
-				"react-is": "^16.8.6",
-				"scheduler": "^0.19.1"
+				"react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
 			},
 			"peerDependencies": {
-				"react": "^16.14.0"
+				"react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/react-test-renderer": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+			"integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+			"dev": true,
+			"dependencies": {
+				"object-assign": "^4.1.1",
+				"react-is": "^17.0.2",
+				"react-shallow-renderer": "^16.13.1",
+				"scheduler": "^0.20.2"
+			},
+			"peerDependencies": {
+				"react": "17.0.2"
 			}
 		},
 		"node_modules/react-test-renderer/node_modules/react-is": {
-			"version": "16.13.1",
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+			"dev": true
+		},
+		"node_modules/react-test-renderer/node_modules/scheduler": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+			"integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
 			"dev": true,
-			"license": "MIT"
+			"dependencies": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1"
+			}
 		},
 		"node_modules/readable-stream": {
 			"version": "3.6.0",
@@ -9401,15 +9412,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/scheduler": {
-			"version": "0.19.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1"
 			}
 		},
 		"node_modules/semver": {
@@ -12018,7 +12020,9 @@
 			"dev": true
 		},
 		"@types/react": {
-			"version": "16.14.25",
+			"version": "17.0.48",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.48.tgz",
+			"integrity": "sha512-zJ6IYlJ8cYYxiJfUaZOQee4lh99mFihBoqkOSEGV+dFi9leROW6+PgstzQ+w3gWTnUfskALtQPGHK6dYmPj+2A==",
 			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
@@ -12034,10 +12038,12 @@
 			}
 		},
 		"@types/react-test-renderer": {
-			"version": "16.9.5",
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+			"integrity": "sha512-+F1KONQTBHDBBhbHuT2GNydeMpPuviduXIVJRB7Y4nma4NR5DrTJfMMZ+jbhEHbpwL+Uqhs1WXh4KHiyrtYTPg==",
 			"dev": true,
 			"requires": {
-				"@types/react": "^16"
+				"@types/react": "^17"
 			}
 		},
 		"@types/resolve": {
@@ -16577,40 +16583,55 @@
 			}
 		},
 		"react": {
-			"version": "16.14.0",
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+			"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
 			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2"
-			}
-		},
-		"react-dom": {
-			"version": "16.14.0",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2",
-				"scheduler": "^0.19.1"
+				"object-assign": "^4.1.1"
 			}
 		},
 		"react-is": {
 			"version": "18.2.0"
 		},
-		"react-test-renderer": {
-			"version": "16.14.0",
+		"react-shallow-renderer": {
+			"version": "16.15.0",
+			"resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+			"integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
 			"dev": true,
 			"requires": {
 				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2",
-				"react-is": "^16.8.6",
-				"scheduler": "^0.19.1"
+				"react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"react-test-renderer": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
+			"integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
+			"dev": true,
+			"requires": {
+				"object-assign": "^4.1.1",
+				"react-is": "^17.0.2",
+				"react-shallow-renderer": "^16.13.1",
+				"scheduler": "^0.20.2"
 			},
 			"dependencies": {
 				"react-is": {
-					"version": "16.13.1",
+					"version": "17.0.2",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+					"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 					"dev": true
+				},
+				"scheduler": {
+					"version": "0.20.2",
+					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+					"integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+					"dev": true,
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1"
+					}
 				}
 			}
 		},
@@ -16819,14 +16840,6 @@
 			"dev": true,
 			"requires": {
 				"xmlchars": "^2.2.0"
-			}
-		},
-		"scheduler": {
-			"version": "0.19.1",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1"
 			}
 		},
 		"semver": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -27,7 +27,7 @@
     ]
   },
   "peerDependencies": {
-    "react": ">=16 || >=17"
+    "react": "^16.14.0 || >=17"
   },
   "dependencies": {
     "json-schema-merge-allof": "^0.8.1",
@@ -43,20 +43,18 @@
     "@babel/plugin-transform-react-jsx": "^7.18.6",
     "@babel/preset-env": "^7.18.9",
     "@babel/preset-react": "^7.18.6",
-    "@types/jest": "^27.5.2",
     "@types/jest-expect-message": "^1.0.4",
     "@types/json-schema": "^7.0.9",
     "@types/json-schema-merge-allof": "^0.6.1",
     "@types/lodash": "^4.14.182",
-    "@types/react": "^16.14.25",
+    "@types/react": "^17.0.48",
     "@types/react-is": "^17.0.3",
-    "@types/react-test-renderer": "^16.9.5",
+    "@types/react-test-renderer": "^17.0.2",
     "dts-cli": "^1.5.2",
     "eslint": "^8.20.0",
     "jest-expect-message": "^1.0.2",
-    "react": "^16.14.0",
-    "react-dom": "^16.14.0",
-    "react-test-renderer": "^16.14.0",
+    "react": "^17.0.2",
+    "react-test-renderer": "^17.0.2",
     "rimraf": "^3.0.2"
   },
   "publishConfig": {


### PR DESCRIPTION
### Reasons for making this change

- Bumped react to 17, fixing react 16.14 in peer dependencies
- Removed `react-dom` because it wasn't needed

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
