### PR TITLE
Emit and publish transpiled code (fix #2966)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "4.2.0",
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
-    "build": "rimraf dist && tsdx build --format cjs,es && cross-env NODE_ENV=production BABEL_ENV=umd webpack --config webpack.config.dist.js",
+    "build": "rimraf dist lib && npx tsc && tsdx build --format cjs,es && cross-env NODE_ENV=production BABEL_ENV=umd webpack --config webpack.config.dist.js",
     "cs-check": "prettier -l \"{src,test}/**/*.js\"",
     "cs-format": "prettier \"{src,test}/**/*.js\" --write",
     "lint": "eslint src test",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,10 @@
   "version": "4.2.0",
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
-    "build": "rimraf dist lib && npx tsc && tsdx build --format cjs,es && cross-env NODE_ENV=production BABEL_ENV=umd webpack --config webpack.config.dist.js",
+    "build": "rimraf dist && tsdx build --format cjs,es && cross-env NODE_ENV=production BABEL_ENV=umd webpack --config webpack.config.dist.js && npm run deprecated:build:cjs && npm run deprecated:build:es && npm run deprecated:build:es:lib",
+    "deprecated:build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --extensions \".js,.jsx,.ts,.tsx\" ./src --out-dir ./dist/cjs",
+    "deprecated:build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --extensions \".js,.jsx,.ts,.tsx\" ./src --out-dir ./dist/es",
+    "deprecated:build:es:lib": "rimraf lib && cross-env NODE_ENV=production BABEL_ENV=es babel --extensions \".js,.jsx,.ts,.tsx\" ./src --out-dir ./lib",
     "cs-check": "prettier -l \"{src,test}/**/*.js\"",
     "cs-format": "prettier \"{src,test}/**/*.js\" --write",
     "lint": "eslint src test",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -7,6 +7,5 @@
       "*": ["src/*", "node_modules/*"]
     },
     "jsx": "react",
-    "outDir": "lib"
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -7,5 +7,6 @@
       "*": ["src/*", "node_modules/*"]
     },
     "jsx": "react",
+    "outDir": "lib"
   }
 }


### PR DESCRIPTION
### Reasons for making this change

Fixes #2966 

When we switched to TSDX, we removed the build steps where babel emitted transpiled code to `lib`, `dist/cjs`, and `dist/es`. This created a breaking change for anyone accessing folders inside of the base package. Restoring all of them should fix the issue in `@rjsf/core` for v4.X.X. I don't think this needs to be merged into `rjsf-v5`, since that branch can withstand the breaking changes that are fixed by this patch.