### PR TITLE
Use responsive grid to show two columns on medium size and larger

### DIFF
--- a/packages/material-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/material-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -28,14 +28,14 @@ const ObjectFieldTemplate = ({
         <TitleField id={`${idSchema.$id}-title`} title={title} required={required} />
       )}
       {description && <DescriptionField id={`${idSchema.$id}-description`} description={description} />}
-      <Grid container={true} spacing={2} style={{ marginTop: '10px' }}>
+      <Grid container={true} direction={'row'} spacing={2} style={{ marginTop: '10px' }}>
         {properties.map((element, index) =>
           // Remove the <Grid> if the inner element is hidden as the <Grid>
           // itself would otherwise still take up space.
           element.hidden ? (
             element.content
           ) : (
-            <Grid item={true} xs={12} key={index} style={{ marginBottom: '10px' }}>
+            <Grid item={true} xs={12} sm={6} key={index} style={{ marginBottom: '10px' }}>
               {element.content}
             </Grid>
           )


### PR DESCRIPTION
### Reasons for making this change

We want to show the form in two columns when viewing on wider screens.

If your PR is non-trivial and you'd like to schedule a synchronous review, please add it to the weekly meeting agenda: https://docs.google.com/document/d/12PjTvv21k6LIky6bNQVnsplMLLnmEuypTLQF8a-8Wss/edit

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

## TODO

- [ ] Figure out how to deal with first field having extra margin