### PR TITLE
Migrate filewidget to functional component

### DIFF
--- a/packages/core/test/StringField_test.js
+++ b/packages/core/test/StringField_test.js
@@ -138,8 +138,10 @@ describe("StringField", () => {
         },
       });
 
-      Simulate.change(node.querySelector("input"), {
-        target: { value: "yo" },
+      act(() => {
+        Simulate.change(node.querySelector("input"), {
+          target: { value: "yo" },
+        });
       });
 
       sinon.assert.calledWithMatch(onChange.lastCall, {
@@ -356,9 +358,10 @@ describe("StringField", () => {
           enum: ["foo", "bar"],
         },
       });
-
-      Simulate.change(node.querySelector("select"), {
-        target: { value: "foo" },
+      act(() => {
+        Simulate.change(node.querySelector("select"), {
+          target: { value: "foo" },
+        });
       });
       sinon.assert.calledWithMatch(onChange.lastCall, {
         formData: "foo",
@@ -1906,12 +1909,13 @@ describe("StringField", () => {
         },
       });
 
-      Simulate.change(node.querySelector("[type=file]"), {
-        target: {
-          files: [{ name: nonUriEncodedValue, size: 1, type: "type" }],
-        },
+      act(() => {
+        Simulate.change(node.querySelector("[type=file]"), {
+          target: {
+            files: [{ name: nonUriEncodedValue, size: 1, type: "type" }],
+          },
+        });
       });
-
       await new Promise(setImmediate);
 
       sinon.assert.calledWithMatch(onChange.lastCall, {


### PR DESCRIPTION
### Reasons for making this change

Migrated FileWidget to functional component.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
