### PR TITLE
fix: able to override className for submit button on core package

### DIFF
--- a/packages/core/src/components/widgets/SubmitButton.tsx
+++ b/packages/core/src/components/widgets/SubmitButton.tsx
@@ -18,7 +18,7 @@ export default function SubmitButton<T, F>({
       <button
         type="submit"
         {...submitButtonProps}
-        className={`btn btn-info ${submitButtonProps.className}`}
+        className={submitButtonProps.className || `btn btn-info`}
       >
         {submitText}
       </button>


### PR DESCRIPTION
### Reasons for making this change


### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
