### PR TITLE
Convert NullField and NumberField to functional components

### DIFF
--- a/packages/antd/jest.config.js
+++ b/packages/antd/jest.config.js
@@ -3,7 +3,4 @@ module.exports = {
     "^react$": "<rootDir>/node_modules/react",
     "^react-dom$": "<rootDir>/node_modules/react-dom",
   },
-  verbose: true,
-  setupFilesAfterEnv: ["./test/setup-jsdom.js"],
-  testMatch: ["**/test/**/*_test.js"]
 };

--- a/packages/bootstrap-4/jest.config.js
+++ b/packages/bootstrap-4/jest.config.js
@@ -3,7 +3,4 @@ module.exports = {
     "^react$": "<rootDir>/node_modules/react",
     "^react-dom$": "<rootDir>/node_modules/react-dom",
   },
-  verbose: true,
-  setupFilesAfterEnv: ["./test/setup-jsdom.js"],
-  testMatch: ["**/test/**/*_test.js"]
 };

--- a/packages/chakra-ui/jest.config.js
+++ b/packages/chakra-ui/jest.config.js
@@ -1,4 +1,8 @@
 module.exports = {
+  moduleNameMapper: {
+    "^react$": "<rootDir>/node_modules/react",
+    "^react-dom$": "<rootDir>/node_modules/react-dom",
+  },
   snapshotSerializers: ["@emotion/jest/serializer"],
   testEnvironment: "jsdom",
   testEnvironmentOptions: {

--- a/packages/core/src/components/fields/NullField.tsx
+++ b/packages/core/src/components/fields/NullField.tsx
@@ -1,4 +1,4 @@
-import { Component } from "react";
+import { useEffect } from "react";
 import { FieldProps } from "@rjsf/utils";
 
 /** The `NullField` component is used to render a field in the schema is null. It also ensures that the `formData` is
@@ -6,22 +6,15 @@ import { FieldProps } from "@rjsf/utils";
  *
  * @param props - The `FieldProps` for this template
  */
-class NullField<T = any, F = any> extends Component<FieldProps<T, F>> {
-  /** React lifecycle method is called after a component mounts. Will convert an undefined formData to a null via the
-   * onChange callback
-   */
-  componentDidMount() {
-    const { formData, onChange } = this.props;
+function NullField<T = any, F = any>(props: FieldProps<T, F>) {
+  const { formData, onChange } = props;
+  useEffect(() => {
     if (formData === undefined) {
       onChange(null as unknown as T);
     }
-  }
+  }, []);
 
-  /** Renders null for the null field
-   */
-  render() {
-    return null;
-  }
+  return null;
 }
 
 export default NullField;

--- a/packages/fluent-ui/jest.config.js
+++ b/packages/fluent-ui/jest.config.js
@@ -1,6 +1,8 @@
 module.exports = {
   moduleNameMapper: {
-    'office-ui-fabric-react/lib/': 'office-ui-fabric-react/lib-commonjs/'
+    "office-ui-fabric-react/lib/": "office-ui-fabric-react/lib-commonjs/",
+    "^react$": "<rootDir>/node_modules/react",
+    "^react-dom$": "<rootDir>/node_modules/react-dom",
   },
   testEnvironment: "jsdom",
   testEnvironmentOptions: {

--- a/packages/material-ui/jest.config.js
+++ b/packages/material-ui/jest.config.js
@@ -3,7 +3,4 @@ module.exports = {
     "^react$": "<rootDir>/node_modules/react",
     "^react-dom$": "<rootDir>/node_modules/react-dom",
   },
-  verbose: true,
-  setupFilesAfterEnv: ["./test/setup-jsdom.js"],
-  testMatch: ["**/test/**/*_test.js"]
 };

--- a/packages/mui/jest.config.js
+++ b/packages/mui/jest.config.js
@@ -1,4 +1,8 @@
 module.exports = {
+  moduleNameMapper: {
+    "^react$": "<rootDir>/node_modules/react",
+    "^react-dom$": "<rootDir>/node_modules/react-dom",
+  },
   snapshotSerializers: ["@emotion/jest/serializer"],
   testEnvironment: "jsdom",
   testEnvironmentOptions: {

--- a/packages/semantic-ui/jest.config.js
+++ b/packages/semantic-ui/jest.config.js
@@ -3,7 +3,4 @@ module.exports = {
     "^react$": "<rootDir>/node_modules/react",
     "^react-dom$": "<rootDir>/node_modules/react-dom",
   },
-  verbose: true,
-  setupFilesAfterEnv: ["./test/setup-jsdom.js"],
-  testMatch: ["**/test/**/*_test.js"]
 };


### PR DESCRIPTION
### Reasons for making this change

- Added or updated `jest.config.js` files to all themes that add `moduleNameMapper` for `react` and `react-dom` to avoid hooks issues
- Updated `NullField` and `NumberField` to be stateless functional components

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
