### PR TITLE
Add getTemplate() function to utils

### DIFF
--- a/packages/antd/src/templates/ArrayFieldTemplate/index.js
+++ b/packages/antd/src/templates/ArrayFieldTemplate/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { getUiOptions } from "@rjsf/utils";
+import { getTemplate, getUiOptions } from "@rjsf/utils";
 import classNames from "classnames";
 import Button from "antd/lib/button";
 import Col from "antd/lib/col";
@@ -28,13 +28,23 @@ const ArrayFieldTemplate = ({
   title,
   uiSchema,
 }) => {
-  const {
-    ArrayFieldDescriptionTemplate,
-    ArrayFieldItemTemplate,
-    ArrayFieldTitleTemplate,
-  } = registry.templates;
-  const { labelAlign = "right", rowGutter = 24 } = formContext;
   const uiOptions = getUiOptions(uiSchema);
+  const ArrayFieldDescriptionTemplate = getTemplate(
+    "ArrayFieldDescriptionTemplate",
+    registry,
+    uiOptions
+  );
+  const ArrayFieldItemTemplate = getTemplate(
+    "ArrayFieldItemTemplate",
+    registry,
+    uiOptions
+  );
+  const ArrayFieldTitleTemplate = getTemplate(
+    "ArrayFieldTitleTemplate",
+    registry,
+    uiOptions
+  );
+  const { labelAlign = "right", rowGutter = 24 } = formContext;
 
   const labelClsBasic = `${prefixCls}-item-label`;
   const labelColClassName = classNames(
@@ -63,6 +73,7 @@ const ArrayFieldTemplate = ({
             <ArrayFieldDescriptionTemplate
               description={uiOptions.description || schema.description}
               idSchema={idSchema}
+              uiSchema={uiSchema}
               registry={registry}
             />
           </Col>

--- a/packages/antd/src/templates/ObjectFieldTemplate/index.js
+++ b/packages/antd/src/templates/ObjectFieldTemplate/index.js
@@ -3,7 +3,7 @@ import classNames from "classnames";
 import isObject from "lodash/isObject";
 import isNumber from "lodash/isNumber";
 
-import { canExpand, getUiOptions } from "@rjsf/utils";
+import { canExpand, getTemplate, getUiOptions } from "@rjsf/utils";
 import Button from "antd/lib/button";
 import Col from "antd/lib/col";
 import Row from "antd/lib/row";
@@ -30,9 +30,18 @@ const ObjectFieldTemplate = ({
   title,
   uiSchema,
 }) => {
-  const { DescriptionFieldTemplate, TitleFieldTemplate } = registry.templates;
-  const { colSpan = 24, labelAlign = "right", rowGutter = 24 } = formContext;
   const uiOptions = getUiOptions(uiSchema);
+  const TitleFieldTemplate = getTemplate(
+    "TitleFieldTemplate",
+    registry,
+    uiOptions
+  );
+  const DescriptionFieldTemplate = getTemplate(
+    "DescriptionFieldTemplate",
+    registry,
+    uiOptions
+  );
+  const { colSpan = 24, labelAlign = "right", rowGutter = 24 } = formContext;
 
   const labelClsBasic = `${prefixCls}-item-label`;
   const labelColClassName = classNames(

--- a/packages/bootstrap-4/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/bootstrap-4/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -5,6 +5,7 @@ import Container from "react-bootstrap/Container";
 import {
   ArrayFieldTemplateItemType,
   ArrayFieldTemplateProps,
+  getTemplate,
   getUiOptions,
 } from "@rjsf/utils";
 
@@ -24,12 +25,23 @@ const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
     schema,
     title,
   } = props;
-  const {
-    ArrayFieldDescriptionTemplate,
-    ArrayFieldItemTemplate,
-    ArrayFieldTitleTemplate,
-  } = registry.templates;
   const uiOptions = getUiOptions(uiSchema);
+  const ArrayFieldDescriptionTemplate =
+    getTemplate<"ArrayFieldDescriptionTemplate">(
+      "ArrayFieldDescriptionTemplate",
+      registry,
+      uiOptions
+    );
+  const ArrayFieldItemTemplate = getTemplate<"ArrayFieldItemTemplate">(
+    "ArrayFieldItemTemplate",
+    registry,
+    uiOptions
+  );
+  const ArrayFieldTitleTemplate = getTemplate<"ArrayFieldTitleTemplate">(
+    "ArrayFieldTitleTemplate",
+    registry,
+    uiOptions
+  );
   return (
     <div>
       <Row className="p-0 m-0">
@@ -45,6 +57,7 @@ const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
             <ArrayFieldDescriptionTemplate
               idSchema={idSchema}
               description={(uiOptions.description || schema.description)!}
+              uiSchema={uiSchema}
               registry={registry}
             />
           )}

--- a/packages/bootstrap-4/src/FileWidget/FileWidget.tsx
+++ b/packages/bootstrap-4/src/FileWidget/FileWidget.tsx
@@ -1,9 +1,13 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { getTemplate, WidgetProps } from "@rjsf/utils";
 
 const FileWidget = (props: WidgetProps) => {
-  const { registry } = props;
-  const { BaseInputTemplate } = registry.templates;
+  const { options, registry } = props;
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate">(
+    "BaseInputTemplate",
+    registry,
+    options
+  );
   return <BaseInputTemplate {...props} type="file" />;
 };
 

--- a/packages/bootstrap-4/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/bootstrap-4/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -4,7 +4,12 @@ import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
 
-import { canExpand, getUiOptions, ObjectFieldTemplateProps } from "@rjsf/utils";
+import {
+  canExpand,
+  getTemplate,
+  getUiOptions,
+  ObjectFieldTemplateProps,
+} from "@rjsf/utils";
 
 import AddButton from "../AddButton/AddButton";
 
@@ -22,8 +27,17 @@ const ObjectFieldTemplate = ({
   readonly,
   registry,
 }: ObjectFieldTemplateProps) => {
-  const { DescriptionFieldTemplate, TitleFieldTemplate } = registry.templates;
   const uiOptions = getUiOptions(uiSchema);
+  const TitleFieldTemplate = getTemplate<"TitleFieldTemplate">(
+    "TitleFieldTemplate",
+    registry,
+    uiOptions
+  );
+  const DescriptionFieldTemplate = getTemplate<"DescriptionFieldTemplate">(
+    "DescriptionFieldTemplate",
+    registry,
+    uiOptions
+  );
   return (
     <>
       {(uiOptions.title || title) && (

--- a/packages/bootstrap-4/src/RangeWidget/RangeWidget.tsx
+++ b/packages/bootstrap-4/src/RangeWidget/RangeWidget.tsx
@@ -1,14 +1,13 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { getTemplate, WidgetProps } from "@rjsf/utils";
 
 const RangeWidget = (props: WidgetProps) => {
-  const {
-    value,
-    label,
-    registry: {
-      templates: { BaseInputTemplate },
-    },
-  } = props;
+  const { value, label, options, registry } = props;
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate">(
+    "BaseInputTemplate",
+    registry,
+    options
+  );
   return (
     <BaseInputTemplate {...props} extraProps={label}>
       <span className="range-view">{value}</span>

--- a/packages/chakra-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/chakra-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Box, Grid, GridItem } from "@chakra-ui/react";
 import {
+  getTemplate,
   getUiOptions,
   ArrayFieldTemplateItemType,
   ArrayFieldTemplateProps,
@@ -22,12 +23,23 @@ const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
     schema,
     title,
   } = props;
-  const {
-    ArrayFieldDescriptionTemplate,
-    ArrayFieldItemTemplate,
-    ArrayFieldTitleTemplate,
-  } = registry.templates;
   const uiOptions = getUiOptions(uiSchema);
+  const ArrayFieldDescriptionTemplate =
+    getTemplate<"ArrayFieldDescriptionTemplate">(
+      "ArrayFieldDescriptionTemplate",
+      registry,
+      uiOptions
+    );
+  const ArrayFieldItemTemplate = getTemplate<"ArrayFieldItemTemplate">(
+    "ArrayFieldItemTemplate",
+    registry,
+    uiOptions
+  );
+  const ArrayFieldTitleTemplate = getTemplate<"ArrayFieldTitleTemplate">(
+    "ArrayFieldTitleTemplate",
+    registry,
+    uiOptions
+  );
   return (
     <Box>
       <ArrayFieldTitleTemplate
@@ -41,6 +53,7 @@ const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
         <ArrayFieldDescriptionTemplate
           idSchema={idSchema}
           description={(uiOptions.description || schema.description)!}
+          uiSchema={uiSchema}
           registry={registry}
         />
       )}

--- a/packages/chakra-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/chakra-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -1,8 +1,11 @@
-import * as React from "react";
-
+import React from "react";
 import { Grid, GridItem } from "@chakra-ui/react";
-
-import { canExpand, getUiOptions, ObjectFieldTemplateProps } from "@rjsf/utils";
+import {
+  canExpand,
+  getTemplate,
+  getUiOptions,
+  ObjectFieldTemplateProps,
+} from "@rjsf/utils";
 
 import AddButton from "../AddButton";
 
@@ -21,8 +24,17 @@ const ObjectFieldTemplate = (props: ObjectFieldTemplateProps) => {
     onAddClick,
     registry,
   } = props;
-  const { DescriptionFieldTemplate, TitleFieldTemplate } = registry.templates;
   const uiOptions = getUiOptions(uiSchema);
+  const TitleFieldTemplate = getTemplate<"TitleFieldTemplate">(
+    "TitleFieldTemplate",
+    registry,
+    uiOptions
+  );
+  const DescriptionFieldTemplate = getTemplate<"DescriptionFieldTemplate">(
+    "DescriptionFieldTemplate",
+    registry,
+    uiOptions
+  );
 
   return (
     <React.Fragment>

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -12,18 +12,20 @@ import {
   RegistryWidgetsType,
   RegistryFieldsType,
   SchemaUtilsType,
+  TemplatesType,
   UiSchema,
   ValidationData,
   ValidatorType,
   WidgetProps,
   createSchemaUtils,
   deepEquals,
+  getTemplate,
+  getUiOptions,
   isObject,
   mergeObjects,
   shouldRender,
   NAME_KEY,
   RJSF_ADDITONAL_PROPERTIES_FLAG,
-  TemplatesType,
 } from "@rjsf/utils";
 import _pick from "lodash/pick";
 import _get from "lodash/get";
@@ -400,7 +402,12 @@ export default class Form<T = any, F = any> extends Component<
   renderErrors(registry: Registry<T, F>) {
     const { errors, errorSchema, schema, uiSchema } = this.state;
     const { showErrorList, formContext } = this.props;
-    const { ErrorListTemplate } = registry.templates;
+    const options = getUiOptions<T, F>(uiSchema);
+    const ErrorListTemplate = getTemplate<"ErrorListTemplate", T, F>(
+      "ErrorListTemplate",
+      registry,
+      options
+    );
 
     if (errors && errors.length && showErrorList != false) {
       return (

--- a/packages/core/src/components/fields/ArrayField.tsx
+++ b/packages/core/src/components/fields/ArrayField.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import {
+  getTemplate,
   getWidget,
   getUiOptions,
   isFixedItems,
@@ -12,7 +13,6 @@ import {
   FieldProps,
   IdSchema,
   RJSFSchema,
-  TemplatesType,
   UiSchema,
   ITEMS_KEY,
 } from "@rjsf/utils";
@@ -20,8 +20,6 @@ import get from "lodash/get";
 import isObject from "lodash/isObject";
 import set from "lodash/set";
 import { nanoid } from "nanoid";
-
-import DefaultArrayFieldTemplate from "../templates/ArrayFieldTemplate";
 
 /** Type used to represent the keyed form data used in the state */
 type KeyedFormDataType<T> = { key: string; item: T };
@@ -378,8 +376,12 @@ class ArrayField<T = any, F = any> extends Component<
     const { schema, uiSchema, idSchema, registry } = this.props;
     const { schemaUtils } = registry;
     if (!(ITEMS_KEY in schema)) {
-      const { templates } = registry;
-      const { UnsupportedFieldTemplate } = templates;
+      const uiOptions = getUiOptions<T[], F>(uiSchema);
+      const UnsupportedFieldTemplate = getTemplate<
+        "UnsupportedFieldTemplate",
+        T[],
+        F
+      >("UnsupportedFieldTemplate", registry, uiOptions);
 
       return (
         <UnsupportedFieldTemplate
@@ -428,8 +430,7 @@ class ArrayField<T = any, F = any> extends Component<
     } = this.props;
     const { keyedFormData } = this.state;
     const title = schema.title === undefined ? name : schema.title;
-    const { schemaUtils, templates, formContext } = registry;
-    const { ArrayFieldTemplate } = templates;
+    const { schemaUtils, formContext } = registry;
     const uiOptions = getUiOptions<T[], F>(uiSchema);
     const _schemaItems = isObject(schema.items)
       ? (schema.items as RJSFSchema)
@@ -486,11 +487,11 @@ class ArrayField<T = any, F = any> extends Component<
       registry,
     };
 
-    // Check if a custom template was passed in
-    const Template: TemplatesType<T[], F>["ArrayFieldTemplate"] =
-      uiOptions.ArrayFieldTemplate ||
-      ArrayFieldTemplate ||
-      DefaultArrayFieldTemplate;
+    const Template = getTemplate<"ArrayFieldTemplate", T[], F>(
+      "ArrayFieldTemplate",
+      registry,
+      uiOptions
+    );
     return <Template {...arrayProps} />;
   }
 
@@ -667,8 +668,7 @@ class ArrayField<T = any, F = any> extends Component<
     let { formData: items = [] } = this.props;
     const title = schema.title || name;
     const uiOptions = getUiOptions<T[], F>(uiSchema);
-    const { schemaUtils, formContext, templates } = registry;
-    const { ArrayFieldTemplate } = templates;
+    const { schemaUtils, formContext } = registry;
     const _schemaItems = isObject(schema.items)
       ? (schema.items as RJSFSchema[])
       : [];
@@ -747,11 +747,11 @@ class ArrayField<T = any, F = any> extends Component<
       rawErrors,
     };
 
-    // Check if a custom template was passed in
-    const Template: TemplatesType<T[], F>["ArrayFieldTemplate"] =
-      uiOptions.ArrayFieldTemplate ||
-      ArrayFieldTemplate ||
-      DefaultArrayFieldTemplate;
+    const Template = getTemplate<"ArrayFieldTemplate", T[], F>(
+      "ArrayFieldTemplate",
+      registry,
+      uiOptions
+    );
     return <Template {...arrayProps} />;
   }
 

--- a/packages/core/src/components/fields/ObjectField.tsx
+++ b/packages/core/src/components/fields/ObjectField.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import {
+  getTemplate,
   getUiOptions,
   orderProperties,
   ErrorSchema,
@@ -7,7 +8,6 @@ import {
   GenericObjectType,
   IdSchema,
   RJSFSchema,
-  TemplatesType,
   ADDITIONAL_PROPERTY_FLAG,
   PROPERTIES_KEY,
   REF_KEY,
@@ -17,8 +17,6 @@ import has from "lodash/has";
 import isObject from "lodash/isObject";
 import set from "lodash/set";
 import unset from "lodash/unset";
-
-import DefaultObjectFieldTemplate from "../templates/ObjectFieldTemplate";
 
 /** Type used for the state of the `ObjectField` component */
 type ObjectFieldState = {
@@ -230,7 +228,7 @@ class ObjectField<T = any, F = any> extends Component<
       registry,
     } = this.props;
 
-    const { fields, formContext, schemaUtils, templates } = registry;
+    const { fields, formContext, schemaUtils } = registry;
     const { SchemaField } = fields;
     const schema = schemaUtils.retrieveSchema(rawSchema, formData);
     const uiOptions = getUiOptions<T, F>(uiSchema);
@@ -254,10 +252,11 @@ class ObjectField<T = any, F = any> extends Component<
       );
     }
 
-    const Template: TemplatesType<T, F>["ObjectFieldTemplate"] =
-      uiOptions.ObjectFieldTemplate ||
-      templates.ObjectFieldTemplate ||
-      DefaultObjectFieldTemplate;
+    const Template = getTemplate<"ObjectFieldTemplate", T, F>(
+      "ObjectFieldTemplate",
+      registry,
+      uiOptions
+    );
 
     const templateProps = {
       title: uiOptions.title || title,

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -4,20 +4,18 @@ import {
   deepEquals,
   getUiOptions,
   getSchemaType,
+  getTemplate,
   FieldProps,
   FieldTemplateProps,
   IdSchema,
   Registry,
   RJSFSchema,
   RJSFSchemaDefinition,
-  TemplatesType,
   UIOptionsType,
   ID_KEY,
 } from "@rjsf/utils";
 import isObject from "lodash/isObject";
 import omit from "lodash/omit";
-
-import DefaultFieldTemplate from "../templates/FieldTemplate";
 
 /** The map of component type to FieldName */
 const COMPONENT_TYPES: { [key: string]: string } = {
@@ -47,7 +45,7 @@ function getFieldComponent<T, F>(
   registry: Registry<T, F>
 ) {
   const field = uiOptions.field;
-  const { fields, templates } = registry;
+  const { fields } = registry;
   if (typeof field === "function") {
     return field;
   }
@@ -70,7 +68,11 @@ function getFieldComponent<T, F>(
   return componentName in fields
     ? fields[componentName]
     : () => {
-        const { UnsupportedFieldTemplate } = templates;
+        const UnsupportedFieldTemplate = getTemplate<
+          "UnsupportedFieldTemplate",
+          T,
+          F
+        >("UnsupportedFieldTemplate", registry, uiOptions);
 
         return (
           <UnsupportedFieldTemplate
@@ -156,10 +158,18 @@ function SchemaFieldRender<T, F>(props: FieldProps<T, F>) {
     registry,
     wasPropertyKeyModified = false,
   } = props;
-  const { formContext, schemaUtils, templates } = registry;
+  const { formContext, schemaUtils } = registry;
   const uiOptions = getUiOptions<T, F>(uiSchema);
-  const FieldTemplate: TemplatesType<T, F>["FieldTemplate"] =
-    uiOptions.FieldTemplate || templates.FieldTemplate || DefaultFieldTemplate;
+  const FieldTemplate = getTemplate<"FieldTemplate", T, F>(
+    "FieldTemplate",
+    registry,
+    uiOptions
+  );
+  const DescriptionFieldTemplate = getTemplate<
+    "DescriptionFieldTemplate",
+    T,
+    F
+  >("DescriptionFieldTemplate", registry, uiOptions);
   const schema = schemaUtils.retrieveSchema(_schema, formData);
   const idSchema = mergeObjects(
     schemaUtils.toIdSchema(schema, undefined, formData, idPrefix, idSeparator),
@@ -171,7 +181,6 @@ function SchemaFieldRender<T, F>(props: FieldProps<T, F>) {
     idSchema,
     registry
   );
-  const { DescriptionFieldTemplate } = templates;
   const disabled = Boolean(props.disabled || uiOptions.disabled);
   const readonly = Boolean(
     props.readonly ||

--- a/packages/core/src/components/templates/ArrayFieldDescriptionTemplate.tsx
+++ b/packages/core/src/components/templates/ArrayFieldDescriptionTemplate.tsx
@@ -1,19 +1,28 @@
 import React from "react";
-import { ArrayFieldDescriptionProps } from "@rjsf/utils";
+import {
+  getTemplate,
+  getUiOptions,
+  ArrayFieldDescriptionProps,
+} from "@rjsf/utils";
 
 /** The `ArrayFieldDescriptionTemplate` component renders a `DescriptionFieldTemplate` with an `id` derived from
  * the `idSchema`.
  *
  * @param props - The `ArrayFieldDescriptionProps` for the component
  */
-export default function ArrayFieldDescriptionTemplate(
+export default function ArrayFieldDescriptionTemplate<T = any, F = any>(
   props: ArrayFieldDescriptionProps
 ) {
-  const { idSchema, description, registry } = props;
+  const { idSchema, description, registry, uiSchema } = props;
   if (!description) {
     return null;
   }
-  const { DescriptionFieldTemplate } = registry.templates;
+  const options = getUiOptions<T, F>(uiSchema);
+  const DescriptionFieldTemplate = getTemplate<
+    "DescriptionFieldTemplate",
+    T,
+    F
+  >("DescriptionFieldTemplate", registry, options);
   const id = `${idSchema.$id}__description`;
   return (
     <DescriptionFieldTemplate

--- a/packages/core/src/components/templates/ArrayFieldTemplate.tsx
+++ b/packages/core/src/components/templates/ArrayFieldTemplate.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  getTemplate,
   getUiOptions,
   ArrayFieldTemplateProps,
   ArrayFieldTemplateItemType,
@@ -28,12 +29,22 @@ export default function ArrayFieldTemplate<T = any, F = any>(
     schema,
     title,
   } = props;
-  const {
-    ArrayFieldDescriptionTemplate,
-    ArrayFieldItemTemplate,
-    ArrayFieldTitleTemplate,
-  } = registry.templates;
   const uiOptions = getUiOptions<T, F>(uiSchema);
+  const ArrayFieldDescriptionTemplate = getTemplate<
+    "ArrayFieldDescriptionTemplate",
+    T,
+    F
+  >("ArrayFieldDescriptionTemplate", registry, uiOptions);
+  const ArrayFieldItemTemplate = getTemplate<"ArrayFieldItemTemplate", T, F>(
+    "ArrayFieldItemTemplate",
+    registry,
+    uiOptions
+  );
+  const ArrayFieldTitleTemplate = getTemplate<"ArrayFieldTitleTemplate", T, F>(
+    "ArrayFieldTitleTemplate",
+    registry,
+    uiOptions
+  );
   return (
     <fieldset className={className} id={idSchema.$id}>
       <ArrayFieldTitleTemplate
@@ -47,6 +58,7 @@ export default function ArrayFieldTemplate<T = any, F = any>(
         <ArrayFieldDescriptionTemplate
           idSchema={idSchema}
           description={(uiOptions.description || schema.description)!}
+          uiSchema={uiSchema}
           registry={registry}
         />
       )}

--- a/packages/core/src/components/templates/ArrayFieldTitleTemplate.tsx
+++ b/packages/core/src/components/templates/ArrayFieldTitleTemplate.tsx
@@ -1,17 +1,30 @@
 import React from "react";
-import { ArrayFieldTitleProps } from "@rjsf/utils";
+import {
+  getTemplate,
+  getUiOptions,
+  ArrayFieldTitleProps,
+  TemplatesType,
+} from "@rjsf/utils";
 
 /** The `ArrayFieldTitleTemplate` component renders a `TitleFieldTemplate` with an `id` derived from
  * the `idSchema`.
  *
  * @param props - The `ArrayFieldTitleProps` for the component
  */
-export default function ArrayFieldTitleTemplate(props: ArrayFieldTitleProps) {
+export default function ArrayFieldTitleTemplate<T = any, F = any>(
+  props: ArrayFieldTitleProps
+) {
   const { idSchema, title, uiSchema, required, registry } = props;
   if (!title) {
     return null;
   }
-  const { TitleFieldTemplate } = registry.templates;
+  const options = getUiOptions<T, F>(uiSchema);
+  const TitleFieldTemplate: TemplatesType<T, F>["TitleFieldTemplate"] =
+    getTemplate<"TitleFieldTemplate", T, F>(
+      "TitleFieldTemplate",
+      registry,
+      options
+    );
   const id = `${idSchema.$id}__title`;
   return (
     <TitleFieldTemplate

--- a/packages/core/src/components/templates/ObjectFieldTemplate.tsx
+++ b/packages/core/src/components/templates/ObjectFieldTemplate.tsx
@@ -3,6 +3,7 @@ import {
   ObjectFieldTemplatePropertyType,
   ObjectFieldTemplateProps,
   canExpand,
+  getTemplate,
   getUiOptions,
 } from "@rjsf/utils";
 import AddButton from "../AddButton";
@@ -30,8 +31,17 @@ export default function ObjectFieldTemplate<T = any, F = any>(
     title,
     uiSchema,
   } = props;
-  const { DescriptionFieldTemplate, TitleFieldTemplate } = registry.templates;
   const options = getUiOptions<T, F>(uiSchema);
+  const TitleFieldTemplate = getTemplate<"TitleFieldTemplate", T, F>(
+    "TitleFieldTemplate",
+    registry,
+    options
+  );
+  const DescriptionFieldTemplate = getTemplate<
+    "DescriptionFieldTemplate",
+    T,
+    F
+  >("DescriptionFieldTemplate", registry, options);
   return (
     <fieldset id={idSchema.$id}>
       {(options.title || title) && (

--- a/packages/core/src/components/widgets/CheckboxWidget.tsx
+++ b/packages/core/src/components/widgets/CheckboxWidget.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { schemaRequiresTrueValue } from "@rjsf/utils";
-import { WidgetProps } from "@rjsf/utils";
+import { getTemplate, schemaRequiresTrueValue, WidgetProps } from "@rjsf/utils";
 
 /** The `CheckBoxWidget` is a widget for rendering boolean properties.
  *  It is typically used to represent a boolean.
@@ -9,6 +8,7 @@ import { WidgetProps } from "@rjsf/utils";
  */
 function CheckboxWidget<T = any, F = any>({
   schema,
+  options,
   id,
   value,
   disabled,
@@ -20,7 +20,11 @@ function CheckboxWidget<T = any, F = any>({
   onChange,
   registry,
 }: WidgetProps<T, F>) {
-  const { DescriptionFieldTemplate } = registry.templates;
+  const DescriptionFieldTemplate = getTemplate<
+    "DescriptionFieldTemplate",
+    T,
+    F
+  >("DescriptionFieldTemplate", registry, options);
   // Because an unchecked checkbox will cause html5 validation to fail, only add
   // the "required" attribute if the field value must be "true", due to the
   // "const" or "enum" keywords

--- a/packages/core/src/components/widgets/ColorWidget.tsx
+++ b/packages/core/src/components/widgets/ColorWidget.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { getTemplate, WidgetProps } from "@rjsf/utils";
 
 /** The `ColorWidget` component uses the `BaseInputTemplate` changing the type to `color` and disables it when it is
  * either disabled or readonly.
@@ -9,13 +9,12 @@ import { WidgetProps } from "@rjsf/utils";
 export default function ColorWidget<T = any, F = any>(
   props: WidgetProps<T, F>
 ) {
-  const {
-    disabled,
-    readonly,
-    registry: {
-      templates: { BaseInputTemplate },
-    },
-  } = props;
+  const { disabled, readonly, options, registry } = props;
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, F>(
+    "BaseInputTemplate",
+    registry,
+    options
+  );
   return (
     <BaseInputTemplate
       type="color"

--- a/packages/core/src/components/widgets/DateTimeWidget.tsx
+++ b/packages/core/src/components/widgets/DateTimeWidget.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { localToUTC, utcToLocal, WidgetProps } from "@rjsf/utils";
+import { getTemplate, localToUTC, utcToLocal, WidgetProps } from "@rjsf/utils";
 
 /** The `DateTimeWidget` component uses the `BaseInputTemplate` changing the type to `datetime-local` and transforms
  * the value to/from utc using the appropriate utility functions.
@@ -9,13 +9,12 @@ import { localToUTC, utcToLocal, WidgetProps } from "@rjsf/utils";
 export default function DateTimeWidget<T = any, F = any>(
   props: WidgetProps<T, F>
 ) {
-  const {
-    onChange,
-    value,
-    registry: {
-      templates: { BaseInputTemplate },
-    },
-  } = props;
+  const { onChange, value, options, registry } = props;
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, F>(
+    "BaseInputTemplate",
+    registry,
+    options
+  );
   return (
     <BaseInputTemplate
       type="datetime-local"

--- a/packages/core/src/components/widgets/DateWidget.tsx
+++ b/packages/core/src/components/widgets/DateWidget.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { getTemplate, WidgetProps } from "@rjsf/utils";
 
 /** The `DateWidget` component uses the `BaseInputTemplate` changing the type to `date` and transforms
  * the value to undefined when it is falsy during the `onChange` handling.
@@ -7,12 +7,12 @@ import { WidgetProps } from "@rjsf/utils";
  * @param props - The `WidgetProps` for this component
  */
 export default function DateWidget<T = any, F = any>(props: WidgetProps<T, F>) {
-  const {
-    onChange,
-    registry: {
-      templates: { BaseInputTemplate },
-    },
-  } = props;
+  const { onChange, options, registry } = props;
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, F>(
+    "BaseInputTemplate",
+    registry,
+    options
+  );
   return (
     <BaseInputTemplate
       type="date"

--- a/packages/core/src/components/widgets/EmailWidget.tsx
+++ b/packages/core/src/components/widgets/EmailWidget.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { getTemplate, WidgetProps } from "@rjsf/utils";
 
 /** The `EmailWidget` component uses the `BaseInputTemplate` changing the type to `email`.
  *
@@ -8,6 +8,11 @@ import { WidgetProps } from "@rjsf/utils";
 export default function EmailWidget<T = any, F = any>(
   props: WidgetProps<T, F>
 ) {
-  const { BaseInputTemplate } = props.registry.templates;
+  const { options, registry } = props;
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, F>(
+    "BaseInputTemplate",
+    registry,
+    options
+  );
   return <BaseInputTemplate type="email" {...props} />;
 }

--- a/packages/core/src/components/widgets/PasswordWidget.tsx
+++ b/packages/core/src/components/widgets/PasswordWidget.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { getTemplate, WidgetProps } from "@rjsf/utils";
 
 /** The `PasswordWidget` component uses the `BaseInputTemplate` changing the type to `password`.
  *
@@ -8,6 +8,11 @@ import { WidgetProps } from "@rjsf/utils";
 export default function PasswordWidget<T = any, F = any>(
   props: WidgetProps<T, F>
 ) {
-  const { BaseInputTemplate } = props.registry.templates;
+  const { options, registry } = props;
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, F>(
+    "BaseInputTemplate",
+    registry,
+    options
+  );
   return <BaseInputTemplate type="password" {...props} />;
 }

--- a/packages/core/src/components/widgets/TextWidget.tsx
+++ b/packages/core/src/components/widgets/TextWidget.tsx
@@ -1,11 +1,16 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { getTemplate, WidgetProps } from "@rjsf/utils";
 
 /** The `TextWidget` component uses the `BaseInputTemplate`.
  *
  * @param props - The `WidgetProps` for this component
  */
 export default function TextWidget<T = any, F = any>(props: WidgetProps<T, F>) {
-  const { BaseInputTemplate } = props.registry.templates;
+  const { options, registry } = props;
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, F>(
+    "BaseInputTemplate",
+    registry,
+    options
+  );
   return <BaseInputTemplate {...props} />;
 }

--- a/packages/core/src/components/widgets/URLWidget.tsx
+++ b/packages/core/src/components/widgets/URLWidget.tsx
@@ -1,11 +1,16 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { getTemplate, WidgetProps } from "@rjsf/utils";
 
 /** The `URLWidget` component uses the `BaseInputTemplate` changing the type to `url`.
  *
  * @param props - The `WidgetProps` for this component
  */
 export default function URLWidget<T = any, F = any>(props: WidgetProps<T, F>) {
-  const { BaseInputTemplate } = props.registry.templates;
+  const { options, registry } = props;
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, F>(
+    "BaseInputTemplate",
+    registry,
+    options
+  );
   return <BaseInputTemplate type="url" {...props} />;
 }

--- a/packages/core/src/components/widgets/UpDownWidget.tsx
+++ b/packages/core/src/components/widgets/UpDownWidget.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { getTemplate, WidgetProps } from "@rjsf/utils";
 
 /** The `UpDownWidget` component uses the `BaseInputTemplate` changing the type to `number`.
  *
@@ -8,6 +8,11 @@ import { WidgetProps } from "@rjsf/utils";
 export default function UpDownWidget<T = any, F = any>(
   props: WidgetProps<T, F>
 ) {
-  const { BaseInputTemplate } = props.registry.templates;
+  const { options, registry } = props;
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, F>(
+    "BaseInputTemplate",
+    registry,
+    options
+  );
   return <BaseInputTemplate type="number" {...props} />;
 }

--- a/packages/fluent-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/fluent-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  getTemplate,
   getUiOptions,
   ArrayFieldTemplateItemType,
   ArrayFieldTemplateProps,
@@ -24,12 +25,23 @@ const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
     schema,
     title,
   } = props;
-  const {
-    ArrayFieldDescriptionTemplate,
-    ArrayFieldItemTemplate,
-    ArrayFieldTitleTemplate,
-  } = registry.templates;
   const uiOptions = getUiOptions(uiSchema);
+  const ArrayFieldDescriptionTemplate =
+    getTemplate<"ArrayFieldDescriptionTemplate">(
+      "ArrayFieldDescriptionTemplate",
+      registry,
+      uiOptions
+    );
+  const ArrayFieldItemTemplate = getTemplate<"ArrayFieldItemTemplate">(
+    "ArrayFieldItemTemplate",
+    registry,
+    uiOptions
+  );
+  const ArrayFieldTitleTemplate = getTemplate<"ArrayFieldTitleTemplate">(
+    "ArrayFieldTitleTemplate",
+    registry,
+    uiOptions
+  );
   return (
     <>
       <ArrayFieldTitleTemplate
@@ -43,6 +55,7 @@ const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
         <ArrayFieldDescriptionTemplate
           idSchema={idSchema}
           description={(uiOptions.description || schema.description)!}
+          uiSchema={uiSchema}
           registry={registry}
         />
       )}

--- a/packages/fluent-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/fluent-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -1,5 +1,9 @@
 import React from "react";
-import { getUiOptions, ObjectFieldTemplateProps } from "@rjsf/utils";
+import {
+  getTemplate,
+  getUiOptions,
+  ObjectFieldTemplateProps,
+} from "@rjsf/utils";
 
 const ObjectFieldTemplate = ({
   description,
@@ -10,8 +14,17 @@ const ObjectFieldTemplate = ({
   idSchema,
   registry,
 }: ObjectFieldTemplateProps) => {
-  const { DescriptionFieldTemplate, TitleFieldTemplate } = registry.templates;
   const uiOptions = getUiOptions(uiSchema);
+  const TitleFieldTemplate = getTemplate<"TitleFieldTemplate">(
+    "TitleFieldTemplate",
+    registry,
+    uiOptions
+  );
+  const DescriptionFieldTemplate = getTemplate<"DescriptionFieldTemplate">(
+    "DescriptionFieldTemplate",
+    registry,
+    uiOptions
+  );
   return (
     <>
       {(uiOptions.title || title) && (
@@ -30,7 +43,6 @@ const ObjectFieldTemplate = ({
           registry={registry}
         />
       )}
-
       <div className="ms-Grid" dir="ltr">
         <div className="ms-Grid-row">
           {properties.map((element) => element.content)}

--- a/packages/fluent-ui/src/TextareaWidget/TextareaWidget.tsx
+++ b/packages/fluent-ui/src/TextareaWidget/TextareaWidget.tsx
@@ -1,9 +1,14 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { getTemplate, getUiOptions, WidgetProps } from "@rjsf/utils";
 
 const TextareaWidget = (props: WidgetProps) => {
-  const { registry } = props;
-  const { BaseInputTemplate } = registry.templates;
+  const { uiSchema, registry } = props;
+  const options = getUiOptions(uiSchema);
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate">(
+    "BaseInputTemplate",
+    registry,
+    options
+  );
   // TODO: rows and columns.
   return <BaseInputTemplate {...props} multiline />;
 };

--- a/packages/material-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/material-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -5,6 +5,7 @@ import Paper from "@material-ui/core/Paper";
 import {
   ArrayFieldTemplateItemType,
   ArrayFieldTemplateProps,
+  getTemplate,
   getUiOptions,
 } from "@rjsf/utils";
 
@@ -24,12 +25,23 @@ const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
     schema,
     title,
   } = props;
-  const {
-    ArrayFieldDescriptionTemplate,
-    ArrayFieldItemTemplate,
-    ArrayFieldTitleTemplate,
-  } = registry.templates;
   const uiOptions = getUiOptions(uiSchema);
+  const ArrayFieldDescriptionTemplate =
+    getTemplate<"ArrayFieldDescriptionTemplate">(
+      "ArrayFieldDescriptionTemplate",
+      registry,
+      uiOptions
+    );
+  const ArrayFieldItemTemplate = getTemplate<"ArrayFieldItemTemplate">(
+    "ArrayFieldItemTemplate",
+    registry,
+    uiOptions
+  );
+  const ArrayFieldTitleTemplate = getTemplate<"ArrayFieldTitleTemplate">(
+    "ArrayFieldTitleTemplate",
+    registry,
+    uiOptions
+  );
   return (
     <Paper elevation={2}>
       <Box p={2}>
@@ -44,6 +56,7 @@ const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
           <ArrayFieldDescriptionTemplate
             idSchema={idSchema}
             description={(uiOptions.description || schema.description)!}
+            uiSchema={uiSchema}
             registry={registry}
           />
         )}

--- a/packages/material-ui/src/DateTimeWidget/DateTimeWidget.tsx
+++ b/packages/material-ui/src/DateTimeWidget/DateTimeWidget.tsx
@@ -1,9 +1,13 @@
 import React from "react";
-import { localToUTC, utcToLocal, WidgetProps } from "@rjsf/utils";
+import { getTemplate, localToUTC, utcToLocal, WidgetProps } from "@rjsf/utils";
 
 const DateTimeWidget = (props: WidgetProps) => {
-  const { registry } = props;
-  const { BaseInputTemplate } = registry.templates;
+  const { options, registry } = props;
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate">(
+    "BaseInputTemplate",
+    registry,
+    options
+  );
   const value = utcToLocal(props.value);
   const onChange = (value: any) => {
     props.onChange(localToUTC(value));

--- a/packages/material-ui/src/DateWidget/DateWidget.tsx
+++ b/packages/material-ui/src/DateWidget/DateWidget.tsx
@@ -1,9 +1,13 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { getTemplate, WidgetProps } from "@rjsf/utils";
 
 const DateWidget = (props: WidgetProps) => {
-  const { registry } = props;
-  const { BaseInputTemplate } = registry.templates;
+  const { options, registry } = props;
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate">(
+    "BaseInputTemplate",
+    registry,
+    options
+  );
   return (
     <BaseInputTemplate
       type="date"

--- a/packages/material-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/material-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import Grid from "@material-ui/core/Grid";
-import { ObjectFieldTemplateProps, canExpand, getUiOptions } from "@rjsf/utils";
+import {
+  ObjectFieldTemplateProps,
+  canExpand,
+  getTemplate,
+  getUiOptions,
+} from "@rjsf/utils";
 
 import AddButton from "../AddButton/AddButton";
 
@@ -18,8 +23,17 @@ const ObjectFieldTemplate = ({
   onAddClick,
   registry,
 }: ObjectFieldTemplateProps) => {
-  const { DescriptionFieldTemplate, TitleFieldTemplate } = registry.templates;
   const uiOptions = getUiOptions(uiSchema);
+  const TitleFieldTemplate = getTemplate<"TitleFieldTemplate">(
+    "TitleFieldTemplate",
+    registry,
+    uiOptions
+  );
+  const DescriptionFieldTemplate = getTemplate<"DescriptionFieldTemplate">(
+    "DescriptionFieldTemplate",
+    registry,
+    uiOptions
+  );
   return (
     <>
       {(uiOptions.title || title) && (

--- a/packages/material-ui/src/TextareaWidget/TextareaWidget.tsx
+++ b/packages/material-ui/src/TextareaWidget/TextareaWidget.tsx
@@ -1,9 +1,13 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { getTemplate, WidgetProps } from "@rjsf/utils";
 
 const TextareaWidget = (props: WidgetProps) => {
   const { options, registry } = props;
-  const { BaseInputTemplate } = registry.templates;
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate">(
+    "BaseInputTemplate",
+    registry,
+    options
+  );
 
   let rows: string | number = 5;
   if (typeof options.rows === "string" || typeof options.rows === "number") {

--- a/packages/mui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/mui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -5,6 +5,7 @@ import Paper from "@mui/material/Paper";
 import {
   ArrayFieldTemplateItemType,
   ArrayFieldTemplateProps,
+  getTemplate,
   getUiOptions,
 } from "@rjsf/utils";
 
@@ -24,12 +25,23 @@ const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
     schema,
     title,
   } = props;
-  const {
-    ArrayFieldDescriptionTemplate,
-    ArrayFieldItemTemplate,
-    ArrayFieldTitleTemplate,
-  } = registry.templates;
   const uiOptions = getUiOptions(uiSchema);
+  const ArrayFieldDescriptionTemplate =
+    getTemplate<"ArrayFieldDescriptionTemplate">(
+      "ArrayFieldDescriptionTemplate",
+      registry,
+      uiOptions
+    );
+  const ArrayFieldItemTemplate = getTemplate<"ArrayFieldItemTemplate">(
+    "ArrayFieldItemTemplate",
+    registry,
+    uiOptions
+  );
+  const ArrayFieldTitleTemplate = getTemplate<"ArrayFieldTitleTemplate">(
+    "ArrayFieldTitleTemplate",
+    registry,
+    uiOptions
+  );
   return (
     <Paper elevation={2}>
       <Box p={2}>
@@ -44,6 +56,7 @@ const ArrayFieldTemplate = (props: ArrayFieldTemplateProps) => {
           <ArrayFieldDescriptionTemplate
             idSchema={idSchema}
             description={(uiOptions.description || schema.description)!}
+            uiSchema={uiSchema}
             registry={registry}
           />
         )}

--- a/packages/mui/src/DateTimeWidget/DateTimeWidget.tsx
+++ b/packages/mui/src/DateTimeWidget/DateTimeWidget.tsx
@@ -1,9 +1,13 @@
 import React from "react";
-import { localToUTC, utcToLocal, WidgetProps } from "@rjsf/utils";
+import { getTemplate, localToUTC, utcToLocal, WidgetProps } from "@rjsf/utils";
 
 const DateTimeWidget = (props: WidgetProps) => {
-  const { registry } = props;
-  const { BaseInputTemplate } = registry.templates;
+  const { options, registry } = props;
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate">(
+    "BaseInputTemplate",
+    registry,
+    options
+  );
   const value = utcToLocal(props.value);
   const onChange = (value: any) => {
     props.onChange(localToUTC(value));

--- a/packages/mui/src/DateWidget/DateWidget.tsx
+++ b/packages/mui/src/DateWidget/DateWidget.tsx
@@ -1,9 +1,13 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { getTemplate, WidgetProps } from "@rjsf/utils";
 
 const DateWidget = (props: WidgetProps) => {
-  const { registry } = props;
-  const { BaseInputTemplate } = registry.templates;
+  const { options, registry } = props;
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate">(
+    "BaseInputTemplate",
+    registry,
+    options
+  );
   return (
     <BaseInputTemplate
       type="date"

--- a/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import Grid from "@mui/material/Grid";
-import { ObjectFieldTemplateProps, canExpand, getUiOptions } from "@rjsf/utils";
+import {
+  ObjectFieldTemplateProps,
+  canExpand,
+  getTemplate,
+  getUiOptions,
+} from "@rjsf/utils";
 
 import AddButton from "../AddButton/AddButton";
 
@@ -18,8 +23,17 @@ const ObjectFieldTemplate = ({
   onAddClick,
   registry,
 }: ObjectFieldTemplateProps) => {
-  const { DescriptionFieldTemplate, TitleFieldTemplate } = registry.templates;
   const uiOptions = getUiOptions(uiSchema);
+  const TitleFieldTemplate = getTemplate<"TitleFieldTemplate">(
+    "TitleFieldTemplate",
+    registry,
+    uiOptions
+  );
+  const DescriptionFieldTemplate = getTemplate<"DescriptionFieldTemplate">(
+    "DescriptionFieldTemplate",
+    registry,
+    uiOptions
+  );
   return (
     <>
       {(uiOptions.title || title) && (

--- a/packages/mui/src/TextareaWidget/TextareaWidget.tsx
+++ b/packages/mui/src/TextareaWidget/TextareaWidget.tsx
@@ -1,9 +1,13 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { getTemplate, WidgetProps } from "@rjsf/utils";
 
 const TextareaWidget = (props: WidgetProps) => {
   const { options, registry } = props;
-  const { BaseInputTemplate } = registry.templates;
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate">(
+    "BaseInputTemplate",
+    registry,
+    options
+  );
 
   let rows: string | number = 5;
   if (typeof options.rows === "string" || typeof options.rows === "number") {

--- a/packages/semantic-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.js
+++ b/packages/semantic-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types,react/destructuring-assignment */
 import React from "react";
-import { getUiOptions, isFixedItems } from "@rjsf/utils";
+import { getTemplate, getUiOptions, isFixedItems } from "@rjsf/utils";
 
 import AddButton from "../AddButton";
 import { cleanClassNames, getSemanticProps } from "../util";
@@ -30,12 +30,22 @@ function ArrayFieldTemplate({
   });
   const { horizontalButtons, wrapItem } = semanticProps;
   const itemProps = { horizontalButtons, wrapItem };
-  const {
-    ArrayFieldDescriptionTemplate,
-    ArrayFieldItemTemplate,
-    ArrayFieldTitleTemplate,
-  } = registry.templates;
   const uiOptions = getUiOptions(uiSchema);
+  const ArrayFieldDescriptionTemplate = getTemplate(
+    "ArrayFieldDescriptionTemplate",
+    registry,
+    uiOptions
+  );
+  const ArrayFieldItemTemplate = getTemplate(
+    "ArrayFieldItemTemplate",
+    registry,
+    uiOptions
+  );
+  const ArrayFieldTitleTemplate = getTemplate(
+    "ArrayFieldTitleTemplate",
+    registry,
+    uiOptions
+  );
   const fieldTitle = uiOptions.title || title;
   const fieldDescription = uiOptions.description || schema.description;
   return (
@@ -57,6 +67,7 @@ function ArrayFieldTemplate({
         <ArrayFieldDescriptionTemplate
           idSchema={idSchema}
           description={fieldDescription}
+          uiSchema={uiSchema}
           registry={registry}
         />
       )}

--- a/packages/semantic-ui/src/CheckboxesWidget/CheckboxesWidget.js
+++ b/packages/semantic-ui/src/CheckboxesWidget/CheckboxesWidget.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types,react/no-array-index-key */
 import React from "react";
 import { Form } from "semantic-ui-react";
+import { getTemplate } from "@rjsf/utils";
 import { getSemanticProps } from "../util";
 
 function selectValue(value, selected, all) {
@@ -32,7 +33,11 @@ function CheckboxesWidget(props) {
     rawErrors = [],
     registry,
   } = props;
-  const { TitleFieldTemplate } = registry.templates;
+  const TitleFieldTemplate = getTemplate(
+    "TitleFieldTemplate",
+    registry,
+    options
+  );
   const { enumOptions, enumDisabled, inline } = options;
   const { title } = schema;
   const semanticProps = getSemanticProps({

--- a/packages/semantic-ui/src/FieldTemplate/FieldTemplate.js
+++ b/packages/semantic-ui/src/FieldTemplate/FieldTemplate.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
+import { getTemplate, getUiOptions } from "@rjsf/utils";
 import { Form } from "semantic-ui-react";
 import HelpField from "../HelpField";
 import RawErrors from "../RawErrors";
@@ -18,12 +19,18 @@ function FieldTemplate({
   hidden,
   rawDescription,
   registry,
+  uiSchema,
   ...props
 }) {
   const semanticProps = getSemanticProps(props);
   const { wrapLabel, wrapContent } = semanticProps;
   const errorOptions = getSemanticErrorProps(props);
-  const { DescriptionFieldTemplate } = registry.templates;
+  const uiOptions = getUiOptions(uiSchema);
+  const DescriptionFieldTemplate = getTemplate(
+    "DescriptionFieldTemplate",
+    registry,
+    uiOptions
+  );
 
   if (hidden) {
     return children;

--- a/packages/semantic-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.js
+++ b/packages/semantic-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { Grid } from "semantic-ui-react";
-import { canExpand, getUiOptions } from "@rjsf/utils";
+import { canExpand, getTemplate, getUiOptions } from "@rjsf/utils";
 import AddButton from "../AddButton/AddButton";
 
 function ObjectFieldTemplate({
@@ -18,8 +18,17 @@ function ObjectFieldTemplate({
   idSchema,
   registry,
 }) {
-  const { DescriptionFieldTemplate, TitleFieldTemplate } = registry.templates;
   const uiOptions = getUiOptions(uiSchema);
+  const TitleFieldTemplate = getTemplate(
+    "TitleFieldTemplate",
+    registry,
+    uiOptions
+  );
+  const DescriptionFieldTemplate = getTemplate(
+    "DescriptionFieldTemplate",
+    registry,
+    uiOptions
+  );
   const fieldTitle = uiOptions.title || title;
   const fieldDescription = uiOptions.description || description;
   return (

--- a/packages/utils/src/getTemplate.ts
+++ b/packages/utils/src/getTemplate.ts
@@ -1,0 +1,22 @@
+import { TemplatesType, Registry, UIOptionsType } from "./types";
+
+/** Returns the template with the given `name` from either the `uiSchema` if it is defined or from the `registry`
+ * otherwise.
+ *
+ * @param name - The name of the template to fetch, restricted to the keys of `TemplatesType`
+ * @param registry - The `Registry` from which to read the template
+ * @param [uiOptions={}] - The `UIOptionsType` from which to read an alternate template
+ * @returns - The template from either the `uiSchema` or `registry` for the `name`
+ */
+export default function getTemplate<
+  Name extends keyof TemplatesType<T, F>,
+  T = any,
+  F = any
+>(
+  name: Name,
+  registry: Registry<T, F>,
+  uiOptions: UIOptionsType<T, F> = {}
+): TemplatesType<T, F>[Name] {
+  const { templates } = registry;
+  return (uiOptions[name] as TemplatesType<T, F>[Name]) || templates[name];
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -8,6 +8,7 @@ import findSchemaDefinition from "./findSchemaDefinition";
 import getInputProps from "./getInputProps";
 import getSchemaType from "./getSchemaType";
 import getSubmitButtonOptions from "./getSubmitButtonOptions";
+import getTemplate from "./getTemplate";
 import getUiOptions from "./getUiOptions";
 import getWidget from "./getWidget";
 import guessType from "./guessType";
@@ -48,6 +49,7 @@ export {
   getInputProps,
   getSchemaType,
   getSubmitButtonOptions,
+  getTemplate,
   getUiOptions,
   getWidget,
   guessType,

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -365,6 +365,8 @@ export type ArrayFieldDescriptionProps<T = any, F = any> = Pick<
 > & {
   /** The idSchema of the field in the hierarchy */
   idSchema: IdSchema<T>;
+  /** The uiSchema object for this description field */
+  uiSchema?: UiSchema<T, F>;
 };
 
 /** The properties of each element in the ArrayFieldTemplateProps.items array */

--- a/packages/utils/test/getTemplate.test.ts
+++ b/packages/utils/test/getTemplate.test.ts
@@ -1,0 +1,76 @@
+import {
+  createSchemaUtils,
+  getTemplate,
+  Registry,
+  TemplatesType,
+  UIOptionsType,
+} from "../src";
+import getTestValidator from "./testUtils/getTestValidator";
+
+const FakeTemplate = () => null;
+
+const CustomTemplate = () => undefined;
+
+const registry: Registry = {
+  formContext: {},
+  rootSchema: {},
+  schemaUtils: createSchemaUtils(getTestValidator({}), {}),
+  templates: {
+    ArrayFieldDescriptionTemplate: FakeTemplate,
+    ArrayFieldItemTemplate: FakeTemplate,
+    ArrayFieldTemplate: FakeTemplate,
+    ArrayFieldTitleTemplate: FakeTemplate,
+    BaseInputTemplate: FakeTemplate,
+    DescriptionFieldTemplate: FakeTemplate,
+    ErrorListTemplate: FakeTemplate,
+    FieldTemplate: FakeTemplate,
+    ObjectFieldTemplate: FakeTemplate,
+    TitleFieldTemplate: FakeTemplate,
+    UnsupportedFieldTemplate: FakeTemplate,
+  },
+  fields: {},
+  widgets: {},
+};
+
+const uiOptions: UIOptionsType = {
+  ArrayFieldDescriptionTemplate:
+    CustomTemplate as unknown as UIOptionsType["ArrayFieldDescriptionTemplate"],
+  ArrayFieldItemTemplate:
+    CustomTemplate as unknown as UIOptionsType["ArrayFieldItemTemplate"],
+  ArrayFieldTemplate:
+    CustomTemplate as unknown as UIOptionsType["ArrayFieldTemplate"],
+  ArrayFieldTitleTemplate:
+    CustomTemplate as unknown as UIOptionsType["ArrayFieldTitleTemplate"],
+  BaseInputTemplate:
+    CustomTemplate as unknown as UIOptionsType["BaseInputTemplate"],
+  DescriptionFieldTemplate:
+    CustomTemplate as unknown as UIOptionsType["DescriptionFieldTemplate"],
+  ErrorListTemplate:
+    CustomTemplate as unknown as UIOptionsType["ErrorListTemplate"],
+  FieldTemplate: CustomTemplate as unknown as UIOptionsType["FieldTemplate"],
+  ObjectFieldTemplate:
+    CustomTemplate as unknown as UIOptionsType["ObjectFieldTemplate"],
+  TitleFieldTemplate:
+    CustomTemplate as unknown as UIOptionsType["TitleFieldTemplate"],
+  UnsupportedFieldTemplate:
+    CustomTemplate as unknown as UIOptionsType["UnsupportedFieldTemplate"],
+};
+
+const KEYS = Object.keys(registry.templates);
+
+describe("getTemplate", () => {
+  it("returns the template from registry", () => {
+    KEYS.forEach((key) => {
+      const name = key as keyof TemplatesType;
+      expect(getTemplate<typeof name>(name, registry)).toBe(FakeTemplate);
+    });
+  });
+  it("returns the template from uiOptions when available", () => {
+    KEYS.forEach((key) => {
+      const name = key as keyof TemplatesType;
+      expect(getTemplate<typeof name>(name, registry, uiOptions)).toBe(
+        CustomTemplate
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Reasons for making this change

Fixes an issue I identified while working on updating the documentation for templates where not all templates were able to be overridden by the `uiSchema`

- Added a new `getTemplate()` function used to fetch a template from either the `uiSchema.options` or the `registry`
  - Exported it from the library and added 100% unit tests
  - Also added an optional `uiSchema` to the `ArrayFieldDescriptionTemplate`
- Updated all uses of getting a template from `registry.templates` to use the `getTemplate()` function instead with the following additions:
  - Updated all `ArrayFieldTemplate`s to use `getTemplate()` for the three templates it uses as well as passing `uiSchema` to the `ArrayFieldDescriptionTemplate`
  - Updated all `ObjectFieldTemplate`s to use `getTemplate()` for the two templates is uses
  - Updated all `Widget` implementations that to use `getTemplate()` for getting the `BaseInputTemplate` (or on occasion the `DescriptionFieldTemplate` or `TitleFieldTemplate`)
  - Updated the `ArrayFieldDescriptionTemplate` and `ArrayFieldTitleTemplate` in `core` to use `getTemplate()` to get `DescriptionFieldTemplate` and `TitleFieldTemplate` respectively
  - Updated the `ArrayField`, `ObjectField` and `SchemaField` in `core` to use `getTemplate()` to fetch all necessary templates
    - Removed the need for the `Defaultxxx` template imports as the registry is guaranteed to have them now
  - Updated the `Form` in `core` to get the `ErrorListTemplate` using `getTemplate()`
  - Updated the `FieldTemplate` in `semantic-ui` to use `getTemplate()` to get its one necessary template

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
