### PR TITLE
Remove unnecessary lodash uses

### DIFF
--- a/packages/antd/src/templates/ObjectFieldTemplate/index.js
+++ b/packages/antd/src/templates/ObjectFieldTemplate/index.js
@@ -1,5 +1,7 @@
 import React from "react";
 import classNames from "classnames";
+import isObject from "lodash/isObject";
+import isNumber from "lodash/isNumber";
 
 import { canExpand } from "@rjsf/utils";
 import Button from "antd/lib/button";
@@ -61,12 +63,12 @@ const ObjectFieldTemplate = ({
         ? 24
         : 12;
 
-    if (colSpan instanceof Object) {
+    if (isObject(colSpan)) {
       return (
         colSpan[widget] || colSpan[field] || colSpan[type] || defaultColSpan
       );
     }
-    if (typeof colSpan === "number") {
+    if (isNumber(colSpan)) {
       return colSpan;
     }
     return defaultColSpan;

--- a/packages/antd/src/templates/ObjectFieldTemplate/index.js
+++ b/packages/antd/src/templates/ObjectFieldTemplate/index.js
@@ -1,6 +1,5 @@
 import React from "react";
 import classNames from "classnames";
-import _ from "lodash";
 
 import { canExpand } from "@rjsf/utils";
 import Button from "antd/lib/button";
@@ -62,12 +61,12 @@ const ObjectFieldTemplate = ({
         ? 24
         : 12;
 
-    if (_.isObject(colSpan)) {
+    if (colSpan instanceof Object) {
       return (
         colSpan[widget] || colSpan[field] || colSpan[type] || defaultColSpan
       );
     }
-    if (_.isNumber(colSpan)) {
+    if (typeof colSpan === "number") {
       return colSpan;
     }
     return defaultColSpan;

--- a/packages/antd/src/widgets/CheckboxesWidget/index.js
+++ b/packages/antd/src/widgets/CheckboxesWidget/index.js
@@ -1,5 +1,4 @@
 import React from "react";
-import _ from "lodash";
 
 import Checkbox from "antd/lib/checkbox";
 
@@ -29,7 +28,7 @@ const CheckboxesWidget = ({
 
   const handleFocus = ({ target }) => onFocus(id, target.value);
 
-  return !_.isEmpty(enumOptions) ? (
+  return Array.isArray(enumOptions) && enumOptions.length > 0 ? (
     <Checkbox.Group
       disabled={disabled || (readonlyAsDisabled && readonly)}
       id={id}

--- a/packages/core/src/components/fields/ArrayField.js
+++ b/packages/core/src/components/fields/ArrayField.js
@@ -1,7 +1,6 @@
 import AddButton from "../AddButton";
 import IconButton from "../IconButton";
 import React, { Component } from "react";
-import includes from "lodash/includes";
 import {
   getWidget,
   getUiOptions,
@@ -249,7 +248,7 @@ class ArrayField extends Component {
     if (Array.isArray(itemSchema.type)) {
       // While we don't yet support composite/nullable jsonschema types, it's
       // future-proof to check for requirement against these.
-      return !includes(itemSchema.type, "null");
+      return !itemSchema.type.includes("null");
     }
     // All non-null array item types are inherently required by design
     return itemSchema.type !== "null";

--- a/packages/utils/src/mergeDefaultsWithFormData.ts
+++ b/packages/utils/src/mergeDefaultsWithFormData.ts
@@ -1,5 +1,4 @@
 import get from "lodash/get";
-import map from "lodash/map";
 
 import isObject from "./isObject";
 
@@ -23,7 +22,7 @@ export default function mergeDefaultsWithFormData<T = any>(
 ): T {
   if (Array.isArray(formData)) {
     const defaultsArray = Array.isArray(defaults) ? defaults : [];
-    const mapped = map(formData, (value, idx) => {
+    const mapped = formData.map((value, idx) => {
       if (defaultsArray[idx]) {
         return mergeDefaultsWithFormData<any>(defaultsArray[idx], value);
       }

--- a/packages/utils/src/mergeSchemas.ts
+++ b/packages/utils/src/mergeSchemas.ts
@@ -1,4 +1,5 @@
 import union from "lodash/union";
+
 import { REQUIRED_KEY } from "./constants";
 import getSchemaType from "./getSchemaType";
 import isObject from "./isObject";

--- a/packages/utils/src/mergeSchemas.ts
+++ b/packages/utils/src/mergeSchemas.ts
@@ -1,3 +1,4 @@
+import union from "lodash/union";
 import { REQUIRED_KEY } from "./constants";
 import getSchemaType from "./getSchemaType";
 import isObject from "./isObject";
@@ -30,7 +31,7 @@ export default function mergeSchemas(
       Array.isArray(right)
     ) {
       // Don't include duplicate values when merging 'required' fields.
-      acc[key] = Array.from(new Set([...left, ...right]));
+      acc[key] = union(left, right);
     } else {
       acc[key] = right;
     }

--- a/packages/utils/src/mergeSchemas.ts
+++ b/packages/utils/src/mergeSchemas.ts
@@ -1,5 +1,3 @@
-import union from "lodash/union";
-
 import { REQUIRED_KEY } from "./constants";
 import getSchemaType from "./getSchemaType";
 import isObject from "./isObject";
@@ -32,7 +30,7 @@ export default function mergeSchemas(
       Array.isArray(right)
     ) {
       // Don't include duplicate values when merging 'required' fields.
-      acc[key] = union(left, right);
+      acc[key] = Array.from(new Set([...left, ...right]));
     } else {
       acc[key] = right;
     }

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -1,5 +1,4 @@
 import get from "lodash/get";
-import fill from "lodash/fill";
 
 import {
   ANY_OF_KEY,
@@ -225,8 +224,9 @@ export function computeDefaults<T = any>(
               AdditionalItemsHandling.Invert
             );
             const fillerDefault = fillerSchema.default;
-            const fillerEntries: T[] = fill(
-              new Array(schema.minItems - defaultsLength),
+            const fillerEntries: T[] = new Array(
+              schema.minItems - defaultsLength
+            ).fill(
               computeDefaults<any>(
                 validator,
                 fillerSchema,

--- a/packages/utils/test/testUtils/getTestValidator.ts
+++ b/packages/utils/test/testUtils/getTestValidator.ts
@@ -1,5 +1,3 @@
-import isEmpty from "lodash/isEmpty";
-
 import { ValidationData } from "../../src";
 import { TestValidatorParams, TestValidatorType } from "../schema/types";
 
@@ -16,15 +14,20 @@ export default function getTestValidator<T = any>({
     _isValid: isValid,
     validator: {
       validateFormData: jest.fn().mockImplementation(() => {
-        // console.warn('validateFormData', JSON.stringify(args));
-        if (!isEmpty(testValidator._data)) {
+        if (
+          Array.isArray(testValidator._data) &&
+          testValidator._data.length > 0
+        ) {
           return testValidator._data.shift();
         }
         return { errors: [], errorSchema: {} };
       }),
       isValid: jest.fn().mockImplementation(() => {
         // console.warn('isValid',  JSON.stringify(args));
-        if (!isEmpty(testValidator._isValid)) {
+        if (
+          Array.isArray(testValidator._isValid) &&
+          testValidator._isValid.length > 0
+        ) {
           return testValidator._isValid.shift();
         }
         return true;

--- a/packages/validator-ajv6/src/createAjvInstance.ts
+++ b/packages/validator-ajv6/src/createAjvInstance.ts
@@ -1,5 +1,4 @@
 import Ajv from "ajv";
-import { isObject } from "lodash";
 
 import { CustomValidatorOptionsType } from "./types";
 
@@ -42,7 +41,7 @@ export default function createAjvInstance(
   }
 
   // add more custom formats to validate against
-  if (isObject(customFormats)) {
+  if (customFormats instanceof Object) {
     Object.keys(customFormats).forEach((formatName) => {
       ajv.addFormat(formatName, customFormats[formatName]);
     });

--- a/packages/validator-ajv6/src/createAjvInstance.ts
+++ b/packages/validator-ajv6/src/createAjvInstance.ts
@@ -1,4 +1,5 @@
 import Ajv from "ajv";
+import isObject from "lodash/isObject";
 
 import { CustomValidatorOptionsType } from "./types";
 
@@ -41,7 +42,7 @@ export default function createAjvInstance(
   }
 
   // add more custom formats to validate against
-  if (customFormats instanceof Object) {
+  if (isObject(customFormats)) {
     Object.keys(customFormats).forEach((formatName) => {
       ajv.addFormat(formatName, customFormats[formatName]);
     });


### PR DESCRIPTION
### Reasons for making this change

Just removing some lodash uses that is more efficiently served by built-in functions, to reduce bundle size.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
