### PR TITLE
Implemented classNames in all themes where it was missing

### DIFF
--- a/packages/bootstrap-4/src/FieldTemplate/WrapIfAdditional.tsx
+++ b/packages/bootstrap-4/src/FieldTemplate/WrapIfAdditional.tsx
@@ -21,6 +21,7 @@ type WrapIfAdditionalProps = { children: React.ReactElement } & Pick<
 >;
 
 const WrapIfAdditional = ({
+  classNames,
   children,
   disabled,
   id,
@@ -37,7 +38,7 @@ const WrapIfAdditional = ({
   const additional = ADDITIONAL_PROPERTY_FLAG in schema;
 
   if (!additional) {
-    return children;
+    return <div className={classNames}>{children}</div>;
   }
 
   const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
@@ -45,7 +46,7 @@ const WrapIfAdditional = ({
   const keyId = `${id}-key`;
 
   return (
-    <Row key={keyId}>
+    <Row className={classNames} key={keyId}>
       <Col xs={5}>
         <Form.Group>
           <Form.Label htmlFor={keyId}>{keyLabel}</Form.Label>

--- a/packages/bootstrap-4/test/__snapshots__/AdditionalProperties.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/AdditionalProperties.test.tsx.snap
@@ -7,154 +7,158 @@ exports[`AdditionalProperties tests show add button and fields if additionalProp
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-undefined"
   >
-    
     <div
-      className="p-0 container-fluid"
+      className="form-group"
     >
+      
       <div
-        className="row"
-        style={
-          Object {
-            "marginBottom": "10px",
-          }
-        }
+        className="p-0 container-fluid"
       >
         <div
-          className="col-12"
+          className="row"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
-           
           <div
-            className="row"
+            className="col-12"
           >
+             
             <div
-              className="col-5"
+              className="form-group field field-string row"
             >
               <div
-                className="form-group"
-              >
-                <label
-                  className="form-label"
-                  htmlFor="root-key"
-                >
-                  additionalProperty Key
-                </label>
-                <input
-                  className="form-control"
-                  defaultValue="additionalProperty"
-                  disabled={false}
-                  id="root-key"
-                  name="root-key"
-                  onBlur={[Function]}
-                  required={false}
-                  type="text"
-                />
-              </div>
-            </div>
-            <div
-              className="col-5"
-            >
-              <div
-                className="form-group"
+                className="col-5"
               >
                 <div
-                  className="mb-0 form-group"
+                  className="form-group"
                 >
                   <label
                     className="form-label"
-                    htmlFor="root"
+                    htmlFor="root-key"
                   >
-                    additionalProperty
+                    additionalProperty Key
                   </label>
                   <input
-                    autoFocus={false}
                     className="form-control"
+                    defaultValue="additionalProperty"
                     disabled={false}
-                    id="root"
+                    id="root-key"
+                    name="root-key"
                     onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    placeholder=""
-                    readOnly={false}
                     required={false}
                     type="text"
-                    value="should appear"
                   />
                 </div>
-                
               </div>
-            </div>
-            <div
-              className="py-4 col-2"
-            >
-              <button
-                className="btn btn-danger btn-block btn-sm"
-                disabled={false}
-                onClick={[Function]}
-                title="Remove"
-                type="button"
+              <div
+                className="col-5"
               >
-                <svg
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  strokeWidth="0"
-                  style={
-                    Object {
-                      "color": undefined,
-                    }
-                  }
-                  viewBox="0 0 512 512"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
+                <div
+                  className="form-group"
                 >
-                  <path
-                    d="M368.5 240h-225c-8.8 0-16 7.2-16 16 0 4.4 1.8 8.4 4.7 11.3 2.9 2.9 6.9 4.7 11.3 4.7h225c8.8 0 16-7.2 16-16s-7.2-16-16-16z"
-                  />
-                </svg>
-              </button>
+                  <div
+                    className="mb-0 form-group"
+                  >
+                    <label
+                      className="form-label"
+                      htmlFor="root"
+                    >
+                      additionalProperty
+                    </label>
+                    <input
+                      autoFocus={false}
+                      className="form-control"
+                      disabled={false}
+                      id="root"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value="should appear"
+                    />
+                  </div>
+                  
+                </div>
+              </div>
+              <div
+                className="py-4 col-2"
+              >
+                <button
+                  className="btn btn-danger btn-block btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  title="Remove"
+                  type="button"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    strokeWidth="0"
+                    style={
+                      Object {
+                        "color": undefined,
+                      }
+                    }
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M368.5 240h-225c-8.8 0-16 7.2-16 16 0 4.4 1.8 8.4 4.7 11.3 2.9 2.9 6.9 4.7 11.3 4.7h225c8.8 0 16-7.2 16-16s-7.2-16-16-16z"
+                    />
+                  </svg>
+                </button>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div
-        className="row"
-      >
         <div
-          className="py-4 col-3 offset-9"
+          className="row"
         >
-          <button
-            className="ml-1 object-property-expand btn btn-primary"
-            disabled={false}
-            onClick={[Function]}
-            style={
-              Object {
-                "width": "100%",
-              }
-            }
-            title="Add Item"
-            type="button"
+          <div
+            className="py-4 col-3 offset-9"
           >
-            <svg
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              strokeWidth="0"
+            <button
+              className="ml-1 object-property-expand btn btn-primary"
+              disabled={false}
+              onClick={[Function]}
               style={
                 Object {
-                  "color": undefined,
+                  "width": "100%",
                 }
               }
-              viewBox="0 0 16 16"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
+              title="Add Item"
+              type="button"
             >
-              <path
-                d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"
-              />
-            </svg>
-          </button>
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 16 16"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"
+                />
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
@@ -7,61 +7,65 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-array"
   >
-    <div>
-      <div
-        className="p-0 m-0 row"
-      >
+    <div
+      className="form-group"
+    >
+      <div>
         <div
-          className="p-0 m-0 col"
+          className="p-0 m-0 row"
         >
           <div
-            className="p-0 m-0 container-fluid"
+            className="p-0 m-0 col"
           >
             <div
-              className="container"
+              className="p-0 m-0 container-fluid"
             >
               <div
-                className="mt-2 row"
+                className="container"
               >
                 <div
-                  className="col-9"
-                />
-                <div
-                  className="py-4 col-lg-3 col-3 col-3"
+                  className="mt-2 row"
                 >
-                  <button
-                    className="ml-1 array-item-add btn btn-primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    style={
-                      Object {
-                        "width": "100%",
-                      }
-                    }
-                    title="Add Item"
-                    type="button"
+                  <div
+                    className="col-9"
+                  />
+                  <div
+                    className="py-4 col-lg-3 col-3 col-3"
                   >
-                    <svg
-                      fill="currentColor"
-                      height="1em"
-                      stroke="currentColor"
-                      strokeWidth="0"
+                    <button
+                      className="ml-1 array-item-add btn btn-primary"
+                      disabled={false}
+                      onClick={[Function]}
                       style={
                         Object {
-                          "color": undefined,
+                          "width": "100%",
                         }
                       }
-                      viewBox="0 0 16 16"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
+                      title="Add Item"
+                      type="button"
                     >
-                      <path
-                        d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"
-                      />
-                    </svg>
-                  </button>
+                      <svg
+                        fill="currentColor"
+                        height="1em"
+                        stroke="currentColor"
+                        strokeWidth="0"
+                        style={
+                          Object {
+                            "color": undefined,
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
@@ -89,379 +93,391 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-array"
   >
-    <div>
-      <div
-        className="p-0 m-0 row"
-      >
+    <div
+      className="form-group"
+    >
+      <div>
         <div
-          className="p-0 m-0 col"
+          className="p-0 m-0 row"
         >
           <div
-            className="p-0 m-0 container-fluid"
+            className="p-0 m-0 col"
           >
-            <div>
-              <div
-                className="mb-2  d-flex align-items-center row"
-              >
-                <div
-                  className="col-lg-9 col-9"
-                >
-                  <div
-                    className="form-group"
-                  >
-                    <div
-                      className="mb-0 form-group"
-                    >
-                      <label
-                        className="form-label"
-                        htmlFor="root_0"
-                      />
-                      <input
-                        autoFocus={false}
-                        className="form-control"
-                        disabled={false}
-                        id="root_0"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder=""
-                        readOnly={false}
-                        required={true}
-                        type="text"
-                        value="a"
-                      />
-                    </div>
-                    
-                  </div>
-                </div>
-                <div
-                  className="py-4 col-lg-3 col-3"
-                >
-                  <div
-                    className="d-flex flex-row"
-                  >
-                    <div
-                      className="m-0 p-0"
-                    >
-                      <button
-                        className="btn btn-light btn-sm"
-                        disabled={true}
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "flex": 1,
-                            "fontWeight": "bold",
-                            "paddingLeft": 6,
-                            "paddingRight": 6,
-                          }
-                        }
-                        title="Move up"
-                        type="button"
-                      >
-                        <svg
-                          fill="currentColor"
-                          height="1em"
-                          stroke="currentColor"
-                          strokeWidth="0"
-                          style={
-                            Object {
-                              "color": undefined,
-                            }
-                          }
-                          viewBox="0 0 1024 1024"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M868 545.5L536.1 163a31.96 31.96 0 0 0-48.3 0L156 545.5a7.97 7.97 0 0 0 6 13.2h81c4.6 0 9-2 12.1-5.5L474 300.9V864c0 4.4 3.6 8 8 8h60c4.4 0 8-3.6 8-8V300.9l218.9 252.3c3 3.5 7.4 5.5 12.1 5.5h81c6.8 0 10.5-8 6-13.2z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      className="m-0 p-0"
-                    >
-                      <button
-                        className="btn btn-light btn-sm"
-                        disabled={false}
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "flex": 1,
-                            "fontWeight": "bold",
-                            "paddingLeft": 6,
-                            "paddingRight": 6,
-                          }
-                        }
-                        title="Move down"
-                        type="button"
-                      >
-                        <svg
-                          fill="currentColor"
-                          height="1em"
-                          stroke="currentColor"
-                          strokeWidth="0"
-                          style={
-                            Object {
-                              "color": undefined,
-                            }
-                          }
-                          viewBox="0 0 1024 1024"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0 0 48.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      className="m-0 p-0"
-                    >
-                      <button
-                        className="btn btn-danger btn-sm"
-                        disabled={false}
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "flex": 1,
-                            "fontWeight": "bold",
-                            "paddingLeft": 6,
-                            "paddingRight": 6,
-                          }
-                        }
-                        title="Remove"
-                        type="button"
-                      >
-                        <svg
-                          fill="currentColor"
-                          height="1em"
-                          stroke="currentColor"
-                          strokeWidth="0"
-                          style={
-                            Object {
-                              "color": undefined,
-                            }
-                          }
-                          viewBox="0 0 512 512"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M368.5 240h-225c-8.8 0-16 7.2-16 16 0 4.4 1.8 8.4 4.7 11.3 2.9 2.9 6.9 4.7 11.3 4.7h225c8.8 0 16-7.2 16-16s-7.2-16-16-16z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div>
-              <div
-                className="mb-2  d-flex align-items-center row"
-              >
-                <div
-                  className="col-lg-9 col-9"
-                >
-                  <div
-                    className="form-group"
-                  >
-                    <div
-                      className="mb-0 form-group"
-                    >
-                      <label
-                        className="form-label"
-                        htmlFor="root_1"
-                      />
-                      <input
-                        autoFocus={false}
-                        className="form-control"
-                        disabled={false}
-                        id="root_1"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder=""
-                        readOnly={false}
-                        required={true}
-                        type="text"
-                        value="b"
-                      />
-                    </div>
-                    
-                  </div>
-                </div>
-                <div
-                  className="py-4 col-lg-3 col-3"
-                >
-                  <div
-                    className="d-flex flex-row"
-                  >
-                    <div
-                      className="m-0 p-0"
-                    >
-                      <button
-                        className="btn btn-light btn-sm"
-                        disabled={false}
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "flex": 1,
-                            "fontWeight": "bold",
-                            "paddingLeft": 6,
-                            "paddingRight": 6,
-                          }
-                        }
-                        title="Move up"
-                        type="button"
-                      >
-                        <svg
-                          fill="currentColor"
-                          height="1em"
-                          stroke="currentColor"
-                          strokeWidth="0"
-                          style={
-                            Object {
-                              "color": undefined,
-                            }
-                          }
-                          viewBox="0 0 1024 1024"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M868 545.5L536.1 163a31.96 31.96 0 0 0-48.3 0L156 545.5a7.97 7.97 0 0 0 6 13.2h81c4.6 0 9-2 12.1-5.5L474 300.9V864c0 4.4 3.6 8 8 8h60c4.4 0 8-3.6 8-8V300.9l218.9 252.3c3 3.5 7.4 5.5 12.1 5.5h81c6.8 0 10.5-8 6-13.2z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      className="m-0 p-0"
-                    >
-                      <button
-                        className="btn btn-light btn-sm"
-                        disabled={true}
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "flex": 1,
-                            "fontWeight": "bold",
-                            "paddingLeft": 6,
-                            "paddingRight": 6,
-                          }
-                        }
-                        title="Move down"
-                        type="button"
-                      >
-                        <svg
-                          fill="currentColor"
-                          height="1em"
-                          stroke="currentColor"
-                          strokeWidth="0"
-                          style={
-                            Object {
-                              "color": undefined,
-                            }
-                          }
-                          viewBox="0 0 1024 1024"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0 0 48.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                    <div
-                      className="m-0 p-0"
-                    >
-                      <button
-                        className="btn btn-danger btn-sm"
-                        disabled={false}
-                        onClick={[Function]}
-                        style={
-                          Object {
-                            "flex": 1,
-                            "fontWeight": "bold",
-                            "paddingLeft": 6,
-                            "paddingRight": 6,
-                          }
-                        }
-                        title="Remove"
-                        type="button"
-                      >
-                        <svg
-                          fill="currentColor"
-                          height="1em"
-                          stroke="currentColor"
-                          strokeWidth="0"
-                          style={
-                            Object {
-                              "color": undefined,
-                            }
-                          }
-                          viewBox="0 0 512 512"
-                          width="1em"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M368.5 240h-225c-8.8 0-16 7.2-16 16 0 4.4 1.8 8.4 4.7 11.3 2.9 2.9 6.9 4.7 11.3 4.7h225c8.8 0 16-7.2 16-16s-7.2-16-16-16z"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
             <div
-              className="container"
+              className="p-0 m-0 container-fluid"
             >
+              <div>
+                <div
+                  className="mb-2  d-flex align-items-center row"
+                >
+                  <div
+                    className="col-lg-9 col-9"
+                  >
+                    <div
+                      className="form-group field field-string"
+                    >
+                      <div
+                        className="form-group"
+                      >
+                        <div
+                          className="mb-0 form-group"
+                        >
+                          <label
+                            className="form-label"
+                            htmlFor="root_0"
+                          />
+                          <input
+                            autoFocus={false}
+                            className="form-control"
+                            disabled={false}
+                            id="root_0"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            placeholder=""
+                            readOnly={false}
+                            required={true}
+                            type="text"
+                            value="a"
+                          />
+                        </div>
+                        
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="py-4 col-lg-3 col-3"
+                  >
+                    <div
+                      className="d-flex flex-row"
+                    >
+                      <div
+                        className="m-0 p-0"
+                      >
+                        <button
+                          className="btn btn-light btn-sm"
+                          disabled={true}
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "flex": 1,
+                              "fontWeight": "bold",
+                              "paddingLeft": 6,
+                              "paddingRight": 6,
+                            }
+                          }
+                          title="Move up"
+                          type="button"
+                        >
+                          <svg
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            strokeWidth="0"
+                            style={
+                              Object {
+                                "color": undefined,
+                              }
+                            }
+                            viewBox="0 0 1024 1024"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M868 545.5L536.1 163a31.96 31.96 0 0 0-48.3 0L156 545.5a7.97 7.97 0 0 0 6 13.2h81c4.6 0 9-2 12.1-5.5L474 300.9V864c0 4.4 3.6 8 8 8h60c4.4 0 8-3.6 8-8V300.9l218.9 252.3c3 3.5 7.4 5.5 12.1 5.5h81c6.8 0 10.5-8 6-13.2z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                      <div
+                        className="m-0 p-0"
+                      >
+                        <button
+                          className="btn btn-light btn-sm"
+                          disabled={false}
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "flex": 1,
+                              "fontWeight": "bold",
+                              "paddingLeft": 6,
+                              "paddingRight": 6,
+                            }
+                          }
+                          title="Move down"
+                          type="button"
+                        >
+                          <svg
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            strokeWidth="0"
+                            style={
+                              Object {
+                                "color": undefined,
+                              }
+                            }
+                            viewBox="0 0 1024 1024"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0 0 48.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                      <div
+                        className="m-0 p-0"
+                      >
+                        <button
+                          className="btn btn-danger btn-sm"
+                          disabled={false}
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "flex": 1,
+                              "fontWeight": "bold",
+                              "paddingLeft": 6,
+                              "paddingRight": 6,
+                            }
+                          }
+                          title="Remove"
+                          type="button"
+                        >
+                          <svg
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            strokeWidth="0"
+                            style={
+                              Object {
+                                "color": undefined,
+                              }
+                            }
+                            viewBox="0 0 512 512"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M368.5 240h-225c-8.8 0-16 7.2-16 16 0 4.4 1.8 8.4 4.7 11.3 2.9 2.9 6.9 4.7 11.3 4.7h225c8.8 0 16-7.2 16-16s-7.2-16-16-16z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div>
+                <div
+                  className="mb-2  d-flex align-items-center row"
+                >
+                  <div
+                    className="col-lg-9 col-9"
+                  >
+                    <div
+                      className="form-group field field-string"
+                    >
+                      <div
+                        className="form-group"
+                      >
+                        <div
+                          className="mb-0 form-group"
+                        >
+                          <label
+                            className="form-label"
+                            htmlFor="root_1"
+                          />
+                          <input
+                            autoFocus={false}
+                            className="form-control"
+                            disabled={false}
+                            id="root_1"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            placeholder=""
+                            readOnly={false}
+                            required={true}
+                            type="text"
+                            value="b"
+                          />
+                        </div>
+                        
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    className="py-4 col-lg-3 col-3"
+                  >
+                    <div
+                      className="d-flex flex-row"
+                    >
+                      <div
+                        className="m-0 p-0"
+                      >
+                        <button
+                          className="btn btn-light btn-sm"
+                          disabled={false}
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "flex": 1,
+                              "fontWeight": "bold",
+                              "paddingLeft": 6,
+                              "paddingRight": 6,
+                            }
+                          }
+                          title="Move up"
+                          type="button"
+                        >
+                          <svg
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            strokeWidth="0"
+                            style={
+                              Object {
+                                "color": undefined,
+                              }
+                            }
+                            viewBox="0 0 1024 1024"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M868 545.5L536.1 163a31.96 31.96 0 0 0-48.3 0L156 545.5a7.97 7.97 0 0 0 6 13.2h81c4.6 0 9-2 12.1-5.5L474 300.9V864c0 4.4 3.6 8 8 8h60c4.4 0 8-3.6 8-8V300.9l218.9 252.3c3 3.5 7.4 5.5 12.1 5.5h81c6.8 0 10.5-8 6-13.2z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                      <div
+                        className="m-0 p-0"
+                      >
+                        <button
+                          className="btn btn-light btn-sm"
+                          disabled={true}
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "flex": 1,
+                              "fontWeight": "bold",
+                              "paddingLeft": 6,
+                              "paddingRight": 6,
+                            }
+                          }
+                          title="Move down"
+                          type="button"
+                        >
+                          <svg
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            strokeWidth="0"
+                            style={
+                              Object {
+                                "color": undefined,
+                              }
+                            }
+                            viewBox="0 0 1024 1024"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0 0 48.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                      <div
+                        className="m-0 p-0"
+                      >
+                        <button
+                          className="btn btn-danger btn-sm"
+                          disabled={false}
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "flex": 1,
+                              "fontWeight": "bold",
+                              "paddingLeft": 6,
+                              "paddingRight": 6,
+                            }
+                          }
+                          title="Remove"
+                          type="button"
+                        >
+                          <svg
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            strokeWidth="0"
+                            style={
+                              Object {
+                                "color": undefined,
+                              }
+                            }
+                            viewBox="0 0 512 512"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M368.5 240h-225c-8.8 0-16 7.2-16 16 0 4.4 1.8 8.4 4.7 11.3 2.9 2.9 6.9 4.7 11.3 4.7h225c8.8 0 16-7.2 16-16s-7.2-16-16-16z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
               <div
-                className="mt-2 row"
+                className="container"
               >
                 <div
-                  className="col-9"
-                />
-                <div
-                  className="py-4 col-lg-3 col-3 col-3"
+                  className="mt-2 row"
                 >
-                  <button
-                    className="ml-1 array-item-add btn btn-primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    style={
-                      Object {
-                        "width": "100%",
-                      }
-                    }
-                    title="Add Item"
-                    type="button"
+                  <div
+                    className="col-9"
+                  />
+                  <div
+                    className="py-4 col-lg-3 col-3 col-3"
                   >
-                    <svg
-                      fill="currentColor"
-                      height="1em"
-                      stroke="currentColor"
-                      strokeWidth="0"
+                    <button
+                      className="ml-1 array-item-add btn btn-primary"
+                      disabled={false}
+                      onClick={[Function]}
                       style={
                         Object {
-                          "color": undefined,
+                          "width": "100%",
                         }
                       }
-                      viewBox="0 0 16 16"
-                      width="1em"
-                      xmlns="http://www.w3.org/2000/svg"
+                      title="Add Item"
+                      type="button"
                     >
-                      <path
-                        d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"
-                      />
-                    </svg>
-                  </button>
+                      <svg
+                        fill="currentColor"
+                        height="1em"
+                        stroke="currentColor"
+                        strokeWidth="0"
+                        style={
+                          Object {
+                            "color": undefined,
+                          }
+                        }
+                        viewBox="0 0 16 16"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
@@ -489,51 +505,55 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-array"
   >
     <div
       className="form-group"
     >
-      <label
-        className="form-label"
-      />
-      <select
-        autoFocus={false}
-        className="custom-select"
-        disabled={false}
-        id="root"
-        multiple={true}
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        readOnly={false}
-        required={false}
-        value={Array []}
+      <div
+        className="form-group"
       >
-        <option
+        <label
+          className="form-label"
+        />
+        <select
+          autoFocus={false}
+          className="custom-select"
           disabled={false}
-          id="a"
-          value="a"
+          id="root"
+          multiple={true}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          readOnly={false}
+          required={false}
+          value={Array []}
         >
-          a
-        </option>
-        <option
-          disabled={false}
-          id="b"
-          value="b"
-        >
-          b
-        </option>
-        <option
-          disabled={false}
-          id="c"
-          value="c"
-        >
-          c
-        </option>
-      </select>
+          <option
+            disabled={false}
+            id="a"
+            value="a"
+          >
+            a
+          </option>
+          <option
+            disabled={false}
+            id="b"
+            value="b"
+          >
+            b
+          </option>
+          <option
+            disabled={false}
+            id="c"
+            value="c"
+          >
+            c
+          </option>
+        </select>
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -554,97 +574,109 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-array"
   >
-    <div>
-      <div
-        className="p-0 m-0 row"
-      >
+    <div
+      className="form-group"
+    >
+      <div>
         <div
-          className="p-0 m-0 col"
+          className="p-0 m-0 row"
         >
           <div
-            className="p-0 m-0 container-fluid"
+            className="p-0 m-0 col"
           >
-            <div>
-              <div
-                className="mb-2  d-flex align-items-center row"
-              >
+            <div
+              className="p-0 m-0 container-fluid"
+            >
+              <div>
                 <div
-                  className="col-lg-9 col-9"
+                  className="mb-2  d-flex align-items-center row"
                 >
                   <div
-                    className="form-group"
+                    className="col-lg-9 col-9"
                   >
                     <div
-                      className="mb-0 form-group"
+                      className="form-group field field-string"
                     >
-                      <label
-                        className="form-label"
-                        htmlFor="root_0"
-                      />
-                      <input
-                        autoFocus={false}
-                        className="form-control"
-                        disabled={false}
-                        id="root_0"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder=""
-                        readOnly={false}
-                        required={true}
-                        type="text"
-                        value=""
-                      />
+                      <div
+                        className="form-group"
+                      >
+                        <div
+                          className="mb-0 form-group"
+                        >
+                          <label
+                            className="form-label"
+                            htmlFor="root_0"
+                          />
+                          <input
+                            autoFocus={false}
+                            className="form-control"
+                            disabled={false}
+                            id="root_0"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            placeholder=""
+                            readOnly={false}
+                            required={true}
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                        
+                      </div>
                     </div>
-                    
                   </div>
+                  <div
+                    className="py-4 col-lg-3 col-3"
+                  />
                 </div>
-                <div
-                  className="py-4 col-lg-3 col-3"
-                />
               </div>
-            </div>
-            <div>
-              <div
-                className="mb-2  d-flex align-items-center row"
-              >
+              <div>
                 <div
-                  className="col-lg-9 col-9"
+                  className="mb-2  d-flex align-items-center row"
                 >
                   <div
-                    className="form-group"
+                    className="col-lg-9 col-9"
                   >
                     <div
-                      className="mb-0 form-group"
+                      className="form-group field field-number"
                     >
-                      <label
-                        className="form-label"
-                        htmlFor="root_1"
-                      />
-                      <input
-                        autoFocus={false}
-                        className="form-control"
-                        disabled={false}
-                        id="root_1"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder=""
-                        readOnly={false}
-                        required={true}
-                        step="any"
-                        type="number"
-                        value=""
-                      />
+                      <div
+                        className="form-group"
+                      >
+                        <div
+                          className="mb-0 form-group"
+                        >
+                          <label
+                            className="form-label"
+                            htmlFor="root_1"
+                          />
+                          <input
+                            autoFocus={false}
+                            className="form-control"
+                            disabled={false}
+                            id="root_1"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            placeholder=""
+                            readOnly={false}
+                            required={true}
+                            step="any"
+                            type="number"
+                            value=""
+                          />
+                        </div>
+                        
+                      </div>
                     </div>
-                    
                   </div>
+                  <div
+                    className="py-4 col-lg-3 col-3"
+                  />
                 </div>
-                <div
-                  className="py-4 col-lg-3 col-3"
-                />
               </div>
             </div>
           </div>

--- a/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
@@ -7,25 +7,29 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-boolean"
   >
     <div
-      className="checkbox  form-group"
+      className="form-group"
     >
       <div
-        className="form-check"
+        className="checkbox  form-group"
       >
-        <input
-          autoFocus={false}
-          checked={false}
-          className="form-check-input position-static"
-          disabled={false}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          type="checkbox"
-        />
+        <div
+          className="form-check"
+        >
+          <input
+            autoFocus={false}
+            checked={false}
+            className="form-check-input position-static"
+            disabled={false}
+            id="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="checkbox"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -48,25 +52,29 @@ exports[`single fields checkbox field 2`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-boolean"
   >
     <div
-      className="checkbox  form-group"
+      className="form-group"
     >
       <div
-        className="form-check"
+        className="checkbox  form-group"
       >
-        <input
-          autoFocus={false}
-          checked={false}
-          className="form-check-input position-static"
-          disabled={false}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          type="checkbox"
-        />
+        <div
+          className="form-check"
+        >
+          <input
+            autoFocus={false}
+            checked={false}
+            className="form-check-input position-static"
+            disabled={false}
+            id="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="checkbox"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -89,125 +97,129 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-array"
   >
-    <label
-      className="form-label"
-      htmlFor="root"
-    />
     <div
       className="form-group"
     >
-      <form
-        className=""
+      <label
+        className="form-label"
+        htmlFor="root"
+      />
+      <div
+        className="form-group"
       >
-        <div
-          className="bg-transparent border-0 custom-control custom-checkbox"
+        <form
+          className=""
         >
-          <input
-            autoFocus={false}
-            checked={false}
-            className="custom-control-input"
-            disabled={false}
-            id="root_0"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            required={false}
-            type="checkbox"
-          />
-          <label
-            className="custom-control-label"
-            htmlFor="root_0"
-            title=""
+          <div
+            className="bg-transparent border-0 custom-control custom-checkbox"
           >
-            foo
-          </label>
-        </div>
-      </form>
-      <form
-        className=""
-      >
-        <div
-          className="bg-transparent border-0 custom-control custom-checkbox"
+            <input
+              autoFocus={false}
+              checked={false}
+              className="custom-control-input"
+              disabled={false}
+              id="root_0"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              required={false}
+              type="checkbox"
+            />
+            <label
+              className="custom-control-label"
+              htmlFor="root_0"
+              title=""
+            >
+              foo
+            </label>
+          </div>
+        </form>
+        <form
+          className=""
         >
-          <input
-            autoFocus={false}
-            checked={false}
-            className="custom-control-input"
-            disabled={false}
-            id="root_1"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            required={false}
-            type="checkbox"
-          />
-          <label
-            className="custom-control-label"
-            htmlFor="root_1"
-            title=""
+          <div
+            className="bg-transparent border-0 custom-control custom-checkbox"
           >
-            bar
-          </label>
-        </div>
-      </form>
-      <form
-        className=""
-      >
-        <div
-          className="bg-transparent border-0 custom-control custom-checkbox"
+            <input
+              autoFocus={false}
+              checked={false}
+              className="custom-control-input"
+              disabled={false}
+              id="root_1"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              required={false}
+              type="checkbox"
+            />
+            <label
+              className="custom-control-label"
+              htmlFor="root_1"
+              title=""
+            >
+              bar
+            </label>
+          </div>
+        </form>
+        <form
+          className=""
         >
-          <input
-            autoFocus={false}
-            checked={false}
-            className="custom-control-input"
-            disabled={false}
-            id="root_2"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            required={false}
-            type="checkbox"
-          />
-          <label
-            className="custom-control-label"
-            htmlFor="root_2"
-            title=""
+          <div
+            className="bg-transparent border-0 custom-control custom-checkbox"
           >
-            fuzz
-          </label>
-        </div>
-      </form>
-      <form
-        className=""
-      >
-        <div
-          className="bg-transparent border-0 custom-control custom-checkbox"
+            <input
+              autoFocus={false}
+              checked={false}
+              className="custom-control-input"
+              disabled={false}
+              id="root_2"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              required={false}
+              type="checkbox"
+            />
+            <label
+              className="custom-control-label"
+              htmlFor="root_2"
+              title=""
+            >
+              fuzz
+            </label>
+          </div>
+        </form>
+        <form
+          className=""
         >
-          <input
-            autoFocus={false}
-            checked={false}
-            className="custom-control-input"
-            disabled={false}
-            id="root_3"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            required={false}
-            type="checkbox"
-          />
-          <label
-            className="custom-control-label"
-            htmlFor="root_3"
-            title=""
+          <div
+            className="bg-transparent border-0 custom-control custom-checkbox"
           >
-            qux
-          </label>
-        </div>
-      </form>
+            <input
+              autoFocus={false}
+              checked={false}
+              className="custom-control-input"
+              disabled={false}
+              id="root_3"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              required={false}
+              type="checkbox"
+            />
+            <label
+              className="custom-control-label"
+              htmlFor="root_3"
+              title=""
+            >
+              qux
+            </label>
+          </div>
+        </form>
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -228,56 +240,64 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-object"
   >
-    
     <div
-      className="p-0 container-fluid"
+      className="form-group"
     >
+      
       <div
-        className="row"
-        style={
-          Object {
-            "marginBottom": "10px",
-          }
-        }
+        className="p-0 container-fluid"
       >
         <div
-          className="col-12"
+          className="row"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
-           
           <div
-            className="form-group"
+            className="col-12"
           >
+             
             <div
-              className="mb-0 form-group"
+              className="form-group field field-string"
             >
-              <label
-                className="form-label"
-                htmlFor="root_my-field"
+              <div
+                className="form-group"
               >
-                my-field
-              </label>
-              <input
-                autoFocus={false}
-                className="form-control"
-                disabled={false}
-                id="root_my-field"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder=""
-                readOnly={false}
-                required={false}
-                type="text"
-                value=""
-              />
+                <div
+                  className="mb-0 form-group"
+                >
+                  <label
+                    className="form-label"
+                    htmlFor="root_my-field"
+                  >
+                    my-field
+                  </label>
+                  <input
+                    autoFocus={false}
+                    className="form-control"
+                    disabled={false}
+                    id="root_my-field"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    readOnly={false}
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <small
+                  className="text-muted form-text"
+                >
+                  some description
+                </small>
+              </div>
             </div>
-            <small
-              className="text-muted form-text"
-            >
-              some description
-            </small>
           </div>
         </div>
       </div>
@@ -302,56 +322,64 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-object"
   >
-    
     <div
-      className="p-0 container-fluid"
+      className="form-group"
     >
+      
       <div
-        className="row"
-        style={
-          Object {
-            "marginBottom": "10px",
-          }
-        }
+        className="p-0 container-fluid"
       >
         <div
-          className="col-12"
+          className="row"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
-           
           <div
-            className="form-group"
+            className="col-12"
           >
+             
             <div
-              className="mb-0 form-group"
+              className="form-group field field-string"
             >
-              <label
-                className="form-label"
-                htmlFor="root_my-field"
+              <div
+                className="form-group"
               >
-                my-field
-              </label>
-              <input
-                autoFocus={false}
-                className="form-control"
-                disabled={false}
-                id="root_my-field"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder=""
-                readOnly={false}
-                required={false}
-                type="text"
-                value=""
-              />
+                <div
+                  className="mb-0 form-group"
+                >
+                  <label
+                    className="form-label"
+                    htmlFor="root_my-field"
+                  >
+                    my-field
+                  </label>
+                  <input
+                    autoFocus={false}
+                    className="form-control"
+                    disabled={false}
+                    id="root_my-field"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    readOnly={false}
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <small
+                  className="text-muted form-text"
+                >
+                  some other description
+                </small>
+              </div>
             </div>
-            <small
-              className="text-muted form-text"
-            >
-              some other description
-            </small>
           </div>
         </div>
       </div>
@@ -376,30 +404,34 @@ exports[`single fields format color 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-string"
   >
     <div
-      className="mb-0 form-group"
+      className="form-group"
     >
-      <label
-        className="form-label"
-        htmlFor="root"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="color"
-        value=""
-      />
+      <div
+        className="mb-0 form-group"
+      >
+        <label
+          className="form-label"
+          htmlFor="root"
+        />
+        <input
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          type="color"
+          value=""
+        />
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -420,30 +452,34 @@ exports[`single fields format date 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-string"
   >
     <div
-      className="mb-0 form-group"
+      className="form-group"
     >
-      <label
-        className="form-label"
-        htmlFor="root"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="date"
-        value=""
-      />
+      <div
+        className="mb-0 form-group"
+      >
+        <label
+          className="form-label"
+          htmlFor="root"
+        />
+        <input
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          type="date"
+          value=""
+        />
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -464,30 +500,34 @@ exports[`single fields format datetime 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-string"
   >
     <div
-      className="mb-0 form-group"
+      className="form-group"
     >
-      <label
-        className="form-label"
-        htmlFor="root"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="datetime-local"
-        value=""
-      />
+      <div
+        className="mb-0 form-group"
+      >
+        <label
+          className="form-label"
+          htmlFor="root"
+        />
+        <input
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          type="datetime-local"
+          value=""
+        />
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -508,33 +548,41 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-object"
   >
-    
     <div
-      className="p-0 container-fluid"
+      className="form-group"
     >
+      
       <div
-        className="d-none row"
-        style={
-          Object {
-            "marginBottom": "10px",
-          }
-        }
+        className="p-0 container-fluid"
       >
         <div
-          className="col-12"
+          className="d-none row"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
-           
           <div
-            className="form-group"
+            className="col-12"
           >
-            <input
-              id="root_my-field"
-              type="hidden"
-              value=""
-            />
-            
+             
+            <div
+              className="form-group field field-string"
+            >
+              <div
+                className="form-group"
+              >
+                <input
+                  id="root_my-field"
+                  type="hidden"
+                  value=""
+                />
+                
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -559,28 +607,32 @@ exports[`single fields hidden label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-string"
   >
     <div
-      className="mb-0 form-group"
+      className="form-group"
     >
-      <label
-        className="form-label"
-        htmlFor="root"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="text"
-        value=""
-      />
+      <div
+        className="mb-0 form-group"
+      >
+        <label
+          className="form-label"
+          htmlFor="root"
+        />
+        <input
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          type="text"
+          value=""
+        />
+      </div>
     </div>
   </div>
   <div>
@@ -602,9 +654,13 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-null"
   >
-    
+    <div
+      className="form-group"
+    >
+      
+    </div>
   </div>
   <div>
     <button
@@ -625,31 +681,35 @@ exports[`single fields number field 0 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-number"
   >
     <div
-      className="mb-0 form-group"
+      className="form-group"
     >
-      <label
-        className="form-label"
-        htmlFor="root"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        step="any"
-        type="number"
-        value={0}
-      />
+      <div
+        className="mb-0 form-group"
+      >
+        <label
+          className="form-label"
+          htmlFor="root"
+        />
+        <input
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          step="any"
+          type="number"
+          value={0}
+        />
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -670,31 +730,35 @@ exports[`single fields number field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-number"
   >
     <div
-      className="mb-0 form-group"
+      className="form-group"
     >
-      <label
-        className="form-label"
-        htmlFor="root"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        step="any"
-        type="number"
-        value=""
-      />
+      <div
+        className="mb-0 form-group"
+      >
+        <label
+          className="form-label"
+          htmlFor="root"
+        />
+        <input
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          step="any"
+          type="number"
+          value=""
+        />
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -715,30 +779,34 @@ exports[`single fields password field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-string"
   >
     <div
-      className="mb-0 form-group"
+      className="form-group"
     >
-      <label
-        className="form-label"
-        htmlFor="root"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="password"
-        value=""
-      />
+      <div
+        className="mb-0 form-group"
+      >
+        <label
+          className="form-label"
+          htmlFor="root"
+        />
+        <input
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          type="password"
+          value=""
+        />
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -759,64 +827,68 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-boolean"
   >
     <div
-      className="mb-0 form-group"
+      className="form-group"
     >
-      <label
-        className="d-block form-label"
-      >
-        
-      </label>
       <div
-        className="form-check"
+        className="mb-0 form-group"
       >
-        <input
-          checked={false}
-          className="form-check-input"
-          disabled={false}
-          id="Yes"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          type="radio"
-          value={true}
-        />
         <label
-          className="form-check-label"
-          htmlFor="Yes"
-          title=""
+          className="d-block form-label"
         >
-          Yes
+          
         </label>
-      </div>
-      <div
-        className="form-check"
-      >
-        <input
-          checked={false}
-          className="form-check-input"
-          disabled={false}
-          id="No"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          type="radio"
-          value={false}
-        />
-        <label
-          className="form-check-label"
-          htmlFor="No"
-          title=""
+        <div
+          className="form-check"
         >
-          No
-        </label>
+          <input
+            checked={false}
+            className="form-check-input"
+            disabled={false}
+            id="Yes"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="radio"
+            value={true}
+          />
+          <label
+            className="form-check-label"
+            htmlFor="Yes"
+            title=""
+          >
+            Yes
+          </label>
+        </div>
+        <div
+          className="form-check"
+        >
+          <input
+            checked={false}
+            className="form-check-input"
+            disabled={false}
+            id="No"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="radio"
+            value={false}
+          />
+          <label
+            className="form-check-label"
+            htmlFor="No"
+            title=""
+          >
+            No
+          </label>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -837,47 +909,51 @@ exports[`single fields select field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-string"
   >
     <div
       className="form-group"
     >
-      <label
-        className="form-label"
-      />
-      <select
-        autoFocus={false}
-        className="custom-select"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        readOnly={false}
-        value=""
+      <div
+        className="form-group"
       >
-        <option
+        <label
+          className="form-label"
+        />
+        <select
+          autoFocus={false}
+          className="custom-select"
+          disabled={false}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          readOnly={false}
           value=""
         >
-          
-        </option>
-        <option
-          disabled={false}
-          id="foo"
-          value="foo"
-        >
-          foo
-        </option>
-        <option
-          disabled={false}
-          id="bar"
-          value="bar"
-        >
-          bar
-        </option>
-      </select>
+          <option
+            value=""
+          >
+            
+          </option>
+          <option
+            disabled={false}
+            id="foo"
+            value="foo"
+          >
+            foo
+          </option>
+          <option
+            disabled={false}
+            id="bar"
+            value="bar"
+          >
+            bar
+          </option>
+        </select>
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -898,38 +974,42 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-integer"
   >
     <div
-      className="mb-0 form-group"
+      className="form-group"
     >
-      <label
-        className="form-label"
-        htmlFor="root"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        max={100}
-        min={42}
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        step={1}
-        type="number"
-        value={75}
-      />
-      <span
-        className="range-view"
+      <div
+        className="mb-0 form-group"
       >
-        75
-      </span>
+        <label
+          className="form-label"
+          htmlFor="root"
+        />
+        <input
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root"
+          max={100}
+          min={42}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          step={1}
+          type="number"
+          value={75}
+        />
+        <span
+          className="range-view"
+        >
+          75
+        </span>
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -950,30 +1030,34 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-string"
   >
     <div
-      className="mb-0 form-group"
+      className="form-group"
     >
-      <label
-        className="form-label"
-        htmlFor="root"
-      />
-      <input
-        autoFocus={false}
-        className="form-control-file"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="file"
-        value=""
-      />
+      <div
+        className="mb-0 form-group"
+      >
+        <label
+          className="form-label"
+          htmlFor="root"
+        />
+        <input
+          autoFocus={false}
+          className="form-control-file"
+          disabled={false}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          type="file"
+          value=""
+        />
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -994,30 +1078,34 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-string"
   >
     <div
-      className="mb-0 form-group"
+      className="form-group"
     >
-      <label
-        className="form-label"
-        htmlFor="root"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="email"
-        value=""
-      />
+      <div
+        className="mb-0 form-group"
+      >
+        <label
+          className="form-label"
+          htmlFor="root"
+        />
+        <input
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          type="email"
+          value=""
+        />
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -1038,30 +1126,34 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-string"
   >
     <div
-      className="mb-0 form-group"
+      className="form-group"
     >
-      <label
-        className="form-label"
-        htmlFor="root"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="url"
-        value=""
-      />
+      <div
+        className="mb-0 form-group"
+      >
+        <label
+          className="form-label"
+          htmlFor="root"
+        />
+        <input
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          type="url"
+          value=""
+        />
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -1082,30 +1174,34 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-string"
   >
     <div
-      className="mb-0 form-group"
+      className="form-group"
     >
-      <label
-        className="form-label"
-        htmlFor="root"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="text"
-        value=""
-      />
+      <div
+        className="mb-0 form-group"
+      >
+        <label
+          className="form-label"
+          htmlFor="root"
+        />
+        <input
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          type="text"
+          value=""
+        />
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -1126,30 +1222,34 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-string"
   >
     <div
-      className="mb-0 form-group"
+      className="form-group"
     >
-      <label
-        className="form-label"
-        htmlFor="root"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder="placeholder"
-        readOnly={false}
-        type="text"
-        value=""
-      />
+      <div
+        className="mb-0 form-group"
+      >
+        <label
+          className="form-label"
+          htmlFor="root"
+        />
+        <input
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder="placeholder"
+          readOnly={false}
+          type="text"
+          value=""
+        />
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -1170,30 +1270,34 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-string"
   >
-    <label
-      htmlFor="root"
-    >
-      
-    </label>
     <div
-      className="input-group"
+      className="form-group"
     >
-      <textarea
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        rows={5}
-      />
+      <label
+        htmlFor="root"
+      >
+        
+      </label>
+      <div
+        className="input-group"
+      >
+        <textarea
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          rows={5}
+        />
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -1214,67 +1318,75 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-object"
   >
     <div
-      className="my-1"
-      id="root-title"
-    >
-      <h5>
-        Titre 1
-      </h5>
-      <hr
-        className="border-0 bg-secondary"
-        style={
-          Object {
-            "height": "1px",
-          }
-        }
-      />
-    </div>
-    <div
-      className="p-0 container-fluid"
+      className="form-group"
     >
       <div
-        className="row"
-        style={
-          Object {
-            "marginBottom": "10px",
+        className="my-1"
+        id="root-title"
+      >
+        <h5>
+          Titre 1
+        </h5>
+        <hr
+          className="border-0 bg-secondary"
+          style={
+            Object {
+              "height": "1px",
+            }
           }
-        }
+        />
+      </div>
+      <div
+        className="p-0 container-fluid"
       >
         <div
-          className="col-12"
+          className="row"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
-           
           <div
-            className="form-group"
+            className="col-12"
           >
+             
             <div
-              className="mb-0 form-group"
+              className="form-group field field-string"
             >
-              <label
-                className="form-label"
-                htmlFor="root_title"
+              <div
+                className="form-group"
               >
-                Titre 2
-              </label>
-              <input
-                autoFocus={false}
-                className="form-control"
-                disabled={false}
-                id="root_title"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder=""
-                readOnly={false}
-                required={false}
-                type="text"
-                value=""
-              />
+                <div
+                  className="mb-0 form-group"
+                >
+                  <label
+                    className="form-label"
+                    htmlFor="root_title"
+                  >
+                    Titre 2
+                  </label>
+                  <input
+                    autoFocus={false}
+                    className="form-control"
+                    disabled={false}
+                    id="root_title"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    readOnly={false}
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                </div>
+                
+              </div>
             </div>
-            
           </div>
         </div>
       </div>
@@ -1299,31 +1411,35 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-undefined"
   >
     <div
-      className="unsupported-field"
+      className="form-group"
     >
-      <p>
-        Unsupported field schema
-        <span>
-           for
-           field 
-          <code>
-            root
-          </code>
-        </span>
-        <em>
-          : 
-          Unknown field type undefined
-        </em>
-        .
-      </p>
-      <pre>
-        {}
-      </pre>
+      <div
+        className="unsupported-field"
+      >
+        <p>
+          Unsupported field schema
+          <span>
+             for
+             field 
+            <code>
+              root
+            </code>
+          </span>
+          <em>
+            : 
+            Unknown field type undefined
+          </em>
+          .
+        </p>
+        <pre>
+          {}
+        </pre>
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -1344,30 +1460,34 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-number"
   >
     <div
-      className="mb-0 form-group"
+      className="form-group"
     >
-      <label
-        className="form-label"
-        htmlFor="root"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="number"
-        value=""
-      />
+      <div
+        className="mb-0 form-group"
+      >
+        <label
+          className="form-label"
+          htmlFor="root"
+        />
+        <input
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          type="number"
+          value=""
+        />
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button
@@ -1388,30 +1508,34 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-string"
   >
     <div
-      className="mb-0 form-group"
+      className="form-group"
     >
-      <label
-        className="form-label"
-        htmlFor="root"
-      />
-      <input
-        autoFocus={false}
-        className="form-control"
-        disabled={false}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        type="text"
-        value=""
-      />
+      <div
+        className="mb-0 form-group"
+      >
+        <label
+          className="form-label"
+          htmlFor="root"
+        />
+        <input
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          type="text"
+          value=""
+        />
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <button

--- a/packages/bootstrap-4/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Object.test.tsx.snap
@@ -7,154 +7,158 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-object"
   >
-    
     <div
-      className="p-0 container-fluid"
+      className="form-group"
     >
+      
       <div
-        className="row"
-        style={
-          Object {
-            "marginBottom": "10px",
-          }
-        }
+        className="p-0 container-fluid"
       >
         <div
-          className="col-12"
+          className="row"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
-           
           <div
-            className="row"
+            className="col-12"
           >
+             
             <div
-              className="col-5"
+              className="form-group field field-string row"
             >
               <div
-                className="form-group"
-              >
-                <label
-                  className="form-label"
-                  htmlFor="root_foo-key"
-                >
-                  foo Key
-                </label>
-                <input
-                  className="form-control"
-                  defaultValue="foo"
-                  disabled={false}
-                  id="root_foo-key"
-                  name="root_foo-key"
-                  onBlur={[Function]}
-                  required={false}
-                  type="text"
-                />
-              </div>
-            </div>
-            <div
-              className="col-5"
-            >
-              <div
-                className="form-group"
+                className="col-5"
               >
                 <div
-                  className="mb-0 form-group"
+                  className="form-group"
                 >
                   <label
                     className="form-label"
-                    htmlFor="root_foo"
+                    htmlFor="root_foo-key"
                   >
-                    foo
+                    foo Key
                   </label>
                   <input
-                    autoFocus={false}
                     className="form-control"
+                    defaultValue="foo"
                     disabled={false}
-                    id="root_foo"
+                    id="root_foo-key"
+                    name="root_foo-key"
                     onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    placeholder=""
-                    readOnly={false}
                     required={false}
                     type="text"
-                    value="foo"
                   />
                 </div>
-                
               </div>
-            </div>
-            <div
-              className="py-4 col-2"
-            >
-              <button
-                className="btn btn-danger btn-block btn-sm"
-                disabled={false}
-                onClick={[Function]}
-                title="Remove"
-                type="button"
+              <div
+                className="col-5"
               >
-                <svg
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  strokeWidth="0"
-                  style={
-                    Object {
-                      "color": undefined,
-                    }
-                  }
-                  viewBox="0 0 512 512"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
+                <div
+                  className="form-group"
                 >
-                  <path
-                    d="M368.5 240h-225c-8.8 0-16 7.2-16 16 0 4.4 1.8 8.4 4.7 11.3 2.9 2.9 6.9 4.7 11.3 4.7h225c8.8 0 16-7.2 16-16s-7.2-16-16-16z"
-                  />
-                </svg>
-              </button>
+                  <div
+                    className="mb-0 form-group"
+                  >
+                    <label
+                      className="form-label"
+                      htmlFor="root_foo"
+                    >
+                      foo
+                    </label>
+                    <input
+                      autoFocus={false}
+                      className="form-control"
+                      disabled={false}
+                      id="root_foo"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value="foo"
+                    />
+                  </div>
+                  
+                </div>
+              </div>
+              <div
+                className="py-4 col-2"
+              >
+                <button
+                  className="btn btn-danger btn-block btn-sm"
+                  disabled={false}
+                  onClick={[Function]}
+                  title="Remove"
+                  type="button"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    strokeWidth="0"
+                    style={
+                      Object {
+                        "color": undefined,
+                      }
+                    }
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M368.5 240h-225c-8.8 0-16 7.2-16 16 0 4.4 1.8 8.4 4.7 11.3 2.9 2.9 6.9 4.7 11.3 4.7h225c8.8 0 16-7.2 16-16s-7.2-16-16-16z"
+                    />
+                  </svg>
+                </button>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div
-        className="row"
-      >
         <div
-          className="py-4 col-3 offset-9"
+          className="row"
         >
-          <button
-            className="ml-1 object-property-expand btn btn-primary"
-            disabled={false}
-            onClick={[Function]}
-            style={
-              Object {
-                "width": "100%",
-              }
-            }
-            title="Add Item"
-            type="button"
+          <div
+            className="py-4 col-3 offset-9"
           >
-            <svg
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              strokeWidth="0"
+            <button
+              className="ml-1 object-property-expand btn btn-primary"
+              disabled={false}
+              onClick={[Function]}
               style={
                 Object {
-                  "color": undefined,
+                  "width": "100%",
                 }
               }
-              viewBox="0 0 16 16"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
+              title="Add Item"
+              type="button"
             >
-              <path
-                d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"
-              />
-            </svg>
-          </button>
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                strokeWidth="0"
+                style={
+                  Object {
+                    "color": undefined,
+                  }
+                }
+                viewBox="0 0 16 16"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4z"
+                />
+              </svg>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -178,96 +182,108 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group"
+    className="form-group field field-object"
   >
-    
     <div
-      className="p-0 container-fluid"
+      className="form-group"
     >
+      
       <div
-        className="row"
-        style={
-          Object {
-            "marginBottom": "10px",
-          }
-        }
+        className="p-0 container-fluid"
       >
         <div
-          className="col-12"
+          className="row"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
-           
           <div
-            className="form-group"
+            className="col-12"
           >
+             
             <div
-              className="mb-0 form-group"
+              className="form-group field field-string"
             >
-              <label
-                className="form-label"
-                htmlFor="root_a"
+              <div
+                className="form-group"
               >
-                A
-              </label>
-              <input
-                autoFocus={false}
-                className="form-control"
-                disabled={false}
-                id="root_a"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder=""
-                readOnly={false}
-                required={false}
-                type="text"
-                value=""
-              />
+                <div
+                  className="mb-0 form-group"
+                >
+                  <label
+                    className="form-label"
+                    htmlFor="root_a"
+                  >
+                    A
+                  </label>
+                  <input
+                    autoFocus={false}
+                    className="form-control"
+                    disabled={false}
+                    id="root_a"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    readOnly={false}
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                </div>
+                
+              </div>
             </div>
-            
           </div>
         </div>
-      </div>
-      <div
-        className="row"
-        style={
-          Object {
-            "marginBottom": "10px",
-          }
-        }
-      >
         <div
-          className="col-12"
+          className="row"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
-           
           <div
-            className="form-group"
+            className="col-12"
           >
+             
             <div
-              className="mb-0 form-group"
+              className="form-group field field-number"
             >
-              <label
-                className="form-label"
-                htmlFor="root_b"
+              <div
+                className="form-group"
               >
-                B
-              </label>
-              <input
-                autoFocus={false}
-                className="form-control"
-                disabled={false}
-                id="root_b"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder=""
-                readOnly={false}
-                required={false}
-                step="any"
-                type="number"
-                value=""
-              />
+                <div
+                  className="mb-0 form-group"
+                >
+                  <label
+                    className="form-label"
+                    htmlFor="root_b"
+                  >
+                    B
+                  </label>
+                  <input
+                    autoFocus={false}
+                    className="form-control"
+                    disabled={false}
+                    id="root_b"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    readOnly={false}
+                    required={false}
+                    step="any"
+                    type="number"
+                    value=""
+                  />
+                </div>
+                
+              </div>
             </div>
-            
           </div>
         </div>
       </div>

--- a/packages/chakra-ui/src/FieldTemplate/WrapIfAdditional.tsx
+++ b/packages/chakra-ui/src/FieldTemplate/WrapIfAdditional.tsx
@@ -25,6 +25,7 @@ type WrapIfAdditionalProps = { children: React.ReactElement } & Pick<
 const WrapIfAdditional = (props: WrapIfAdditionalProps) => {
   const {
     children,
+    classNames,
     disabled,
     id,
     label,
@@ -38,7 +39,7 @@ const WrapIfAdditional = (props: WrapIfAdditionalProps) => {
   const { RemoveButton } = registry.templates.ButtonTemplates;
   const additional = ADDITIONAL_PROPERTY_FLAG in schema;
   if (!additional) {
-    return <>{children}</>;
+    return <div className={classNames}>{children}</div>;
   }
   const keyLabel = `${label} Key`;
 
@@ -46,7 +47,7 @@ const WrapIfAdditional = (props: WrapIfAdditionalProps) => {
     onKeyChange(target.value);
 
   return (
-    <Grid key={`${id}-key`} alignItems="center" gap={2}>
+    <Grid key={`${id}-key`} className={classNames} alignItems="center" gap={2}>
       <GridItem>
         <FormControl isRequired={required}>
           <FormLabel htmlFor={`${id}-key`} id={`${id}-key-label`}>

--- a/packages/chakra-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Array.test.tsx.snap
@@ -79,47 +79,51 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-array"
   >
     <div
-      className="emotion-0"
+      className="chakra-form-control emotion-0"
+      role="group"
     >
       <div
-        className="emotion-2"
+        className="emotion-0"
       >
         <div
-          className="emotion-0"
-        />
-        <div
-          className="emotion-4"
+          className="emotion-2"
         >
           <div
-            className="emotion-5"
+            className="emotion-0"
+          />
+          <div
+            className="emotion-4"
           >
-            <button
-              className="chakra-button array-item-add emotion-6"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
+            <div
+              className="emotion-5"
             >
-              <span
-                className="chakra-button__icon emotion-7"
+              <button
+                className="chakra-button array-item-add emotion-6"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  className="chakra-icon emotion-8"
-                  focusable={false}
-                  viewBox="0 0 24 24"
+                <span
+                  className="chakra-button__icon emotion-7"
                 >
-                  <path
-                    d="M0,12a1.5,1.5,0,0,0,1.5,1.5h8.75a.25.25,0,0,1,.25.25V22.5a1.5,1.5,0,0,0,3,0V13.75a.25.25,0,0,1,.25-.25H22.5a1.5,1.5,0,0,0,0-3H13.75a.25.25,0,0,1-.25-.25V1.5a1.5,1.5,0,0,0-3,0v8.75a.25.25,0,0,1-.25.25H1.5A1.5,1.5,0,0,0,0,12Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </span>
-              Add Item
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    className="chakra-icon emotion-8"
+                    focusable={false}
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M0,12a1.5,1.5,0,0,0,1.5,1.5h8.75a.25.25,0,0,1,.25.25V22.5a1.5,1.5,0,0,0,3,0V13.75a.25.25,0,0,1,.25-.25H22.5a1.5,1.5,0,0,0,0-3H13.75a.25.25,0,0,1-.25-.25V1.5a1.5,1.5,0,0,0-3,0v8.75a.25.25,0,0,1-.25.25H1.5A1.5,1.5,0,0,0,0,12Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+                Add Item
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -308,260 +312,272 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-array"
   >
     <div
-      className="emotion-0"
+      className="chakra-form-control emotion-0"
+      role="group"
     >
       <div
-        className="emotion-2"
+        className="emotion-0"
       >
         <div
-          className="emotion-0"
+          className="emotion-2"
         >
           <div
-            className="chakra-stack emotion-4"
+            className="emotion-0"
           >
             <div
-              className="emotion-5"
+              className="chakra-stack emotion-4"
             >
               <div
-                className="chakra-form-control emotion-0"
-                role="group"
+                className="emotion-5"
               >
                 <div
-                  className="chakra-form-control emotion-7"
+                  className="form-group field field-string"
+                >
+                  <div
+                    className="chakra-form-control emotion-0"
+                    role="group"
+                  >
+                    <div
+                      className="chakra-form-control emotion-7"
+                      role="group"
+                    >
+                      <input
+                        aria-required={true}
+                        autoFocus={false}
+                        className="chakra-input emotion-0"
+                        disabled={false}
+                        id="root_0"
+                        name="root_0"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder=""
+                        readOnly={false}
+                        required={true}
+                        type="text"
+                        value="a"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="emotion-0"
+              >
+                <div
+                  className="chakra-button__group emotion-10"
                   role="group"
                 >
-                  <input
-                    aria-required={true}
-                    autoFocus={false}
-                    className="chakra-input emotion-0"
+                  <button
+                    aria-label="Move up"
+                    className="chakra-button emotion-11"
+                    disabled={true}
+                    onClick={[Function]}
+                    title="Move up"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="chakra-icon emotion-12"
+                      focusable={false}
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    aria-label="Move down"
+                    className="chakra-button emotion-11"
                     disabled={false}
-                    id="root_0"
-                    name="root_0"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    placeholder=""
-                    readOnly={false}
-                    required={true}
-                    type="text"
-                    value="a"
-                  />
+                    onClick={[Function]}
+                    title="Move down"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="chakra-icon emotion-12"
+                      focusable={false}
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    aria-label="Remove"
+                    className="chakra-button emotion-11"
+                    disabled={false}
+                    onClick={[Function]}
+                    title="Remove"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="chakra-icon emotion-12"
+                      focusable={false}
+                      viewBox="0 0 24 24"
+                    >
+                      <g
+                        fill="currentColor"
+                      >
+                        <path
+                          d="M19.452 7.5H4.547a.5.5 0 00-.5.545l1.287 14.136A2 2 0 007.326 24h9.347a2 2 0 001.992-1.819L19.95 8.045a.5.5 0 00-.129-.382.5.5 0 00-.369-.163zm-9.2 13a.75.75 0 01-1.5 0v-9a.75.75 0 011.5 0zm5 0a.75.75 0 01-1.5 0v-9a.75.75 0 011.5 0zM22 4h-4.75a.25.25 0 01-.25-.25V2.5A2.5 2.5 0 0014.5 0h-5A2.5 2.5 0 007 2.5v1.25a.25.25 0 01-.25.25H2a1 1 0 000 2h20a1 1 0 000-2zM9 3.75V2.5a.5.5 0 01.5-.5h5a.5.5 0 01.5.5v1.25a.25.25 0 01-.25.25h-5.5A.25.25 0 019 3.75z"
+                        />
+                      </g>
+                    </svg>
+                  </button>
                 </div>
               </div>
             </div>
             <div
-              className="emotion-0"
+              className="chakra-stack emotion-4"
             >
               <div
-                className="chakra-button__group emotion-10"
-                role="group"
-              >
-                <button
-                  aria-label="Move up"
-                  className="chakra-button emotion-11"
-                  disabled={true}
-                  onClick={[Function]}
-                  title="Move up"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="chakra-icon emotion-12"
-                    focusable={false}
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </button>
-                <button
-                  aria-label="Move down"
-                  className="chakra-button emotion-11"
-                  disabled={false}
-                  onClick={[Function]}
-                  title="Move down"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="chakra-icon emotion-12"
-                    focusable={false}
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </button>
-                <button
-                  aria-label="Remove"
-                  className="chakra-button emotion-11"
-                  disabled={false}
-                  onClick={[Function]}
-                  title="Remove"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="chakra-icon emotion-12"
-                    focusable={false}
-                    viewBox="0 0 24 24"
-                  >
-                    <g
-                      fill="currentColor"
-                    >
-                      <path
-                        d="M19.452 7.5H4.547a.5.5 0 00-.5.545l1.287 14.136A2 2 0 007.326 24h9.347a2 2 0 001.992-1.819L19.95 8.045a.5.5 0 00-.129-.382.5.5 0 00-.369-.163zm-9.2 13a.75.75 0 01-1.5 0v-9a.75.75 0 011.5 0zm5 0a.75.75 0 01-1.5 0v-9a.75.75 0 011.5 0zM22 4h-4.75a.25.25 0 01-.25-.25V2.5A2.5 2.5 0 0014.5 0h-5A2.5 2.5 0 007 2.5v1.25a.25.25 0 01-.25.25H2a1 1 0 000 2h20a1 1 0 000-2zM9 3.75V2.5a.5.5 0 01.5-.5h5a.5.5 0 01.5.5v1.25a.25.25 0 01-.25.25h-5.5A.25.25 0 019 3.75z"
-                      />
-                    </g>
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </div>
-          <div
-            className="chakra-stack emotion-4"
-          >
-            <div
-              className="emotion-5"
-            >
-              <div
-                className="chakra-form-control emotion-0"
-                role="group"
+                className="emotion-5"
               >
                 <div
-                  className="chakra-form-control emotion-7"
+                  className="form-group field field-string"
+                >
+                  <div
+                    className="chakra-form-control emotion-0"
+                    role="group"
+                  >
+                    <div
+                      className="chakra-form-control emotion-7"
+                      role="group"
+                    >
+                      <input
+                        aria-required={true}
+                        autoFocus={false}
+                        className="chakra-input emotion-0"
+                        disabled={false}
+                        id="root_1"
+                        name="root_1"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder=""
+                        readOnly={false}
+                        required={true}
+                        type="text"
+                        value="b"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="emotion-0"
+              >
+                <div
+                  className="chakra-button__group emotion-10"
                   role="group"
                 >
-                  <input
-                    aria-required={true}
-                    autoFocus={false}
-                    className="chakra-input emotion-0"
+                  <button
+                    aria-label="Move up"
+                    className="chakra-button emotion-11"
                     disabled={false}
-                    id="root_1"
-                    name="root_1"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    placeholder=""
-                    readOnly={false}
-                    required={true}
-                    type="text"
-                    value="b"
-                  />
+                    onClick={[Function]}
+                    title="Move up"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="chakra-icon emotion-12"
+                      focusable={false}
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    aria-label="Move down"
+                    className="chakra-button emotion-11"
+                    disabled={true}
+                    onClick={[Function]}
+                    title="Move down"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="chakra-icon emotion-12"
+                      focusable={false}
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    aria-label="Remove"
+                    className="chakra-button emotion-11"
+                    disabled={false}
+                    onClick={[Function]}
+                    title="Remove"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="chakra-icon emotion-12"
+                      focusable={false}
+                      viewBox="0 0 24 24"
+                    >
+                      <g
+                        fill="currentColor"
+                      >
+                        <path
+                          d="M19.452 7.5H4.547a.5.5 0 00-.5.545l1.287 14.136A2 2 0 007.326 24h9.347a2 2 0 001.992-1.819L19.95 8.045a.5.5 0 00-.129-.382.5.5 0 00-.369-.163zm-9.2 13a.75.75 0 01-1.5 0v-9a.75.75 0 011.5 0zm5 0a.75.75 0 01-1.5 0v-9a.75.75 0 011.5 0zM22 4h-4.75a.25.25 0 01-.25-.25V2.5A2.5 2.5 0 0014.5 0h-5A2.5 2.5 0 007 2.5v1.25a.25.25 0 01-.25.25H2a1 1 0 000 2h20a1 1 0 000-2zM9 3.75V2.5a.5.5 0 01.5-.5h5a.5.5 0 01.5.5v1.25a.25.25 0 01-.25.25h-5.5A.25.25 0 019 3.75z"
+                        />
+                      </g>
+                    </svg>
+                  </button>
                 </div>
               </div>
             </div>
-            <div
-              className="emotion-0"
-            >
-              <div
-                className="chakra-button__group emotion-10"
-                role="group"
-              >
-                <button
-                  aria-label="Move up"
-                  className="chakra-button emotion-11"
-                  disabled={false}
-                  onClick={[Function]}
-                  title="Move up"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="chakra-icon emotion-12"
-                    focusable={false}
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </button>
-                <button
-                  aria-label="Move down"
-                  className="chakra-button emotion-11"
-                  disabled={true}
-                  onClick={[Function]}
-                  title="Move down"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="chakra-icon emotion-12"
-                    focusable={false}
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </button>
-                <button
-                  aria-label="Remove"
-                  className="chakra-button emotion-11"
-                  disabled={false}
-                  onClick={[Function]}
-                  title="Remove"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="chakra-icon emotion-12"
-                    focusable={false}
-                    viewBox="0 0 24 24"
-                  >
-                    <g
-                      fill="currentColor"
-                    >
-                      <path
-                        d="M19.452 7.5H4.547a.5.5 0 00-.5.545l1.287 14.136A2 2 0 007.326 24h9.347a2 2 0 001.992-1.819L19.95 8.045a.5.5 0 00-.129-.382.5.5 0 00-.369-.163zm-9.2 13a.75.75 0 01-1.5 0v-9a.75.75 0 011.5 0zm5 0a.75.75 0 01-1.5 0v-9a.75.75 0 011.5 0zM22 4h-4.75a.25.25 0 01-.25-.25V2.5A2.5 2.5 0 0014.5 0h-5A2.5 2.5 0 007 2.5v1.25a.25.25 0 01-.25.25H2a1 1 0 000 2h20a1 1 0 000-2zM9 3.75V2.5a.5.5 0 01.5-.5h5a.5.5 0 01.5.5v1.25a.25.25 0 01-.25.25h-5.5A.25.25 0 019 3.75z"
-                      />
-                    </g>
-                  </svg>
-                </button>
-              </div>
-            </div>
           </div>
-        </div>
-        <div
-          className="emotion-30"
-        >
           <div
-            className="emotion-31"
+            className="emotion-30"
           >
-            <button
-              className="chakra-button array-item-add emotion-32"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
+            <div
+              className="emotion-31"
             >
-              <span
-                className="chakra-button__icon emotion-33"
+              <button
+                className="chakra-button array-item-add emotion-32"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
               >
-                <svg
-                  aria-hidden={true}
-                  className="chakra-icon emotion-12"
-                  focusable={false}
-                  viewBox="0 0 24 24"
+                <span
+                  className="chakra-button__icon emotion-33"
                 >
-                  <path
-                    d="M0,12a1.5,1.5,0,0,0,1.5,1.5h8.75a.25.25,0,0,1,.25.25V22.5a1.5,1.5,0,0,0,3,0V13.75a.25.25,0,0,1,.25-.25H22.5a1.5,1.5,0,0,0,0-3H13.75a.25.25,0,0,1-.25-.25V1.5a1.5,1.5,0,0,0-3,0v8.75a.25.25,0,0,1-.25.25H1.5A1.5,1.5,0,0,0,0,12Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </span>
-              Add Item
-            </button>
+                  <svg
+                    aria-hidden={true}
+                    className="chakra-icon emotion-12"
+                    focusable={false}
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M0,12a1.5,1.5,0,0,0,1.5,1.5h8.75a.25.25,0,0,1,.25.25V22.5a1.5,1.5,0,0,0,3,0V13.75a.25.25,0,0,1,.25-.25H22.5a1.5,1.5,0,0,0,0-3H13.75a.25.25,0,0,1-.25-.25V1.5a1.5,1.5,0,0,0-3,0v8.75a.25.25,0,0,1-.25.25H1.5A1.5,1.5,0,0,0,0,12Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </span>
+                Add Item
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -789,98 +805,102 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-array"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
       <div
-        className=" emotion-2"
-        onKeyDown={[Function]}
+        className="chakra-form-control emotion-1"
+        role="group"
       >
-        <span
-          className="emotion-3"
-          id="react-select-2-live-region"
-        />
-        <span
-          aria-atomic="false"
-          aria-live="polite"
-          aria-relevant="additions text"
-          className="emotion-3"
-        />
         <div
-          className=" emotion-5"
-          onMouseDown={[Function]}
-          onTouchEnd={[Function]}
+          className=" emotion-2"
+          onKeyDown={[Function]}
         >
-          <div
-            className=" emotion-6"
-          >
-            <div
-              className=" emotion-7"
-              id="react-select-2-placeholder"
-            >
-              Select...
-            </div>
-            <div
-              className=" emotion-8"
-              data-value=""
-            >
-              <input
-                aria-autocomplete="list"
-                aria-describedby="react-select-2-placeholder"
-                aria-expanded={false}
-                aria-haspopup={true}
-                autoCapitalize="none"
-                autoComplete="off"
-                autoCorrect="off"
-                className=" emotion-9"
-                disabled={false}
-                id="root"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                role="combobox"
-                spellCheck="false"
-                tabIndex={0}
-                type="text"
-                value=""
-              />
-            </div>
-          </div>
-          <div
-            className=" emotion-10"
-          >
-            <hr
-              aria-orientation="vertical"
-              className="chakra-divider emotion-11"
-            />
-            <div
-              aria-hidden="true"
-              className=" emotion-12"
-              onMouseDown={[Function]}
-              onTouchEnd={[Function]}
-            >
-              <svg
-                className="chakra-icon emotion-13"
-                focusable={false}
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
-                  fill="currentColor"
-                />
-              </svg>
-            </div>
-          </div>
-        </div>
-        <div>
-          <input
-            name="root"
-            type="hidden"
+          <span
+            className="emotion-3"
+            id="react-select-2-live-region"
           />
+          <span
+            aria-atomic="false"
+            aria-live="polite"
+            aria-relevant="additions text"
+            className="emotion-3"
+          />
+          <div
+            className=" emotion-5"
+            onMouseDown={[Function]}
+            onTouchEnd={[Function]}
+          >
+            <div
+              className=" emotion-6"
+            >
+              <div
+                className=" emotion-7"
+                id="react-select-2-placeholder"
+              >
+                Select...
+              </div>
+              <div
+                className=" emotion-8"
+                data-value=""
+              >
+                <input
+                  aria-autocomplete="list"
+                  aria-describedby="react-select-2-placeholder"
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  autoCapitalize="none"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  className=" emotion-9"
+                  disabled={false}
+                  id="root"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  role="combobox"
+                  spellCheck="false"
+                  tabIndex={0}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <div
+              className=" emotion-10"
+            >
+              <hr
+                aria-orientation="vertical"
+                className="chakra-divider emotion-11"
+              />
+              <div
+                aria-hidden="true"
+                className=" emotion-12"
+                onMouseDown={[Function]}
+                onTouchEnd={[Function]}
+              >
+                <svg
+                  className="chakra-icon emotion-13"
+                  focusable={false}
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </div>
+            </div>
+          </div>
+          <div>
+            <input
+              name="root"
+              type="hidden"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -976,83 +996,95 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-array"
   >
     <div
-      className="emotion-0"
+      className="chakra-form-control emotion-0"
+      role="group"
     >
       <div
-        className="emotion-2"
+        className="emotion-0"
       >
         <div
-          className="emotion-0"
+          className="emotion-2"
         >
           <div
-            className="chakra-stack emotion-4"
+            className="emotion-0"
           >
             <div
-              className="emotion-5"
+              className="chakra-stack emotion-4"
             >
               <div
-                className="chakra-form-control emotion-0"
-                role="group"
+                className="emotion-5"
               >
                 <div
-                  className="chakra-form-control emotion-7"
-                  role="group"
+                  className="form-group field field-string"
                 >
-                  <input
-                    aria-required={true}
-                    autoFocus={false}
-                    className="chakra-input emotion-0"
-                    disabled={false}
-                    id="root_0"
-                    name="root_0"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    placeholder=""
-                    readOnly={false}
-                    required={true}
-                    type="text"
-                    value=""
-                  />
+                  <div
+                    className="chakra-form-control emotion-0"
+                    role="group"
+                  >
+                    <div
+                      className="chakra-form-control emotion-7"
+                      role="group"
+                    >
+                      <input
+                        aria-required={true}
+                        autoFocus={false}
+                        className="chakra-input emotion-0"
+                        disabled={false}
+                        id="root_0"
+                        name="root_0"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder=""
+                        readOnly={false}
+                        required={true}
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            className="chakra-stack emotion-4"
-          >
             <div
-              className="emotion-5"
+              className="chakra-stack emotion-4"
             >
               <div
-                className="chakra-form-control emotion-0"
-                role="group"
+                className="emotion-5"
               >
                 <div
-                  className="chakra-form-control emotion-7"
-                  role="group"
+                  className="form-group field field-number"
                 >
-                  <input
-                    aria-required={true}
-                    autoFocus={false}
-                    className="chakra-input emotion-0"
-                    disabled={false}
-                    id="root_1"
-                    name="root_1"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    placeholder=""
-                    readOnly={false}
-                    required={true}
-                    step="any"
-                    type="number"
-                    value=""
-                  />
+                  <div
+                    className="chakra-form-control emotion-0"
+                    role="group"
+                  >
+                    <div
+                      className="chakra-form-control emotion-7"
+                      role="group"
+                    >
+                      <input
+                        aria-required={true}
+                        autoFocus={false}
+                        className="chakra-input emotion-0"
+                        disabled={false}
+                        id="root_1"
+                        name="root_1"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder=""
+                        readOnly={false}
+                        required={true}
+                        step="any"
+                        type="number"
+                        value=""
+                      />
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
@@ -87,54 +87,58 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-boolean"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
-      <label
-        className="chakra-checkbox emotion-2"
-        onClick={[Function]}
+      <div
+        className="chakra-form-control emotion-1"
+        role="group"
       >
-        <input
-          aria-disabled={false}
-          checked={false}
-          className="chakra-checkbox__input"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
+        <label
+          className="chakra-checkbox emotion-2"
+          onClick={[Function]}
+        >
+          <input
+            aria-disabled={false}
+            checked={false}
+            className="chakra-checkbox__input"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
             }
-          }
-          type="checkbox"
-        />
-        <span
-          aria-hidden={true}
-          className="chakra-checkbox__control emotion-3"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        
-      </label>
+            type="checkbox"
+          />
+          <span
+            aria-hidden={true}
+            className="chakra-checkbox__control emotion-3"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          
+        </label>
+      </div>
     </div>
   </div>
   <div
@@ -238,54 +242,58 @@ exports[`single fields checkbox field 2`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-boolean"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
-      <label
-        className="chakra-checkbox emotion-2"
-        onClick={[Function]}
+      <div
+        className="chakra-form-control emotion-1"
+        role="group"
       >
-        <input
-          aria-disabled={false}
-          checked={false}
-          className="chakra-checkbox__input"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
+        <label
+          className="chakra-checkbox emotion-2"
+          onClick={[Function]}
+        >
+          <input
+            aria-disabled={false}
+            checked={false}
+            className="chakra-checkbox__input"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
             }
-          }
-          type="checkbox"
-        />
-        <span
-          aria-hidden={true}
-          className="chakra-checkbox__control emotion-3"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        
-      </label>
+            type="checkbox"
+          />
+          <span
+            aria-hidden={true}
+            className="chakra-checkbox__control emotion-3"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          
+        </label>
+      </div>
     </div>
   </div>
   <div
@@ -418,225 +426,229 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-array"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
-      <label
-        className="chakra-form__label emotion-2"
-        htmlFor="root"
-        id="root-label"
-      />
       <div
-        className="chakra-stack emotion-3"
+        className="chakra-form-control emotion-1"
+        role="group"
       >
         <label
-          className="chakra-checkbox emotion-4"
-          onClick={[Function]}
+          className="chakra-form__label emotion-2"
+          htmlFor="root"
+          id="root-label"
+        />
+        <div
+          className="chakra-stack emotion-3"
         >
-          <input
-            aria-disabled={false}
-            checked={false}
-            className="chakra-checkbox__input"
-            disabled={false}
-            id="root_0"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            style={
-              Object {
-                "border": "0px",
-                "clip": "rect(0px, 0px, 0px, 0px)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0px",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
-              }
-            }
-            type="checkbox"
-            value="foo"
-          />
-          <span
-            aria-hidden={true}
-            className="chakra-checkbox__control emotion-5"
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-          />
-          <span
-            className="chakra-checkbox__label emotion-6"
-            onMouseDown={[Function]}
-            onTouchStart={[Function]}
+          <label
+            className="chakra-checkbox emotion-4"
+            onClick={[Function]}
           >
-            <p
-              className="chakra-text emotion-0"
-            >
-              foo
-            </p>
-          </span>
-        </label>
-        <label
-          className="chakra-checkbox emotion-4"
-          onClick={[Function]}
-        >
-          <input
-            aria-disabled={false}
-            checked={false}
-            className="chakra-checkbox__input"
-            disabled={false}
-            id="root_1"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            style={
-              Object {
-                "border": "0px",
-                "clip": "rect(0px, 0px, 0px, 0px)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0px",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
+            <input
+              aria-disabled={false}
+              checked={false}
+              className="chakra-checkbox__input"
+              disabled={false}
+              id="root_0"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              style={
+                Object {
+                  "border": "0px",
+                  "clip": "rect(0px, 0px, 0px, 0px)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0px",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
               }
-            }
-            type="checkbox"
-            value="bar"
-          />
-          <span
-            aria-hidden={true}
-            className="chakra-checkbox__control emotion-5"
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-          />
-          <span
-            className="chakra-checkbox__label emotion-6"
-            onMouseDown={[Function]}
-            onTouchStart={[Function]}
-          >
-            <p
-              className="chakra-text emotion-0"
+              type="checkbox"
+              value="foo"
+            />
+            <span
+              aria-hidden={true}
+              className="chakra-checkbox__control emotion-5"
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+            />
+            <span
+              className="chakra-checkbox__label emotion-6"
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
             >
-              bar
-            </p>
-          </span>
-        </label>
-        <label
-          className="chakra-checkbox emotion-4"
-          onClick={[Function]}
-        >
-          <input
-            aria-disabled={false}
-            checked={false}
-            className="chakra-checkbox__input"
-            disabled={false}
-            id="root_2"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            style={
-              Object {
-                "border": "0px",
-                "clip": "rect(0px, 0px, 0px, 0px)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0px",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
+              <p
+                className="chakra-text emotion-0"
+              >
+                foo
+              </p>
+            </span>
+          </label>
+          <label
+            className="chakra-checkbox emotion-4"
+            onClick={[Function]}
+          >
+            <input
+              aria-disabled={false}
+              checked={false}
+              className="chakra-checkbox__input"
+              disabled={false}
+              id="root_1"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              style={
+                Object {
+                  "border": "0px",
+                  "clip": "rect(0px, 0px, 0px, 0px)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0px",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
               }
-            }
-            type="checkbox"
-            value="fuzz"
-          />
-          <span
-            aria-hidden={true}
-            className="chakra-checkbox__control emotion-5"
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-          />
-          <span
-            className="chakra-checkbox__label emotion-6"
-            onMouseDown={[Function]}
-            onTouchStart={[Function]}
-          >
-            <p
-              className="chakra-text emotion-0"
+              type="checkbox"
+              value="bar"
+            />
+            <span
+              aria-hidden={true}
+              className="chakra-checkbox__control emotion-5"
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+            />
+            <span
+              className="chakra-checkbox__label emotion-6"
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
             >
-              fuzz
-            </p>
-          </span>
-        </label>
-        <label
-          className="chakra-checkbox emotion-4"
-          onClick={[Function]}
-        >
-          <input
-            aria-disabled={false}
-            checked={false}
-            className="chakra-checkbox__input"
-            disabled={false}
-            id="root_3"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            style={
-              Object {
-                "border": "0px",
-                "clip": "rect(0px, 0px, 0px, 0px)",
-                "height": "1px",
-                "margin": "-1px",
-                "overflow": "hidden",
-                "padding": "0px",
-                "position": "absolute",
-                "whiteSpace": "nowrap",
-                "width": "1px",
+              <p
+                className="chakra-text emotion-0"
+              >
+                bar
+              </p>
+            </span>
+          </label>
+          <label
+            className="chakra-checkbox emotion-4"
+            onClick={[Function]}
+          >
+            <input
+              aria-disabled={false}
+              checked={false}
+              className="chakra-checkbox__input"
+              disabled={false}
+              id="root_2"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              style={
+                Object {
+                  "border": "0px",
+                  "clip": "rect(0px, 0px, 0px, 0px)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0px",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
               }
-            }
-            type="checkbox"
-            value="qux"
-          />
-          <span
-            aria-hidden={true}
-            className="chakra-checkbox__control emotion-5"
-            onMouseDown={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-          />
-          <span
-            className="chakra-checkbox__label emotion-6"
-            onMouseDown={[Function]}
-            onTouchStart={[Function]}
-          >
-            <p
-              className="chakra-text emotion-0"
+              type="checkbox"
+              value="fuzz"
+            />
+            <span
+              aria-hidden={true}
+              className="chakra-checkbox__control emotion-5"
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+            />
+            <span
+              className="chakra-checkbox__label emotion-6"
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
             >
-              qux
-            </p>
-          </span>
-        </label>
+              <p
+                className="chakra-text emotion-0"
+              >
+                fuzz
+              </p>
+            </span>
+          </label>
+          <label
+            className="chakra-checkbox emotion-4"
+            onClick={[Function]}
+          >
+            <input
+              aria-disabled={false}
+              checked={false}
+              className="chakra-checkbox__input"
+              disabled={false}
+              id="root_3"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              style={
+                Object {
+                  "border": "0px",
+                  "clip": "rect(0px, 0px, 0px, 0px)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0px",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+              type="checkbox"
+              value="qux"
+            />
+            <span
+              aria-hidden={true}
+              className="chakra-checkbox__control emotion-5"
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+            />
+            <span
+              className="chakra-checkbox__label emotion-6"
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            >
+              <p
+                className="chakra-text emotion-0"
+              >
+                qux
+              </p>
+            </span>
+          </label>
+        </div>
       </div>
     </div>
   </div>
@@ -713,52 +725,60 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-object"
   >
-    
     <div
-      className="emotion-1"
+      className="chakra-form-control emotion-0"
+      role="group"
     >
+      
       <div
-        className="emotion-0"
+        className="emotion-1"
       >
         <div
-          className="chakra-form-control emotion-0"
-          role="group"
+          className="emotion-0"
         >
           <div
-            className="chakra-form-control emotion-4"
-            role="group"
+            className="form-group field field-string"
           >
-            <label
-              className="chakra-form__label emotion-5"
-              htmlFor="root_my-field"
-              id="root_my-field-label"
+            <div
+              className="chakra-form-control emotion-0"
+              role="group"
             >
-              my-field
-            </label>
-            <input
-              autoFocus={false}
-              className="chakra-input emotion-0"
-              disabled={false}
-              id="root_my-field"
-              name="root_my-field"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              placeholder=""
-              readOnly={false}
-              required={false}
-              type="text"
-              value=""
-            />
+              <div
+                className="chakra-form-control emotion-4"
+                role="group"
+              >
+                <label
+                  className="chakra-form__label emotion-5"
+                  htmlFor="root_my-field"
+                  id="root_my-field-label"
+                >
+                  my-field
+                </label>
+                <input
+                  autoFocus={false}
+                  className="chakra-input emotion-0"
+                  disabled={false}
+                  id="root_my-field"
+                  name="root_my-field"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <p
+                className="chakra-text emotion-7"
+              >
+                some description
+              </p>
+            </div>
           </div>
-          <p
-            className="chakra-text emotion-7"
-          >
-            some description
-          </p>
         </div>
       </div>
     </div>
@@ -836,52 +856,60 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-object"
   >
-    
     <div
-      className="emotion-1"
+      className="chakra-form-control emotion-0"
+      role="group"
     >
+      
       <div
-        className="emotion-0"
+        className="emotion-1"
       >
         <div
-          className="chakra-form-control emotion-0"
-          role="group"
+          className="emotion-0"
         >
           <div
-            className="chakra-form-control emotion-4"
-            role="group"
+            className="form-group field field-string"
           >
-            <label
-              className="chakra-form__label emotion-5"
-              htmlFor="root_my-field"
-              id="root_my-field-label"
+            <div
+              className="chakra-form-control emotion-0"
+              role="group"
             >
-              my-field
-            </label>
-            <input
-              autoFocus={false}
-              className="chakra-input emotion-0"
-              disabled={false}
-              id="root_my-field"
-              name="root_my-field"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              placeholder=""
-              readOnly={false}
-              required={false}
-              type="text"
-              value=""
-            />
+              <div
+                className="chakra-form-control emotion-4"
+                role="group"
+              >
+                <label
+                  className="chakra-form__label emotion-5"
+                  htmlFor="root_my-field"
+                  id="root_my-field-label"
+                >
+                  my-field
+                </label>
+                <input
+                  autoFocus={false}
+                  className="chakra-input emotion-0"
+                  disabled={false}
+                  id="root_my-field"
+                  name="root_my-field"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
+              </div>
+              <p
+                className="chakra-text emotion-7"
+              >
+                some other description
+              </p>
+            </div>
           </div>
-          <p
-            className="chakra-text emotion-7"
-          >
-            some other description
-          </p>
         </div>
       </div>
     </div>
@@ -944,28 +972,32 @@ exports[`single fields format color 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-string"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
-      <input
-        autoFocus={false}
-        className="chakra-input emotion-0"
-        disabled={false}
-        id="root"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        required={false}
-        type="color"
-        value=""
-      />
+      <div
+        className="chakra-form-control emotion-1"
+        role="group"
+      >
+        <input
+          autoFocus={false}
+          className="chakra-input emotion-0"
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          required={false}
+          type="color"
+          value=""
+        />
+      </div>
     </div>
   </div>
   <div
@@ -1026,28 +1058,32 @@ exports[`single fields format date 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-string"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
-      <input
-        autoFocus={false}
-        className="chakra-input emotion-0"
-        disabled={false}
-        id="root"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        required={false}
-        type="date"
-        value=""
-      />
+      <div
+        className="chakra-form-control emotion-1"
+        role="group"
+      >
+        <input
+          autoFocus={false}
+          className="chakra-input emotion-0"
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          required={false}
+          type="date"
+          value=""
+        />
+      </div>
     </div>
   </div>
   <div
@@ -1108,28 +1144,32 @@ exports[`single fields format datetime 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-string"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
-      <input
-        autoFocus={false}
-        className="chakra-input emotion-0"
-        disabled={false}
-        id="root"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        required={false}
-        type="datetime-local"
-        value=""
-      />
+      <div
+        className="chakra-form-control emotion-1"
+        role="group"
+      >
+        <input
+          autoFocus={false}
+          className="chakra-input emotion-0"
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          required={false}
+          type="datetime-local"
+          value=""
+        />
+      </div>
     </div>
   </div>
   <div
@@ -1192,18 +1232,22 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-object"
   >
-    
     <div
-      className="emotion-1"
+      className="chakra-form-control emotion-0"
+      role="group"
     >
-      <input
-        id="root_my-field"
-        type="hidden"
-        value=""
-      />
+      
+      <div
+        className="emotion-1"
+      >
+        <input
+          id="root_my-field"
+          type="hidden"
+          value=""
+        />
+      </div>
     </div>
   </div>
   <div
@@ -1264,28 +1308,32 @@ exports[`single fields hidden label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-string"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
-      <input
-        autoFocus={false}
-        className="chakra-input emotion-0"
-        disabled={false}
-        id="root"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        required={false}
-        type="text"
-        value=""
-      />
+      <div
+        className="chakra-form-control emotion-1"
+        role="group"
+      >
+        <input
+          autoFocus={false}
+          className="chakra-input emotion-0"
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          required={false}
+          type="text"
+          value=""
+        />
+      </div>
     </div>
   </div>
   <div
@@ -1342,9 +1390,13 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
-  />
+    className="form-group field field-null"
+  >
+    <div
+      className="chakra-form-control emotion-0"
+      role="group"
+    />
+  </div>
   <div
     className="emotion-1"
   >
@@ -1403,29 +1455,33 @@ exports[`single fields number field 0 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-number"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
-      <input
-        autoFocus={false}
-        className="chakra-input emotion-0"
-        disabled={false}
-        id="root"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        required={false}
-        step="any"
-        type="number"
-        value={0}
-      />
+      <div
+        className="chakra-form-control emotion-1"
+        role="group"
+      >
+        <input
+          autoFocus={false}
+          className="chakra-input emotion-0"
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          required={false}
+          step="any"
+          type="number"
+          value={0}
+        />
+      </div>
     </div>
   </div>
   <div
@@ -1486,29 +1542,33 @@ exports[`single fields number field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-number"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
-      <input
-        autoFocus={false}
-        className="chakra-input emotion-0"
-        disabled={false}
-        id="root"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        required={false}
-        step="any"
-        type="number"
-        value=""
-      />
+      <div
+        className="chakra-form-control emotion-1"
+        role="group"
+      >
+        <input
+          autoFocus={false}
+          className="chakra-input emotion-0"
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          required={false}
+          step="any"
+          type="number"
+          value=""
+        />
+      </div>
     </div>
   </div>
   <div
@@ -1569,28 +1629,32 @@ exports[`single fields password field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-string"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
-      <input
-        autoFocus={false}
-        className="chakra-input emotion-0"
-        disabled={false}
-        id="root"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        required={false}
-        type="password"
-        value=""
-      />
+      <div
+        className="chakra-form-control emotion-1"
+        role="group"
+      >
+        <input
+          autoFocus={false}
+          className="chakra-input emotion-0"
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          required={false}
+          type="password"
+          value=""
+        />
+      </div>
     </div>
   </div>
   <div
@@ -1715,125 +1779,129 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-boolean"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
-      <label
-        className="chakra-form__label emotion-2"
-        htmlFor="root"
-        id="root-label"
-      />
       <div
-        className="chakra-radio-group emotion-0"
-        onBlur={[Function]}
-        onFocus={[Function]}
-        role="radiogroup"
+        className="chakra-form-control emotion-1"
+        role="group"
       >
+        <label
+          className="chakra-form__label emotion-2"
+          htmlFor="root"
+          id="root-label"
+        />
         <div
-          className="chakra-stack emotion-4"
+          className="chakra-radio-group emotion-0"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          role="radiogroup"
         >
-          <label
-            className="chakra-radio emotion-5"
+          <div
+            className="chakra-stack emotion-4"
           >
-            <input
-              checked={false}
-              className="chakra-radio__input"
-              disabled={false}
-              id="root-radio-true"
-              name="root"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              readOnly={false}
-              required={false}
-              style={
-                Object {
-                  "border": "0px",
-                  "clip": "rect(0px, 0px, 0px, 0px)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0px",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
-                }
-              }
-              type="radio"
-              value="true"
-            />
-            <span
-              aria-hidden={true}
-              className="chakra-radio__control emotion-6"
-              disabled={false}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-            />
-            <span
-              className="chakra-radio__label emotion-7"
-              onMouseDown={[Function]}
-              onTouchStart={[Function]}
+            <label
+              className="chakra-radio emotion-5"
             >
-              Yes
-            </span>
-          </label>
-          <label
-            className="chakra-radio emotion-5"
-          >
-            <input
-              checked={false}
-              className="chakra-radio__input"
-              disabled={false}
-              id="root-radio-false"
-              name="root"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              readOnly={false}
-              required={false}
-              style={
-                Object {
-                  "border": "0px",
-                  "clip": "rect(0px, 0px, 0px, 0px)",
-                  "height": "1px",
-                  "margin": "-1px",
-                  "overflow": "hidden",
-                  "padding": "0px",
-                  "position": "absolute",
-                  "whiteSpace": "nowrap",
-                  "width": "1px",
+              <input
+                checked={false}
+                className="chakra-radio__input"
+                disabled={false}
+                id="root-radio-true"
+                name="root"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                readOnly={false}
+                required={false}
+                style={
+                  Object {
+                    "border": "0px",
+                    "clip": "rect(0px, 0px, 0px, 0px)",
+                    "height": "1px",
+                    "margin": "-1px",
+                    "overflow": "hidden",
+                    "padding": "0px",
+                    "position": "absolute",
+                    "whiteSpace": "nowrap",
+                    "width": "1px",
+                  }
                 }
-              }
-              type="radio"
-              value="false"
-            />
-            <span
-              aria-hidden={true}
-              className="chakra-radio__control emotion-6"
-              disabled={false}
-              onMouseDown={[Function]}
-              onMouseEnter={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-            />
-            <span
-              className="chakra-radio__label emotion-7"
-              onMouseDown={[Function]}
-              onTouchStart={[Function]}
+                type="radio"
+                value="true"
+              />
+              <span
+                aria-hidden={true}
+                className="chakra-radio__control emotion-6"
+                disabled={false}
+                onMouseDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+              />
+              <span
+                className="chakra-radio__label emotion-7"
+                onMouseDown={[Function]}
+                onTouchStart={[Function]}
+              >
+                Yes
+              </span>
+            </label>
+            <label
+              className="chakra-radio emotion-5"
             >
-              No
-            </span>
-          </label>
+              <input
+                checked={false}
+                className="chakra-radio__input"
+                disabled={false}
+                id="root-radio-false"
+                name="root"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                readOnly={false}
+                required={false}
+                style={
+                  Object {
+                    "border": "0px",
+                    "clip": "rect(0px, 0px, 0px, 0px)",
+                    "height": "1px",
+                    "margin": "-1px",
+                    "overflow": "hidden",
+                    "padding": "0px",
+                    "position": "absolute",
+                    "whiteSpace": "nowrap",
+                    "width": "1px",
+                  }
+                }
+                type="radio"
+                value="false"
+              />
+              <span
+                aria-hidden={true}
+                className="chakra-radio__control emotion-6"
+                disabled={false}
+                onMouseDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+              />
+              <span
+                className="chakra-radio__label emotion-7"
+                onMouseDown={[Function]}
+                onTouchStart={[Function]}
+              >
+                No
+              </span>
+            </label>
+          </div>
         </div>
       </div>
     </div>
@@ -1936,67 +2004,71 @@ exports[`single fields select field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-string"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
       <div
-        className="chakra-select__wrapper emotion-2"
+        className="chakra-form-control emotion-1"
+        role="group"
       >
-        <select
-          autoFocus={false}
-          className="chakra-select emotion-3"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          readOnly={false}
-          required={false}
-          value=""
+        <div
+          className="chakra-select__wrapper emotion-2"
         >
-          <option
+          <select
+            autoFocus={false}
+            className="chakra-select emotion-3"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            readOnly={false}
+            required={false}
             value=""
           >
-             
-          </option>
-          <option
-            value="foo"
+            <option
+              value=""
+            >
+               
+            </option>
+            <option
+              value="foo"
+            >
+              foo
+            </option>
+            <option
+              value="bar"
+            >
+              bar
+            </option>
+          </select>
+          <div
+            className="chakra-select__icon-wrapper emotion-4"
           >
-            foo
-          </option>
-          <option
-            value="bar"
-          >
-            bar
-          </option>
-        </select>
-        <div
-          className="chakra-select__icon-wrapper emotion-4"
-        >
-          <svg
-            aria-hidden={true}
-            className="chakra-select__icon"
-            focusable={false}
-            role="presentation"
-            style={
-              Object {
-                "color": "currentColor",
-                "height": "1em",
-                "width": "1em",
+            <svg
+              aria-hidden={true}
+              className="chakra-select__icon"
+              focusable={false}
+              role="presentation"
+              style={
+                Object {
+                  "color": "currentColor",
+                  "height": "1em",
+                  "width": "1em",
+                }
               }
-            }
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
-              fill="currentColor"
-            />
-          </svg>
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                fill="currentColor"
+              />
+            </svg>
+          </div>
         </div>
       </div>
     </div>
@@ -2059,85 +2131,89 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-integer"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
       <div
-        className="chakra-slider emotion-0"
-        label=""
-        onBlur={[Function]}
-        onFocus={[Function]}
-        style={
-          Object {
-            "WebkitTapHighlightColor": "rgba(0,0,0,0)",
-            "outline": 0,
-            "paddingBottom": 0,
-            "paddingTop": 0,
-            "position": "relative",
-            "touchAction": "none",
-            "userSelect": "none",
-          }
-        }
-        tabIndex={-1}
+        className="chakra-form-control emotion-1"
+        role="group"
       >
         <div
-          className="chakra-slider__track emotion-0"
-          id="slider-track-root"
-          style={
-            Object {
-              "position": "absolute",
-              "top": "50%",
-              "transform": "translateY(-50%)",
-              "width": "100%",
-            }
-          }
-        >
-          <div
-            className="chakra-slider__filled-track emotion-0"
-            style={
-              Object {
-                "left": "0%",
-                "position": "absolute",
-                "top": "50%",
-                "transform": "translateY(-50%)",
-                "width": "56.89655172413793%",
-              }
-            }
-          />
-        </div>
-        <div
-          aria-orientation="horizontal"
-          aria-valuemax={100}
-          aria-valuemin={42}
-          aria-valuenow={75}
-          className="chakra-slider__thumb emotion-0"
-          id="slider-thumb-root"
+          className="chakra-slider emotion-0"
+          label=""
           onBlur={[Function]}
           onFocus={[Function]}
-          onKeyDown={[Function]}
-          role="slider"
           style={
             Object {
-              "MozUserSelect": "none",
-              "WebkitUserSelect": "none",
-              "left": "calc(56.89655172413793% - 0px)",
-              "msUserSelect": "none",
-              "position": "absolute",
+              "WebkitTapHighlightColor": "rgba(0,0,0,0)",
+              "outline": 0,
+              "paddingBottom": 0,
+              "paddingTop": 0,
+              "position": "relative",
               "touchAction": "none",
               "userSelect": "none",
             }
           }
-          tabIndex={0}
-        />
-        <input
-          name="root"
-          type="hidden"
-          value={75}
-        />
+          tabIndex={-1}
+        >
+          <div
+            className="chakra-slider__track emotion-0"
+            id="slider-track-root"
+            style={
+              Object {
+                "position": "absolute",
+                "top": "50%",
+                "transform": "translateY(-50%)",
+                "width": "100%",
+              }
+            }
+          >
+            <div
+              className="chakra-slider__filled-track emotion-0"
+              style={
+                Object {
+                  "left": "0%",
+                  "position": "absolute",
+                  "top": "50%",
+                  "transform": "translateY(-50%)",
+                  "width": "56.89655172413793%",
+                }
+              }
+            />
+          </div>
+          <div
+            aria-orientation="horizontal"
+            aria-valuemax={100}
+            aria-valuemin={42}
+            aria-valuenow={75}
+            className="chakra-slider__thumb emotion-0"
+            id="slider-thumb-root"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role="slider"
+            style={
+              Object {
+                "MozUserSelect": "none",
+                "WebkitUserSelect": "none",
+                "left": "calc(56.89655172413793% - 0px)",
+                "msUserSelect": "none",
+                "position": "absolute",
+                "touchAction": "none",
+                "userSelect": "none",
+              }
+            }
+            tabIndex={0}
+          />
+          <input
+            name="root"
+            type="hidden"
+            value={75}
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -2195,20 +2271,24 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-string"
   >
-    <div>
-      <p>
-        <input
-          autoFocus={false}
-          defaultValue=""
-          disabled={false}
-          id="root"
-          onChange={[Function]}
-          type="file"
-        />
-      </p>
+    <div
+      className="chakra-form-control emotion-0"
+      role="group"
+    >
+      <div>
+        <p>
+          <input
+            autoFocus={false}
+            defaultValue=""
+            disabled={false}
+            id="root"
+            onChange={[Function]}
+            type="file"
+          />
+        </p>
+      </div>
     </div>
   </div>
   <div
@@ -2269,28 +2349,32 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-string"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
-      <input
-        autoFocus={false}
-        className="chakra-input emotion-0"
-        disabled={false}
-        id="root"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        required={false}
-        type="email"
-        value=""
-      />
+      <div
+        className="chakra-form-control emotion-1"
+        role="group"
+      >
+        <input
+          autoFocus={false}
+          className="chakra-input emotion-0"
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          required={false}
+          type="email"
+          value=""
+        />
+      </div>
     </div>
   </div>
   <div
@@ -2351,28 +2435,32 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-string"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
-      <input
-        autoFocus={false}
-        className="chakra-input emotion-0"
-        disabled={false}
-        id="root"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        required={false}
-        type="url"
-        value=""
-      />
+      <div
+        className="chakra-form-control emotion-1"
+        role="group"
+      >
+        <input
+          autoFocus={false}
+          className="chakra-input emotion-0"
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          required={false}
+          type="url"
+          value=""
+        />
+      </div>
     </div>
   </div>
   <div
@@ -2433,28 +2521,32 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-string"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
-      <input
-        autoFocus={false}
-        className="chakra-input emotion-0"
-        disabled={false}
-        id="root"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        required={false}
-        type="text"
-        value=""
-      />
+      <div
+        className="chakra-form-control emotion-1"
+        role="group"
+      >
+        <input
+          autoFocus={false}
+          className="chakra-input emotion-0"
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          required={false}
+          type="text"
+          value=""
+        />
+      </div>
     </div>
   </div>
   <div
@@ -2515,28 +2607,32 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-string"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
-      <input
-        autoFocus={false}
-        className="chakra-input emotion-0"
-        disabled={false}
-        id="root"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder="placeholder"
-        readOnly={false}
-        required={false}
-        type="text"
-        value=""
-      />
+      <div
+        className="chakra-form-control emotion-1"
+        role="group"
+      >
+        <input
+          autoFocus={false}
+          className="chakra-input emotion-0"
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder="placeholder"
+          readOnly={false}
+          required={false}
+          type="text"
+          value=""
+        />
+      </div>
     </div>
   </div>
   <div
@@ -2597,27 +2693,31 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-string"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
-      <textarea
-        autoFocus={false}
-        className="chakra-textarea emotion-0"
-        disabled={false}
-        id="root"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        required={false}
-        value=""
-      />
+      <div
+        className="chakra-form-control emotion-1"
+        role="group"
+      >
+        <textarea
+          autoFocus={false}
+          className="chakra-textarea emotion-0"
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          required={false}
+          value=""
+        />
+      </div>
     </div>
   </div>
   <div
@@ -2700,59 +2800,67 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-object"
   >
     <div
-      className="emotion-1"
-      id="root-title"
-    >
-      <h5
-        className="chakra-heading emotion-0"
-      >
-        Titre 1
-      </h5>
-      <hr
-        aria-orientation="horizontal"
-        className="chakra-divider emotion-3"
-      />
-    </div>
-    <div
-      className="emotion-4"
+      className="chakra-form-control emotion-0"
+      role="group"
     >
       <div
-        className="emotion-0"
+        className="emotion-1"
+        id="root-title"
+      >
+        <h5
+          className="chakra-heading emotion-0"
+        >
+          Titre 1
+        </h5>
+        <hr
+          aria-orientation="horizontal"
+          className="chakra-divider emotion-3"
+        />
+      </div>
+      <div
+        className="emotion-4"
       >
         <div
-          className="chakra-form-control emotion-0"
-          role="group"
+          className="emotion-0"
         >
           <div
-            className="chakra-form-control emotion-7"
-            role="group"
+            className="form-group field field-string"
           >
-            <label
-              className="chakra-form__label emotion-8"
-              htmlFor="root_title"
-              id="root_title-label"
+            <div
+              className="chakra-form-control emotion-0"
+              role="group"
             >
-              title
-            </label>
-            <input
-              autoFocus={false}
-              className="chakra-input emotion-0"
-              disabled={false}
-              id="root_title"
-              name="root_title"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              placeholder=""
-              readOnly={false}
-              required={false}
-              type="text"
-              value=""
-            />
+              <div
+                className="chakra-form-control emotion-7"
+                role="group"
+              >
+                <label
+                  className="chakra-form__label emotion-8"
+                  htmlFor="root_title"
+                  id="root_title-label"
+                >
+                  title
+                </label>
+                <input
+                  autoFocus={false}
+                  className="chakra-input emotion-0"
+                  disabled={false}
+                  id="root_title"
+                  name="root_title"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -2812,30 +2920,34 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-undefined"
   >
     <div
-      className="unsupported-field"
+      className="chakra-form-control emotion-0"
+      role="group"
     >
-      <p>
-        Unsupported field schema
-        <span>
-           for
-           field 
-          <code>
-            root
-          </code>
-        </span>
-        <em>
-          : 
-          Unknown field type undefined
-        </em>
-        .
-      </p>
-      <pre>
-        {}
-      </pre>
+      <div
+        className="unsupported-field"
+      >
+        <p>
+          Unsupported field schema
+          <span>
+             for
+             field 
+            <code>
+              root
+            </code>
+          </span>
+          <em>
+            : 
+            Unknown field type undefined
+          </em>
+          .
+        </p>
+        <pre>
+          {}
+        </pre>
+      </div>
     </div>
   </div>
   <div
@@ -2959,85 +3071,89 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-number"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
       <div
-        className="chakra-numberinput emotion-2"
-        value=""
+        className="chakra-form-control emotion-1"
+        role="group"
       >
-        <input
-          aria-readonly={false}
-          aria-required={false}
-          aria-valuemax={9007199254740991}
-          aria-valuemin={-9007199254740991}
-          autoComplete="off"
-          autoCorrect="off"
-          className="chakra-numberinput__field emotion-3"
-          disabled={false}
-          id="root"
-          inputMode="decimal"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          pattern="[0-9]*(.[0-9]+)?"
-          readOnly={false}
-          required={false}
-          role="spinbutton"
-          type="text"
-          value=""
-        />
         <div
-          aria-hidden={true}
-          className="emotion-4"
+          className="chakra-numberinput emotion-2"
+          value=""
         >
-          <div
-            className="emotion-5"
+          <input
+            aria-readonly={false}
+            aria-required={false}
+            aria-valuemax={9007199254740991}
+            aria-valuemin={-9007199254740991}
+            autoComplete="off"
+            autoCorrect="off"
+            className="chakra-numberinput__field emotion-3"
             disabled={false}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            role="button"
-            tabIndex={-1}
-          >
-            <svg
-              className="chakra-icon emotion-6"
-              focusable={false}
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M12.8,5.4c-0.377-0.504-1.223-0.504-1.6,0l-9,12c-0.228,0.303-0.264,0.708-0.095,1.047 C2.275,18.786,2.621,19,3,19h18c0.379,0,0.725-0.214,0.895-0.553c0.169-0.339,0.133-0.744-0.095-1.047L12.8,5.4z"
-                fill="currentColor"
-              />
-            </svg>
-          </div>
+            id="root"
+            inputMode="decimal"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            pattern="[0-9]*(.[0-9]+)?"
+            readOnly={false}
+            required={false}
+            role="spinbutton"
+            type="text"
+            value=""
+          />
           <div
-            className="emotion-5"
-            disabled={false}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            role="button"
-            tabIndex={-1}
+            aria-hidden={true}
+            className="emotion-4"
           >
-            <svg
-              className="chakra-icon emotion-6"
-              focusable={false}
-              viewBox="0 0 24 24"
+            <div
+              className="emotion-5"
+              disabled={false}
+              onMouseDown={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              role="button"
+              tabIndex={-1}
             >
-              <path
-                d="M21,5H3C2.621,5,2.275,5.214,2.105,5.553C1.937,5.892,1.973,6.297,2.2,6.6l9,12 c0.188,0.252,0.485,0.4,0.8,0.4s0.611-0.148,0.8-0.4l9-12c0.228-0.303,0.264-0.708,0.095-1.047C21.725,5.214,21.379,5,21,5z"
-                fill="currentColor"
-              />
-            </svg>
+              <svg
+                className="chakra-icon emotion-6"
+                focusable={false}
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12.8,5.4c-0.377-0.504-1.223-0.504-1.6,0l-9,12c-0.228,0.303-0.264,0.708-0.095,1.047 C2.275,18.786,2.621,19,3,19h18c0.379,0,0.725-0.214,0.895-0.553c0.169-0.339,0.133-0.744-0.095-1.047L12.8,5.4z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+            <div
+              className="emotion-5"
+              disabled={false}
+              onMouseDown={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              role="button"
+              tabIndex={-1}
+            >
+              <svg
+                className="chakra-icon emotion-6"
+                focusable={false}
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M21,5H3C2.621,5,2.275,5.214,2.105,5.553C1.937,5.892,1.973,6.297,2.2,6.6l9,12 c0.188,0.252,0.485,0.4,0.8,0.4s0.611-0.148,0.8-0.4l9-12c0.228-0.303,0.264-0.708,0.095-1.047C21.725,5.214,21.379,5,21,5z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
           </div>
         </div>
       </div>
@@ -3101,28 +3217,32 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-string"
   >
     <div
-      className="chakra-form-control emotion-1"
+      className="chakra-form-control emotion-0"
       role="group"
     >
-      <input
-        autoFocus={false}
-        className="chakra-input emotion-0"
-        disabled={false}
-        id="root"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        placeholder=""
-        readOnly={false}
-        required={false}
-        type="text"
-        value=""
-      />
+      <div
+        className="chakra-form-control emotion-1"
+        role="group"
+      >
+        <input
+          autoFocus={false}
+          className="chakra-input emotion-0"
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          required={false}
+          type="text"
+          value=""
+        />
+      </div>
     </div>
   </div>
   <div

--- a/packages/chakra-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Object.test.tsx.snap
@@ -125,93 +125,126 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-object"
   >
-    
     <div
-      className="emotion-1"
+      className="chakra-form-control emotion-0"
+      role="group"
     >
+      
       <div
-        className="emotion-0"
+        className="emotion-1"
       >
         <div
-          className="emotion-3"
+          className="emotion-0"
         >
           <div
-            className="emotion-0"
+            className="form-group field field-string emotion-3"
           >
             <div
-              className="chakra-form-control emotion-0"
-              role="group"
-            >
-              <label
-                className="chakra-form__label emotion-6"
-                htmlFor="root_foo-key"
-                id="root_foo-key-label"
-              >
-                foo Key
-              </label>
-              <input
-                className="chakra-input emotion-7"
-                defaultValue="foo"
-                disabled={false}
-                id="root_foo-key"
-                name="root_foo-key"
-                onBlur={[Function]}
-                onFocus={[Function]}
-                readOnly={false}
-                required={false}
-                type="text"
-              />
-            </div>
-          </div>
-          <div
-            className="emotion-0"
-          >
-            <div
-              className="chakra-form-control emotion-0"
-              role="group"
+              className="emotion-0"
             >
               <div
-                className="chakra-form-control emotion-7"
+                className="chakra-form-control emotion-0"
                 role="group"
               >
                 <label
                   className="chakra-form__label emotion-6"
-                  htmlFor="root_foo"
-                  id="root_foo-label"
+                  htmlFor="root_foo-key"
+                  id="root_foo-key-label"
                 >
-                  foo
+                  foo Key
                 </label>
                 <input
-                  autoFocus={false}
-                  className="chakra-input emotion-0"
+                  className="chakra-input emotion-7"
+                  defaultValue="foo"
                   disabled={false}
-                  id="root_foo"
-                  name="root_foo"
+                  id="root_foo-key"
+                  name="root_foo-key"
                   onBlur={[Function]}
-                  onChange={[Function]}
                   onFocus={[Function]}
-                  placeholder=""
                   readOnly={false}
                   required={false}
                   type="text"
-                  value="foo"
                 />
               </div>
             </div>
+            <div
+              className="emotion-0"
+            >
+              <div
+                className="chakra-form-control emotion-0"
+                role="group"
+              >
+                <div
+                  className="chakra-form-control emotion-7"
+                  role="group"
+                >
+                  <label
+                    className="chakra-form__label emotion-6"
+                    htmlFor="root_foo"
+                    id="root_foo-label"
+                  >
+                    foo
+                  </label>
+                  <input
+                    autoFocus={false}
+                    className="chakra-input emotion-0"
+                    disabled={false}
+                    id="root_foo"
+                    name="root_foo"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    readOnly={false}
+                    required={false}
+                    type="text"
+                    value="foo"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              className="emotion-0"
+            >
+              <button
+                aria-label="Remove"
+                className="chakra-button emotion-14"
+                disabled={false}
+                onClick={[Function]}
+                title="Remove"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="chakra-icon emotion-15"
+                  focusable={false}
+                  viewBox="0 0 24 24"
+                >
+                  <g
+                    fill="currentColor"
+                  >
+                    <path
+                      d="M19.452 7.5H4.547a.5.5 0 00-.5.545l1.287 14.136A2 2 0 007.326 24h9.347a2 2 0 001.992-1.819L19.95 8.045a.5.5 0 00-.129-.382.5.5 0 00-.369-.163zm-9.2 13a.75.75 0 01-1.5 0v-9a.75.75 0 011.5 0zm5 0a.75.75 0 01-1.5 0v-9a.75.75 0 011.5 0zM22 4h-4.75a.25.25 0 01-.25-.25V2.5A2.5 2.5 0 0014.5 0h-5A2.5 2.5 0 007 2.5v1.25a.25.25 0 01-.25.25H2a1 1 0 000 2h20a1 1 0 000-2zM9 3.75V2.5a.5.5 0 01.5-.5h5a.5.5 0 01.5.5v1.25a.25.25 0 01-.25.25h-5.5A.25.25 0 019 3.75z"
+                    />
+                  </g>
+                </svg>
+              </button>
+            </div>
           </div>
-          <div
-            className="emotion-0"
+        </div>
+        <div
+          className="emotion-16"
+        >
+          <button
+            className="chakra-button object-property-expand emotion-17"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
           >
-            <button
-              aria-label="Remove"
-              className="chakra-button emotion-14"
-              disabled={false}
-              onClick={[Function]}
-              title="Remove"
-              type="button"
+            <span
+              className="chakra-button__icon emotion-18"
             >
               <svg
                 aria-hidden={true}
@@ -219,44 +252,15 @@ exports[`object fields additionalProperties 1`] = `
                 focusable={false}
                 viewBox="0 0 24 24"
               >
-                <g
+                <path
+                  d="M0,12a1.5,1.5,0,0,0,1.5,1.5h8.75a.25.25,0,0,1,.25.25V22.5a1.5,1.5,0,0,0,3,0V13.75a.25.25,0,0,1,.25-.25H22.5a1.5,1.5,0,0,0,0-3H13.75a.25.25,0,0,1-.25-.25V1.5a1.5,1.5,0,0,0-3,0v8.75a.25.25,0,0,1-.25.25H1.5A1.5,1.5,0,0,0,0,12Z"
                   fill="currentColor"
-                >
-                  <path
-                    d="M19.452 7.5H4.547a.5.5 0 00-.5.545l1.287 14.136A2 2 0 007.326 24h9.347a2 2 0 001.992-1.819L19.95 8.045a.5.5 0 00-.129-.382.5.5 0 00-.369-.163zm-9.2 13a.75.75 0 01-1.5 0v-9a.75.75 0 011.5 0zm5 0a.75.75 0 01-1.5 0v-9a.75.75 0 011.5 0zM22 4h-4.75a.25.25 0 01-.25-.25V2.5A2.5 2.5 0 0014.5 0h-5A2.5 2.5 0 007 2.5v1.25a.25.25 0 01-.25.25H2a1 1 0 000 2h20a1 1 0 000-2zM9 3.75V2.5a.5.5 0 01.5-.5h5a.5.5 0 01.5.5v1.25a.25.25 0 01-.25.25h-5.5A.25.25 0 019 3.75z"
-                  />
-                </g>
+                />
               </svg>
-            </button>
-          </div>
+            </span>
+            Add Item
+          </button>
         </div>
-      </div>
-      <div
-        className="emotion-16"
-      >
-        <button
-          className="chakra-button object-property-expand emotion-17"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-        >
-          <span
-            className="chakra-button__icon emotion-18"
-          >
-            <svg
-              aria-hidden={true}
-              className="chakra-icon emotion-15"
-              focusable={false}
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M0,12a1.5,1.5,0,0,0,1.5,1.5h8.75a.25.25,0,0,1,.25.25V22.5a1.5,1.5,0,0,0,3,0V13.75a.25.25,0,0,1,.25-.25H22.5a1.5,1.5,0,0,0,0-3H13.75a.25.25,0,0,1-.25-.25V1.5a1.5,1.5,0,0,0-3,0v8.75a.25.25,0,0,1-.25.25H1.5A1.5,1.5,0,0,0,0,12Z"
-                fill="currentColor"
-              />
-            </svg>
-          </span>
-          Add Item
-        </button>
       </div>
     </div>
   </div>
@@ -329,83 +333,95 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="chakra-form-control emotion-0"
-    role="group"
+    className="form-group field field-object"
   >
-    
     <div
-      className="emotion-1"
+      className="chakra-form-control emotion-0"
+      role="group"
     >
+      
       <div
-        className="emotion-0"
+        className="emotion-1"
       >
         <div
-          className="chakra-form-control emotion-0"
-          role="group"
+          className="emotion-0"
         >
           <div
-            className="chakra-form-control emotion-4"
-            role="group"
+            className="form-group field field-string"
           >
-            <label
-              className="chakra-form__label emotion-5"
-              htmlFor="root_a"
-              id="root_a-label"
+            <div
+              className="chakra-form-control emotion-0"
+              role="group"
             >
-              A
-            </label>
-            <input
-              autoFocus={false}
-              className="chakra-input emotion-0"
-              disabled={false}
-              id="root_a"
-              name="root_a"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              placeholder=""
-              readOnly={false}
-              required={false}
-              type="text"
-              value=""
-            />
+              <div
+                className="chakra-form-control emotion-4"
+                role="group"
+              >
+                <label
+                  className="chakra-form__label emotion-5"
+                  htmlFor="root_a"
+                  id="root_a-label"
+                >
+                  A
+                </label>
+                <input
+                  autoFocus={false}
+                  className="chakra-input emotion-0"
+                  disabled={false}
+                  id="root_a"
+                  name="root_a"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-      <div
-        className="emotion-0"
-      >
         <div
-          className="chakra-form-control emotion-0"
-          role="group"
+          className="emotion-0"
         >
           <div
-            className="chakra-form-control emotion-4"
-            role="group"
+            className="form-group field field-number"
           >
-            <label
-              className="chakra-form__label emotion-5"
-              htmlFor="root_b"
-              id="root_b-label"
+            <div
+              className="chakra-form-control emotion-0"
+              role="group"
             >
-              B
-            </label>
-            <input
-              autoFocus={false}
-              className="chakra-input emotion-0"
-              disabled={false}
-              id="root_b"
-              name="root_b"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              placeholder=""
-              readOnly={false}
-              required={false}
-              step="any"
-              type="number"
-              value=""
-            />
+              <div
+                className="chakra-form-control emotion-4"
+                role="group"
+              >
+                <label
+                  className="chakra-form__label emotion-5"
+                  htmlFor="root_b"
+                  id="root_b-label"
+                >
+                  B
+                </label>
+                <input
+                  autoFocus={false}
+                  className="chakra-input emotion-0"
+                  disabled={false}
+                  id="root_b"
+                  name="root_b"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  step="any"
+                  type="number"
+                  value=""
+                />
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/material-ui/src/FieldTemplate/WrapIfAdditional.tsx
+++ b/packages/material-ui/src/FieldTemplate/WrapIfAdditional.tsx
@@ -21,6 +21,7 @@ type WrapIfAdditionalProps = { children: React.ReactElement } & Pick<
 
 const WrapIfAdditional = ({
   children,
+  classNames,
   disabled,
   id,
   label,
@@ -42,15 +43,21 @@ const WrapIfAdditional = ({
   };
 
   if (!additional) {
-    return <>{children}</>;
+    return <div className={classNames}>{children}</div>;
   }
 
   const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
     onKeyChange(target.value);
 
   return (
-    <Grid container={true} key={`${id}-key`} alignItems="center" spacing={2}>
-      <Grid item={true} xs>
+    <Grid
+      container
+      key={`${id}-key`}
+      alignItems="center"
+      spacing={2}
+      className={classNames}
+    >
+      <Grid item xs>
         <FormControl fullWidth={true} required={required}>
           <InputLabel>{keyLabel}</InputLabel>
           <Input

--- a/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
@@ -7,60 +7,64 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-array"
   >
     <div
-      className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiBox-root MuiBox-root-1"
+        className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
       >
         <div
-          className="MuiGrid-root MuiGrid-container"
+          className="MuiBox-root MuiBox-root-1"
         >
           <div
-            className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
+            className="MuiGrid-root MuiGrid-container"
           >
             <div
-              className="MuiGrid-root MuiGrid-item"
+              className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
             >
               <div
-                className="MuiBox-root MuiBox-root-2"
+                className="MuiGrid-root MuiGrid-item"
               >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorSecondary"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  tabIndex={0}
-                  title="Add Item"
-                  type="button"
+                <div
+                  className="MuiBox-root MuiBox-root-2"
                 >
-                  <span
-                    className="MuiIconButton-label"
+                  <button
+                    className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorSecondary"
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    tabIndex={0}
+                    title="Add Item"
+                    type="button"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root"
-                      focusable="false"
-                      viewBox="0 0 24 24"
+                    <span
+                      className="MuiIconButton-label"
                     >
-                      <path
-                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                      />
-                    </svg>
-                  </span>
-                </button>
+                      <svg
+                        aria-hidden={true}
+                        className="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -105,412 +109,124 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-array"
   >
     <div
-      className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiBox-root MuiBox-root-11"
+        className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
       >
         <div
-          className="MuiGrid-root MuiGrid-container"
+          className="MuiBox-root MuiBox-root-11"
         >
           <div
-            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+            className="MuiGrid-root MuiGrid-container"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-              style={
-                Object {
-                  "overflow": "auto",
-                }
-              }
+              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
             >
               <div
-                className="MuiBox-root MuiBox-root-12"
+                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+                style={
+                  Object {
+                    "overflow": "auto",
+                  }
+                }
               >
                 <div
-                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                  className="MuiBox-root MuiBox-root-12"
                 >
                   <div
-                    className="MuiBox-root MuiBox-root-13"
+                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                   >
                     <div
-                      className="MuiFormControl-root MuiFormControl-fullWidth"
+                      className="MuiBox-root MuiBox-root-13"
                     >
                       <div
-                        className="MuiFormControl-root MuiTextField-root"
+                        className="form-group field field-string"
                       >
                         <div
-                          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                          onClick={[Function]}
+                          className="MuiFormControl-root MuiFormControl-fullWidth"
                         >
-                          <input
-                            aria-invalid={false}
-                            autoFocus={false}
-                            className="MuiInputBase-input MuiInput-input"
-                            disabled={false}
-                            id="root_0"
-                            onAnimationStart={[Function]}
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            onFocus={[Function]}
-                            placeholder=""
-                            required={true}
-                            type="text"
-                            value="a"
-                          />
+                          <div
+                            className="MuiFormControl-root MuiTextField-root"
+                          >
+                            <div
+                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                              onClick={[Function]}
+                            >
+                              <input
+                                aria-invalid={false}
+                                autoFocus={false}
+                                className="MuiInputBase-input MuiInput-input"
+                                disabled={false}
+                                id="root_0"
+                                onAnimationStart={[Function]}
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder=""
+                                required={true}
+                                type="text"
+                                value="a"
+                              />
+                            </div>
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              className="MuiGrid-root MuiGrid-item"
-            >
-              <button
-                className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
-                disabled={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onDragLeave={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                style={
-                  Object {
-                    "flex": 1,
-                    "fontWeight": "bold",
-                    "minWidth": 0,
-                    "paddingLeft": 6,
-                    "paddingRight": 6,
-                  }
-                }
-                tabIndex={-1}
-                title="Move up"
-                type="button"
-              >
-                <span
-                  className="MuiIconButton-label"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                    />
-                  </svg>
-                </span>
-              </button>
-              <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onDragLeave={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                style={
-                  Object {
-                    "flex": 1,
-                    "fontWeight": "bold",
-                    "minWidth": 0,
-                    "paddingLeft": 6,
-                    "paddingRight": 6,
-                  }
-                }
-                tabIndex={0}
-                title="Move down"
-                type="button"
-              >
-                <span
-                  className="MuiIconButton-label"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                    />
-                  </svg>
-                </span>
-                <span
-                  className="MuiTouchRipple-root"
-                />
-              </button>
-              <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onDragLeave={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                style={
-                  Object {
-                    "flex": 1,
-                    "fontWeight": "bold",
-                    "minWidth": 0,
-                    "paddingLeft": 6,
-                    "paddingRight": 6,
-                  }
-                }
-                tabIndex={0}
-                title="Remove"
-                type="button"
-              >
-                <span
-                  className="MuiIconButton-label"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M19 13H5v-2h14v2z"
-                    />
-                  </svg>
-                </span>
-                <span
-                  className="MuiTouchRipple-root"
-                />
-              </button>
-            </div>
-          </div>
-          <div
-            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
-          >
-            <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-              style={
-                Object {
-                  "overflow": "auto",
-                }
-              }
-            >
               <div
-                className="MuiBox-root MuiBox-root-14"
-              >
-                <div
-                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
-                >
-                  <div
-                    className="MuiBox-root MuiBox-root-15"
-                  >
-                    <div
-                      className="MuiFormControl-root MuiFormControl-fullWidth"
-                    >
-                      <div
-                        className="MuiFormControl-root MuiTextField-root"
-                      >
-                        <div
-                          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                          onClick={[Function]}
-                        >
-                          <input
-                            aria-invalid={false}
-                            autoFocus={false}
-                            className="MuiInputBase-input MuiInput-input"
-                            disabled={false}
-                            id="root_1"
-                            onAnimationStart={[Function]}
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            onFocus={[Function]}
-                            placeholder=""
-                            required={true}
-                            type="text"
-                            value="b"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              className="MuiGrid-root MuiGrid-item"
-            >
-              <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onDragLeave={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                style={
-                  Object {
-                    "flex": 1,
-                    "fontWeight": "bold",
-                    "minWidth": 0,
-                    "paddingLeft": 6,
-                    "paddingRight": 6,
-                  }
-                }
-                tabIndex={0}
-                title="Move up"
-                type="button"
-              >
-                <span
-                  className="MuiIconButton-label"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                    />
-                  </svg>
-                </span>
-                <span
-                  className="MuiTouchRipple-root"
-                />
-              </button>
-              <button
-                className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
-                disabled={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onDragLeave={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                style={
-                  Object {
-                    "flex": 1,
-                    "fontWeight": "bold",
-                    "minWidth": 0,
-                    "paddingLeft": 6,
-                    "paddingRight": 6,
-                  }
-                }
-                tabIndex={-1}
-                title="Move down"
-                type="button"
-              >
-                <span
-                  className="MuiIconButton-label"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                    />
-                  </svg>
-                </span>
-              </button>
-              <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onDragLeave={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                style={
-                  Object {
-                    "flex": 1,
-                    "fontWeight": "bold",
-                    "minWidth": 0,
-                    "paddingLeft": 6,
-                    "paddingRight": 6,
-                  }
-                }
-                tabIndex={0}
-                title="Remove"
-                type="button"
-              >
-                <span
-                  className="MuiIconButton-label"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M19 13H5v-2h14v2z"
-                    />
-                  </svg>
-                </span>
-                <span
-                  className="MuiTouchRipple-root"
-                />
-              </button>
-            </div>
-          </div>
-          <div
-            className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
-          >
-            <div
-              className="MuiGrid-root MuiGrid-item"
-            >
-              <div
-                className="MuiBox-root MuiBox-root-16"
+                className="MuiGrid-root MuiGrid-item"
               >
                 <button
-                  className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorSecondary"
+                  className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
+                  disabled={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "flex": 1,
+                      "fontWeight": "bold",
+                      "minWidth": 0,
+                      "paddingLeft": 6,
+                      "paddingRight": 6,
+                    }
+                  }
+                  tabIndex={-1}
+                  title="Move up"
+                  type="button"
+                >
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
                   disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -524,8 +240,17 @@ exports[`array fields array icons 1`] = `
                   onTouchEnd={[Function]}
                   onTouchMove={[Function]}
                   onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "flex": 1,
+                      "fontWeight": "bold",
+                      "minWidth": 0,
+                      "paddingLeft": 6,
+                      "paddingRight": 6,
+                    }
+                  }
                   tabIndex={0}
-                  title="Add Item"
+                  title="Move down"
                   type="button"
                 >
                   <span
@@ -533,12 +258,12 @@ exports[`array fields array icons 1`] = `
                   >
                     <svg
                       aria-hidden={true}
-                      className="MuiSvgIcon-root"
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 24 24"
                     >
                       <path
-                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                        d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
                       />
                     </svg>
                   </span>
@@ -546,6 +271,297 @@ exports[`array fields array icons 1`] = `
                     className="MuiTouchRipple-root"
                   />
                 </button>
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "flex": 1,
+                      "fontWeight": "bold",
+                      "minWidth": 0,
+                      "paddingLeft": 6,
+                      "paddingRight": 6,
+                    }
+                  }
+                  tabIndex={0}
+                  title="Remove"
+                  type="button"
+                >
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 13H5v-2h14v2z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
+            <div
+              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+            >
+              <div
+                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+                style={
+                  Object {
+                    "overflow": "auto",
+                  }
+                }
+              >
+                <div
+                  className="MuiBox-root MuiBox-root-14"
+                >
+                  <div
+                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                  >
+                    <div
+                      className="MuiBox-root MuiBox-root-15"
+                    >
+                      <div
+                        className="form-group field field-string"
+                      >
+                        <div
+                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                        >
+                          <div
+                            className="MuiFormControl-root MuiTextField-root"
+                          >
+                            <div
+                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                              onClick={[Function]}
+                            >
+                              <input
+                                aria-invalid={false}
+                                autoFocus={false}
+                                className="MuiInputBase-input MuiInput-input"
+                                disabled={false}
+                                id="root_1"
+                                onAnimationStart={[Function]}
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder=""
+                                required={true}
+                                type="text"
+                                value="b"
+                              />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="MuiGrid-root MuiGrid-item"
+              >
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "flex": 1,
+                      "fontWeight": "bold",
+                      "minWidth": 0,
+                      "paddingLeft": 6,
+                      "paddingRight": 6,
+                    }
+                  }
+                  tabIndex={0}
+                  title="Move up"
+                  type="button"
+                >
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
+                  />
+                </button>
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
+                  disabled={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "flex": 1,
+                      "fontWeight": "bold",
+                      "minWidth": 0,
+                      "paddingLeft": 6,
+                      "paddingRight": 6,
+                    }
+                  }
+                  tabIndex={-1}
+                  title="Move down"
+                  type="button"
+                >
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "flex": 1,
+                      "fontWeight": "bold",
+                      "minWidth": 0,
+                      "paddingLeft": 6,
+                      "paddingRight": 6,
+                    }
+                  }
+                  tabIndex={0}
+                  title="Remove"
+                  type="button"
+                >
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 13H5v-2h14v2z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
+                  />
+                </button>
+              </div>
+            </div>
+            <div
+              className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
+            >
+              <div
+                className="MuiGrid-root MuiGrid-item"
+              >
+                <div
+                  className="MuiBox-root MuiBox-root-16"
+                >
+                  <button
+                    className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorSecondary"
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    tabIndex={0}
+                    title="Add Item"
+                    type="button"
+                  >
+                    <span
+                      className="MuiIconButton-label"
+                    >
+                      <svg
+                        aria-hidden={true}
+                        className="MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      className="MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -593,55 +609,59 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-array"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root"
       >
         <div
-          aria-haspopup="listbox"
-          aria-labelledby="root"
-          className="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-          id="root"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseDown={[Function]}
-          role="button"
-          tabIndex={0}
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
         >
-          <span
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "&#8203;",
+          <div
+            aria-haspopup="listbox"
+            aria-labelledby="root"
+            className="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+            id="root"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "&#8203;",
+                }
               }
-            }
+            />
+          </div>
+          <input
+            aria-hidden={true}
+            autoFocus={false}
+            className="MuiSelect-nativeInput"
+            onAnimationStart={[Function]}
+            onChange={[Function]}
+            required={false}
+            tabIndex={-1}
+            value=""
           />
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSelect-icon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
         </div>
-        <input
-          aria-hidden={true}
-          autoFocus={false}
-          className="MuiSelect-nativeInput"
-          onAnimationStart={[Function]}
-          onChange={[Function]}
-          required={false}
-          tabIndex={-1}
-          value=""
-        />
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSelect-icon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M7 10l5 5 5-5z"
-          />
-        </svg>
       </div>
     </div>
   </div>
@@ -682,62 +702,70 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-array"
   >
     <div
-      className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiBox-root MuiBox-root-4"
+        className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
       >
         <div
-          className="MuiGrid-root MuiGrid-container"
+          className="MuiBox-root MuiBox-root-4"
         >
           <div
-            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+            className="MuiGrid-root MuiGrid-container"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-              style={
-                Object {
-                  "overflow": "auto",
-                }
-              }
+              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
             >
               <div
-                className="MuiBox-root MuiBox-root-5"
+                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+                style={
+                  Object {
+                    "overflow": "auto",
+                  }
+                }
               >
                 <div
-                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                  className="MuiBox-root MuiBox-root-5"
                 >
                   <div
-                    className="MuiBox-root MuiBox-root-6"
+                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                   >
                     <div
-                      className="MuiFormControl-root MuiFormControl-fullWidth"
+                      className="MuiBox-root MuiBox-root-6"
                     >
                       <div
-                        className="MuiFormControl-root MuiTextField-root"
+                        className="form-group field field-string"
                       >
                         <div
-                          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                          onClick={[Function]}
+                          className="MuiFormControl-root MuiFormControl-fullWidth"
                         >
-                          <input
-                            aria-invalid={false}
-                            autoFocus={false}
-                            className="MuiInputBase-input MuiInput-input"
-                            disabled={false}
-                            id="root_0"
-                            onAnimationStart={[Function]}
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            onFocus={[Function]}
-                            placeholder=""
-                            required={true}
-                            type="text"
-                            value=""
-                          />
+                          <div
+                            className="MuiFormControl-root MuiTextField-root"
+                          >
+                            <div
+                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                              onClick={[Function]}
+                            >
+                              <input
+                                aria-invalid={false}
+                                autoFocus={false}
+                                className="MuiInputBase-input MuiInput-input"
+                                disabled={false}
+                                id="root_0"
+                                onAnimationStart={[Function]}
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder=""
+                                required={true}
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -745,53 +773,57 @@ exports[`array fields fixed array 1`] = `
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
-          >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-              style={
-                Object {
-                  "overflow": "auto",
-                }
-              }
+              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
             >
               <div
-                className="MuiBox-root MuiBox-root-7"
+                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+                style={
+                  Object {
+                    "overflow": "auto",
+                  }
+                }
               >
                 <div
-                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                  className="MuiBox-root MuiBox-root-7"
                 >
                   <div
-                    className="MuiBox-root MuiBox-root-8"
+                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                   >
                     <div
-                      className="MuiFormControl-root MuiFormControl-fullWidth"
+                      className="MuiBox-root MuiBox-root-8"
                     >
                       <div
-                        className="MuiFormControl-root MuiTextField-root"
+                        className="form-group field field-number"
                       >
                         <div
-                          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                          onClick={[Function]}
+                          className="MuiFormControl-root MuiFormControl-fullWidth"
                         >
-                          <input
-                            aria-invalid={false}
-                            autoFocus={false}
-                            className="MuiInputBase-input MuiInput-input"
-                            disabled={false}
-                            id="root_1"
-                            onAnimationStart={[Function]}
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            onFocus={[Function]}
-                            placeholder=""
-                            required={true}
-                            step="any"
-                            type="number"
-                            value=""
-                          />
+                          <div
+                            className="MuiFormControl-root MuiTextField-root"
+                          >
+                            <div
+                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                              onClick={[Function]}
+                            >
+                              <input
+                                aria-invalid={false}
+                                autoFocus={false}
+                                className="MuiInputBase-input MuiInput-input"
+                                disabled={false}
+                                id="root_1"
+                                onAnimationStart={[Function]}
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder=""
+                                required={true}
+                                step="any"
+                                type="number"
+                                value=""
+                              />
+                            </div>
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -7,59 +7,63 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-boolean"
   >
-    <label
-      className="MuiFormControlLabel-root"
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
-      <span
-        aria-disabled={false}
-        className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-        onBlur={[Function]}
-        onDragLeave={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        tabIndex={null}
+      <label
+        className="MuiFormControlLabel-root"
       >
         <span
-          className="MuiIconButton-label"
+          aria-disabled={false}
+          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+          onBlur={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={null}
         >
-          <input
-            autoFocus={false}
-            checked={false}
-            className="PrivateSwitchBase-input-20"
-            data-indeterminate={false}
-            disabled={false}
-            id="root"
-            onChange={[Function]}
-            required={false}
-            type="checkbox"
-          />
-          <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root"
-            focusable="false"
-            viewBox="0 0 24 24"
+          <span
+            className="MuiIconButton-label"
           >
-            <path
-              d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+            <input
+              autoFocus={false}
+              checked={false}
+              className="PrivateSwitchBase-input-20"
+              data-indeterminate={false}
+              disabled={false}
+              id="root"
+              onChange={[Function]}
+              required={false}
+              type="checkbox"
             />
-          </svg>
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+          </span>
         </span>
-      </span>
-      <span
-        className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-      >
-        
-      </span>
-    </label>
+        <span
+          className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+        >
+          
+        </span>
+      </label>
+    </div>
   </div>
   <div
     className="MuiBox-root MuiBox-root-21"
@@ -98,62 +102,66 @@ exports[`single fields checkbox field 2`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-boolean"
   >
-    <label
-      className="MuiFormControlLabel-root"
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
-      <span
-        aria-disabled={false}
-        className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-        onBlur={[Function]}
-        onDragLeave={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        tabIndex={null}
+      <label
+        className="MuiFormControlLabel-root"
       >
         <span
-          className="MuiIconButton-label"
+          aria-disabled={false}
+          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+          onBlur={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={null}
         >
-          <input
-            autoFocus={false}
-            checked={false}
-            className="PrivateSwitchBase-input-20"
-            data-indeterminate={false}
-            disabled={false}
-            id="root"
-            onChange={[Function]}
-            required={false}
-            type="checkbox"
-          />
-          <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root"
-            focusable="false"
-            viewBox="0 0 24 24"
+          <span
+            className="MuiIconButton-label"
           >
-            <path
-              d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+            <input
+              autoFocus={false}
+              checked={false}
+              className="PrivateSwitchBase-input-20"
+              data-indeterminate={false}
+              disabled={false}
+              id="root"
+              onChange={[Function]}
+              required={false}
+              type="checkbox"
             />
-          </svg>
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+          </span>
+          <span
+            className="MuiTouchRipple-root"
+          />
         </span>
         <span
-          className="MuiTouchRipple-root"
-        />
-      </span>
-      <span
-        className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-      >
-        
-      </span>
-    </label>
+          className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+        >
+          
+        </span>
+      </label>
+    </div>
   </div>
   <div
     className="MuiBox-root MuiBox-root-22"
@@ -195,216 +203,220 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-array"
   >
-    <label
-      className="MuiFormLabel-root"
-      htmlFor="root"
-    />
     <div
-      className="MuiFormGroup-root"
-      id="root"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <label
-        className="MuiFormControlLabel-root"
+        className="MuiFormLabel-root"
+        htmlFor="root"
+      />
+      <div
+        className="MuiFormGroup-root"
+        id="root"
       >
-        <span
-          aria-disabled={false}
-          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-          onBlur={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
+        <label
+          className="MuiFormControlLabel-root"
         >
           <span
-            className="MuiIconButton-label"
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
           >
-            <input
-              autoFocus={false}
-              checked={false}
-              className="PrivateSwitchBase-input-20"
-              data-indeterminate={false}
-              disabled={false}
-              id="root_0"
-              onChange={[Function]}
-              type="checkbox"
-            />
-            <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <span
+              className="MuiIconButton-label"
             >
-              <path
-                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              <input
+                autoFocus={false}
+                checked={false}
+                className="PrivateSwitchBase-input-20"
+                data-indeterminate={false}
+                disabled={false}
+                id="root_0"
+                onChange={[Function]}
+                type="checkbox"
               />
-            </svg>
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
           </span>
-        </span>
-        <span
-          className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-        >
-          foo
-        </span>
-      </label>
-      <label
-        className="MuiFormControlLabel-root"
-      >
-        <span
-          aria-disabled={false}
-          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-          onBlur={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            foo
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root"
         >
           <span
-            className="MuiIconButton-label"
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
           >
-            <input
-              autoFocus={false}
-              checked={false}
-              className="PrivateSwitchBase-input-20"
-              data-indeterminate={false}
-              disabled={false}
-              id="root_1"
-              onChange={[Function]}
-              type="checkbox"
-            />
-            <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <span
+              className="MuiIconButton-label"
             >
-              <path
-                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              <input
+                autoFocus={false}
+                checked={false}
+                className="PrivateSwitchBase-input-20"
+                data-indeterminate={false}
+                disabled={false}
+                id="root_1"
+                onChange={[Function]}
+                type="checkbox"
               />
-            </svg>
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
           </span>
-        </span>
-        <span
-          className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-        >
-          bar
-        </span>
-      </label>
-      <label
-        className="MuiFormControlLabel-root"
-      >
-        <span
-          aria-disabled={false}
-          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-          onBlur={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            bar
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root"
         >
           <span
-            className="MuiIconButton-label"
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
           >
-            <input
-              autoFocus={false}
-              checked={false}
-              className="PrivateSwitchBase-input-20"
-              data-indeterminate={false}
-              disabled={false}
-              id="root_2"
-              onChange={[Function]}
-              type="checkbox"
-            />
-            <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <span
+              className="MuiIconButton-label"
             >
-              <path
-                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              <input
+                autoFocus={false}
+                checked={false}
+                className="PrivateSwitchBase-input-20"
+                data-indeterminate={false}
+                disabled={false}
+                id="root_2"
+                onChange={[Function]}
+                type="checkbox"
               />
-            </svg>
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
           </span>
-        </span>
-        <span
-          className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-        >
-          fuzz
-        </span>
-      </label>
-      <label
-        className="MuiFormControlLabel-root"
-      >
-        <span
-          aria-disabled={false}
-          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-          onBlur={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            fuzz
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root"
         >
           <span
-            className="MuiIconButton-label"
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
           >
-            <input
-              autoFocus={false}
-              checked={false}
-              className="PrivateSwitchBase-input-20"
-              data-indeterminate={false}
-              disabled={false}
-              id="root_3"
-              onChange={[Function]}
-              type="checkbox"
-            />
-            <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <span
+              className="MuiIconButton-label"
             >
-              <path
-                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              <input
+                autoFocus={false}
+                checked={false}
+                className="PrivateSwitchBase-input-20"
+                data-indeterminate={false}
+                disabled={false}
+                id="root_3"
+                onChange={[Function]}
+                type="checkbox"
               />
-            </svg>
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
           </span>
-        </span>
-        <span
-          className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-        >
-          qux
-        </span>
-      </label>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            qux
+          </span>
+        </label>
+      </div>
     </div>
   </div>
   <div
@@ -444,65 +456,73 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-object"
   >
-    
     <div
-      className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
-      style={
-        Object {
-          "marginTop": "10px",
-        }
-      }
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
+      
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
         style={
           Object {
-            "marginBottom": "10px",
+            "marginTop": "10px",
           }
         }
       >
         <div
-          className="MuiFormControl-root MuiFormControl-fullWidth"
+          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
           <div
-            className="MuiFormControl-root MuiTextField-root"
+            className="form-group field field-string"
           >
-            <label
-              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
-              data-shrink={false}
-              htmlFor="root_my-field"
-              id="root_my-field-label"
-            >
-              my-field
-            </label>
             <div
-              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-              onClick={[Function]}
+              className="MuiFormControl-root MuiFormControl-fullWidth"
             >
-              <input
-                aria-invalid={false}
-                autoFocus={false}
-                className="MuiInputBase-input MuiInput-input"
-                disabled={false}
-                id="root_my-field"
-                onAnimationStart={[Function]}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder=""
-                required={false}
-                type="text"
-                value=""
-              />
+              <div
+                className="MuiFormControl-root MuiTextField-root"
+              >
+                <label
+                  className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+                  data-shrink={false}
+                  htmlFor="root_my-field"
+                  id="root_my-field-label"
+                >
+                  my-field
+                </label>
+                <div
+                  className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                  onClick={[Function]}
+                >
+                  <input
+                    aria-invalid={false}
+                    autoFocus={false}
+                    className="MuiInputBase-input MuiInput-input"
+                    disabled={false}
+                    id="root_my-field"
+                    onAnimationStart={[Function]}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+              <span
+                className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+              >
+                some description
+              </span>
             </div>
           </div>
-          <span
-            className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-          >
-            some description
-          </span>
         </div>
       </div>
     </div>
@@ -544,65 +564,73 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-object"
   >
-    
     <div
-      className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
-      style={
-        Object {
-          "marginTop": "10px",
-        }
-      }
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
+      
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
         style={
           Object {
-            "marginBottom": "10px",
+            "marginTop": "10px",
           }
         }
       >
         <div
-          className="MuiFormControl-root MuiFormControl-fullWidth"
+          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
           <div
-            className="MuiFormControl-root MuiTextField-root"
+            className="form-group field field-string"
           >
-            <label
-              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
-              data-shrink={false}
-              htmlFor="root_my-field"
-              id="root_my-field-label"
-            >
-              my-field
-            </label>
             <div
-              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-              onClick={[Function]}
+              className="MuiFormControl-root MuiFormControl-fullWidth"
             >
-              <input
-                aria-invalid={false}
-                autoFocus={false}
-                className="MuiInputBase-input MuiInput-input"
-                disabled={false}
-                id="root_my-field"
-                onAnimationStart={[Function]}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder=""
-                required={false}
-                type="text"
-                value=""
-              />
+              <div
+                className="MuiFormControl-root MuiTextField-root"
+              >
+                <label
+                  className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+                  data-shrink={false}
+                  htmlFor="root_my-field"
+                  id="root_my-field-label"
+                >
+                  my-field
+                </label>
+                <div
+                  className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                  onClick={[Function]}
+                >
+                  <input
+                    aria-invalid={false}
+                    autoFocus={false}
+                    className="MuiInputBase-input MuiInput-input"
+                    disabled={false}
+                    id="root_my-field"
+                    onAnimationStart={[Function]}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+              <span
+                className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+              >
+                some other description
+              </span>
             </div>
           </div>
-          <span
-            className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-          >
-            some other description
-          </span>
         </div>
       </div>
     </div>
@@ -647,30 +675,34 @@ exports[`single fields format color 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="color"
-          value=""
-        />
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="color"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -714,30 +746,34 @@ exports[`single fields format date 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="date"
-          value=""
-        />
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="date"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -778,30 +814,34 @@ exports[`single fields format datetime 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="datetime-local"
-          value=""
-        />
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="datetime-local"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -845,22 +885,26 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-object"
   >
-    
     <div
-      className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
-      style={
-        Object {
-          "marginTop": "10px",
-        }
-      }
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
-      <input
-        id="root_my-field"
-        type="hidden"
-        value=""
-      />
+      
+      <div
+        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
+        style={
+          Object {
+            "marginTop": "10px",
+          }
+        }
+      >
+        <input
+          id="root_my-field"
+          type="hidden"
+          value=""
+        />
+      </div>
     </div>
   </div>
   <div
@@ -903,30 +947,34 @@ exports[`single fields hidden label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="text"
-          value=""
-        />
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -970,8 +1018,12 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
-  />
+    className="form-group field field-null"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth"
+    />
+  </div>
   <div
     className="MuiBox-root MuiBox-root-8"
   >
@@ -1012,31 +1064,35 @@ exports[`single fields number field 0 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-number"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          step="any"
-          type="number"
-          value={0}
-        />
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            step="any"
+            type="number"
+            value={0}
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1077,31 +1133,35 @@ exports[`single fields number field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-number"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          step="any"
-          type="number"
-          value=""
-        />
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            step="any"
+            type="number"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1145,30 +1205,34 @@ exports[`single fields password field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="password"
-          value=""
-        />
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="password"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1209,151 +1273,155 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-boolean"
   >
-    <label
-      className="MuiFormLabel-root"
-      htmlFor="root"
-    />
     <div
-      className="MuiFormGroup-root"
-      id="root"
-      onBlur={[Function]}
-      onFocus={[Function]}
-      role="radiogroup"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <label
-        className="MuiFormControlLabel-root"
+        className="MuiFormLabel-root"
+        htmlFor="root"
+      />
+      <div
+        className="MuiFormGroup-root"
+        id="root"
+        onBlur={[Function]}
+        onFocus={[Function]}
+        role="radiogroup"
       >
-        <span
-          aria-disabled={false}
-          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiRadio-root MuiRadio-colorPrimary MuiIconButton-colorPrimary"
-          onBlur={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
+        <label
+          className="MuiFormControlLabel-root"
         >
           <span
-            className="MuiIconButton-label"
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiRadio-root MuiRadio-colorPrimary MuiIconButton-colorPrimary"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
           >
-            <input
-              checked={false}
-              className="PrivateSwitchBase-input-20"
-              disabled={false}
-              name="root-0"
-              onChange={[Function]}
-              type="radio"
-              value="true"
-            />
-            <div
-              className="PrivateRadioButtonIcon-root-24"
+            <span
+              className="MuiIconButton-label"
             >
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <input
+                checked={false}
+                className="PrivateSwitchBase-input-20"
+                disabled={false}
+                name="root-0"
+                onChange={[Function]}
+                type="radio"
+                value="true"
+              />
+              <div
+                className="PrivateRadioButtonIcon-root-24"
               >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                />
-              </svg>
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-25"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                />
-              </svg>
-            </div>
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                  />
+                </svg>
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-25"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                  />
+                </svg>
+              </div>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
           </span>
           <span
-            className="MuiTouchRipple-root"
-          />
-        </span>
-        <span
-          className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-        >
-          Yes
-        </span>
-      </label>
-      <label
-        className="MuiFormControlLabel-root"
-      >
-        <span
-          aria-disabled={false}
-          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiRadio-root MuiRadio-colorPrimary MuiIconButton-colorPrimary"
-          onBlur={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            Yes
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root"
         >
           <span
-            className="MuiIconButton-label"
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiRadio-root MuiRadio-colorPrimary MuiIconButton-colorPrimary"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
           >
-            <input
-              checked={false}
-              className="PrivateSwitchBase-input-20"
-              disabled={false}
-              name="root-1"
-              onChange={[Function]}
-              type="radio"
-              value="false"
-            />
-            <div
-              className="PrivateRadioButtonIcon-root-24"
+            <span
+              className="MuiIconButton-label"
             >
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
+              <input
+                checked={false}
+                className="PrivateSwitchBase-input-20"
+                disabled={false}
+                name="root-1"
+                onChange={[Function]}
+                type="radio"
+                value="false"
+              />
+              <div
+                className="PrivateRadioButtonIcon-root-24"
               >
-                <path
-                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-                />
-              </svg>
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-25"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-                />
-              </svg>
-            </div>
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                  />
+                </svg>
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-25"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                  />
+                </svg>
+              </div>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
           </span>
           <span
-            className="MuiTouchRipple-root"
-          />
-        </span>
-        <span
-          className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-        >
-          No
-        </span>
-      </label>
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            No
+          </span>
+        </label>
+      </div>
     </div>
   </div>
   <div
@@ -1396,55 +1464,59 @@ exports[`single fields select field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root"
       >
         <div
-          aria-haspopup="listbox"
-          aria-labelledby="root"
-          className="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
-          id="root"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseDown={[Function]}
-          role="button"
-          tabIndex={0}
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
         >
-          <span
-            dangerouslySetInnerHTML={
-              Object {
-                "__html": "&#8203;",
+          <div
+            aria-haspopup="listbox"
+            aria-labelledby="root"
+            className="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input"
+            id="root"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            role="button"
+            tabIndex={0}
+          >
+            <span
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "&#8203;",
+                }
               }
-            }
+            />
+          </div>
+          <input
+            aria-hidden={true}
+            autoFocus={false}
+            className="MuiSelect-nativeInput"
+            onAnimationStart={[Function]}
+            onChange={[Function]}
+            required={false}
+            tabIndex={-1}
+            value=""
           />
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSelect-icon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
         </div>
-        <input
-          aria-hidden={true}
-          autoFocus={false}
-          className="MuiSelect-nativeInput"
-          onAnimationStart={[Function]}
-          onChange={[Function]}
-          required={false}
-          tabIndex={-1}
-          value=""
-        />
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSelect-icon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M7 10l5 5 5-5z"
-          />
-        </svg>
       </div>
     </div>
   </div>
@@ -1488,73 +1560,77 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-integer"
   >
-    <label
-      className="MuiFormLabel-root"
-      id="root"
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
-      
-    </label>
-    <span
-      className="MuiSlider-root MuiSlider-colorPrimary"
-      id="root"
-      label=""
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-    >
+      <label
+        className="MuiFormLabel-root"
+        id="root"
+      >
+        
+      </label>
       <span
-        className="MuiSlider-rail"
-      />
-      <span
-        className="MuiSlider-track"
-        style={
-          Object {
-            "left": "0%",
-            "width": "56.89655172413793%",
-          }
-        }
-      />
-      <input
-        type="hidden"
-        value="75"
-      />
-      <span
-        aria-orientation="horizontal"
-        aria-valuemax={100}
-        aria-valuemin={42}
-        aria-valuenow={75}
-        className="MuiSlider-thumb MuiSlider-thumbColorPrimary PrivateValueLabel-thumb-28"
-        data-index={0}
+        className="MuiSlider-root MuiSlider-colorPrimary"
+        id="root"
+        label=""
         onBlur={[Function]}
         onFocus={[Function]}
-        onKeyDown={[Function]}
-        onMouseLeave={[Function]}
-        onMouseOver={[Function]}
-        role="slider"
-        style={
-          Object {
-            "left": "56.89655172413793%",
-          }
-        }
-        tabIndex={0}
+        onMouseDown={[Function]}
       >
         <span
-          className="PrivateValueLabel-offset-30 MuiSlider-valueLabel"
+          className="MuiSlider-rail"
+        />
+        <span
+          className="MuiSlider-track"
+          style={
+            Object {
+              "left": "0%",
+              "width": "56.89655172413793%",
+            }
+          }
+        />
+        <input
+          type="hidden"
+          value="75"
+        />
+        <span
+          aria-orientation="horizontal"
+          aria-valuemax={100}
+          aria-valuemin={42}
+          aria-valuenow={75}
+          className="MuiSlider-thumb MuiSlider-thumbColorPrimary PrivateValueLabel-thumb-28"
+          data-index={0}
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          role="slider"
+          style={
+            Object {
+              "left": "56.89655172413793%",
+            }
+          }
+          tabIndex={0}
         >
           <span
-            className="PrivateValueLabel-circle-31"
+            className="PrivateValueLabel-offset-30 MuiSlider-valueLabel"
           >
             <span
-              className="PrivateValueLabel-label-32"
+              className="PrivateValueLabel-circle-31"
             >
-              75
+              <span
+                className="PrivateValueLabel-label-32"
+              >
+                75
+              </span>
             </span>
           </span>
         </span>
       </span>
-    </span>
+    </div>
   </div>
   <div
     className="MuiBox-root MuiBox-root-33"
@@ -1593,19 +1669,23 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-string"
   >
-    <div>
-      <p>
-        <input
-          autoFocus={false}
-          defaultValue=""
-          disabled={false}
-          id="root"
-          onChange={[Function]}
-          type="file"
-        />
-      </p>
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth"
+    >
+      <div>
+        <p>
+          <input
+            autoFocus={false}
+            defaultValue=""
+            disabled={false}
+            id="root"
+            onChange={[Function]}
+            type="file"
+          />
+        </p>
+      </div>
     </div>
   </div>
   <div
@@ -1648,30 +1728,34 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="email"
-          value=""
-        />
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="email"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1715,30 +1799,34 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="url"
-          value=""
-        />
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="url"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1779,30 +1867,34 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="text"
-          value=""
-        />
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1843,30 +1935,34 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder="placeholder"
-          required={false}
-          type="text"
-          value=""
-        />
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="placeholder"
+            required={false}
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1907,30 +2003,34 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-multiline MuiInput-multiline"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root"
       >
-        <textarea
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiInput-input MuiInputBase-inputMultiline MuiInput-inputMultiline"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          rows={5}
-          value=""
-        />
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl MuiInputBase-multiline MuiInput-multiline"
+          onClick={[Function]}
+        >
+          <textarea
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input MuiInputBase-inputMultiline MuiInput-inputMultiline"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            rows={5}
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -1971,70 +2071,78 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-object"
   >
     <div
-      className="MuiBox-root MuiBox-root-37"
-      id="root-title"
-    >
-      <h5
-        className="MuiTypography-root MuiTypography-h5"
-      >
-        Titre 1
-      </h5>
-      <hr
-        className="MuiDivider-root"
-      />
-    </div>
-    <div
-      className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
-      style={
-        Object {
-          "marginTop": "10px",
-        }
-      }
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+        className="MuiBox-root MuiBox-root-37"
+        id="root-title"
+      >
+        <h5
+          className="MuiTypography-root MuiTypography-h5"
+        >
+          Titre 1
+        </h5>
+        <hr
+          className="MuiDivider-root"
+        />
+      </div>
+      <div
+        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
         style={
           Object {
-            "marginBottom": "10px",
+            "marginTop": "10px",
           }
         }
       >
         <div
-          className="MuiFormControl-root MuiFormControl-fullWidth"
+          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
           <div
-            className="MuiFormControl-root MuiTextField-root"
+            className="form-group field field-string"
           >
-            <label
-              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
-              data-shrink={false}
-              htmlFor="root_title"
-              id="root_title-label"
-            >
-              title
-            </label>
             <div
-              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-              onClick={[Function]}
+              className="MuiFormControl-root MuiFormControl-fullWidth"
             >
-              <input
-                aria-invalid={false}
-                autoFocus={false}
-                className="MuiInputBase-input MuiInput-input"
-                disabled={false}
-                id="root_title"
-                onAnimationStart={[Function]}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder=""
-                required={false}
-                type="text"
-                value=""
-              />
+              <div
+                className="MuiFormControl-root MuiTextField-root"
+              >
+                <label
+                  className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+                  data-shrink={false}
+                  htmlFor="root_title"
+                  id="root_title-label"
+                >
+                  title
+                </label>
+                <div
+                  className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                  onClick={[Function]}
+                >
+                  <input
+                    aria-invalid={false}
+                    autoFocus={false}
+                    className="MuiInputBase-input MuiInput-input"
+                    disabled={false}
+                    id="root_title"
+                    onAnimationStart={[Function]}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -2078,29 +2186,33 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-undefined"
   >
     <div
-      className="unsupported-field"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
-      <p>
-        Unsupported field schema
-        <span>
-           for
-           field 
-          <code>
-            root
-          </code>
-        </span>
-        <em>
-          : 
-          Unknown field type undefined
-        </em>
-        .
-      </p>
-      <pre>
-        {}
-      </pre>
+      <div
+        className="unsupported-field"
+      >
+        <p>
+          Unsupported field schema
+          <span>
+             for
+             field 
+            <code>
+              root
+            </code>
+          </span>
+          <em>
+            : 
+            Unknown field type undefined
+          </em>
+          .
+        </p>
+        <pre>
+          {}
+        </pre>
+      </div>
     </div>
   </div>
   <div
@@ -2140,30 +2252,34 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-number"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="number"
-          value=""
-        />
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="number"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -2207,30 +2323,34 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root"
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiInput-input"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="text"
-          value=""
-        />
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="text"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
@@ -7,77 +7,42 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-object"
   >
-    
     <div
-      className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
-      style={
-        Object {
-          "marginTop": "10px",
-        }
-      }
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
+      
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
         style={
           Object {
-            "marginBottom": "10px",
+            "marginTop": "10px",
           }
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center"
+          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
           <div
-            className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+            className="MuiGrid-root form-group field field-string MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-center"
           >
             <div
-              className="MuiFormControl-root MuiFormControl-fullWidth"
-            >
-              <label
-                className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
-                data-shrink={false}
-              >
-                foo Key
-              </label>
-              <div
-                className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                onClick={[Function]}
-              >
-                <input
-                  aria-invalid={false}
-                  className="MuiInputBase-input MuiInput-input"
-                  defaultValue="foo"
-                  disabled={false}
-                  id="root_foo-key"
-                  name="root_foo-key"
-                  onAnimationStart={[Function]}
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  required={false}
-                  type="text"
-                />
-              </div>
-            </div>
-          </div>
-          <div
-            className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-          >
-            <div
-              className="MuiFormControl-root MuiFormControl-fullWidth"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
             >
               <div
-                className="MuiFormControl-root MuiTextField-root"
+                className="MuiFormControl-root MuiFormControl-fullWidth"
               >
                 <label
                   className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
                   data-shrink={false}
-                  htmlFor="root_foo"
-                  id="root_foo-label"
                 >
-                  foo
+                  foo Key
                 </label>
                 <div
                   className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
@@ -85,28 +50,120 @@ exports[`object fields additionalProperties 1`] = `
                 >
                   <input
                     aria-invalid={false}
-                    autoFocus={false}
                     className="MuiInputBase-input MuiInput-input"
+                    defaultValue="foo"
                     disabled={false}
-                    id="root_foo"
+                    id="root_foo-key"
+                    name="root_foo-key"
                     onAnimationStart={[Function]}
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
-                    placeholder=""
                     required={false}
                     type="text"
-                    value="foo"
                   />
                 </div>
               </div>
             </div>
+            <div
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+            >
+              <div
+                className="MuiFormControl-root MuiFormControl-fullWidth"
+              >
+                <div
+                  className="MuiFormControl-root MuiTextField-root"
+                >
+                  <label
+                    className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+                    data-shrink={false}
+                    htmlFor="root_foo"
+                    id="root_foo-label"
+                  >
+                    foo
+                  </label>
+                  <div
+                    className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                    onClick={[Function]}
+                  >
+                    <input
+                      aria-invalid={false}
+                      autoFocus={false}
+                      className="MuiInputBase-input MuiInput-input"
+                      disabled={false}
+                      id="root_foo"
+                      onAnimationStart={[Function]}
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      placeholder=""
+                      required={false}
+                      type="text"
+                      value="foo"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="MuiGrid-root MuiGrid-item"
+            >
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13H5v-2h14v2z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  className="MuiTouchRipple-root"
+                />
+              </button>
+            </div>
           </div>
+        </div>
+        <div
+          className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
+        >
           <div
             className="MuiGrid-root MuiGrid-item"
           >
             <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+              className="MuiButtonBase-root MuiIconButton-root object-property-expand MuiIconButton-colorSecondary"
               disabled={false}
               onBlur={[Function]}
               onClick={[Function]}
@@ -120,16 +177,8 @@ exports[`object fields additionalProperties 1`] = `
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
-              style={
-                Object {
-                  "flex": 1,
-                  "fontWeight": "bold",
-                  "paddingLeft": 6,
-                  "paddingRight": 6,
-                }
-              }
               tabIndex={0}
-              title="Remove"
+              title="Add Item"
               type="button"
             >
               <span
@@ -142,7 +191,7 @@ exports[`object fields additionalProperties 1`] = `
                   viewBox="0 0 24 24"
                 >
                   <path
-                    d="M19 13H5v-2h14v2z"
+                    d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
                   />
                 </svg>
               </span>
@@ -151,51 +200,6 @@ exports[`object fields additionalProperties 1`] = `
               />
             </button>
           </div>
-        </div>
-      </div>
-      <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
-      >
-        <div
-          className="MuiGrid-root MuiGrid-item"
-        >
-          <button
-            className="MuiButtonBase-root MuiIconButton-root object-property-expand MuiIconButton-colorSecondary"
-            disabled={false}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={0}
-            title="Add Item"
-            type="button"
-          >
-            <span
-              className="MuiIconButton-label"
-            >
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                />
-              </svg>
-            </span>
-            <span
-              className="MuiTouchRipple-root"
-            />
-          </button>
         </div>
       </div>
     </div>
@@ -240,104 +244,116 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth"
+    className="form-group field field-object"
   >
-    
     <div
-      className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
-      style={
-        Object {
-          "marginTop": "10px",
-        }
-      }
+      className="MuiFormControl-root MuiFormControl-fullWidth"
     >
+      
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
         style={
           Object {
-            "marginBottom": "10px",
+            "marginTop": "10px",
           }
         }
       >
         <div
-          className="MuiFormControl-root MuiFormControl-fullWidth"
+          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
           <div
-            className="MuiFormControl-root MuiTextField-root"
+            className="form-group field field-string"
           >
-            <label
-              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
-              data-shrink={false}
-              htmlFor="root_a"
-              id="root_a-label"
-            >
-              A
-            </label>
             <div
-              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-              onClick={[Function]}
+              className="MuiFormControl-root MuiFormControl-fullWidth"
             >
-              <input
-                aria-invalid={false}
-                autoFocus={false}
-                className="MuiInputBase-input MuiInput-input"
-                disabled={false}
-                id="root_a"
-                onAnimationStart={[Function]}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder=""
-                required={false}
-                type="text"
-                value=""
-              />
+              <div
+                className="MuiFormControl-root MuiTextField-root"
+              >
+                <label
+                  className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+                  data-shrink={false}
+                  htmlFor="root_a"
+                  id="root_a-label"
+                >
+                  A
+                </label>
+                <div
+                  className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                  onClick={[Function]}
+                >
+                  <input
+                    aria-invalid={false}
+                    autoFocus={false}
+                    className="MuiInputBase-input MuiInput-input"
+                    disabled={false}
+                    id="root_a"
+                    onAnimationStart={[Function]}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
-        style={
-          Object {
-            "marginBottom": "10px",
-          }
-        }
-      >
         <div
-          className="MuiFormControl-root MuiFormControl-fullWidth"
+          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
           <div
-            className="MuiFormControl-root MuiTextField-root"
+            className="form-group field field-number"
           >
-            <label
-              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
-              data-shrink={false}
-              htmlFor="root_b"
-              id="root_b-label"
-            >
-              B
-            </label>
             <div
-              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-              onClick={[Function]}
+              className="MuiFormControl-root MuiFormControl-fullWidth"
             >
-              <input
-                aria-invalid={false}
-                autoFocus={false}
-                className="MuiInputBase-input MuiInput-input"
-                disabled={false}
-                id="root_b"
-                onAnimationStart={[Function]}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder=""
-                required={false}
-                step="any"
-                type="number"
-                value=""
-              />
+              <div
+                className="MuiFormControl-root MuiTextField-root"
+              >
+                <label
+                  className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+                  data-shrink={false}
+                  htmlFor="root_b"
+                  id="root_b-label"
+                >
+                  B
+                </label>
+                <div
+                  className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                  onClick={[Function]}
+                >
+                  <input
+                    aria-invalid={false}
+                    autoFocus={false}
+                    className="MuiInputBase-input MuiInput-input"
+                    disabled={false}
+                    id="root_b"
+                    onAnimationStart={[Function]}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    required={false}
+                    step="any"
+                    type="number"
+                    value=""
+                  />
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/packages/mui/src/FieldTemplate/WrapIfAdditional.tsx
+++ b/packages/mui/src/FieldTemplate/WrapIfAdditional.tsx
@@ -21,6 +21,7 @@ type WrapIfAdditionalProps = { children: React.ReactElement } & Pick<
 
 const WrapIfAdditional = ({
   children,
+  classNames,
   disabled,
   id,
   label,
@@ -42,15 +43,21 @@ const WrapIfAdditional = ({
   };
 
   if (!additional) {
-    return <>{children}</>;
+    return <div className={classNames}>{children}</div>;
   }
 
   const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
     onKeyChange(target.value);
 
   return (
-    <Grid container={true} key={`${id}-key`} alignItems="center" spacing={2}>
-      <Grid item={true} xs>
+    <Grid
+      container
+      key={`${id}-key`}
+      alignItems="center"
+      spacing={2}
+      className={classNames}
+    >
+      <Grid item xs>
         <FormControl fullWidth={true} required={required}>
           <InputLabel>{keyLabel}</InputLabel>
           <Input

--- a/packages/mui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Array.test.tsx.snap
@@ -286,58 +286,62 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-array"
   >
     <div
-      className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiBox-root emotion-2"
+        className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
       >
         <div
-          className="MuiGrid-root MuiGrid-container emotion-3"
+          className="MuiBox-root emotion-2"
         >
           <div
-            className="MuiGrid-root MuiGrid-container emotion-4"
+            className="MuiGrid-root MuiGrid-container emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-item emotion-5"
+              className="MuiGrid-root MuiGrid-container emotion-4"
             >
               <div
-                className="MuiBox-root emotion-6"
+                className="MuiGrid-root MuiGrid-item emotion-5"
               >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeMedium array-item-add emotion-7"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  tabIndex={0}
-                  title="Add Item"
-                  type="button"
+                <div
+                  className="MuiBox-root emotion-6"
                 >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-8"
-                    data-testid="AddIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
+                  <button
+                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeMedium array-item-add emotion-7"
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onContextMenu={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    tabIndex={0}
+                    title="Add Item"
+                    type="button"
                   >
-                    <path
-                      d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                    />
-                  </svg>
-                </button>
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-8"
+                      data-testid="AddIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                      />
+                    </svg>
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -1150,428 +1154,136 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-array"
   >
     <div
-      className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiBox-root emotion-2"
+        className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
       >
         <div
-          className="MuiGrid-root MuiGrid-container emotion-3"
+          className="MuiBox-root emotion-2"
         >
           <div
-            className="MuiGrid-root MuiGrid-container emotion-4"
+            className="MuiGrid-root MuiGrid-container emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-5"
-              style={
-                Object {
-                  "overflow": "auto",
-                }
-              }
+              className="MuiGrid-root MuiGrid-container emotion-4"
             >
               <div
-                className="MuiBox-root emotion-6"
+                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-5"
+                style={
+                  Object {
+                    "overflow": "auto",
+                  }
+                }
               >
                 <div
-                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                  className="MuiBox-root emotion-6"
                 >
                   <div
-                    className="MuiBox-root emotion-2"
+                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                   >
                     <div
-                      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                      className="MuiBox-root emotion-2"
                     >
                       <div
-                        className="MuiFormControl-root MuiTextField-root emotion-10"
+                        className="form-group field field-string"
                       >
                         <div
-                          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-11"
-                          onClick={[Function]}
+                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                         >
-                          <input
-                            aria-invalid={false}
-                            autoFocus={false}
-                            className="MuiInputBase-input MuiOutlinedInput-input emotion-12"
-                            disabled={false}
-                            id="root_0"
-                            onAnimationStart={[Function]}
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            onFocus={[Function]}
-                            placeholder=""
-                            required={true}
-                            type="text"
-                            value="a"
-                          />
-                          <fieldset
-                            aria-hidden={true}
-                            className="MuiOutlinedInput-notchedOutline emotion-13"
+                          <div
+                            className="MuiFormControl-root MuiTextField-root emotion-10"
                           >
-                            <legend
-                              className="emotion-14"
+                            <div
+                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-11"
+                              onClick={[Function]}
                             >
-                              <span
-                                className="notranslate"
+                              <input
+                                aria-invalid={false}
+                                autoFocus={false}
+                                className="MuiInputBase-input MuiOutlinedInput-input emotion-12"
+                                disabled={false}
+                                id="root_0"
+                                onAnimationStart={[Function]}
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder=""
+                                required={true}
+                                type="text"
+                                value="a"
+                              />
+                              <fieldset
+                                aria-hidden={true}
+                                className="MuiOutlinedInput-notchedOutline emotion-13"
                               >
-                                ​
-                              </span>
-                            </legend>
-                          </fieldset>
+                                <legend
+                                  className="emotion-14"
+                                >
+                                  <span
+                                    className="notranslate"
+                                  >
+                                    ​
+                                  </span>
+                                </legend>
+                              </fieldset>
+                            </div>
+                          </div>
                         </div>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              className="MuiGrid-root MuiGrid-item emotion-15"
-            >
-              <button
-                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-16"
-                disabled={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onContextMenu={[Function]}
-                onDragLeave={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                style={
-                  Object {
-                    "flex": 1,
-                    "fontWeight": "bold",
-                    "minWidth": 0,
-                    "paddingLeft": 6,
-                    "paddingRight": 6,
-                  }
-                }
-                tabIndex={-1}
-                title="Move up"
-                type="button"
-              >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
-                  data-testid="ArrowUpwardIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                  />
-                </svg>
-              </button>
-              <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-16"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onContextMenu={[Function]}
-                onDragLeave={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                style={
-                  Object {
-                    "flex": 1,
-                    "fontWeight": "bold",
-                    "minWidth": 0,
-                    "paddingLeft": 6,
-                    "paddingRight": 6,
-                  }
-                }
-                tabIndex={0}
-                title="Move down"
-                type="button"
-              >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
-                  data-testid="ArrowDownwardIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                  />
-                </svg>
-                <span
-                  className="MuiTouchRipple-root emotion-20"
-                />
-              </button>
-              <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-21"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onContextMenu={[Function]}
-                onDragLeave={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                style={
-                  Object {
-                    "flex": 1,
-                    "fontWeight": "bold",
-                    "minWidth": 0,
-                    "paddingLeft": 6,
-                    "paddingRight": 6,
-                  }
-                }
-                tabIndex={0}
-                title="Remove"
-                type="button"
-              >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
-                  data-testid="RemoveIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M19 13H5v-2h14v2z"
-                  />
-                </svg>
-                <span
-                  className="MuiTouchRipple-root emotion-20"
-                />
-              </button>
-            </div>
-          </div>
-          <div
-            className="MuiGrid-root MuiGrid-container emotion-4"
-          >
-            <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-5"
-              style={
-                Object {
-                  "overflow": "auto",
-                }
-              }
-            >
               <div
-                className="MuiBox-root emotion-6"
-              >
-                <div
-                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
-                >
-                  <div
-                    className="MuiBox-root emotion-2"
-                  >
-                    <div
-                      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
-                    >
-                      <div
-                        className="MuiFormControl-root MuiTextField-root emotion-10"
-                      >
-                        <div
-                          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-11"
-                          onClick={[Function]}
-                        >
-                          <input
-                            aria-invalid={false}
-                            autoFocus={false}
-                            className="MuiInputBase-input MuiOutlinedInput-input emotion-12"
-                            disabled={false}
-                            id="root_1"
-                            onAnimationStart={[Function]}
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            onFocus={[Function]}
-                            placeholder=""
-                            required={true}
-                            type="text"
-                            value="b"
-                          />
-                          <fieldset
-                            aria-hidden={true}
-                            className="MuiOutlinedInput-notchedOutline emotion-13"
-                          >
-                            <legend
-                              className="emotion-14"
-                            >
-                              <span
-                                className="notranslate"
-                              >
-                                ​
-                              </span>
-                            </legend>
-                          </fieldset>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              className="MuiGrid-root MuiGrid-item emotion-15"
-            >
-              <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-16"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onContextMenu={[Function]}
-                onDragLeave={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                style={
-                  Object {
-                    "flex": 1,
-                    "fontWeight": "bold",
-                    "minWidth": 0,
-                    "paddingLeft": 6,
-                    "paddingRight": 6,
-                  }
-                }
-                tabIndex={0}
-                title="Move up"
-                type="button"
-              >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
-                  data-testid="ArrowUpwardIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                  />
-                </svg>
-                <span
-                  className="MuiTouchRipple-root emotion-20"
-                />
-              </button>
-              <button
-                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-16"
-                disabled={true}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onContextMenu={[Function]}
-                onDragLeave={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                style={
-                  Object {
-                    "flex": 1,
-                    "fontWeight": "bold",
-                    "minWidth": 0,
-                    "paddingLeft": 6,
-                    "paddingRight": 6,
-                  }
-                }
-                tabIndex={-1}
-                title="Move down"
-                type="button"
-              >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
-                  data-testid="ArrowDownwardIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                  />
-                </svg>
-              </button>
-              <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-21"
-                disabled={false}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onContextMenu={[Function]}
-                onDragLeave={[Function]}
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseLeave={[Function]}
-                onMouseUp={[Function]}
-                onTouchEnd={[Function]}
-                onTouchMove={[Function]}
-                onTouchStart={[Function]}
-                style={
-                  Object {
-                    "flex": 1,
-                    "fontWeight": "bold",
-                    "minWidth": 0,
-                    "paddingLeft": 6,
-                    "paddingRight": 6,
-                  }
-                }
-                tabIndex={0}
-                title="Remove"
-                type="button"
-              >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
-                  data-testid="RemoveIcon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M19 13H5v-2h14v2z"
-                  />
-                </svg>
-                <span
-                  className="MuiTouchRipple-root emotion-20"
-                />
-              </button>
-            </div>
-          </div>
-          <div
-            className="MuiGrid-root MuiGrid-container emotion-44"
-          >
-            <div
-              className="MuiGrid-root MuiGrid-item emotion-15"
-            >
-              <div
-                className="MuiBox-root emotion-46"
+                className="MuiGrid-root MuiGrid-item emotion-15"
               >
                 <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeMedium array-item-add emotion-47"
+                  className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-16"
+                  disabled={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "flex": 1,
+                      "fontWeight": "bold",
+                      "minWidth": 0,
+                      "paddingLeft": 6,
+                      "paddingRight": 6,
+                    }
+                  }
+                  tabIndex={-1}
+                  title="Move up"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
+                    data-testid="ArrowUpwardIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-16"
                   disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -1586,25 +1298,329 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
                   onTouchEnd={[Function]}
                   onTouchMove={[Function]}
                   onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "flex": 1,
+                      "fontWeight": "bold",
+                      "minWidth": 0,
+                      "paddingLeft": 6,
+                      "paddingRight": 6,
+                    }
+                  }
                   tabIndex={0}
-                  title="Add Item"
+                  title="Move down"
                   type="button"
                 >
                   <svg
                     aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-48"
-                    data-testid="AddIcon"
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
+                    data-testid="ArrowDownwardIcon"
                     focusable="false"
                     viewBox="0 0 24 24"
                   >
                     <path
-                      d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                      d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
                     />
                   </svg>
                   <span
                     className="MuiTouchRipple-root emotion-20"
                   />
                 </button>
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-21"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "flex": 1,
+                      "fontWeight": "bold",
+                      "minWidth": 0,
+                      "paddingLeft": 6,
+                      "paddingRight": 6,
+                    }
+                  }
+                  tabIndex={0}
+                  title="Remove"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
+                    data-testid="RemoveIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13H5v-2h14v2z"
+                    />
+                  </svg>
+                  <span
+                    className="MuiTouchRipple-root emotion-20"
+                  />
+                </button>
+              </div>
+            </div>
+            <div
+              className="MuiGrid-root MuiGrid-container emotion-4"
+            >
+              <div
+                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-5"
+                style={
+                  Object {
+                    "overflow": "auto",
+                  }
+                }
+              >
+                <div
+                  className="MuiBox-root emotion-6"
+                >
+                  <div
+                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                  >
+                    <div
+                      className="MuiBox-root emotion-2"
+                    >
+                      <div
+                        className="form-group field field-string"
+                      >
+                        <div
+                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                        >
+                          <div
+                            className="MuiFormControl-root MuiTextField-root emotion-10"
+                          >
+                            <div
+                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-11"
+                              onClick={[Function]}
+                            >
+                              <input
+                                aria-invalid={false}
+                                autoFocus={false}
+                                className="MuiInputBase-input MuiOutlinedInput-input emotion-12"
+                                disabled={false}
+                                id="root_1"
+                                onAnimationStart={[Function]}
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder=""
+                                required={true}
+                                type="text"
+                                value="b"
+                              />
+                              <fieldset
+                                aria-hidden={true}
+                                className="MuiOutlinedInput-notchedOutline emotion-13"
+                              >
+                                <legend
+                                  className="emotion-14"
+                                >
+                                  <span
+                                    className="notranslate"
+                                  >
+                                    ​
+                                  </span>
+                                </legend>
+                              </fieldset>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="MuiGrid-root MuiGrid-item emotion-15"
+              >
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-16"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "flex": 1,
+                      "fontWeight": "bold",
+                      "minWidth": 0,
+                      "paddingLeft": 6,
+                      "paddingRight": 6,
+                    }
+                  }
+                  tabIndex={0}
+                  title="Move up"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
+                    data-testid="ArrowUpwardIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                    />
+                  </svg>
+                  <span
+                    className="MuiTouchRipple-root emotion-20"
+                  />
+                </button>
+                <button
+                  className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-16"
+                  disabled={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "flex": 1,
+                      "fontWeight": "bold",
+                      "minWidth": 0,
+                      "paddingLeft": 6,
+                      "paddingRight": 6,
+                    }
+                  }
+                  tabIndex={-1}
+                  title="Move down"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
+                    data-testid="ArrowDownwardIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-21"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "flex": 1,
+                      "fontWeight": "bold",
+                      "minWidth": 0,
+                      "paddingLeft": 6,
+                      "paddingRight": 6,
+                    }
+                  }
+                  tabIndex={0}
+                  title="Remove"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
+                    data-testid="RemoveIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13H5v-2h14v2z"
+                    />
+                  </svg>
+                  <span
+                    className="MuiTouchRipple-root emotion-20"
+                  />
+                </button>
+              </div>
+            </div>
+            <div
+              className="MuiGrid-root MuiGrid-container emotion-44"
+            >
+              <div
+                className="MuiGrid-root MuiGrid-item emotion-15"
+              >
+                <div
+                  className="MuiBox-root emotion-46"
+                >
+                  <button
+                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeMedium array-item-add emotion-47"
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onContextMenu={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    tabIndex={0}
+                    title="Add Item"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-48"
+                      data-testid="AddIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                      />
+                    </svg>
+                    <span
+                      className="MuiTouchRipple-root emotion-20"
+                    />
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -2041,71 +2057,75 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-array"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
-        onClick={[Function]}
-        variant="outlined"
+        className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-labelledby="root"
-          className="MuiSelect-select MuiSelect-outlined MuiSelect-multiple MuiInputBase-input MuiOutlinedInput-input emotion-3"
-          id="root"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseDown={[Function]}
-          role="button"
-          tabIndex={0}
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
+          onClick={[Function]}
+          variant="outlined"
         >
-          <span
-            className="notranslate"
-          >
-            ​
-          </span>
-        </div>
-        <input
-          aria-hidden={true}
-          autoFocus={false}
-          className="MuiSelect-nativeInput emotion-4"
-          disabled={false}
-          onAnimationStart={[Function]}
-          onChange={[Function]}
-          required={false}
-          tabIndex={-1}
-          value=""
-        />
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined emotion-5"
-          data-testid="ArrowDropDownIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M7 10l5 5 5-5z"
-          />
-        </svg>
-        <fieldset
-          aria-hidden={true}
-          className="MuiOutlinedInput-notchedOutline emotion-6"
-        >
-          <legend
-            className="emotion-7"
+          <div
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-labelledby="root"
+            className="MuiSelect-select MuiSelect-outlined MuiSelect-multiple MuiInputBase-input MuiOutlinedInput-input emotion-3"
+            id="root"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            role="button"
+            tabIndex={0}
           >
             <span
               className="notranslate"
             >
               ​
             </span>
-          </legend>
-        </fieldset>
+          </div>
+          <input
+            aria-hidden={true}
+            autoFocus={false}
+            className="MuiSelect-nativeInput emotion-4"
+            disabled={false}
+            onAnimationStart={[Function]}
+            onChange={[Function]}
+            required={false}
+            tabIndex={-1}
+            value=""
+          />
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined emotion-5"
+            data-testid="ArrowDropDownIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+          <fieldset
+            aria-hidden={true}
+            className="MuiOutlinedInput-notchedOutline emotion-6"
+          >
+            <legend
+              className="emotion-7"
+            >
+              <span
+                className="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
       </div>
     </div>
   </div>
@@ -2591,76 +2611,84 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-array"
   >
     <div
-      className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiBox-root emotion-2"
+        className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
       >
         <div
-          className="MuiGrid-root MuiGrid-container emotion-3"
+          className="MuiBox-root emotion-2"
         >
           <div
-            className="MuiGrid-root MuiGrid-container emotion-4"
+            className="MuiGrid-root MuiGrid-container emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-5"
-              style={
-                Object {
-                  "overflow": "auto",
-                }
-              }
+              className="MuiGrid-root MuiGrid-container emotion-4"
             >
               <div
-                className="MuiBox-root emotion-6"
+                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-5"
+                style={
+                  Object {
+                    "overflow": "auto",
+                  }
+                }
               >
                 <div
-                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                  className="MuiBox-root emotion-6"
                 >
                   <div
-                    className="MuiBox-root emotion-2"
+                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                   >
                     <div
-                      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                      className="MuiBox-root emotion-2"
                     >
                       <div
-                        className="MuiFormControl-root MuiTextField-root emotion-10"
+                        className="form-group field field-string"
                       >
                         <div
-                          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-11"
-                          onClick={[Function]}
+                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                         >
-                          <input
-                            aria-invalid={false}
-                            autoFocus={false}
-                            className="MuiInputBase-input MuiOutlinedInput-input emotion-12"
-                            disabled={false}
-                            id="root_0"
-                            onAnimationStart={[Function]}
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            onFocus={[Function]}
-                            placeholder=""
-                            required={true}
-                            type="text"
-                            value=""
-                          />
-                          <fieldset
-                            aria-hidden={true}
-                            className="MuiOutlinedInput-notchedOutline emotion-13"
+                          <div
+                            className="MuiFormControl-root MuiTextField-root emotion-10"
                           >
-                            <legend
-                              className="emotion-14"
+                            <div
+                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-11"
+                              onClick={[Function]}
                             >
-                              <span
-                                className="notranslate"
+                              <input
+                                aria-invalid={false}
+                                autoFocus={false}
+                                className="MuiInputBase-input MuiOutlinedInput-input emotion-12"
+                                disabled={false}
+                                id="root_0"
+                                onAnimationStart={[Function]}
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder=""
+                                required={true}
+                                type="text"
+                                value=""
+                              />
+                              <fieldset
+                                aria-hidden={true}
+                                className="MuiOutlinedInput-notchedOutline emotion-13"
                               >
-                                ​
-                              </span>
-                            </legend>
-                          </fieldset>
+                                <legend
+                                  className="emotion-14"
+                                >
+                                  <span
+                                    className="notranslate"
+                                  >
+                                    ​
+                                  </span>
+                                </legend>
+                              </fieldset>
+                            </div>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -2668,67 +2696,71 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            className="MuiGrid-root MuiGrid-container emotion-4"
-          >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-5"
-              style={
-                Object {
-                  "overflow": "auto",
-                }
-              }
+              className="MuiGrid-root MuiGrid-container emotion-4"
             >
               <div
-                className="MuiBox-root emotion-6"
+                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-5"
+                style={
+                  Object {
+                    "overflow": "auto",
+                  }
+                }
               >
                 <div
-                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                  className="MuiBox-root emotion-6"
                 >
                   <div
-                    className="MuiBox-root emotion-2"
+                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                   >
                     <div
-                      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                      className="MuiBox-root emotion-2"
                     >
                       <div
-                        className="MuiFormControl-root MuiTextField-root emotion-10"
+                        className="form-group field field-number"
                       >
                         <div
-                          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-11"
-                          onClick={[Function]}
+                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                         >
-                          <input
-                            aria-invalid={false}
-                            autoFocus={false}
-                            className="MuiInputBase-input MuiOutlinedInput-input emotion-12"
-                            disabled={false}
-                            id="root_1"
-                            onAnimationStart={[Function]}
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            onFocus={[Function]}
-                            placeholder=""
-                            required={true}
-                            step="any"
-                            type="number"
-                            value=""
-                          />
-                          <fieldset
-                            aria-hidden={true}
-                            className="MuiOutlinedInput-notchedOutline emotion-13"
+                          <div
+                            className="MuiFormControl-root MuiTextField-root emotion-10"
                           >
-                            <legend
-                              className="emotion-14"
+                            <div
+                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-11"
+                              onClick={[Function]}
                             >
-                              <span
-                                className="notranslate"
+                              <input
+                                aria-invalid={false}
+                                autoFocus={false}
+                                className="MuiInputBase-input MuiOutlinedInput-input emotion-12"
+                                disabled={false}
+                                id="root_1"
+                                onAnimationStart={[Function]}
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder=""
+                                required={true}
+                                step="any"
+                                type="number"
+                                value=""
+                              />
+                              <fieldset
+                                aria-hidden={true}
+                                className="MuiOutlinedInput-notchedOutline emotion-13"
                               >
-                                ​
-                              </span>
-                            </legend>
-                          </fieldset>
+                                <legend
+                                  className="emotion-14"
+                                >
+                                  <span
+                                    className="notranslate"
+                                  >
+                                    ​
+                                  </span>
+                                </legend>
+                              </fieldset>
+                            </div>
+                          </div>
                         </div>
                       </div>
                     </div>

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -268,59 +268,63 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-boolean"
   >
-    <label
-      className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-1"
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
-      <span
-        className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary emotion-2"
-        onBlur={[Function]}
-        onContextMenu={[Function]}
-        onDragLeave={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        tabIndex={null}
+      <label
+        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-1"
       >
-        <input
-          autoFocus={false}
-          checked={false}
-          className="PrivateSwitchBase-input emotion-3"
-          data-indeterminate={false}
-          disabled={false}
-          id="root"
-          onChange={[Function]}
-          required={false}
-          type="checkbox"
-        />
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-4"
-          data-testid="CheckBoxOutlineBlankIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-          />
-        </svg>
         <span
-          className="MuiTouchRipple-root emotion-5"
-        />
-      </span>
-      <span
-        className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-6"
-      >
-        
-      </span>
-    </label>
+          className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary emotion-2"
+          onBlur={[Function]}
+          onContextMenu={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={null}
+        >
+          <input
+            autoFocus={false}
+            checked={false}
+            className="PrivateSwitchBase-input emotion-3"
+            data-indeterminate={false}
+            disabled={false}
+            id="root"
+            onChange={[Function]}
+            required={false}
+            type="checkbox"
+          />
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-4"
+            data-testid="CheckBoxOutlineBlankIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+            />
+          </svg>
+          <span
+            className="MuiTouchRipple-root emotion-5"
+          />
+        </span>
+        <span
+          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-6"
+        >
+          
+        </span>
+      </label>
+    </div>
   </div>
   <div
     className="MuiBox-root emotion-7"
@@ -608,56 +612,60 @@ exports[`single fields checkbox field 2`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-boolean"
   >
-    <label
-      className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-1"
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
-      <span
-        className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary emotion-2"
-        onBlur={[Function]}
-        onContextMenu={[Function]}
-        onDragLeave={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        tabIndex={null}
+      <label
+        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-1"
       >
-        <input
-          autoFocus={false}
-          checked={false}
-          className="PrivateSwitchBase-input emotion-3"
-          data-indeterminate={false}
-          disabled={false}
-          id="root"
-          onChange={[Function]}
-          required={false}
-          type="checkbox"
-        />
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-4"
-          data-testid="CheckBoxOutlineBlankIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
+        <span
+          className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary emotion-2"
+          onBlur={[Function]}
+          onContextMenu={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={null}
         >
-          <path
-            d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+          <input
+            autoFocus={false}
+            checked={false}
+            className="PrivateSwitchBase-input emotion-3"
+            data-indeterminate={false}
+            disabled={false}
+            id="root"
+            onChange={[Function]}
+            required={false}
+            type="checkbox"
           />
-        </svg>
-      </span>
-      <span
-        className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-5"
-      >
-        
-      </span>
-    </label>
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-4"
+            data-testid="CheckBoxOutlineBlankIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+            />
+          </svg>
+        </span>
+        <span
+          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-5"
+        >
+          
+        </span>
+      </label>
+    </div>
   </div>
   <div
     className="MuiBox-root emotion-6"
@@ -991,216 +999,220 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-array"
   >
-    <label
-      className="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-1"
-      htmlFor="root"
-    />
     <div
-      className="MuiFormGroup-root emotion-2"
-      id="root"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <label
-        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
+        className="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-1"
+        htmlFor="root"
+      />
+      <div
+        className="MuiFormGroup-root emotion-2"
+        id="root"
       >
-        <span
-          className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary emotion-4"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
+        <label
+          className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
         >
-          <input
-            autoFocus={false}
-            checked={false}
-            className="PrivateSwitchBase-input emotion-5"
-            data-indeterminate={false}
-            disabled={false}
-            id="root_0"
-            onChange={[Function]}
-            type="checkbox"
-          />
-          <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-6"
-            data-testid="CheckBoxOutlineBlankIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-            />
-          </svg>
           <span
-            className="MuiTouchRipple-root emotion-7"
-          />
-        </span>
-        <span
-          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-8"
-        >
-          foo
-        </span>
-      </label>
-      <label
-        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
-      >
-        <span
-          className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary emotion-4"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
-        >
-          <input
-            autoFocus={false}
-            checked={false}
-            className="PrivateSwitchBase-input emotion-5"
-            data-indeterminate={false}
-            disabled={false}
-            id="root_1"
-            onChange={[Function]}
-            type="checkbox"
-          />
-          <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-6"
-            data-testid="CheckBoxOutlineBlankIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
+            className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary emotion-4"
+            onBlur={[Function]}
+            onContextMenu={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
           >
-            <path
-              d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+            <input
+              autoFocus={false}
+              checked={false}
+              className="PrivateSwitchBase-input emotion-5"
+              data-indeterminate={false}
+              disabled={false}
+              id="root_0"
+              onChange={[Function]}
+              type="checkbox"
             />
-          </svg>
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-6"
+              data-testid="CheckBoxOutlineBlankIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+            <span
+              className="MuiTouchRipple-root emotion-7"
+            />
+          </span>
           <span
-            className="MuiTouchRipple-root emotion-7"
-          />
-        </span>
-        <span
-          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-8"
-        >
-          bar
-        </span>
-      </label>
-      <label
-        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
-      >
-        <span
-          className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary emotion-4"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
-        >
-          <input
-            autoFocus={false}
-            checked={false}
-            className="PrivateSwitchBase-input emotion-5"
-            data-indeterminate={false}
-            disabled={false}
-            id="root_2"
-            onChange={[Function]}
-            type="checkbox"
-          />
-          <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-6"
-            data-testid="CheckBoxOutlineBlankIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
+            className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-8"
           >
-            <path
-              d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-            />
-          </svg>
+            foo
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
+        >
           <span
-            className="MuiTouchRipple-root emotion-7"
-          />
-        </span>
-        <span
-          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-8"
-        >
-          fuzz
-        </span>
-      </label>
-      <label
-        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
-      >
-        <span
-          className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary emotion-4"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
-        >
-          <input
-            autoFocus={false}
-            checked={false}
-            className="PrivateSwitchBase-input emotion-5"
-            data-indeterminate={false}
-            disabled={false}
-            id="root_3"
-            onChange={[Function]}
-            type="checkbox"
-          />
-          <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-6"
-            data-testid="CheckBoxOutlineBlankIcon"
-            focusable="false"
-            viewBox="0 0 24 24"
+            className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary emotion-4"
+            onBlur={[Function]}
+            onContextMenu={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
           >
-            <path
-              d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+            <input
+              autoFocus={false}
+              checked={false}
+              className="PrivateSwitchBase-input emotion-5"
+              data-indeterminate={false}
+              disabled={false}
+              id="root_1"
+              onChange={[Function]}
+              type="checkbox"
             />
-          </svg>
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-6"
+              data-testid="CheckBoxOutlineBlankIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+            <span
+              className="MuiTouchRipple-root emotion-7"
+            />
+          </span>
           <span
-            className="MuiTouchRipple-root emotion-7"
-          />
-        </span>
-        <span
-          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-8"
+            className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-8"
+          >
+            bar
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
         >
-          qux
-        </span>
-      </label>
+          <span
+            className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary emotion-4"
+            onBlur={[Function]}
+            onContextMenu={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <input
+              autoFocus={false}
+              checked={false}
+              className="PrivateSwitchBase-input emotion-5"
+              data-indeterminate={false}
+              disabled={false}
+              id="root_2"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-6"
+              data-testid="CheckBoxOutlineBlankIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+            <span
+              className="MuiTouchRipple-root emotion-7"
+            />
+          </span>
+          <span
+            className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-8"
+          >
+            fuzz
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
+        >
+          <span
+            className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary emotion-4"
+            onBlur={[Function]}
+            onContextMenu={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <input
+              autoFocus={false}
+              checked={false}
+              className="PrivateSwitchBase-input emotion-5"
+              data-indeterminate={false}
+              disabled={false}
+              id="root_3"
+              onChange={[Function]}
+              type="checkbox"
+            />
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-6"
+              data-testid="CheckBoxOutlineBlankIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+            <span
+              className="MuiTouchRipple-root emotion-7"
+            />
+          </span>
+          <span
+            className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-8"
+          >
+            qux
+          </span>
+        </label>
+      </div>
     </div>
   </div>
   <div
@@ -1726,77 +1738,85 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-object"
   >
-    
     <div
-      className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
-      style={
-        Object {
-          "marginTop": "10px",
-        }
-      }
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
+      
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
         style={
           Object {
-            "marginBottom": "10px",
+            "marginTop": "10px",
           }
         }
       >
         <div
-          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
           <div
-            className="MuiFormControl-root MuiTextField-root emotion-4"
+            className="form-group field field-string"
           >
-            <label
-              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary emotion-5"
-              data-shrink={false}
-              htmlFor="root_my-field"
-              id="root_my-field-label"
-            >
-              my-field
-            </label>
             <div
-              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-6"
-              onClick={[Function]}
+              className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
             >
-              <input
-                aria-invalid={false}
-                autoFocus={false}
-                className="MuiInputBase-input MuiOutlinedInput-input emotion-7"
-                disabled={false}
-                id="root_my-field"
-                onAnimationStart={[Function]}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder=""
-                required={false}
-                type="text"
-                value=""
-              />
-              <fieldset
-                aria-hidden={true}
-                className="MuiOutlinedInput-notchedOutline emotion-8"
+              <div
+                className="MuiFormControl-root MuiTextField-root emotion-4"
               >
-                <legend
-                  className="emotion-9"
+                <label
+                  className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary emotion-5"
+                  data-shrink={false}
+                  htmlFor="root_my-field"
+                  id="root_my-field-label"
                 >
-                  <span>
-                    my-field
-                  </span>
-                </legend>
-              </fieldset>
+                  my-field
+                </label>
+                <div
+                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-6"
+                  onClick={[Function]}
+                >
+                  <input
+                    aria-invalid={false}
+                    autoFocus={false}
+                    className="MuiInputBase-input MuiOutlinedInput-input emotion-7"
+                    disabled={false}
+                    id="root_my-field"
+                    onAnimationStart={[Function]}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                  <fieldset
+                    aria-hidden={true}
+                    className="MuiOutlinedInput-notchedOutline emotion-8"
+                  >
+                    <legend
+                      className="emotion-9"
+                    >
+                      <span>
+                        my-field
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+              <span
+                className="MuiTypography-root MuiTypography-caption emotion-10"
+              >
+                some description
+              </span>
             </div>
           </div>
-          <span
-            className="MuiTypography-root MuiTypography-caption emotion-10"
-          >
-            some description
-          </span>
         </div>
       </div>
     </div>
@@ -2312,77 +2332,85 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-object"
   >
-    
     <div
-      className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
-      style={
-        Object {
-          "marginTop": "10px",
-        }
-      }
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
+      
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
         style={
           Object {
-            "marginBottom": "10px",
+            "marginTop": "10px",
           }
         }
       >
         <div
-          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
           <div
-            className="MuiFormControl-root MuiTextField-root emotion-4"
+            className="form-group field field-string"
           >
-            <label
-              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary emotion-5"
-              data-shrink={false}
-              htmlFor="root_my-field"
-              id="root_my-field-label"
-            >
-              my-field
-            </label>
             <div
-              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-6"
-              onClick={[Function]}
+              className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
             >
-              <input
-                aria-invalid={false}
-                autoFocus={false}
-                className="MuiInputBase-input MuiOutlinedInput-input emotion-7"
-                disabled={false}
-                id="root_my-field"
-                onAnimationStart={[Function]}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder=""
-                required={false}
-                type="text"
-                value=""
-              />
-              <fieldset
-                aria-hidden={true}
-                className="MuiOutlinedInput-notchedOutline emotion-8"
+              <div
+                className="MuiFormControl-root MuiTextField-root emotion-4"
               >
-                <legend
-                  className="emotion-9"
+                <label
+                  className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary emotion-5"
+                  data-shrink={false}
+                  htmlFor="root_my-field"
+                  id="root_my-field-label"
                 >
-                  <span>
-                    my-field
-                  </span>
-                </legend>
-              </fieldset>
+                  my-field
+                </label>
+                <div
+                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-6"
+                  onClick={[Function]}
+                >
+                  <input
+                    aria-invalid={false}
+                    autoFocus={false}
+                    className="MuiInputBase-input MuiOutlinedInput-input emotion-7"
+                    disabled={false}
+                    id="root_my-field"
+                    onAnimationStart={[Function]}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                  <fieldset
+                    aria-hidden={true}
+                    className="MuiOutlinedInput-notchedOutline emotion-8"
+                  >
+                    <legend
+                      className="emotion-9"
+                    >
+                      <span>
+                        my-field
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+              <span
+                className="MuiTypography-root MuiTypography-caption emotion-10"
+              >
+                some other description
+              </span>
             </div>
           </div>
-          <span
-            className="MuiTypography-root MuiTypography-caption emotion-10"
-          >
-            some other description
-          </span>
         </div>
       </div>
     </div>
@@ -2748,44 +2776,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root emotion-1"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="color"
-          value=""
-        />
-        <fieldset
-          aria-hidden={true}
-          className="MuiOutlinedInput-notchedOutline emotion-4"
+        <div
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
+          onClick={[Function]}
         >
-          <legend
-            className="emotion-5"
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="color"
+            value=""
+          />
+          <fieldset
+            aria-hidden={true}
+            className="MuiOutlinedInput-notchedOutline emotion-4"
           >
-            <span
-              className="notranslate"
+            <legend
+              className="emotion-5"
             >
-              ​
-            </span>
-          </legend>
-        </fieldset>
+              <span
+                className="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
       </div>
     </div>
   </div>
@@ -3141,44 +3173,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root emotion-1"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="date"
-          value=""
-        />
-        <fieldset
-          aria-hidden={true}
-          className="MuiOutlinedInput-notchedOutline emotion-4"
+        <div
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
+          onClick={[Function]}
         >
-          <legend
-            className="emotion-5"
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="date"
+            value=""
+          />
+          <fieldset
+            aria-hidden={true}
+            className="MuiOutlinedInput-notchedOutline emotion-4"
           >
-            <span
-              className="notranslate"
+            <legend
+              className="emotion-5"
             >
-              ​
-            </span>
-          </legend>
-        </fieldset>
+              <span
+                className="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
       </div>
     </div>
   </div>
@@ -3543,44 +3579,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root emotion-1"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="datetime-local"
-          value=""
-        />
-        <fieldset
-          aria-hidden={true}
-          className="MuiOutlinedInput-notchedOutline emotion-4"
+        <div
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
+          onClick={[Function]}
         >
-          <legend
-            className="emotion-5"
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="datetime-local"
+            value=""
+          />
+          <fieldset
+            aria-hidden={true}
+            className="MuiOutlinedInput-notchedOutline emotion-4"
           >
-            <span
-              className="notranslate"
+            <legend
+              className="emotion-5"
             >
-              ​
-            </span>
-          </legend>
-        </fieldset>
+              <span
+                className="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
       </div>
     </div>
   </div>
@@ -3761,22 +3801,26 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-object"
   >
-    
     <div
-      className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
-      style={
-        Object {
-          "marginTop": "10px",
-        }
-      }
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
-      <input
-        id="root_my-field"
-        type="hidden"
-        value=""
-      />
+      
+      <div
+        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
+        style={
+          Object {
+            "marginTop": "10px",
+          }
+        }
+      >
+        <input
+          id="root_my-field"
+          type="hidden"
+          value=""
+        />
+      </div>
     </div>
   </div>
   <div
@@ -4182,45 +4226,49 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-4:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
-      <label
-        className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary emotion-2"
-        data-shrink={false}
-        htmlFor="root"
-      />
       <div
-        className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-3"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root emotion-1"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiOutlinedInput-input emotion-4"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="text"
-          value=""
+        <label
+          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary emotion-2"
+          data-shrink={false}
+          htmlFor="root"
         />
-        <fieldset
-          aria-hidden={true}
-          className="MuiOutlinedInput-notchedOutline emotion-5"
+        <div
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-3"
+          onClick={[Function]}
         >
-          <legend
-            className="emotion-6"
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiOutlinedInput-input emotion-4"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="text"
+            value=""
+          />
+          <fieldset
+            aria-hidden={true}
+            className="MuiOutlinedInput-notchedOutline emotion-5"
           >
-            <span />
-          </legend>
-        </fieldset>
+            <legend
+              className="emotion-6"
+            >
+              <span />
+            </legend>
+          </fieldset>
+        </div>
       </div>
     </div>
   </div>
@@ -4383,8 +4431,12 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
-  />
+    className="form-group field field-null"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    />
+  </div>
   <div
     className="MuiBox-root emotion-1"
   >
@@ -4737,45 +4789,49 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-number"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root emotion-1"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          step="any"
-          type="number"
-          value={0}
-        />
-        <fieldset
-          aria-hidden={true}
-          className="MuiOutlinedInput-notchedOutline emotion-4"
+        <div
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
+          onClick={[Function]}
         >
-          <legend
-            className="emotion-5"
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            step="any"
+            type="number"
+            value={0}
+          />
+          <fieldset
+            aria-hidden={true}
+            className="MuiOutlinedInput-notchedOutline emotion-4"
           >
-            <span
-              className="notranslate"
+            <legend
+              className="emotion-5"
             >
-              ​
-            </span>
-          </legend>
-        </fieldset>
+              <span
+                className="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
       </div>
     </div>
   </div>
@@ -5140,45 +5196,49 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-number"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root emotion-1"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          step="any"
-          type="number"
-          value=""
-        />
-        <fieldset
-          aria-hidden={true}
-          className="MuiOutlinedInput-notchedOutline emotion-4"
+        <div
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
+          onClick={[Function]}
         >
-          <legend
-            className="emotion-5"
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            step="any"
+            type="number"
+            value=""
+          />
+          <fieldset
+            aria-hidden={true}
+            className="MuiOutlinedInput-notchedOutline emotion-4"
           >
-            <span
-              className="notranslate"
+            <legend
+              className="emotion-5"
             >
-              ​
-            </span>
-          </legend>
-        </fieldset>
+              <span
+                className="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
       </div>
     </div>
   </div>
@@ -5534,44 +5594,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root emotion-1"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="password"
-          value=""
-        />
-        <fieldset
-          aria-hidden={true}
-          className="MuiOutlinedInput-notchedOutline emotion-4"
+        <div
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
+          onClick={[Function]}
         >
-          <legend
-            className="emotion-5"
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="password"
+            value=""
+          />
+          <fieldset
+            aria-hidden={true}
+            className="MuiOutlinedInput-notchedOutline emotion-4"
           >
-            <span
-              className="notranslate"
+            <legend
+              className="emotion-5"
             >
-              ​
-            </span>
-          </legend>
-        </fieldset>
+              <span
+                className="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
       </div>
     </div>
   </div>
@@ -5931,141 +5995,145 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-boolean"
   >
-    <label
-      className="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-1"
-      htmlFor="root"
-    />
     <div
-      className="MuiFormGroup-root emotion-2"
-      id="root"
-      onBlur={[Function]}
-      onFocus={[Function]}
-      role="radiogroup"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <label
-        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
+        className="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-1"
+        htmlFor="root"
+      />
+      <div
+        className="MuiFormGroup-root emotion-2"
+        id="root"
+        onBlur={[Function]}
+        onFocus={[Function]}
+        role="radiogroup"
       >
-        <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary emotion-4"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
+        <label
+          className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
         >
-          <input
-            checked={false}
-            className="PrivateSwitchBase-input emotion-5"
-            disabled={false}
-            name="root-0"
-            onChange={[Function]}
-            type="radio"
-            value="true"
-          />
           <span
-            className="emotion-6"
+            className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary emotion-4"
+            onBlur={[Function]}
+            onContextMenu={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
           >
-            <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-7"
-              data-testid="RadioButtonUncheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
+            <input
+              checked={false}
+              className="PrivateSwitchBase-input emotion-5"
+              disabled={false}
+              name="root-0"
+              onChange={[Function]}
+              type="radio"
+              value="true"
+            />
+            <span
+              className="emotion-6"
             >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-8"
-              data-testid="RadioButtonCheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-              />
-            </svg>
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-7"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-8"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
           </span>
-        </span>
-        <span
-          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-9"
-        >
-          Yes
-        </span>
-      </label>
-      <label
-        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
-      >
-        <span
-          className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary emotion-4"
-          onBlur={[Function]}
-          onContextMenu={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
-        >
-          <input
-            checked={false}
-            className="PrivateSwitchBase-input emotion-5"
-            disabled={false}
-            name="root-1"
-            onChange={[Function]}
-            type="radio"
-            value="false"
-          />
           <span
-            className="emotion-6"
+            className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-9"
           >
-            <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-7"
-              data-testid="RadioButtonUncheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
-              />
-            </svg>
-            <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-8"
-              data-testid="RadioButtonCheckedIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
-              />
-            </svg>
+            Yes
           </span>
-        </span>
-        <span
-          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-9"
+        </label>
+        <label
+          className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
         >
-          No
-        </span>
-      </label>
+          <span
+            className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary emotion-4"
+            onBlur={[Function]}
+            onContextMenu={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <input
+              checked={false}
+              className="PrivateSwitchBase-input emotion-5"
+              disabled={false}
+              name="root-1"
+              onChange={[Function]}
+              type="radio"
+              value="false"
+            />
+            <span
+              className="emotion-6"
+            >
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-7"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-8"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-9"
+          >
+            No
+          </span>
+        </label>
+      </div>
     </div>
   </div>
   <div
@@ -6494,71 +6562,75 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
-        onClick={[Function]}
-        variant="outlined"
+        className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-labelledby="root"
-          className="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input emotion-3"
-          id="root"
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseDown={[Function]}
-          role="button"
-          tabIndex={0}
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
+          onClick={[Function]}
+          variant="outlined"
         >
-          <span
-            className="notranslate"
-          >
-            ​
-          </span>
-        </div>
-        <input
-          aria-hidden={true}
-          autoFocus={false}
-          className="MuiSelect-nativeInput emotion-4"
-          disabled={false}
-          onAnimationStart={[Function]}
-          onChange={[Function]}
-          required={false}
-          tabIndex={-1}
-          value=""
-        />
-        <svg
-          aria-hidden={true}
-          className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined emotion-5"
-          data-testid="ArrowDropDownIcon"
-          focusable="false"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M7 10l5 5 5-5z"
-          />
-        </svg>
-        <fieldset
-          aria-hidden={true}
-          className="MuiOutlinedInput-notchedOutline emotion-6"
-        >
-          <legend
-            className="emotion-7"
+          <div
+            aria-expanded="false"
+            aria-haspopup="listbox"
+            aria-labelledby="root"
+            className="MuiSelect-select MuiSelect-outlined MuiInputBase-input MuiOutlinedInput-input emotion-3"
+            id="root"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            role="button"
+            tabIndex={0}
           >
             <span
               className="notranslate"
             >
               ​
             </span>
-          </legend>
-        </fieldset>
+          </div>
+          <input
+            aria-hidden={true}
+            autoFocus={false}
+            className="MuiSelect-nativeInput emotion-4"
+            disabled={false}
+            onAnimationStart={[Function]}
+            onChange={[Function]}
+            required={false}
+            tabIndex={-1}
+            value=""
+          />
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiSelect-icon MuiSelect-iconOutlined emotion-5"
+            data-testid="ArrowDropDownIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M7 10l5 5 5-5z"
+            />
+          </svg>
+          <fieldset
+            aria-hidden={true}
+            className="MuiOutlinedInput-notchedOutline emotion-6"
+          >
+            <legend
+              className="emotion-7"
+            >
+              <span
+                className="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
       </div>
     </div>
   </div>
@@ -6942,93 +7014,97 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-integer"
   >
-    <label
-      className="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-1"
-      id="root"
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
-      
-    </label>
-    <span
-      className="MuiSlider-root MuiSlider-colorPrimary MuiSlider-sizeMedium emotion-2"
-      id="root"
-      label=""
-      onBlur={[Function]}
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-    >
-      <span
-        className="MuiSlider-rail emotion-3"
-      />
-      <span
-        className="MuiSlider-track emotion-4"
-        style={
-          Object {
-            "left": "0%",
-            "width": "56.89655172413793%",
-          }
-        }
-      />
-      <span
-        className="MuiSlider-thumb MuiSlider-thumbColorPrimary MuiSlider-thumbSizeMedium emotion-5"
-        data-focusvisible={false}
-        data-index={0}
-        onMouseLeave={[Function]}
-        onMouseOver={[Function]}
-        style={
-          Object {
-            "left": "56.89655172413793%",
-            "pointerEvents": undefined,
-          }
-        }
+      <label
+        className="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-1"
+        id="root"
       >
-        <input
-          aria-orientation="horizontal"
-          aria-valuemax={100}
-          aria-valuemin={42}
-          aria-valuenow={75}
-          data-index={0}
-          disabled={false}
-          max={100}
-          min={42}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          step={1}
-          style={
-            Object {
-              "border": 0,
-              "clip": "rect(0 0 0 0)",
-              "direction": "ltr",
-              "height": "100%",
-              "margin": -1,
-              "overflow": "hidden",
-              "padding": 0,
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "100%",
-            }
-          }
-          type="range"
-          value={75}
+        
+      </label>
+      <span
+        className="MuiSlider-root MuiSlider-colorPrimary MuiSlider-sizeMedium emotion-2"
+        id="root"
+        label=""
+        onBlur={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+      >
+        <span
+          className="MuiSlider-rail emotion-3"
         />
         <span
-          aria-hidden={true}
-          className="MuiSlider-valueLabel emotion-6"
+          className="MuiSlider-track emotion-4"
+          style={
+            Object {
+              "left": "0%",
+              "width": "56.89655172413793%",
+            }
+          }
+        />
+        <span
+          className="MuiSlider-thumb MuiSlider-thumbColorPrimary MuiSlider-thumbSizeMedium emotion-5"
+          data-focusvisible={false}
+          data-index={0}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          style={
+            Object {
+              "left": "56.89655172413793%",
+              "pointerEvents": undefined,
+            }
+          }
         >
+          <input
+            aria-orientation="horizontal"
+            aria-valuemax={100}
+            aria-valuemin={42}
+            aria-valuenow={75}
+            data-index={0}
+            disabled={false}
+            max={100}
+            min={42}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            step={1}
+            style={
+              Object {
+                "border": 0,
+                "clip": "rect(0 0 0 0)",
+                "direction": "ltr",
+                "height": "100%",
+                "margin": -1,
+                "overflow": "hidden",
+                "padding": 0,
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "100%",
+              }
+            }
+            type="range"
+            value={75}
+          />
           <span
-            className="MuiSlider-valueLabelCircle"
+            aria-hidden={true}
+            className="MuiSlider-valueLabel emotion-6"
           >
             <span
-              className="MuiSlider-valueLabelLabel"
+              className="MuiSlider-valueLabelCircle"
             >
-              75
+              <span
+                className="MuiSlider-valueLabelLabel"
+              >
+                75
+              </span>
             </span>
           </span>
         </span>
       </span>
-    </span>
+    </div>
   </div>
   <div
     className="MuiBox-root emotion-7"
@@ -7192,19 +7268,23 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-string"
   >
-    <div>
-      <p>
-        <input
-          autoFocus={false}
-          defaultValue=""
-          disabled={false}
-          id="root"
-          onChange={[Function]}
-          type="file"
-        />
-      </p>
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    >
+      <div>
+        <p>
+          <input
+            autoFocus={false}
+            defaultValue=""
+            disabled={false}
+            id="root"
+            onChange={[Function]}
+            type="file"
+          />
+        </p>
+      </div>
     </div>
   </div>
   <div
@@ -7571,44 +7651,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root emotion-1"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="email"
-          value=""
-        />
-        <fieldset
-          aria-hidden={true}
-          className="MuiOutlinedInput-notchedOutline emotion-4"
+        <div
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
+          onClick={[Function]}
         >
-          <legend
-            className="emotion-5"
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="email"
+            value=""
+          />
+          <fieldset
+            aria-hidden={true}
+            className="MuiOutlinedInput-notchedOutline emotion-4"
           >
-            <span
-              className="notranslate"
+            <legend
+              className="emotion-5"
             >
-              ​
-            </span>
-          </legend>
-        </fieldset>
+              <span
+                className="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
       </div>
     </div>
   </div>
@@ -7964,44 +8048,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root emotion-1"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="url"
-          value=""
-        />
-        <fieldset
-          aria-hidden={true}
-          className="MuiOutlinedInput-notchedOutline emotion-4"
+        <div
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
+          onClick={[Function]}
         >
-          <legend
-            className="emotion-5"
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="url"
+            value=""
+          />
+          <fieldset
+            aria-hidden={true}
+            className="MuiOutlinedInput-notchedOutline emotion-4"
           >
-            <span
-              className="notranslate"
+            <legend
+              className="emotion-5"
             >
-              ​
-            </span>
-          </legend>
-        </fieldset>
+              <span
+                className="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
       </div>
     </div>
   </div>
@@ -8354,44 +8442,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root emotion-1"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="text"
-          value=""
-        />
-        <fieldset
-          aria-hidden={true}
-          className="MuiOutlinedInput-notchedOutline emotion-4"
+        <div
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
+          onClick={[Function]}
         >
-          <legend
-            className="emotion-5"
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="text"
+            value=""
+          />
+          <fieldset
+            aria-hidden={true}
+            className="MuiOutlinedInput-notchedOutline emotion-4"
           >
-            <span
-              className="notranslate"
+            <legend
+              className="emotion-5"
             >
-              ​
-            </span>
-          </legend>
-        </fieldset>
+              <span
+                className="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
       </div>
     </div>
   </div>
@@ -8744,44 +8836,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root emotion-1"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder="placeholder"
-          required={false}
-          type="text"
-          value=""
-        />
-        <fieldset
-          aria-hidden={true}
-          className="MuiOutlinedInput-notchedOutline emotion-4"
+        <div
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
+          onClick={[Function]}
         >
-          <legend
-            className="emotion-5"
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="placeholder"
+            required={false}
+            type="text"
+            value=""
+          />
+          <fieldset
+            aria-hidden={true}
+            className="MuiOutlinedInput-notchedOutline emotion-4"
           >
-            <span
-              className="notranslate"
+            <legend
+              className="emotion-5"
             >
-              ​
-            </span>
-          </legend>
-        </fieldset>
+              <span
+                className="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
       </div>
     </div>
   </div>
@@ -9150,68 +9246,72 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline emotion-2"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root emotion-1"
       >
-        <textarea
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline emotion-3"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          rows={5}
-          style={
-            Object {
-              "height": 500,
-              "overflow": null,
-            }
-          }
-          value=""
-        />
-        <textarea
-          aria-hidden={true}
-          className="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline emotion-3"
-          readOnly={true}
-          style={
-            Object {
-              "height": 0,
-              "left": 0,
-              "overflow": "hidden",
-              "padding": 0,
-              "position": "absolute",
-              "top": 0,
-              "transform": "translateZ(0)",
-              "visibility": "hidden",
-            }
-          }
-          tabIndex={-1}
-        />
-        <fieldset
-          aria-hidden={true}
-          className="MuiOutlinedInput-notchedOutline emotion-5"
+        <div
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-multiline emotion-2"
+          onClick={[Function]}
         >
-          <legend
-            className="emotion-6"
+          <textarea
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline emotion-3"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            rows={5}
+            style={
+              Object {
+                "height": 500,
+                "overflow": null,
+              }
+            }
+            value=""
+          />
+          <textarea
+            aria-hidden={true}
+            className="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputMultiline emotion-3"
+            readOnly={true}
+            style={
+              Object {
+                "height": 0,
+                "left": 0,
+                "overflow": "hidden",
+                "padding": 0,
+                "position": "absolute",
+                "top": 0,
+                "transform": "translateZ(0)",
+                "visibility": "hidden",
+              }
+            }
+            tabIndex={-1}
+          />
+          <fieldset
+            aria-hidden={true}
+            className="MuiOutlinedInput-notchedOutline emotion-5"
           >
-            <span
-              className="notranslate"
+            <legend
+              className="emotion-6"
             >
-              ​
-            </span>
-          </legend>
-        </fieldset>
+              <span
+                className="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
       </div>
     </div>
   </div>
@@ -9753,82 +9853,90 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-10:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-object"
   >
     <div
-      className="MuiBox-root emotion-1"
-      id="root-title"
-    >
-      <h5
-        className="MuiTypography-root MuiTypography-h5 emotion-2"
-      >
-        Titre 1
-      </h5>
-      <hr
-        className="MuiDivider-root MuiDivider-fullWidth emotion-3"
-      />
-    </div>
-    <div
-      className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-4"
-      style={
-        Object {
-          "marginTop": "10px",
-        }
-      }
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-5"
+        className="MuiBox-root emotion-1"
+        id="root-title"
+      >
+        <h5
+          className="MuiTypography-root MuiTypography-h5 emotion-2"
+        >
+          Titre 1
+        </h5>
+        <hr
+          className="MuiDivider-root MuiDivider-fullWidth emotion-3"
+        />
+      </div>
+      <div
+        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-4"
         style={
           Object {
-            "marginBottom": "10px",
+            "marginTop": "10px",
           }
         }
       >
         <div
-          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-5"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
           <div
-            className="MuiFormControl-root MuiTextField-root emotion-7"
+            className="form-group field field-string"
           >
-            <label
-              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary emotion-8"
-              data-shrink={false}
-              htmlFor="root_title"
-              id="root_title-label"
-            >
-              title
-            </label>
             <div
-              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-9"
-              onClick={[Function]}
+              className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
             >
-              <input
-                aria-invalid={false}
-                autoFocus={false}
-                className="MuiInputBase-input MuiOutlinedInput-input emotion-10"
-                disabled={false}
-                id="root_title"
-                onAnimationStart={[Function]}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder=""
-                required={false}
-                type="text"
-                value=""
-              />
-              <fieldset
-                aria-hidden={true}
-                className="MuiOutlinedInput-notchedOutline emotion-11"
+              <div
+                className="MuiFormControl-root MuiTextField-root emotion-7"
               >
-                <legend
-                  className="emotion-12"
+                <label
+                  className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary emotion-8"
+                  data-shrink={false}
+                  htmlFor="root_title"
+                  id="root_title-label"
                 >
-                  <span>
-                    title
-                  </span>
-                </legend>
-              </fieldset>
+                  title
+                </label>
+                <div
+                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-9"
+                  onClick={[Function]}
+                >
+                  <input
+                    aria-invalid={false}
+                    autoFocus={false}
+                    className="MuiInputBase-input MuiOutlinedInput-input emotion-10"
+                    disabled={false}
+                    id="root_title"
+                    onAnimationStart={[Function]}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                  <fieldset
+                    aria-hidden={true}
+                    className="MuiOutlinedInput-notchedOutline emotion-11"
+                  >
+                    <legend
+                      className="emotion-12"
+                    >
+                      <span>
+                        title
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -9985,29 +10093,33 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-undefined"
   >
     <div
-      className="unsupported-field"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
-      <p>
-        Unsupported field schema
-        <span>
-           for
-           field 
-          <code>
-            root
-          </code>
-        </span>
-        <em>
-          : 
-          Unknown field type undefined
-        </em>
-        .
-      </p>
-      <pre>
-        {}
-      </pre>
+      <div
+        className="unsupported-field"
+      >
+        <p>
+          Unsupported field schema
+          <span>
+             for
+             field 
+            <code>
+              root
+            </code>
+          </span>
+          <em>
+            : 
+            Unknown field type undefined
+          </em>
+          .
+        </p>
+        <pre>
+          {}
+        </pre>
+      </div>
     </div>
   </div>
   <div
@@ -10371,44 +10483,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-number"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root emotion-1"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="number"
-          value=""
-        />
-        <fieldset
-          aria-hidden={true}
-          className="MuiOutlinedInput-notchedOutline emotion-4"
+        <div
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
+          onClick={[Function]}
         >
-          <legend
-            className="emotion-5"
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="number"
+            value=""
+          />
+          <fieldset
+            aria-hidden={true}
+            className="MuiOutlinedInput-notchedOutline emotion-4"
           >
-            <span
-              className="notranslate"
+            <legend
+              className="emotion-5"
             >
-              ​
-            </span>
-          </legend>
-        </fieldset>
+              <span
+                className="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
       </div>
     </div>
   </div>
@@ -10776,44 +10892,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-string"
   >
     <div
-      className="MuiFormControl-root MuiTextField-root emotion-1"
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
-        onClick={[Function]}
+        className="MuiFormControl-root MuiTextField-root emotion-1"
       >
-        <input
-          aria-invalid={false}
-          autoFocus={false}
-          className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
-          disabled={false}
-          id="root"
-          onAnimationStart={[Function]}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          required={false}
-          type="text"
-          value=""
-        />
-        <fieldset
-          aria-hidden={true}
-          className="MuiOutlinedInput-notchedOutline emotion-4"
+        <div
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
+          onClick={[Function]}
         >
-          <legend
-            className="emotion-5"
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
+            disabled={false}
+            id="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="text"
+            value=""
+          />
+          <fieldset
+            aria-hidden={true}
+            className="MuiOutlinedInput-notchedOutline emotion-4"
           >
-            <span
-              className="notranslate"
+            <legend
+              className="emotion-5"
             >
-              ​
-            </span>
-          </legend>
-        </fieldset>
+              <span
+                className="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/mui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Object.test.tsx.snap
@@ -814,91 +814,42 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-object"
   >
-    
     <div
-      className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
-      style={
-        Object {
-          "marginTop": "10px",
-        }
-      }
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
+      
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
         style={
           Object {
-            "marginBottom": "10px",
+            "marginTop": "10px",
           }
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-3"
+          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
           <div
-            className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+            className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 form-group field field-string emotion-3"
           >
             <div
-              className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
-            >
-              <label
-                className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary emotion-6"
-                data-shrink={false}
-              >
-                foo Key
-              </label>
-              <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-7"
-                onClick={[Function]}
-              >
-                <input
-                  aria-invalid={false}
-                  className="MuiInputBase-input MuiOutlinedInput-input emotion-8"
-                  defaultValue="foo"
-                  disabled={false}
-                  id="root_foo-key"
-                  name="root_foo-key"
-                  onAnimationStart={[Function]}
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  required={false}
-                  type="text"
-                />
-                <fieldset
-                  aria-hidden={true}
-                  className="MuiOutlinedInput-notchedOutline emotion-9"
-                >
-                  <legend
-                    className="emotion-10"
-                  >
-                    <span
-                      className="notranslate"
-                    >
-                      ​
-                    </span>
-                  </legend>
-                </fieldset>
-              </div>
-            </div>
-          </div>
-          <div
-            className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
-          >
-            <div
-              className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
             >
               <div
-                className="MuiFormControl-root MuiTextField-root emotion-13"
+                className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
               >
                 <label
                   className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary emotion-6"
                   data-shrink={false}
-                  htmlFor="root_foo"
-                  id="root_foo-label"
                 >
-                  foo
+                  foo Key
                 </label>
                 <div
                   className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-7"
@@ -906,40 +857,144 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
                 >
                   <input
                     aria-invalid={false}
-                    autoFocus={false}
                     className="MuiInputBase-input MuiOutlinedInput-input emotion-8"
+                    defaultValue="foo"
                     disabled={false}
-                    id="root_foo"
+                    id="root_foo-key"
+                    name="root_foo-key"
                     onAnimationStart={[Function]}
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
-                    placeholder=""
                     required={false}
                     type="text"
-                    value="foo"
                   />
                   <fieldset
                     aria-hidden={true}
                     className="MuiOutlinedInput-notchedOutline emotion-9"
                   >
                     <legend
-                      className="emotion-18"
+                      className="emotion-10"
                     >
-                      <span>
-                        foo
+                      <span
+                        className="notranslate"
+                      >
+                        ​
                       </span>
                     </legend>
                   </fieldset>
                 </div>
               </div>
             </div>
+            <div
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+            >
+              <div
+                className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+              >
+                <div
+                  className="MuiFormControl-root MuiTextField-root emotion-13"
+                >
+                  <label
+                    className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary emotion-6"
+                    data-shrink={false}
+                    htmlFor="root_foo"
+                    id="root_foo-label"
+                  >
+                    foo
+                  </label>
+                  <div
+                    className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-7"
+                    onClick={[Function]}
+                  >
+                    <input
+                      aria-invalid={false}
+                      autoFocus={false}
+                      className="MuiInputBase-input MuiOutlinedInput-input emotion-8"
+                      disabled={false}
+                      id="root_foo"
+                      onAnimationStart={[Function]}
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      placeholder=""
+                      required={false}
+                      type="text"
+                      value="foo"
+                    />
+                    <fieldset
+                      aria-hidden={true}
+                      className="MuiOutlinedInput-notchedOutline emotion-9"
+                    >
+                      <legend
+                        className="emotion-18"
+                      >
+                        <span>
+                          foo
+                        </span>
+                      </legend>
+                    </fieldset>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="MuiGrid-root MuiGrid-item emotion-19"
+            >
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-20"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  Object {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-21"
+                  data-testid="RemoveIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 13H5v-2h14v2z"
+                  />
+                </svg>
+                <span
+                  className="MuiTouchRipple-root emotion-22"
+                />
+              </button>
+            </div>
           </div>
+        </div>
+        <div
+          className="MuiGrid-root MuiGrid-container emotion-23"
+        >
           <div
             className="MuiGrid-root MuiGrid-item emotion-19"
           >
             <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-20"
+              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeMedium object-property-expand emotion-25"
               disabled={false}
               onBlur={[Function]}
               onClick={[Function]}
@@ -954,27 +1009,19 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               onTouchEnd={[Function]}
               onTouchMove={[Function]}
               onTouchStart={[Function]}
-              style={
-                Object {
-                  "flex": 1,
-                  "fontWeight": "bold",
-                  "paddingLeft": 6,
-                  "paddingRight": 6,
-                }
-              }
               tabIndex={0}
-              title="Remove"
+              title="Add Item"
               type="button"
             >
               <svg
                 aria-hidden={true}
                 className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-21"
-                data-testid="RemoveIcon"
+                data-testid="AddIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
                 <path
-                  d="M19 13H5v-2h14v2z"
+                  d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
                 />
               </svg>
               <span
@@ -982,49 +1029,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               />
             </button>
           </div>
-        </div>
-      </div>
-      <div
-        className="MuiGrid-root MuiGrid-container emotion-23"
-      >
-        <div
-          className="MuiGrid-root MuiGrid-item emotion-19"
-        >
-          <button
-            className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeMedium object-property-expand emotion-25"
-            disabled={false}
-            onBlur={[Function]}
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={0}
-            title="Add Item"
-            type="button"
-          >
-            <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-21"
-              data-testid="AddIcon"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-              />
-            </svg>
-            <span
-              className="MuiTouchRipple-root emotion-22"
-            />
-          </button>
         </div>
       </div>
     </div>
@@ -1530,128 +1534,140 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    className="form-group field field-object"
   >
-    
     <div
-      className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
-      style={
-        Object {
-          "marginTop": "10px",
-        }
-      }
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
+      
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
         style={
           Object {
-            "marginBottom": "10px",
+            "marginTop": "10px",
           }
         }
       >
         <div
-          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
           <div
-            className="MuiFormControl-root MuiTextField-root emotion-4"
+            className="form-group field field-string"
           >
-            <label
-              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary emotion-5"
-              data-shrink={false}
-              htmlFor="root_a"
-              id="root_a-label"
-            >
-              A
-            </label>
             <div
-              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-6"
-              onClick={[Function]}
+              className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
             >
-              <input
-                aria-invalid={false}
-                autoFocus={false}
-                className="MuiInputBase-input MuiOutlinedInput-input emotion-7"
-                disabled={false}
-                id="root_a"
-                onAnimationStart={[Function]}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder=""
-                required={false}
-                type="text"
-                value=""
-              />
-              <fieldset
-                aria-hidden={true}
-                className="MuiOutlinedInput-notchedOutline emotion-8"
+              <div
+                className="MuiFormControl-root MuiTextField-root emotion-4"
               >
-                <legend
-                  className="emotion-9"
+                <label
+                  className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary emotion-5"
+                  data-shrink={false}
+                  htmlFor="root_a"
+                  id="root_a-label"
                 >
-                  <span>
-                    A
-                  </span>
-                </legend>
-              </fieldset>
+                  A
+                </label>
+                <div
+                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-6"
+                  onClick={[Function]}
+                >
+                  <input
+                    aria-invalid={false}
+                    autoFocus={false}
+                    className="MuiInputBase-input MuiOutlinedInput-input emotion-7"
+                    disabled={false}
+                    id="root_a"
+                    onAnimationStart={[Function]}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                  <fieldset
+                    aria-hidden={true}
+                    className="MuiOutlinedInput-notchedOutline emotion-8"
+                  >
+                    <legend
+                      className="emotion-9"
+                    >
+                      <span>
+                        A
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
-        style={
-          Object {
-            "marginBottom": "10px",
-          }
-        }
-      >
         <div
-          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+          style={
+            Object {
+              "marginBottom": "10px",
+            }
+          }
         >
           <div
-            className="MuiFormControl-root MuiTextField-root emotion-4"
+            className="form-group field field-number"
           >
-            <label
-              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary emotion-5"
-              data-shrink={false}
-              htmlFor="root_b"
-              id="root_b-label"
-            >
-              B
-            </label>
             <div
-              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-6"
-              onClick={[Function]}
+              className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
             >
-              <input
-                aria-invalid={false}
-                autoFocus={false}
-                className="MuiInputBase-input MuiOutlinedInput-input emotion-7"
-                disabled={false}
-                id="root_b"
-                onAnimationStart={[Function]}
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                placeholder=""
-                required={false}
-                step="any"
-                type="number"
-                value=""
-              />
-              <fieldset
-                aria-hidden={true}
-                className="MuiOutlinedInput-notchedOutline emotion-8"
+              <div
+                className="MuiFormControl-root MuiTextField-root emotion-4"
               >
-                <legend
-                  className="emotion-9"
+                <label
+                  className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary emotion-5"
+                  data-shrink={false}
+                  htmlFor="root_b"
+                  id="root_b-label"
                 >
-                  <span>
-                    B
-                  </span>
-                </legend>
-              </fieldset>
+                  B
+                </label>
+                <div
+                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-6"
+                  onClick={[Function]}
+                >
+                  <input
+                    aria-invalid={false}
+                    autoFocus={false}
+                    className="MuiInputBase-input MuiOutlinedInput-input emotion-7"
+                    disabled={false}
+                    id="root_b"
+                    onAnimationStart={[Function]}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    required={false}
+                    step="any"
+                    type="number"
+                    value=""
+                  />
+                  <fieldset
+                    aria-hidden={true}
+                    className="MuiOutlinedInput-notchedOutline emotion-8"
+                  >
+                    <legend
+                      className="emotion-9"
+                    >
+                      <span>
+                        B
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/packages/semantic-ui/src/FieldTemplate/WrapIfAdditional.js
+++ b/packages/semantic-ui/src/FieldTemplate/WrapIfAdditional.js
@@ -23,7 +23,7 @@ const WrapIfAdditional = ({
   const additional = ADDITIONAL_PROPERTY_FLAG in schema;
 
   if (!additional) {
-    return <>{children}</>;
+    return <div className={classNames}>{children}</div>;
   }
 
   const handleBlur = ({ target }) => onKeyChange(target.value);

--- a/packages/semantic-ui/test/__snapshots__/Array.test.js.snap
+++ b/packages/semantic-ui/test/__snapshots__/Array.test.js.snap
@@ -7,35 +7,39 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-array"
   >
     <div
-      className="field field-array field-array-of-string sortable-form-fields"
+      className="grouped equal width fields"
     >
-      <div>
-        <div
-          className="row array-item-list"
-        />
-        <div
-          style={
-            Object {
-              "marginTop": "1rem",
-              "position": "relative",
-              "textAlign": "right",
+      <div
+        className="field field-array field-array-of-string sortable-form-fields"
+      >
+        <div>
+          <div
+            className="row array-item-list"
+          />
+          <div
+            style={
+              Object {
+                "marginTop": "1rem",
+                "position": "relative",
+                "textAlign": "right",
+              }
             }
-          }
-        >
-          <button
-            className="ui tiny icon left labeled button"
-            onClick={[Function]}
-            title="Add Item"
           >
-            <i
-              aria-hidden="true"
-              className="plus icon"
+            <button
+              className="ui tiny icon left labeled button"
               onClick={[Function]}
-            />
-          </button>
+              title="Add Item"
+            >
+              <i
+                aria-hidden="true"
+                className="plus icon"
+                onClick={[Function]}
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -57,212 +61,224 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-array"
   >
     <div
-      className="field field-array field-array-of-string sortable-form-fields"
+      className="grouped equal width fields"
     >
-      <div>
-        <div
-          className="row array-item-list"
-        >
+      <div
+        className="field field-array field-array-of-string sortable-form-fields"
+      >
+        <div>
           <div
-            className="array-item"
+            className="row array-item-list"
           >
             <div
-              className="ui grid"
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "grid",
-                  "gridTemplateColumns": "1fr 65px",
-                }
-              }
+              className="array-item"
             >
               <div
-                className="middle aligned sixteen wide column"
+                className="ui grid"
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "grid",
+                    "gridTemplateColumns": "1fr 65px",
+                  }
+                }
               >
                 <div
-                  className="grouped equal width fields"
+                  className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="required field"
+                    className="form-group field field-string"
                   >
                     <div
-                      className="ui fluid input"
+                      className="grouped equal width fields"
                     >
-                      <input
-                        aria-describedby={null}
-                        autoFocus={false}
-                        disabled={false}
-                        id="root_0"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder=""
-                        required={true}
-                        type="text"
-                        value="a"
-                      />
+                      <div
+                        className="required field"
+                      >
+                        <div
+                          className="ui fluid input"
+                        >
+                          <input
+                            aria-describedby={null}
+                            autoFocus={false}
+                            disabled={false}
+                            id="root_0"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            placeholder=""
+                            required={true}
+                            type="text"
+                            value="a"
+                          />
+                        </div>
+                      </div>
+                      
                     </div>
                   </div>
-                  
+                </div>
+                <div
+                  className="column"
+                >
+                  <div
+                    className="ui mini vertical buttons"
+                  >
+                    <button
+                      className="ui icon disabled button array-item-move-up"
+                      disabled={true}
+                      onClick={[Function]}
+                      tabIndex={-1}
+                      title="Move up"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="angle up icon"
+                        onClick={[Function]}
+                      />
+                    </button>
+                    <button
+                      className="ui icon button array-item-move-down"
+                      onClick={[Function]}
+                      title="Move down"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="angle down icon"
+                        onClick={[Function]}
+                      />
+                    </button>
+                    <button
+                      className="ui icon button array-item-remove"
+                      onClick={[Function]}
+                      title="Remove"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="trash icon"
+                        onClick={[Function]}
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
+            </div>
+            <div
+              className="array-item"
+            >
               <div
-                className="column"
+                className="ui grid"
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "grid",
+                    "gridTemplateColumns": "1fr 65px",
+                  }
+                }
               >
                 <div
-                  className="ui mini vertical buttons"
+                  className="middle aligned sixteen wide column"
                 >
-                  <button
-                    className="ui icon disabled button array-item-move-up"
-                    disabled={true}
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    title="Move up"
+                  <div
+                    className="form-group field field-string"
                   >
-                    <i
-                      aria-hidden="true"
-                      className="angle up icon"
-                      onClick={[Function]}
-                    />
-                  </button>
-                  <button
-                    className="ui icon button array-item-move-down"
-                    onClick={[Function]}
-                    title="Move down"
+                    <div
+                      className="grouped equal width fields"
+                    >
+                      <div
+                        className="required field"
+                      >
+                        <div
+                          className="ui fluid input"
+                        >
+                          <input
+                            aria-describedby={null}
+                            autoFocus={false}
+                            disabled={false}
+                            id="root_1"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            placeholder=""
+                            required={true}
+                            type="text"
+                            value="b"
+                          />
+                        </div>
+                      </div>
+                      
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="column"
+                >
+                  <div
+                    className="ui mini vertical buttons"
                   >
-                    <i
-                      aria-hidden="true"
-                      className="angle down icon"
+                    <button
+                      className="ui icon button array-item-move-up"
                       onClick={[Function]}
-                    />
-                  </button>
-                  <button
-                    className="ui icon button array-item-remove"
-                    onClick={[Function]}
-                    title="Remove"
-                  >
-                    <i
-                      aria-hidden="true"
-                      className="trash icon"
+                      title="Move up"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="angle up icon"
+                        onClick={[Function]}
+                      />
+                    </button>
+                    <button
+                      className="ui icon disabled button array-item-move-down"
+                      disabled={true}
                       onClick={[Function]}
-                    />
-                  </button>
+                      tabIndex={-1}
+                      title="Move down"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="angle down icon"
+                        onClick={[Function]}
+                      />
+                    </button>
+                    <button
+                      className="ui icon button array-item-remove"
+                      onClick={[Function]}
+                      title="Remove"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="trash icon"
+                        onClick={[Function]}
+                      />
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
           <div
-            className="array-item"
-          >
-            <div
-              className="ui grid"
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "grid",
-                  "gridTemplateColumns": "1fr 65px",
-                }
+            style={
+              Object {
+                "marginTop": "1rem",
+                "position": "relative",
+                "textAlign": "right",
               }
-            >
-              <div
-                className="middle aligned sixteen wide column"
-              >
-                <div
-                  className="grouped equal width fields"
-                >
-                  <div
-                    className="required field"
-                  >
-                    <div
-                      className="ui fluid input"
-                    >
-                      <input
-                        aria-describedby={null}
-                        autoFocus={false}
-                        disabled={false}
-                        id="root_1"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder=""
-                        required={true}
-                        type="text"
-                        value="b"
-                      />
-                    </div>
-                  </div>
-                  
-                </div>
-              </div>
-              <div
-                className="column"
-              >
-                <div
-                  className="ui mini vertical buttons"
-                >
-                  <button
-                    className="ui icon button array-item-move-up"
-                    onClick={[Function]}
-                    title="Move up"
-                  >
-                    <i
-                      aria-hidden="true"
-                      className="angle up icon"
-                      onClick={[Function]}
-                    />
-                  </button>
-                  <button
-                    className="ui icon disabled button array-item-move-down"
-                    disabled={true}
-                    onClick={[Function]}
-                    tabIndex={-1}
-                    title="Move down"
-                  >
-                    <i
-                      aria-hidden="true"
-                      className="angle down icon"
-                      onClick={[Function]}
-                    />
-                  </button>
-                  <button
-                    className="ui icon button array-item-remove"
-                    onClick={[Function]}
-                    title="Remove"
-                  >
-                    <i
-                      aria-hidden="true"
-                      className="trash icon"
-                      onClick={[Function]}
-                    />
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          style={
-            Object {
-              "marginTop": "1rem",
-              "position": "relative",
-              "textAlign": "right",
             }
-          }
-        >
-          <button
-            className="ui tiny icon left labeled button"
-            onClick={[Function]}
-            title="Add Item"
           >
-            <i
-              aria-hidden="true"
-              className="plus icon"
+            <button
+              className="ui tiny icon left labeled button"
               onClick={[Function]}
-            />
-          </button>
+              title="Add Item"
+            >
+              <i
+                aria-hidden="true"
+                className="plus icon"
+                onClick={[Function]}
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -284,99 +300,103 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-array"
   >
     <div
-      className="field"
+      className="grouped equal width fields"
     >
       <div
-        aria-describedby={null}
-        aria-disabled={false}
-        aria-expanded={false}
-        aria-multiselectable={true}
-        autoFocus={false}
-        className="ui fluid multiple selection scrolling dropdown"
-        inverted="false"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onMouseDown={[Function]}
-        readOnly={false}
-        required={false}
-        role="listbox"
-        tabIndex={0}
+        className="field"
       >
-        <i
-          aria-hidden="true"
-          className="dropdown icon"
-          onClick={[Function]}
-        />
         <div
-          className="menu transition"
+          aria-describedby={null}
+          aria-disabled={false}
+          aria-expanded={false}
+          aria-multiselectable={true}
+          autoFocus={false}
+          className="ui fluid multiple selection scrolling dropdown"
+          inverted="false"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          readOnly={false}
+          required={false}
+          role="listbox"
+          tabIndex={0}
         >
-          <div
-            aria-checked={false}
-            aria-disabled={false}
-            aria-selected={true}
-            className="selected item"
+          <i
+            aria-hidden="true"
+            className="dropdown icon"
             onClick={[Function]}
-            role="option"
-            style={
-              Object {
-                "pointerEvents": "all",
-              }
-            }
-          >
-            <span
-              className="text"
-            >
-              a
-            </span>
-          </div>
+          />
           <div
-            aria-checked={false}
-            aria-disabled={false}
-            aria-selected={false}
-            className="item"
-            onClick={[Function]}
-            role="option"
-            style={
-              Object {
-                "pointerEvents": "all",
-              }
-            }
+            className="menu transition"
           >
-            <span
-              className="text"
-            >
-              b
-            </span>
-          </div>
-          <div
-            aria-checked={false}
-            aria-disabled={false}
-            aria-selected={false}
-            className="item"
-            onClick={[Function]}
-            role="option"
-            style={
-              Object {
-                "pointerEvents": "all",
+            <div
+              aria-checked={false}
+              aria-disabled={false}
+              aria-selected={true}
+              className="selected item"
+              onClick={[Function]}
+              role="option"
+              style={
+                Object {
+                  "pointerEvents": "all",
+                }
               }
-            }
-          >
-            <span
-              className="text"
             >
-              c
-            </span>
+              <span
+                className="text"
+              >
+                a
+              </span>
+            </div>
+            <div
+              aria-checked={false}
+              aria-disabled={false}
+              aria-selected={false}
+              className="item"
+              onClick={[Function]}
+              role="option"
+              style={
+                Object {
+                  "pointerEvents": "all",
+                }
+              }
+            >
+              <span
+                className="text"
+              >
+                b
+              </span>
+            </div>
+            <div
+              aria-checked={false}
+              aria-disabled={false}
+              aria-selected={false}
+              className="item"
+              onClick={[Function]}
+              role="option"
+              style={
+                Object {
+                  "pointerEvents": "all",
+                }
+              }
+            >
+              <span
+                className="text"
+              >
+                c
+              </span>
+            </div>
           </div>
         </div>
       </div>
+      
     </div>
-    
   </div>
   <button
     className="ui primary button"
@@ -395,102 +415,114 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-array"
   >
     <div
-      className="field field-array field-array-fixed-items"
+      className="grouped equal width fields"
     >
-      <div>
-        <div
-          className="row array-item-list"
-        >
+      <div
+        className="field field-array field-array-fixed-items"
+      >
+        <div>
           <div
-            className="array-item"
+            className="row array-item-list"
           >
             <div
-              className="ui grid"
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "grid",
-                  "gridTemplateColumns": "1fr 65px",
-                }
-              }
+              className="array-item"
             >
               <div
-                className="middle aligned sixteen wide column"
+                className="ui grid"
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "grid",
+                    "gridTemplateColumns": "1fr 65px",
+                  }
+                }
               >
                 <div
-                  className="grouped equal width fields"
+                  className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="required field"
+                    className="form-group field field-string"
                   >
                     <div
-                      className="ui fluid input"
+                      className="grouped equal width fields"
                     >
-                      <input
-                        aria-describedby={null}
-                        autoFocus={false}
-                        disabled={false}
-                        id="root_0"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder=""
-                        required={true}
-                        type="text"
-                        value=""
-                      />
+                      <div
+                        className="required field"
+                      >
+                        <div
+                          className="ui fluid input"
+                        >
+                          <input
+                            aria-describedby={null}
+                            autoFocus={false}
+                            disabled={false}
+                            id="root_0"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            placeholder=""
+                            required={true}
+                            type="text"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      
                     </div>
                   </div>
-                  
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            className="array-item"
-          >
             <div
-              className="ui grid"
-              style={
-                Object {
-                  "alignItems": "center",
-                  "display": "grid",
-                  "gridTemplateColumns": "1fr 65px",
-                }
-              }
+              className="array-item"
             >
               <div
-                className="middle aligned sixteen wide column"
+                className="ui grid"
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "display": "grid",
+                    "gridTemplateColumns": "1fr 65px",
+                  }
+                }
               >
                 <div
-                  className="grouped equal width fields"
+                  className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="required field"
+                    className="form-group field field-number"
                   >
                     <div
-                      className="ui fluid input"
+                      className="grouped equal width fields"
                     >
-                      <input
-                        aria-describedby={null}
-                        autoFocus={false}
-                        disabled={false}
-                        id="root_1"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        placeholder=""
-                        required={true}
-                        step="any"
-                        type="number"
-                        value=""
-                      />
+                      <div
+                        className="required field"
+                      >
+                        <div
+                          className="ui fluid input"
+                        >
+                          <input
+                            aria-describedby={null}
+                            autoFocus={false}
+                            disabled={false}
+                            id="root_1"
+                            onBlur={[Function]}
+                            onChange={[Function]}
+                            onFocus={[Function]}
+                            placeholder=""
+                            required={true}
+                            step="any"
+                            type="number"
+                            value=""
+                          />
+                        </div>
+                      </div>
+                      
                     </div>
                   </div>
-                  
                 </div>
               </div>
             </div>

--- a/packages/semantic-ui/test/__snapshots__/Form.test.js.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.js.snap
@@ -7,35 +7,39 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-boolean"
   >
     <div
-      className="field"
+      className="grouped equal width fields"
     >
       <div
-        className="ui checkbox"
-        inverted={false}
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
+        className="field"
       >
-        <input
-          aria-describedby={null}
-          autoFocus={false}
-          checked={false}
-          className="hidden"
-          disabled={false}
-          id="root"
-          readOnly={true}
-          tabIndex={0}
-          type="checkbox"
-        />
-        <label
-          htmlFor="root"
-        />
+        <div
+          className="ui checkbox"
+          inverted={false}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+        >
+          <input
+            aria-describedby={null}
+            autoFocus={false}
+            checked={false}
+            className="hidden"
+            disabled={false}
+            id="root"
+            readOnly={true}
+            tabIndex={0}
+            type="checkbox"
+          />
+          <label
+            htmlFor="root"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -56,35 +60,39 @@ exports[`single fields checkbox field 2`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-boolean"
   >
     <div
-      className="field"
+      className="grouped equal width fields"
     >
       <div
-        className="ui checkbox"
-        inverted={false}
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
+        className="field"
       >
-        <input
-          aria-describedby={null}
-          autoFocus={false}
-          checked={false}
-          className="hidden"
-          disabled={false}
-          id="root"
-          readOnly={true}
-          tabIndex={0}
-          type="checkbox"
-        />
-        <label
-          htmlFor="root"
-        />
+        <div
+          className="ui checkbox"
+          inverted={false}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+        >
+          <input
+            aria-describedby={null}
+            autoFocus={false}
+            checked={false}
+            className="hidden"
+            disabled={false}
+            id="root"
+            readOnly={true}
+            tabIndex={0}
+            type="checkbox"
+          />
+          <label
+            htmlFor="root"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -105,138 +113,142 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-array"
   >
     <div
-      className="grouped fields"
-      id="root"
+      className="grouped equal width fields"
     >
       <div
-        className="field"
+        className="grouped fields"
+        id="root"
       >
         <div
-          className="ui checkbox"
-          inverted={false}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
+          className="field"
         >
-          <input
-            aria-describedby={null}
-            autoFocus={false}
-            checked={false}
-            className="hidden"
-            disabled={false}
-            id="root_0"
-            readOnly={true}
-            tabIndex={0}
-            type="checkbox"
-          />
-          <label
-            htmlFor="root_0"
+          <div
+            className="ui checkbox"
+            inverted={false}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
           >
-            foo
-          </label>
+            <input
+              aria-describedby={null}
+              autoFocus={false}
+              checked={false}
+              className="hidden"
+              disabled={false}
+              id="root_0"
+              readOnly={true}
+              tabIndex={0}
+              type="checkbox"
+            />
+            <label
+              htmlFor="root_0"
+            >
+              foo
+            </label>
+          </div>
         </div>
-      </div>
-      <div
-        className="field"
-      >
         <div
-          className="ui checkbox"
-          inverted={false}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
+          className="field"
         >
-          <input
-            aria-describedby={null}
-            autoFocus={false}
-            checked={false}
-            className="hidden"
-            disabled={false}
-            id="root_1"
-            readOnly={true}
-            tabIndex={0}
-            type="checkbox"
-          />
-          <label
-            htmlFor="root_1"
+          <div
+            className="ui checkbox"
+            inverted={false}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
           >
-            bar
-          </label>
+            <input
+              aria-describedby={null}
+              autoFocus={false}
+              checked={false}
+              className="hidden"
+              disabled={false}
+              id="root_1"
+              readOnly={true}
+              tabIndex={0}
+              type="checkbox"
+            />
+            <label
+              htmlFor="root_1"
+            >
+              bar
+            </label>
+          </div>
         </div>
-      </div>
-      <div
-        className="field"
-      >
         <div
-          className="ui checkbox"
-          inverted={false}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
+          className="field"
         >
-          <input
-            aria-describedby={null}
-            autoFocus={false}
-            checked={false}
-            className="hidden"
-            disabled={false}
-            id="root_2"
-            readOnly={true}
-            tabIndex={0}
-            type="checkbox"
-          />
-          <label
-            htmlFor="root_2"
+          <div
+            className="ui checkbox"
+            inverted={false}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
           >
-            fuzz
-          </label>
+            <input
+              aria-describedby={null}
+              autoFocus={false}
+              checked={false}
+              className="hidden"
+              disabled={false}
+              id="root_2"
+              readOnly={true}
+              tabIndex={0}
+              type="checkbox"
+            />
+            <label
+              htmlFor="root_2"
+            >
+              fuzz
+            </label>
+          </div>
         </div>
-      </div>
-      <div
-        className="field"
-      >
         <div
-          className="ui checkbox"
-          inverted={false}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
+          className="field"
         >
-          <input
-            aria-describedby={null}
-            autoFocus={false}
-            checked={false}
-            className="hidden"
-            disabled={false}
-            id="root_3"
-            readOnly={true}
-            tabIndex={0}
-            type="checkbox"
-          />
-          <label
-            htmlFor="root_3"
+          <div
+            className="ui checkbox"
+            inverted={false}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
           >
-            qux
-          </label>
+            <input
+              aria-describedby={null}
+              autoFocus={false}
+              checked={false}
+              className="hidden"
+              disabled={false}
+              id="root_3"
+              readOnly={true}
+              tabIndex={0}
+              type="checkbox"
+            />
+            <label
+              htmlFor="root_3"
+            >
+              qux
+            </label>
+          </div>
         </div>
       </div>
+      
     </div>
-    
   </div>
   <button
     className="ui primary button"
@@ -255,44 +267,52 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-object"
   >
-    
     <div
       className="grouped equal width fields"
     >
+      
       <div
-        className="field"
+        className="form-group field field-string"
       >
-        <label
-          htmlFor="root_my-field"
-        >
-          my-field
-        </label>
         <div
-          className="ui fluid input"
+          className="grouped equal width fields"
         >
-          <input
-            aria-describedby={null}
-            autoFocus={false}
-            disabled={false}
-            id="root_my-field"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder=""
-            required={false}
-            type="text"
-            value=""
-          />
+          <div
+            className="field"
+          >
+            <label
+              htmlFor="root_my-field"
+            >
+              my-field
+            </label>
+            <div
+              className="ui fluid input"
+            >
+              <input
+                aria-describedby={null}
+                autoFocus={false}
+                disabled={false}
+                id="root_my-field"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                placeholder=""
+                required={false}
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <p
+            className="sui-description"
+            id="root_my-field-description"
+          >
+            some description
+          </p>
         </div>
       </div>
-      <p
-        className="sui-description"
-        id="root_my-field-description"
-      >
-        some description
-      </p>
     </div>
   </div>
   <button
@@ -312,44 +332,52 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-object"
   >
-    
     <div
       className="grouped equal width fields"
     >
+      
       <div
-        className="field"
+        className="form-group field field-string"
       >
-        <label
-          htmlFor="root_my-field"
-        >
-          my-field
-        </label>
         <div
-          className="ui fluid input"
+          className="grouped equal width fields"
         >
-          <input
-            aria-describedby={null}
-            autoFocus={false}
-            disabled={false}
-            id="root_my-field"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder=""
-            required={false}
-            type="text"
-            value=""
-          />
+          <div
+            className="field"
+          >
+            <label
+              htmlFor="root_my-field"
+            >
+              my-field
+            </label>
+            <div
+              className="ui fluid input"
+            >
+              <input
+                aria-describedby={null}
+                autoFocus={false}
+                disabled={false}
+                id="root_my-field"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                placeholder=""
+                required={false}
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <p
+            className="sui-description"
+            id="root_my-field-description"
+          >
+            some other description
+          </p>
         </div>
       </div>
-      <p
-        className="sui-description"
-        id="root_my-field-description"
-      >
-        some other description
-      </p>
     </div>
   </div>
   <button
@@ -369,29 +397,620 @@ exports[`single fields field with special semantic options 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-object"
   >
-    <h5
-      className="ui dividing header"
-      id="root-title"
+    <div
+      className="grouped equal width fields"
     >
-      A registration form
-    </h5>
-    <p
-      className="sui-description"
-      id="root-description"
-    >
-      A simple test theme form example.
-    </p>
+      <h5
+        className="ui dividing header"
+        id="root-title"
+      >
+        A registration form
+      </h5>
+      <p
+        className="sui-description"
+        id="root-description"
+      >
+        A simple test theme form example.
+      </p>
+      <div
+        className="form-group field field-undefined"
+      >
+        <div
+          className="grouped equal width fields"
+        >
+          <div
+            className="required field"
+          >
+            <label>
+              test
+            </label>
+            <div
+              aria-describedby={null}
+              aria-disabled={false}
+              aria-expanded={false}
+              aria-multiselectable={false}
+              autoFocus={false}
+              className="ui fluid selection scrolling dropdown"
+              inverted="false"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseDown={[Function]}
+              readOnly={false}
+              required={true}
+              role="listbox"
+              tabIndex={0}
+            >
+              <div
+                aria-atomic={true}
+                aria-live="polite"
+                className="divider text"
+                role="alert"
+              >
+                
+              </div>
+              <i
+                aria-hidden="true"
+                className="dropdown icon"
+                onClick={[Function]}
+              />
+              <div
+                className="menu transition"
+              >
+                <div
+                  aria-checked={false}
+                  aria-disabled={false}
+                  aria-selected={true}
+                  className="selected item"
+                  onClick={[Function]}
+                  role="option"
+                  style={
+                    Object {
+                      "pointerEvents": "all",
+                    }
+                  }
+                >
+                  <span
+                    className="text"
+                  >
+                    1
+                  </span>
+                </div>
+                <div
+                  aria-checked={false}
+                  aria-disabled={false}
+                  aria-selected={false}
+                  className="item"
+                  onClick={[Function]}
+                  role="option"
+                  style={
+                    Object {
+                      "pointerEvents": "all",
+                    }
+                  }
+                >
+                  <span
+                    className="text"
+                  >
+                    2
+                  </span>
+                </div>
+                <div
+                  aria-checked={false}
+                  aria-disabled={false}
+                  aria-selected={false}
+                  className="item"
+                  onClick={[Function]}
+                  role="option"
+                  style={
+                    Object {
+                      "pointerEvents": "all",
+                    }
+                  }
+                >
+                  <span
+                    className="text"
+                  >
+                    3
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
+exports[`single fields format color 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="required field"
+        className="field"
       >
-        <label>
-          test
-        </label>
+        <div
+          className="ui fluid input"
+        >
+          <input
+            aria-describedby={null}
+            autoFocus={false}
+            disabled={false}
+            id="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            type="color"
+            value=""
+          />
+        </div>
+      </div>
+      
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
+exports[`single fields format date 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      <div
+        className="field"
+      >
+        <div
+          className="ui fluid input"
+        >
+          <input
+            aria-describedby={null}
+            autoFocus={false}
+            disabled={false}
+            id="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            type="date"
+            value=""
+          />
+        </div>
+      </div>
+      
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
+exports[`single fields format datetime 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      <div
+        className="field"
+      >
+        <div
+          className="ui fluid input"
+        >
+          <input
+            aria-describedby={null}
+            autoFocus={false}
+            disabled={false}
+            id="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            type="datetime-local"
+            value=""
+          />
+        </div>
+      </div>
+      
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
+exports[`single fields hidden field 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-object"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      
+      <input
+        id="root_my-field"
+        type="hidden"
+        value=""
+      />
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
+exports[`single fields hidden label 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      <div
+        className="field"
+      >
+        <div
+          className="ui fluid input"
+        >
+          <input
+            aria-describedby={null}
+            autoFocus={false}
+            disabled={false}
+            id="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
+exports[`single fields null field 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-null"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
+exports[`single fields number field 0 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-number"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      <div
+        className="field"
+      >
+        <div
+          className="ui fluid input"
+        >
+          <input
+            aria-describedby={null}
+            autoFocus={false}
+            disabled={false}
+            id="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            step="any"
+            type="number"
+            value={0}
+          />
+        </div>
+      </div>
+      
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
+exports[`single fields number field 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-number"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      <div
+        className="field"
+      >
+        <div
+          className="ui fluid input"
+        >
+          <input
+            aria-describedby={null}
+            autoFocus={false}
+            disabled={false}
+            id="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            step="any"
+            type="number"
+            value=""
+          />
+        </div>
+      </div>
+      
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
+exports[`single fields password field 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      <div
+        className="field"
+      >
+        <div
+          className="ui fluid input"
+        >
+          <input
+            aria-describedby={null}
+            autoFocus={false}
+            disabled={false}
+            id="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            type="password"
+            value=""
+          />
+        </div>
+      </div>
+      
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
+exports[`single fields radio field 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-boolean"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      <div
+        className="grouped fields"
+      >
+        <div
+          className="field"
+        >
+          <div
+            className="ui radio checkbox"
+            fluid={true}
+            inverted={false}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+          >
+            <input
+              aria-describedby={null}
+              checked={false}
+              className="hidden"
+              disabled={false}
+              name="root-radio-true"
+              readOnly={true}
+              tabIndex={0}
+              type="radio"
+              value="true"
+            />
+            <label>
+              Yes
+            </label>
+          </div>
+        </div>
+        <div
+          className="field"
+        >
+          <div
+            className="ui radio checkbox"
+            fluid={true}
+            inverted={false}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+          >
+            <input
+              aria-describedby={null}
+              checked={false}
+              className="hidden"
+              disabled={false}
+              name="root-radio-false"
+              readOnly={true}
+              tabIndex={0}
+              type="radio"
+              value="false"
+            />
+            <label>
+              No
+            </label>
+          </div>
+        </div>
+      </div>
+      
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
+exports[`single fields select field 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      <div
+        className="field"
+      >
         <div
           aria-describedby={null}
           aria-disabled={false}
@@ -407,7 +1026,6 @@ exports[`single fields field with special semantic options 1`] = `
           onKeyDown={[Function]}
           onMouseDown={[Function]}
           readOnly={false}
-          required={true}
           role="listbox"
           tabIndex={0}
         >
@@ -443,7 +1061,7 @@ exports[`single fields field with special semantic options 1`] = `
               <span
                 className="text"
               >
-                1
+                foo
               </span>
             </div>
             <div
@@ -462,26 +1080,7 @@ exports[`single fields field with special semantic options 1`] = `
               <span
                 className="text"
               >
-                2
-              </span>
-            </div>
-            <div
-              aria-checked={false}
-              aria-disabled={false}
-              aria-selected={false}
-              className="item"
-              onClick={[Function]}
-              role="option"
-              style={
-                Object {
-                  "pointerEvents": "all",
-                }
-              }
-            >
-              <span
-                className="text"
-              >
-                3
+                bar
               </span>
             </div>
           </div>
@@ -489,525 +1088,6 @@ exports[`single fields field with special semantic options 1`] = `
       </div>
       
     </div>
-  </div>
-  <button
-    className="ui primary button"
-    onClick={[Function]}
-    type="submit"
-  >
-    Submit
-  </button>
-</form>
-`;
-
-exports[`single fields format color 1`] = `
-<form
-  className="ui form rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="grouped equal width fields"
-  >
-    <div
-      className="field"
-    >
-      <div
-        className="ui fluid input"
-      >
-        <input
-          aria-describedby={null}
-          autoFocus={false}
-          disabled={false}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          type="color"
-          value=""
-        />
-      </div>
-    </div>
-    
-  </div>
-  <button
-    className="ui primary button"
-    onClick={[Function]}
-    type="submit"
-  >
-    Submit
-  </button>
-</form>
-`;
-
-exports[`single fields format date 1`] = `
-<form
-  className="ui form rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="grouped equal width fields"
-  >
-    <div
-      className="field"
-    >
-      <div
-        className="ui fluid input"
-      >
-        <input
-          aria-describedby={null}
-          autoFocus={false}
-          disabled={false}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          type="date"
-          value=""
-        />
-      </div>
-    </div>
-    
-  </div>
-  <button
-    className="ui primary button"
-    onClick={[Function]}
-    type="submit"
-  >
-    Submit
-  </button>
-</form>
-`;
-
-exports[`single fields format datetime 1`] = `
-<form
-  className="ui form rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="grouped equal width fields"
-  >
-    <div
-      className="field"
-    >
-      <div
-        className="ui fluid input"
-      >
-        <input
-          aria-describedby={null}
-          autoFocus={false}
-          disabled={false}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          type="datetime-local"
-          value=""
-        />
-      </div>
-    </div>
-    
-  </div>
-  <button
-    className="ui primary button"
-    onClick={[Function]}
-    type="submit"
-  >
-    Submit
-  </button>
-</form>
-`;
-
-exports[`single fields hidden field 1`] = `
-<form
-  className="ui form rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="grouped equal width fields"
-  >
-    
-    <input
-      id="root_my-field"
-      type="hidden"
-      value=""
-    />
-  </div>
-  <button
-    className="ui primary button"
-    onClick={[Function]}
-    type="submit"
-  >
-    Submit
-  </button>
-</form>
-`;
-
-exports[`single fields hidden label 1`] = `
-<form
-  className="ui form rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="grouped equal width fields"
-  >
-    <div
-      className="field"
-    >
-      <div
-        className="ui fluid input"
-      >
-        <input
-          aria-describedby={null}
-          autoFocus={false}
-          disabled={false}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          type="text"
-          value=""
-        />
-      </div>
-    </div>
-  </div>
-  <button
-    className="ui primary button"
-    onClick={[Function]}
-    type="submit"
-  >
-    Submit
-  </button>
-</form>
-`;
-
-exports[`single fields null field 1`] = `
-<form
-  className="ui form rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="grouped equal width fields"
-  >
-    
-  </div>
-  <button
-    className="ui primary button"
-    onClick={[Function]}
-    type="submit"
-  >
-    Submit
-  </button>
-</form>
-`;
-
-exports[`single fields number field 0 1`] = `
-<form
-  className="ui form rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="grouped equal width fields"
-  >
-    <div
-      className="field"
-    >
-      <div
-        className="ui fluid input"
-      >
-        <input
-          aria-describedby={null}
-          autoFocus={false}
-          disabled={false}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          step="any"
-          type="number"
-          value={0}
-        />
-      </div>
-    </div>
-    
-  </div>
-  <button
-    className="ui primary button"
-    onClick={[Function]}
-    type="submit"
-  >
-    Submit
-  </button>
-</form>
-`;
-
-exports[`single fields number field 1`] = `
-<form
-  className="ui form rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="grouped equal width fields"
-  >
-    <div
-      className="field"
-    >
-      <div
-        className="ui fluid input"
-      >
-        <input
-          aria-describedby={null}
-          autoFocus={false}
-          disabled={false}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          step="any"
-          type="number"
-          value=""
-        />
-      </div>
-    </div>
-    
-  </div>
-  <button
-    className="ui primary button"
-    onClick={[Function]}
-    type="submit"
-  >
-    Submit
-  </button>
-</form>
-`;
-
-exports[`single fields password field 1`] = `
-<form
-  className="ui form rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="grouped equal width fields"
-  >
-    <div
-      className="field"
-    >
-      <div
-        className="ui fluid input"
-      >
-        <input
-          aria-describedby={null}
-          autoFocus={false}
-          disabled={false}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          type="password"
-          value=""
-        />
-      </div>
-    </div>
-    
-  </div>
-  <button
-    className="ui primary button"
-    onClick={[Function]}
-    type="submit"
-  >
-    Submit
-  </button>
-</form>
-`;
-
-exports[`single fields radio field 1`] = `
-<form
-  className="ui form rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="grouped equal width fields"
-  >
-    <div
-      className="grouped fields"
-    >
-      <div
-        className="field"
-      >
-        <div
-          className="ui radio checkbox"
-          fluid={true}
-          inverted={false}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-        >
-          <input
-            aria-describedby={null}
-            checked={false}
-            className="hidden"
-            disabled={false}
-            name="root-radio-true"
-            readOnly={true}
-            tabIndex={0}
-            type="radio"
-            value="true"
-          />
-          <label>
-            Yes
-          </label>
-        </div>
-      </div>
-      <div
-        className="field"
-      >
-        <div
-          className="ui radio checkbox"
-          fluid={true}
-          inverted={false}
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-        >
-          <input
-            aria-describedby={null}
-            checked={false}
-            className="hidden"
-            disabled={false}
-            name="root-radio-false"
-            readOnly={true}
-            tabIndex={0}
-            type="radio"
-            value="false"
-          />
-          <label>
-            No
-          </label>
-        </div>
-      </div>
-    </div>
-    
-  </div>
-  <button
-    className="ui primary button"
-    onClick={[Function]}
-    type="submit"
-  >
-    Submit
-  </button>
-</form>
-`;
-
-exports[`single fields select field 1`] = `
-<form
-  className="ui form rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="grouped equal width fields"
-  >
-    <div
-      className="field"
-    >
-      <div
-        aria-describedby={null}
-        aria-disabled={false}
-        aria-expanded={false}
-        aria-multiselectable={false}
-        autoFocus={false}
-        className="ui fluid selection scrolling dropdown"
-        inverted="false"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onMouseDown={[Function]}
-        readOnly={false}
-        role="listbox"
-        tabIndex={0}
-      >
-        <div
-          aria-atomic={true}
-          aria-live="polite"
-          className="divider text"
-          role="alert"
-        >
-          
-        </div>
-        <i
-          aria-hidden="true"
-          className="dropdown icon"
-          onClick={[Function]}
-        />
-        <div
-          className="menu transition"
-        >
-          <div
-            aria-checked={false}
-            aria-disabled={false}
-            aria-selected={true}
-            className="selected item"
-            onClick={[Function]}
-            role="option"
-            style={
-              Object {
-                "pointerEvents": "all",
-              }
-            }
-          >
-            <span
-              className="text"
-            >
-              foo
-            </span>
-          </div>
-          <div
-            aria-checked={false}
-            aria-disabled={false}
-            aria-selected={false}
-            className="item"
-            onClick={[Function]}
-            role="option"
-            style={
-              Object {
-                "pointerEvents": "all",
-              }
-            }
-          >
-            <span
-              className="text"
-            >
-              bar
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-    
   </div>
   <button
     className="ui primary button"
@@ -1026,27 +1106,31 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-integer"
   >
     <div
-      className="ui fluid input"
+      className="grouped equal width fields"
     >
-      <input
-        disabled={false}
-        id="root"
-        max={100}
-        min={42}
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        type="range"
-        value={75}
-      />
+      <div
+        className="ui fluid input"
+      >
+        <input
+          disabled={false}
+          id="root"
+          max={100}
+          min={42}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          type="range"
+          value={75}
+        />
+      </div>
+      <span>
+        75
+      </span>
+      
     </div>
-    <span>
-      75
-    </span>
-    
   </div>
   <button
     className="ui primary button"
@@ -1065,21 +1149,25 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-string"
   >
-    <div>
-      <p>
-        <input
-          autoFocus={false}
-          defaultValue=""
-          disabled={false}
-          id="root"
-          onChange={[Function]}
-          type="file"
-        />
-      </p>
+    <div
+      className="grouped equal width fields"
+    >
+      <div>
+        <p>
+          <input
+            autoFocus={false}
+            defaultValue=""
+            disabled={false}
+            id="root"
+            onChange={[Function]}
+            type="file"
+          />
+        </p>
+      </div>
+      
     </div>
-    
   </div>
   <button
     className="ui primary button"
@@ -1098,29 +1186,33 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-string"
   >
     <div
-      className="field"
+      className="grouped equal width fields"
     >
       <div
-        className="ui fluid input"
+        className="field"
       >
-        <input
-          aria-describedby={null}
-          autoFocus={false}
-          disabled={false}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          type="email"
-          value=""
-        />
+        <div
+          className="ui fluid input"
+        >
+          <input
+            aria-describedby={null}
+            autoFocus={false}
+            disabled={false}
+            id="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            type="email"
+            value=""
+          />
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <button
     className="ui primary button"
@@ -1139,29 +1231,33 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-string"
   >
     <div
-      className="field"
+      className="grouped equal width fields"
     >
       <div
-        className="ui fluid input"
+        className="field"
       >
-        <input
-          aria-describedby={null}
-          autoFocus={false}
-          disabled={false}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          type="url"
-          value=""
-        />
+        <div
+          className="ui fluid input"
+        >
+          <input
+            aria-describedby={null}
+            autoFocus={false}
+            disabled={false}
+            id="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            type="url"
+            value=""
+          />
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <button
     className="ui primary button"
@@ -1180,29 +1276,33 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-string"
   >
     <div
-      className="field"
+      className="grouped equal width fields"
     >
       <div
-        className="ui fluid input"
+        className="field"
       >
-        <input
-          aria-describedby={null}
-          autoFocus={false}
-          disabled={false}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          type="text"
-          value=""
-        />
+        <div
+          className="ui fluid input"
+        >
+          <input
+            aria-describedby={null}
+            autoFocus={false}
+            disabled={false}
+            id="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            type="text"
+            value=""
+          />
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <button
     className="ui primary button"
@@ -1221,29 +1321,33 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-string"
   >
     <div
-      className="field"
+      className="grouped equal width fields"
     >
       <div
-        className="ui fluid input"
+        className="field"
       >
-        <input
-          aria-describedby={null}
-          autoFocus={false}
-          disabled={false}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder="placeholder"
-          type="text"
-          value=""
-        />
+        <div
+          className="ui fluid input"
+        >
+          <input
+            aria-describedby={null}
+            autoFocus={false}
+            disabled={false}
+            id="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="placeholder"
+            type="text"
+            value=""
+          />
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <button
     className="ui primary button"
@@ -1262,27 +1366,31 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-string"
   >
     <div
-      className="field"
+      className="grouped equal width fields"
     >
-      <textarea
-        aria-describedby={null}
-        autoFocus={false}
-        disabled={false}
-        id="root"
-        inverted={false}
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onInput={[Function]}
-        placeholder=""
-        rows={5}
-        value=""
-      />
+      <div
+        className="field"
+      >
+        <textarea
+          aria-describedby={null}
+          autoFocus={false}
+          disabled={false}
+          id="root"
+          inverted={false}
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onInput={[Function]}
+          placeholder=""
+          rows={5}
+          value=""
+        />
+      </div>
+      
     </div>
-    
   </div>
   <button
     className="ui primary button"
@@ -1301,44 +1409,52 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-object"
   >
-    <h5
-      className="ui dividing header"
-      id="root-title"
-    >
-      Titre 1
-    </h5>
     <div
       className="grouped equal width fields"
     >
-      <div
-        className="field"
+      <h5
+        className="ui dividing header"
+        id="root-title"
       >
-        <label
-          htmlFor="root_title"
-        >
-          title
-        </label>
+        Titre 1
+      </h5>
+      <div
+        className="form-group field field-string"
+      >
         <div
-          className="ui fluid input"
+          className="grouped equal width fields"
         >
-          <input
-            aria-describedby={null}
-            autoFocus={false}
-            disabled={false}
-            id="root_title"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder=""
-            required={false}
-            type="text"
-            value=""
-          />
+          <div
+            className="field"
+          >
+            <label
+              htmlFor="root_title"
+            >
+              title
+            </label>
+            <div
+              className="ui fluid input"
+            >
+              <input
+                aria-describedby={null}
+                autoFocus={false}
+                disabled={false}
+                id="root_title"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                placeholder=""
+                required={false}
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          
         </div>
       </div>
-      
     </div>
   </div>
   <button
@@ -1358,31 +1474,35 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-undefined"
   >
     <div
-      className="unsupported-field"
+      className="grouped equal width fields"
     >
-      <p>
-        Unsupported field schema
-        <span>
-           for
-           field 
-          <code>
-            root
-          </code>
-        </span>
-        <em>
-          : 
-          Unknown field type undefined
-        </em>
-        .
-      </p>
-      <pre>
-        {}
-      </pre>
+      <div
+        className="unsupported-field"
+      >
+        <p>
+          Unsupported field schema
+          <span>
+             for
+             field 
+            <code>
+              root
+            </code>
+          </span>
+          <em>
+            : 
+            Unknown field type undefined
+          </em>
+          .
+        </p>
+        <pre>
+          {}
+        </pre>
+      </div>
+      
     </div>
-    
   </div>
   <button
     className="ui primary button"
@@ -1401,29 +1521,33 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-number"
   >
     <div
-      className="field"
+      className="grouped equal width fields"
     >
       <div
-        className="ui fluid input"
+        className="field"
       >
-        <input
-          aria-describedby={null}
-          autoFocus={false}
-          disabled={false}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          type="number"
-          value=""
-        />
+        <div
+          className="ui fluid input"
+        >
+          <input
+            aria-describedby={null}
+            autoFocus={false}
+            disabled={false}
+            id="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            type="number"
+            value=""
+          />
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <button
     className="ui primary button"
@@ -1442,29 +1566,33 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-string"
   >
     <div
-      className="field"
+      className="grouped equal width fields"
     >
       <div
-        className="ui fluid input"
+        className="field"
       >
-        <input
-          aria-describedby={null}
-          autoFocus={false}
-          disabled={false}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          type="text"
-          value=""
-        />
+        <div
+          className="ui fluid input"
+        >
+          <input
+            aria-describedby={null}
+            autoFocus={false}
+            disabled={false}
+            id="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            type="text"
+            value=""
+          />
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <button
     className="ui primary button"

--- a/packages/semantic-ui/test/__snapshots__/Object.test.js.snap
+++ b/packages/semantic-ui/test/__snapshots__/Object.test.js.snap
@@ -7,131 +7,135 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-object"
   >
-    
     <div
-      className="form-group field field-string"
+      className="grouped equal width fields"
     >
+      
       <div
-        className="ui equal width grid"
+        className="form-group field field-string"
+      >
+        <div
+          className="ui equal width grid"
+        >
+          <div
+            className="row"
+          >
+            <div
+              className="column form-additional"
+            >
+              <div
+                className="grouped equal width fields"
+              >
+                <div
+                  className="field form-group"
+                >
+                  <label
+                    htmlFor="root_foo"
+                  >
+                    foo Key
+                  </label>
+                  <div
+                    className="ui fluid input"
+                    hasFeedback={true}
+                    htmlFor="root_foo"
+                  >
+                    <input
+                      aria-describedby={null}
+                      defaultValue="foo"
+                      disabled={false}
+                      id="root_foo"
+                      name="root_foo"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      required={false}
+                      type="text"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="middle aligned column form-additional"
+            >
+              <div
+                className="grouped equal width fields"
+              >
+                <div
+                  className="field"
+                >
+                  <label
+                    htmlFor="root_foo"
+                  >
+                    foo
+                  </label>
+                  <div
+                    className="ui fluid input"
+                  >
+                    <input
+                      aria-describedby={null}
+                      autoFocus={false}
+                      disabled={false}
+                      id="root_foo"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      placeholder=""
+                      required={false}
+                      type="text"
+                      value="foo"
+                    />
+                  </div>
+                </div>
+                
+              </div>
+            </div>
+            <div
+              className="column"
+            >
+              <button
+                className="ui mini icon button array-item-remove"
+                onClick={[Function]}
+                title="Remove"
+              >
+                <i
+                  aria-hidden="true"
+                  className="trash icon"
+                  onClick={[Function]}
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="middle aligned sixteen wide column"
       >
         <div
           className="row"
         >
           <div
-            className="column form-additional"
-          >
-            <div
-              className="grouped equal width fields"
-            >
-              <div
-                className="field form-group"
-              >
-                <label
-                  htmlFor="root_foo"
-                >
-                  foo Key
-                </label>
-                <div
-                  className="ui fluid input"
-                  hasFeedback={true}
-                  htmlFor="root_foo"
-                >
-                  <input
-                    aria-describedby={null}
-                    defaultValue="foo"
-                    disabled={false}
-                    id="root_foo"
-                    name="root_foo"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    required={false}
-                    type="text"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="middle aligned column form-additional"
-          >
-            <div
-              className="grouped equal width fields"
-            >
-              <div
-                className="field"
-              >
-                <label
-                  htmlFor="root_foo"
-                >
-                  foo
-                </label>
-                <div
-                  className="ui fluid input"
-                >
-                  <input
-                    aria-describedby={null}
-                    autoFocus={false}
-                    disabled={false}
-                    id="root_foo"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    placeholder=""
-                    required={false}
-                    type="text"
-                    value="foo"
-                  />
-                </div>
-              </div>
-              
-            </div>
-          </div>
-          <div
-            className="column"
+            style={
+              Object {
+                "marginTop": "1rem",
+                "position": "relative",
+                "textAlign": "right",
+              }
+            }
           >
             <button
-              className="ui mini icon button array-item-remove"
+              className="ui tiny icon left labeled button"
               onClick={[Function]}
-              title="Remove"
+              title="Add Item"
             >
               <i
                 aria-hidden="true"
-                className="trash icon"
+                className="plus icon"
                 onClick={[Function]}
               />
             </button>
           </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="middle aligned sixteen wide column"
-    >
-      <div
-        className="row"
-      >
-        <div
-          style={
-            Object {
-              "marginTop": "1rem",
-              "position": "relative",
-              "textAlign": "right",
-            }
-          }
-        >
-          <button
-            className="ui tiny icon left labeled button"
-            onClick={[Function]}
-            title="Add Item"
-          >
-            <i
-              aria-hidden="true"
-              className="plus icon"
-              onClick={[Function]}
-            />
-          </button>
         </div>
       </div>
     </div>
@@ -153,71 +157,83 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="grouped equal width fields"
+    className="form-group field field-object"
   >
-    
     <div
       className="grouped equal width fields"
     >
+      
       <div
-        className="field"
+        className="form-group field field-string"
       >
-        <label
-          htmlFor="root_a"
-        >
-          A
-        </label>
         <div
-          className="ui fluid input"
+          className="grouped equal width fields"
         >
-          <input
-            aria-describedby={null}
-            autoFocus={false}
-            disabled={false}
-            id="root_a"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder=""
-            required={false}
-            type="text"
-            value=""
-          />
+          <div
+            className="field"
+          >
+            <label
+              htmlFor="root_a"
+            >
+              A
+            </label>
+            <div
+              className="ui fluid input"
+            >
+              <input
+                aria-describedby={null}
+                autoFocus={false}
+                disabled={false}
+                id="root_a"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                placeholder=""
+                required={false}
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          
         </div>
       </div>
-      
-    </div>
-    <div
-      className="grouped equal width fields"
-    >
       <div
-        className="field"
+        className="form-group field field-number"
       >
-        <label
-          htmlFor="root_b"
-        >
-          B
-        </label>
         <div
-          className="ui fluid input"
+          className="grouped equal width fields"
         >
-          <input
-            aria-describedby={null}
-            autoFocus={false}
-            disabled={false}
-            id="root_b"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder=""
-            required={false}
-            step="any"
-            type="number"
-            value=""
-          />
+          <div
+            className="field"
+          >
+            <label
+              htmlFor="root_b"
+            >
+              B
+            </label>
+            <div
+              className="ui fluid input"
+            >
+              <input
+                aria-describedby={null}
+                autoFocus={false}
+                disabled={false}
+                id="root_b"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                placeholder=""
+                required={false}
+                step="any"
+                type="number"
+                value=""
+              />
+            </div>
+          </div>
+          
         </div>
       </div>
-      
     </div>
   </div>
   <button


### PR DESCRIPTION
### Reasons for making this change

- Updated the `WrapIfAdditional` component to add `classNames` to the outer wrapper in a manner consistent with the `core` theme, for the following themes:
  - bootstrap-4, chakra-ui, material-ui, mui and semantic-ui
- Updated the snapshots to add the missing `classNames` classes
- 
### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
