### PR TITLE
Bumped the dependencies for semantic-ui

### DIFF
--- a/packages/semantic-ui/package-lock.json
+++ b/packages/semantic-ui/package-lock.json
@@ -23,7 +23,7 @@
 				"atob": "^2.0.3",
 				"eslint": "^8.20.0",
 				"jest": "^25.4.0",
-				"nanoid": "^3.1.23",
+				"nanoid": "^3.3.4",
 				"prop-types": "^15.8.1",
 				"react": "^16.14.0",
 				"react-dom": "^16.14.0",
@@ -37,7 +37,7 @@
 			"peerDependencies": {
 				"@rjsf/core": "^4.2.0",
 				"@rjsf/utils": "^4.2.0",
-				"react": ">=16",
+				"react": "^16.14.0 || >=17",
 				"semantic-ui-css": "^2.4.1",
 				"semantic-ui-react": "1.3.1"
 			}
@@ -6539,7 +6539,7 @@
 				"@types/react-is": "^17.0.3",
 				"@types/react-test-renderer": "^16.9.5",
 				"dts-cli": "^1.5.2",
-				"eslint": "^8.19.0",
+				"eslint": "^8.20.0",
 				"jest-expect-message": "^1.0.2",
 				"react": "^16.14.0",
 				"react-dom": "^16.14.0",
@@ -14396,10 +14396,14 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.9.2",
-			"license": "MIT",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+			"integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
 			"dependencies": {
 				"regenerator-runtime": "^0.13.4"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
@@ -14410,10 +14414,6 @@
 				"core-js-pure": "^3.0.0",
 				"regenerator-runtime": "^0.13.4"
 			}
-		},
-		"node_modules/@babel/runtime/node_modules/regenerator-runtime": {
-			"version": "0.13.5",
-			"license": "MIT"
 		},
 		"node_modules/@babel/template": {
 			"version": "7.18.6",
@@ -14590,7 +14590,8 @@
 		},
 		"node_modules/@fluentui/react-component-event-listener": {
 			"version": "0.51.7",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-component-event-listener/-/react-component-event-listener-0.51.7.tgz",
+			"integrity": "sha512-NjVm+crN0T9A7vITL8alZeHnuV8zi2gos0nezU/2YOxaUAB9E4zKiPxt/6k5U50rJs/gj8Nu45iXxnjO41HbZg==",
 			"dependencies": {
 				"@babel/runtime": "^7.10.4"
 			},
@@ -14599,19 +14600,10 @@
 				"react-dom": "^16.8.0 || ^17"
 			}
 		},
-		"node_modules/@fluentui/react-component-event-listener/node_modules/@babel/runtime": {
-			"version": "7.16.3",
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@fluentui/react-component-ref": {
 			"version": "0.51.7",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-component-ref/-/react-component-ref-0.51.7.tgz",
+			"integrity": "sha512-CX27jVJYaFoBCWpuWAizQZ2se137ku1dmDyn8sw+ySNJa+kkQf7LnMydiPW5K7cRdUSqUJW3eS4EjKRvVAx8xA==",
 			"dependencies": {
 				"@babel/runtime": "^7.10.4",
 				"react-is": "^16.6.3"
@@ -14619,16 +14611,6 @@
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17",
 				"react-dom": "^16.8.0 || ^17"
-			}
-		},
-		"node_modules/@fluentui/react-component-ref/node_modules/@babel/runtime": {
-			"version": "7.16.3",
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			},
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -15751,15 +15733,16 @@
 			}
 		},
 		"node_modules/@semantic-ui-react/event-stack": {
-			"version": "3.1.2",
-			"license": "MIT",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-3.1.3.tgz",
+			"integrity": "sha512-FdTmJyWvJaYinHrKRsMLDrz4tTMGdFfds299Qory53hBugiDvGC0tEJf+cHsi5igDwWb/CLOgOiChInHwq8URQ==",
 			"dependencies": {
 				"exenv": "^1.2.2",
 				"prop-types": "^15.6.2"
 			},
 			"peerDependencies": {
-				"react": "^16.0.0 || ^17.0.0",
-				"react-dom": "^16.0.0 || ^17.0.0"
+				"react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+				"react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
 		"node_modules/@sinonjs/commons": {
@@ -19333,7 +19316,8 @@
 		},
 		"node_modules/exenv": {
 			"version": "1.2.2",
-			"license": "BSD-3-Clause"
+			"resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+			"integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
 		},
 		"node_modules/exit": {
 			"version": "0.1.2",
@@ -25400,7 +25384,8 @@
 		},
 		"node_modules/react": {
 			"version": "16.14.0",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+			"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -25412,7 +25397,8 @@
 		},
 		"node_modules/react-dom": {
 			"version": "16.14.0",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+			"integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -25445,8 +25431,9 @@
 		},
 		"node_modules/react-test-renderer": {
 			"version": "16.14.0",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
+			"integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
@@ -26158,7 +26145,8 @@
 		},
 		"node_modules/scheduler": {
 			"version": "0.19.1",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+			"integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -26191,16 +26179,6 @@
 			"peerDependencies": {
 				"react": "^16.8.0",
 				"react-dom": "^16.8.0"
-			}
-		},
-		"node_modules/semantic-ui-react/node_modules/@babel/runtime": {
-			"version": "7.16.3",
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			},
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/semver": {
@@ -27776,17 +27754,6 @@
 				"node": ">=6.0"
 			}
 		},
