### PR TITLE
fix(@rjsf/core): Nested into items schema allOf blocks with multiple …

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,7 +44,7 @@
     "@types/json-schema": "^7.0.7",
     "ajv": "^6.7.0",
     "core-js-pure": "^3.6.5",
-    "json-schema-merge-allof": "^0.6.0",
+    "json-schema-merge-allof": "^0.8.1",
     "jsonpointer": "^5.0.0",
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.15",

--- a/packages/core/src/utils.js
+++ b/packages/core/src/utils.js
@@ -755,39 +755,9 @@ export function retrieveSchema(schema, rootSchema = {}, formData = {}) {
     return resolveCondition(schema, rootSchema, formData);
   }
 
-  // For each level of the dependency, we need to recursively determine the appropriate resolved schema given the current state of formData.
-  // Otherwise, nested allOf subschemas will not be correctly displayed.
-  if (resolvedSchema.properties) {
-    const properties = {};
-
-    Object.entries(resolvedSchema.properties).forEach(entries => {
-      const propName = entries[0];
-      const propSchema = entries[1];
-      const rawPropData = formData && formData[propName];
-      const propData = isObject(rawPropData) ? rawPropData : {};
-      const resolvedPropSchema = retrieveSchema(
-        propSchema,
-        rootSchema,
-        propData
-      );
-
-      properties[propName] = resolvedPropSchema;
-
-      if (
-        propSchema !== resolvedPropSchema &&
-        resolvedSchema.properties !== properties
-      ) {
-        resolvedSchema = { ...resolvedSchema, properties };
-      }
-    });
-  }
-
   if ("allOf" in schema) {
     try {
-      resolvedSchema = mergeAllOf({
-        ...resolvedSchema,
-        allOf: resolvedSchema.allOf,
-      });
+      resolvedSchema = mergeAllOf(resolvedSchema, { deep: false });
     } catch (e) {
       console.warn("could not merge subschemas in allOf:\n" + e);
       const { allOf, ...resolvedSchemaWithoutAllOf } = resolvedSchema;

--- a/packages/core/test/utils_test.js
+++ b/packages/core/test/utils_test.js
@@ -2671,14 +2671,52 @@ describe("utils", () => {
                   title: "Breed name",
                   type: "string",
                 },
-                Spots: {
-                  default: "small",
-                  enum: ["large", "small"],
-                  title: "Spots",
-                  type: "string",
-                },
               },
-              required: ["BreedName", "Spots"],
+              allOf: [
+                {
+                  if: {
+                    required: ["BreedName"],
+                    properties: {
+                      BreedName: {
+                        const: "Alsatian",
+                      },
+                    },
+                  },
+                  then: {
+                    properties: {
+                      Fur: {
+                        default: "brown",
+                        enum: ["black", "brown"],
+                        title: "Fur",
+                        type: "string",
+                      },
+                    },
+                    required: ["Fur"],
+                  },
+                },
+                {
+                  if: {
+                    required: ["BreedName"],
+                    properties: {
+                      BreedName: {
+                        const: "Dalmation",
+                      },
+                    },
+                  },
+                  then: {
+                    properties: {
+                      Spots: {
+                        default: "small",
+                        enum: ["large", "small"],
+                        title: "Spots",
+                        type: "string",
+                      },
+                    },
+                    required: ["Spots"],
+                  },
+                },
+              ],
+              required: ["BreedName"],
               title: "Breed",
             },
           },

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -54,7 +54,6 @@
     "core-js": "^3.19.2",
     "dayjs": "^1.8.28",
     "framer-motion": "^5.5.5",
-    "json-schema-merge-allof": "^0.6.0",
     "jss": "^10.0.3",
     "less": "^3.11.3",
     "less-loader": "^5.0.0",


### PR DESCRIPTION
…if/then/else statements fail to render correctly

