### PR TITLE
fix(semantic-ui): update main field

### DIFF
--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rjsf/semantic-ui",
   "version": "4.2.0",
-  "main": "dist/cjs/index.js",
+  "main": "dist/index.js",
   "module": "dist/semantic-ui.esm.js",
   "description": "Semantic UI theme, fields and widgets for react-jsonschema-form",
   "files": [


### PR DESCRIPTION
### Reasons for making this change

The `main` points to `dist/cjs/index.js` which doesn't exist. It should be `dist/index.js`

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