-		"node_modules/tsdx/node_modules/aria-query/node_modules/@babel/runtime": {
-			"version": "7.18.6",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/tsdx/node_modules/array-includes": {
 			"version": "3.1.5",
 			"dev": true,
@@ -28112,17 +28079,6 @@
 			},
 			"peerDependencies": {
 				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
-			}
-		},
-		"node_modules/tsdx/node_modules/eslint-plugin-jsx-a11y/node_modules/@babel/runtime": {
-			"version": "7.18.6",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			},
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/tsdx/node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
@@ -30564,14 +30520,11 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.9.2",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+			"integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
-			},
-			"dependencies": {
-				"regenerator-runtime": {
-					"version": "0.13.5"
-				}
 			}
 		},
 		"@babel/runtime-corejs3": {
@@ -30705,31 +30658,19 @@
 		},
 		"@fluentui/react-component-event-listener": {
 			"version": "0.51.7",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-component-event-listener/-/react-component-event-listener-0.51.7.tgz",
+			"integrity": "sha512-NjVm+crN0T9A7vITL8alZeHnuV8zi2gos0nezU/2YOxaUAB9E4zKiPxt/6k5U50rJs/gj8Nu45iXxnjO41HbZg==",
 			"requires": {
 				"@babel/runtime": "^7.10.4"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.16.3",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
 			}
 		},
 		"@fluentui/react-component-ref": {
 			"version": "0.51.7",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-component-ref/-/react-component-ref-0.51.7.tgz",
+			"integrity": "sha512-CX27jVJYaFoBCWpuWAizQZ2se137ku1dmDyn8sw+ySNJa+kkQf7LnMydiPW5K7cRdUSqUJW3eS4EjKRvVAx8xA==",
 			"requires": {
 				"@babel/runtime": "^7.10.4",
 				"react-is": "^16.6.3"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.16.3",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
 			}
 		},
 		"@humanwhocodes/config-array": {
@@ -32842,7 +32783,7 @@
 						"@types/react-is": "^17.0.3",
 						"@types/react-test-renderer": "^16.9.5",
 						"dts-cli": "^1.5.2",
-						"eslint": "^8.19.0",
+						"eslint": "^8.20.0",
 						"jest-expect-message": "^1.0.2",
 						"json-schema-merge-allof": "^0.8.1",
 						"jsonpointer": "^5.0.1",
@@ -39797,7 +39738,7 @@
 				"@types/react-is": "^17.0.3",
 				"@types/react-test-renderer": "^16.9.5",
 				"dts-cli": "^1.5.2",
-				"eslint": "^8.19.0",
+				"eslint": "^8.20.0",
 				"jest-expect-message": "^1.0.2",
 				"json-schema-merge-allof": "^0.8.1",
 				"jsonpointer": "^5.0.1",
@@ -43908,7 +43849,9 @@
 			}
 		},
 		"@semantic-ui-react/event-stack": {
-			"version": "3.1.2",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-3.1.3.tgz",
+			"integrity": "sha512-FdTmJyWvJaYinHrKRsMLDrz4tTMGdFfds299Qory53hBugiDvGC0tEJf+cHsi5igDwWb/CLOgOiChInHwq8URQ==",
 			"requires": {
 				"exenv": "^1.2.2",
 				"prop-types": "^15.6.2"
@@ -46244,7 +46187,9 @@
 			}
 		},
 		"exenv": {
-			"version": "1.2.2"
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+			"integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
 		},
 		"exit": {
 			"version": "0.1.2",
@@ -50195,6 +50140,8 @@
 		},
 		"react": {
 			"version": "16.14.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+			"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -50203,6 +50150,8 @@
 		},
 		"react-dom": {
 			"version": "16.14.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+			"integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -50227,6 +50176,8 @@
 		},
 		"react-test-renderer": {
 			"version": "16.14.0",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
+			"integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
 			"dev": true,
 			"requires": {
 				"object-assign": "^4.1.1",
@@ -50698,6 +50649,8 @@
 		},
 		"scheduler": {
 			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+			"integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -50724,14 +50677,6 @@
 				"react-is": "^16.8.6",
 				"react-popper": "^1.3.7",
 				"shallowequal": "^1.1.0"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.16.3",
-					"requires": {
-						"regenerator-runtime": "^0.13.4"
-					}
-				}
 			}
 		},
 		"semver": {
@@ -51751,15 +51696,6 @@
 					"requires": {
 						"@babel/runtime": "^7.10.2",
 						"@babel/runtime-corejs3": "^7.10.2"
-					},
-					"dependencies": {
-						"@babel/runtime": {
-							"version": "7.18.6",
-							"dev": true,
-							"requires": {
-								"regenerator-runtime": "^0.13.4"
-							}
-						}
 					}
 				},
 				"array-includes": {
@@ -52007,13 +51943,6 @@
 						"semver": "^6.3.0"
 					},
 					"dependencies": {
-						"@babel/runtime": {
-							"version": "7.18.6",
-							"dev": true,
-							"requires": {
-								"regenerator-runtime": "^0.13.4"
-							}
-						},
 						"emoji-regex": {
 							"version": "9.2.2",
 							"dev": true

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -35,7 +35,7 @@
   "peerDependencies": {
     "@rjsf/core": "^4.2.0",
     "@rjsf/utils": "^4.2.0",
-    "react": ">=16",
+    "react": "^16.14.0 || >=17",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "1.3.1"
   },
@@ -53,7 +53,7 @@
     "atob": "^2.0.3",
     "eslint": "^8.20.0",
     "jest": "^25.4.0",
-    "nanoid": "^3.1.23",
+    "nanoid": "^3.3.4",
     "prop-types": "^15.8.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",


### PR DESCRIPTION
### Reasons for making this change

- Fixed react 16.14 adding >=17 in peer dependencies
   - Didn't bump to react 17 officially to avoid peer dependencies issues with `semantic-ui` which is stuck on 16
- Bumped nanoid to the latest minor version

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