When schema (or subschema) has `allOf` in the root AND has an array field with a property where exists `allOf` with few conditions RJSF doesn't handle this case properly. The console shows the warning `could not merge subschemas in allOf` and dependent properties don't reflect the schema. This is an [example](https://rjsf-team.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6eyJub25Db21wbGlhbmNlcyI6W3sic3ViQ2F0ZWdvcnkiOiJBU0VMIiwiY2F0ZWdvcnkiOiJPdGhlciJ9XSwiaXNzdWVzIjpbeyJyZWZlcnJlZCI6ZmFsc2UsImNhdGVnb3J5IjoiU291cmNpbmcgYW5kIHByZXBhcmF0aW9uIn1dLCJmaXJzdE5hbWUiOiJDaHVjayIsImxhc3ROYW1lIjoiTm9ycmlzIiwiYWdlIjo3NSwiYmlvIjoiUm91bmRob3VzZSBraWNraW5nIGFzc2VzIHNpbmNlIDE5NDAiLCJwYXNzd29yZCI6Im5vbmVlZCJ9LCJzY2hlbWEiOnsidHlwZSI6Im9iamVjdCIsImFsbE9mIjpbXSwicHJvcGVydGllcyI6eyJub25Db21wbGlhbmNlcyI6eyJ0eXBlIjoiYXJyYXkiLCJ0aXRsZSI6Ik5vbiBjb21wbGlhbmNlcyIsIml0ZW1zIjp7InRpdGxlIjoiIiwidHlwZSI6Im9iamVjdCIsInJlcXVpcmVkIjpbImNhdGVnb3J5Iiwic3ViQ2F0ZWdvcnkiLCJjcmVhdGVkQXQiLCJ1cGRhdGVkQXQiXSwicHJvcGVydGllcyI6eyJjYXRlZ29yeSI6eyJ0eXBlIjoic3RyaW5nIiwidGl0bGUiOiJDYXRlZ29yeSIsImVudW0iOlsiU291cmNpbmcgYW5kIHByZXBhcmF0aW9uIiwiTG9hZGluZyIsIlJlamVjdGlvbiBjcml0ZXJpYSIsIkZpcnN0IDQ4IiwiUGVyc29ubmVsIiwiRGFpbHkgUm91dGluZSIsIkZlZWQgJiBXYXRlciIsIk1lZGljYXRpb25zIiwiVHJlYXRtZW50LyBldXRoYW5hc2lhIiwiVmVudGlsYXRpb24iLCJQZW4gQ29uZGl0aW9ucyIsIkhlYWx0aCBhbmQgV2VsZmFyZSIsIkRpc2NoYXJnZSIsIkV4cG9ydGVyIiwiVmVzc2VsIiwiVGFyZ2V0IG9ic2VydmF0aW9ucyIsIk90aGVyIl19LCJzdWJDYXRlZ29yeSI6eyJ0eXBlIjoic3RyaW5nIiwidGl0bGUiOiJTdWIgY2F0ZWdvcnkiLCJlbnVtIjpbIkFTRUwiLCJBRVAgJiBWb3lhZ2UgSW5zdHJ1Y3Rpb25zIiwiQXBwcm92ZWQgQXJyYW5nZW1lbnRzIiwiQWRkaXRpb25hbCBDb25kaXRpb25zIiwiRXhwb3J0ZXIgZG9jdW1lbnRhdGlvbiIsIk90aGVyIl19LCJyZWZlcnJlZCI6eyJ0eXBlIjoiYm9vbGVhbiIsInRpdGxlIjoiUmVmZXIgdG8gTEFFQiJ9LCJkb2N1bWVudFJlZmVyZW5jZSI6eyJ0eXBlIjoic3RyaW5nIiwidGl0bGUiOiJEb2N1bWVudCByZWZlcmVuY2UifSwiY3JlYXRlZEF0Ijp7InR5cGUiOiJzdHJpbmciLCJmb3JtYXQiOiJkYXRlLXRpbWUifSwidXBkYXRlZEF0Ijp7InR5cGUiOiJzdHJpbmciLCJmb3JtYXQiOiJkYXRlLXRpbWUifX0sImFsbE9mIjpbeyJpZiI6eyJwcm9wZXJ0aWVzIjp7ImNhdGVnb3J5Ijp7ImNvbnN0IjoiT3RoZXIifX0sInJlcXVpcmVkIjpbImNhdGVnb3J5Il19LCJ0aGVuIjp7InByb3BlcnRpZXMiOnsib3RoZXJEZXRhaWwiOnsidHlwZSI6InN0cmluZyIsInRpdGxlIjoiT3RoZXIgZGV0YWlsIiwibWF4TGVuZ3RoIjo1MH19LCJyZXF1aXJlZCI6WyJvdGhlckRldGFpbCJdfX0seyJpZiI6eyJwcm9wZXJ0aWVzIjp7InN1YkNhdGVnb3J5Ijp7ImNvbnN0IjoiQVNFTCJ9fSwicmVxdWlyZWQiOlsic3ViQ2F0ZWdvcnkiXX0sInRoZW4iOnsicHJvcGVydGllcyI6eyJhc2VsU3RhbmRhcmQiOnsidHlwZSI6InN0cmluZyIsInRpdGxlIjoiQVNFTCBzdGFuZGFyZCJ9fSwicmVxdWlyZWQiOlsiYXNlbFN0YW5kYXJkIl19fV19fX19LCJ1aVNjaGVtYSI6eyJmaXJzdE5hbWUiOnsidWk6YXV0b2ZvY3VzIjp0cnVlLCJ1aTplbXB0eVZhbHVlIjoiIiwidWk6YXV0b2NvbXBsZXRlIjoiZmFtaWx5LW5hbWUifSwibGFzdE5hbWUiOnsidWk6ZW1wdHlWYWx1ZSI6IiIsInVpOmF1dG9jb21wbGV0ZSI6ImdpdmVuLW5hbWUifSwiYWdlIjp7InVpOndpZGdldCI6InVwZG93biIsInVpOnRpdGxlIjoiQWdlIG9mIHBlcnNvbiIsInVpOmRlc2NyaXB0aW9uIjoiKGVhcnRoaWFuIHllYXIpIn0sImJpbyI6eyJ1aTp3aWRnZXQiOiJ0ZXh0YXJlYSJ9LCJwYXNzd29yZCI6eyJ1aTp3aWRnZXQiOiJwYXNzd29yZCIsInVpOmhlbHAiOiJIaW50OiBNYWtlIGl0IHN0cm9uZyEifSwiZGF0ZSI6eyJ1aTp3aWRnZXQiOiJhbHQtZGF0ZXRpbWUifSwidGVsZXBob25lIjp7InVpOm9wdGlvbnMiOnsiaW5wdXRUeXBlIjoidGVsIn19fSwidGhlbWUiOiJkZWZhdWx0IiwibGl2ZVNldHRpbmdzIjp7InZhbGlkYXRlIjpmYWxzZSwiZGlzYWJsZSI6ZmFsc2UsInJlYWRvbmx5IjpmYWxzZSwib21pdEV4dHJhRGF0YSI6ZmFsc2UsImxpdmVPbWl0IjpmYWxzZX19) - if you remove root `allOf` the playground example will work.

After diving into the RJSF source code and looking around at dependent libraries, I found the solution, which makes these schemas work.

- Upgrading `json-schema-merge-allof@0.8.1` - this version allows to resolve only the top-level `allOf` keyword in the schema;
- Patch the `utils.retreiveSchema` method - pass `{ deep: false }` into the merger;
- Remove https://github.com/rjsf-team/react-jsonschema-form/pull/2839 change - looks like now it is redundant.

I'm not sure about any regression this change may introduce, but it works for the first look. All tests (except the fixed one that checked a nested merging `allOf` blocks) pass. All my schemas (including schemas that required https://github.com/rjsf-team/react-jsonschema-form/pull/2839) works

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
