### PR TITLE
fix(@rjsf/core): Add formElement to Form TS definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Feature for ui:submitButtonOptions on the submit button for forms (https://github.com/rjsf-team/react-jsonschema-form/pull/2640)
 - Fix `ui:orderable` and `ui:removable` in arrays (#2797)
 - Fix for nested allOf blocks with multiple if/then/else statements failing to render correctly (https://github.com/rjsf-team/react-jsonschema-form/pull/2839)
+- Fix for TypeScript definitions to correctly include `formElement` inside the `Form` object
 
 ## Dev / docs / playground
 - Enable ui options in playground, to demonstrate submit button options (https://github.com/rjsf-team/react-jsonschema-form/pull/2640)

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -69,6 +69,7 @@ declare module '@rjsf/core' {
         onChange: (formData: T, newErrorSchema: ErrorSchema) => void;
         onBlur: (id: string, value: any) => void;
         submit: () => void;
+        formElement: null | HTMLFormElement;
     }
 
     export type UISchemaSubmitButtonOptions = {


### PR DESCRIPTION
### Reasons for making this change

Adds the `formElement` definition to the Form TS interface

The `Form` object internally manages a reference called `formElement`, [initially null](https://github.com/rjsf-team/react-jsonschema-form/blob/master/packages/core/src/components/Form.js#L42) that can be set via the [ref property](https://github.com/rjsf-team/react-jsonschema-form/blob/master/packages/core/src/components/Form.js#L495).

However, the TS definitions do not reflect this, therefore, consuming the library from a pure TS project will throw an error when attempting to access it.

I think this is the only change needed, but let me know if I'm missing anything

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
