### PR TITLE
Fixed Form and withTheme to properly merge ButtonTemplates

### DIFF
--- a/packages/antd/src/index.js
+++ b/packages/antd/src/index.js
@@ -1,4 +1,4 @@
-import { withTheme, getDefaultRegistry } from "@rjsf/core";
+import { withTheme } from "@rjsf/core";
 
 import ArrayFieldItemTemplate from "./templates/ArrayFieldItemTemplate";
 import ArrayFieldTemplate from "./templates/ArrayFieldTemplate";
@@ -28,10 +28,6 @@ import RangeWidget from "./widgets/RangeWidget";
 import SelectWidget from "./widgets/SelectWidget";
 import TextareaWidget from "./widgets/TextareaWidget";
 
-// import './index.less';
-
-const { fields, templates, widgets } = getDefaultRegistry();
-
 export const Widgets = {
   AltDateTimeWidget,
   AltDateWidget,
@@ -47,9 +43,7 @@ export const Widgets = {
 };
 
 export const Theme = {
-  fields,
   templates: {
-    ...templates,
     ArrayFieldItemTemplate,
     ArrayFieldTemplate,
     BaseInputTemplate,
@@ -66,7 +60,7 @@ export const Theme = {
     ObjectFieldTemplate,
     TitleFieldTemplate: TitleField,
   },
-  widgets: { ...widgets, ...Widgets },
+  widgets: Widgets,
 };
 
 export const Form = withTheme(Theme);

--- a/packages/bootstrap-4/src/Theme/Theme.tsx
+++ b/packages/bootstrap-4/src/Theme/Theme.tsx
@@ -1,14 +1,11 @@
 import Templates from "../Templates";
 import Widgets from "../Widgets";
 
-import { WithThemeProps, getDefaultRegistry } from "@rjsf/core";
-
-const { fields, templates, widgets } = getDefaultRegistry();
+import { WithThemeProps } from "@rjsf/core";
 
 const Theme: WithThemeProps = {
-  fields,
-  templates: { ...templates, ...Templates },
-  widgets: { ...widgets, ...Widgets },
+  templates: Templates,
+  widgets: Widgets,
 };
 
 export default Theme;

--- a/packages/chakra-ui/src/Theme/Theme.tsx
+++ b/packages/chakra-ui/src/Theme/Theme.tsx
@@ -1,14 +1,11 @@
-import { WithThemeProps, getDefaultRegistry } from "@rjsf/core";
+import { WithThemeProps } from "@rjsf/core";
 
 import Templates from "../Templates";
 import Widgets from "../Widgets";
 
-const { fields, templates, widgets } = getDefaultRegistry();
-
 const Theme: WithThemeProps = {
-  fields: fields,
-  templates: { ...templates, ...Templates },
-  widgets: { ...widgets, ...Widgets },
+  templates: Templates,
+  widgets: Widgets,
 };
 
 export default Theme;

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -695,7 +695,7 @@ export default class Form<T = any, F = any> extends Component<
         ...this.props.templates,
         ButtonTemplates: {
           ...templates.ButtonTemplates,
-          ...(this.props.templates && this.props.templates.ButtonTemplates),
+          ...this.props.templates?.ButtonTemplates,
         },
       },
       widgets: { ...widgets, ...this.props.widgets },

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -71,7 +71,9 @@ export interface FormProps<T = any, F = any> {
   /** The dictionary of registered fields in the form */
   fields?: RegistryFieldsType<T, F>;
   /** The dictionary of registered templates in the form; Partial allows a subset to be provided beyond the defaults */
-  templates?: Partial<TemplatesType<T, F>>;
+  templates?: Partial<Omit<TemplatesType<T, F>, "ButtonTemplates">> & {
+    ButtonTemplates?: Partial<TemplatesType<T, F>["ButtonTemplates"]>;
+  };
   /** The dictionary of registered widgets in the form */
   widgets?: RegistryWidgetsType<T, F>;
   // Callbacks
@@ -685,15 +687,20 @@ export default class Form<T = any, F = any> extends Component<
   /** Returns the registry for the form */
   getRegistry(): Registry<T, F> {
     const { schemaUtils } = this.state;
-    // For BC, accept passed SchemaField and TitleField props and pass them to
-    // the 'fields' registry one.
-    const { fields, templates, widgets } = getDefaultRegistry();
+    const { fields, templates, widgets, formContext } = getDefaultRegistry();
     return {
       fields: { ...fields, ...this.props.fields },
-      templates: { ...templates, ...this.props.templates },
+      templates: {
+        ...templates,
+        ...this.props.templates,
+        ButtonTemplates: {
+          ...templates.ButtonTemplates,
+          ...(this.props.templates && this.props.templates.ButtonTemplates),
+        },
+      },
       widgets: { ...widgets, ...this.props.widgets },
       rootSchema: this.props.schema,
-      formContext: this.props.formContext || ({} as F),
+      formContext: this.props.formContext || formContext,
       schemaUtils,
     };
   }

--- a/packages/core/src/withTheme.tsx
+++ b/packages/core/src/withTheme.tsx
@@ -16,11 +16,19 @@ export default function withTheme<T = any, F = any>(
 ) {
   return forwardRef(
     (
-      { fields, widgets, ...directProps }: FormProps<T, F>,
+      { fields, widgets, templates, ...directProps }: FormProps<T, F>,
       ref: ForwardedRef<Form<T, F>>
     ) => {
       fields = { ...themeProps.fields, ...fields };
       widgets = { ...themeProps.widgets, ...widgets };
+      templates = {
+        ...themeProps.templates,
+        ...templates,
+        ButtonTemplates: {
+          ...themeProps?.templates?.ButtonTemplates,
+          ...templates?.ButtonTemplates,
+        },
+      };
 
       return (
         <Form<T, F>
@@ -28,6 +36,7 @@ export default function withTheme<T = any, F = any>(
           {...directProps}
           fields={fields}
           widgets={widgets}
+          templates={templates}
           ref={ref}
         />
       );

--- a/packages/core/test/withTheme_test.js
+++ b/packages/core/test/withTheme_test.js
@@ -260,18 +260,93 @@ describe("withTheme", () => {
       );
     });
 
-    it("should forward the ref", () => {
-      const ref = createRef();
-      const schema = {};
+    it("should use the withTheme submit button template", () => {
+      const themeTemplates = {
+        ButtonTemplates: {
+          SubmitButton() {
+            return (
+              <button className="with-theme-button-template">
+                ThemeSubmit
+              </button>
+            );
+          },
+        },
+      };
+      const schema = {
+        type: "object",
+        properties: {
+          fieldA: {
+            type: "string",
+          },
+          fieldB: {
+            type: "string",
+          },
+        },
+      };
       const uiSchema = {};
-
-      createComponent(withTheme({}), {
-        schema,
-        uiSchema,
-        ref,
-      });
-
-      expect(ref.current.submit).not.eql(undefined);
+      let { node } = createComponent(
+        WrapperClassComponent({ templates: themeTemplates }),
+        {
+          schema,
+          uiSchema,
+        }
+      );
+      expect(
+        node.querySelectorAll(".with-theme-button-template")
+      ).to.have.length.of(1);
     });
+
+    it("should use only the user defined submit button", () => {
+      const themeTemplates = {
+        ButtonTemplates: {
+          SubmitButton() {
+            return (
+              <button className="with-theme-button-template">
+                ThemeSubmit
+              </button>
+            );
+          },
+        },
+      };
+      const userTemplates = {
+        ButtonTemplates: {
+          SubmitButton() {
+            return <button className="user-button-template">UserSubmit</button>;
+          },
+        },
+      };
+
+      const schema = {
+        type: "object",
+        properties: { foo: { type: "string" }, bar: { type: "string" } },
+      };
+      let { node } = createComponent(
+        WrapperClassComponent({ templates: themeTemplates }),
+        {
+          schema,
+          templates: userTemplates,
+        }
+      );
+      expect(
+        node.querySelectorAll(".with-theme-button-template")
+      ).to.have.length.of(0);
+      expect(node.querySelectorAll(".user-button-template")).to.have.length.of(
+        1
+      );
+    });
+  });
+
+  it("should forward the ref", () => {
+    const ref = createRef();
+    const schema = {};
+    const uiSchema = {};
+
+    createComponent(withTheme({}), {
+      schema,
+      uiSchema,
+      ref,
+    });
+
+    expect(ref.current.submit).not.eql(undefined);
   });
 });

--- a/packages/fluent-ui/src/Theme/Theme.ts
+++ b/packages/fluent-ui/src/Theme/Theme.ts
@@ -1,14 +1,11 @@
 import Templates from "../Templates";
 import Widgets from "../Widgets";
 
-import { WithThemeProps, getDefaultRegistry } from "@rjsf/core";
-
-const { fields, templates, widgets } = getDefaultRegistry();
+import { WithThemeProps } from "@rjsf/core";
 
 const Theme: WithThemeProps = {
-  fields,
-  templates: { ...templates, ...Templates },
-  widgets: { ...widgets, ...Widgets },
+  templates: Templates,
+  widgets: Widgets,
 };
 
 export default Theme;

--- a/packages/material-ui/src/Theme/Theme.tsx
+++ b/packages/material-ui/src/Theme/Theme.tsx
@@ -1,16 +1,11 @@
-import { getDefaultRegistry, WithThemeProps } from "@rjsf/core";
+import { WithThemeProps } from "@rjsf/core";
 
 import Templates from "../Templates";
 import Widgets from "../Widgets";
 
-const { fields, templates, widgets } = getDefaultRegistry();
-
-/** The Material UI 4 theme, with the `Mui4FormWrapper`
- */
 const Theme: WithThemeProps = {
-  fields,
-  templates: { ...templates, ...Templates },
-  widgets: { ...widgets, ...Widgets },
+  templates: Templates,
+  widgets: Widgets,
 };
 
 export default Theme;

--- a/packages/mui/src/Theme/Theme.tsx
+++ b/packages/mui/src/Theme/Theme.tsx
@@ -1,16 +1,11 @@
-import { WithThemeProps, getDefaultRegistry } from "@rjsf/core";
+import { WithThemeProps } from "@rjsf/core";
 
 import Templates from "../Templates";
 import Widgets from "../Widgets";
 
-const { fields, templates, widgets } = getDefaultRegistry();
-
-/** The Material UI 5 theme, with the `Mui5FormWrapper
- */
 const Theme: WithThemeProps = {
-  fields,
-  templates: { ...templates, ...Templates },
-  widgets: { ...widgets, ...Widgets },
+  templates: Templates,
+  widgets: Widgets,
 };
 
 export default Theme;

--- a/packages/semantic-ui/src/Theme/Theme.js
+++ b/packages/semantic-ui/src/Theme/Theme.js
@@ -1,14 +1,10 @@
-import { getDefaultRegistry } from "@rjsf/core";
 import { Form as SuiForm } from "semantic-ui-react";
 import Templates from "../Templates";
 import Widgets from "../Widgets";
 
-const { fields, templates, widgets } = getDefaultRegistry();
-
 const Theme = {
-  fields,
-  templates: { ...templates, ...Templates },
-  widgets: { ...widgets, ...Widgets },
+  templates: Templates,
+  widgets: Widgets,
   _internalFormWrapper: SuiForm,
 };
 


### PR DESCRIPTION
### Reasons for making this change

- Updated `Form` to update the `templates` prop to make `ButtonTemplates` optional (via `Omit<>` and explicit add)
  - Updated the `getRegistry()` function to merge `ButtonTemplates` from `props.templates.ButtonProps` and the default `templates.ButtonProps`
- Updated the `withTheme()` function to merge `ButtonTemplates` from the theme and user props
  - Added tests to ensure the merge is happening
- Updated all the themes no longer pull the `getDefaultRegistry()` in as the registry merge happens properly in the two core components

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
