### PR TITLE
Fix the docs for formElement in Form

### DIFF
--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -232,7 +232,9 @@ export default class Form<T = any, F = any> extends Component<
   FormProps<T, F>,
   FormState<T, F>
 > {
-  /** The ref used to hold the `form` element */
+  /** The ref used to hold the `form` element, this needs to be `any` because `tagName` or `_internalFormWrapper` can
+   * provide any possible type here
+   */
   formElement: React.RefObject<any>;
 
   /** Constructs the `Form` from the `props`. Will setup the initial state from the props. It will also call the


### PR DESCRIPTION
### Reasons for making this change

- Added an explanation for why the `any` type is specified

### Checklist

* [x] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
