### PR TITLE
Fix hidden widget in several themes and SelectWidget in bootstrap-4

### DIFF
--- a/packages/bootstrap-4/src/SelectWidget/SelectWidget.tsx
+++ b/packages/bootstrap-4/src/SelectWidget/SelectWidget.tsx
@@ -55,7 +55,7 @@ const SelectWidget = ({
         value={typeof value === "undefined" ? emptyValue : value}
         required={required}
         multiple={multiple}
-        disabled={disabled && readonly}
+        disabled={disabled || readonly}
         autoFocus={autofocus}
         className={rawErrors.length > 0 ? "is-invalid" : ""}
         onBlur={

--- a/packages/bootstrap-4/src/SelectWidget/SelectWidget.tsx
+++ b/packages/bootstrap-4/src/SelectWidget/SelectWidget.tsx
@@ -41,7 +41,10 @@ const SelectWidget = ({
 
   return (
     <Form.Group>
-      <Form.Label className={rawErrors.length > 0 ? "text-danger" : ""}>
+      <Form.Label
+        className={rawErrors.length > 0 ? "text-danger" : ""}
+        htmlFor={id}
+      >
         {label || schema.title}
         {(label || schema.title) && required ? "*" : null}
       </Form.Label>
@@ -52,8 +55,7 @@ const SelectWidget = ({
         value={typeof value === "undefined" ? emptyValue : value}
         required={required}
         multiple={multiple}
-        disabled={disabled}
-        readOnly={readonly}
+        disabled={disabled && readonly}
         autoFocus={autofocus}
         className={rawErrors.length > 0 ? "is-invalid" : ""}
         onBlur={

--- a/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
@@ -515,6 +515,7 @@ exports[`array fields checkboxes 1`] = `
       >
         <label
           className="form-label"
+          htmlFor="root"
         />
         <select
           autoFocus={false}
@@ -525,7 +526,6 @@ exports[`array fields checkboxes 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          readOnly={false}
           required={false}
           value={Array []}
         >

--- a/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
@@ -919,6 +919,7 @@ exports[`single fields select field 1`] = `
       >
         <label
           className="form-label"
+          htmlFor="root"
         />
         <select
           autoFocus={false}
@@ -928,7 +929,6 @@ exports[`single fields select field 1`] = `
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
-          readOnly={false}
           value=""
         >
           <option

--- a/packages/chakra-ui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/chakra-ui/src/FieldTemplate/FieldTemplate.tsx
@@ -33,7 +33,7 @@ const FieldTemplate = (props: FieldTemplateProps) => {
   } = props;
 
   if (hidden) {
-    return <>{children}</>;
+    return <div style={{ display: "none" }}>{children}</div>;
   }
 
   return (

--- a/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
@@ -1242,11 +1242,19 @@ exports[`single fields hidden field 1`] = `
       <div
         className="emotion-1"
       >
-        <input
-          id="root_my-field"
-          type="hidden"
-          value=""
-        />
+        <div
+          style={
+            Object {
+              "display": "none",
+            }
+          }
+        >
+          <input
+            id="root_my-field"
+            type="hidden"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,6 @@
     "start": "dts watch",
     "test": "dts test",
     "test:watch": "dts test --watch",
-    "test:update": "dts test --u",
     "test-coverage": "dts test --coverage"
   },
   "lint-staged": {

--- a/packages/material-ui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/material-ui/src/FieldTemplate/FieldTemplate.tsx
@@ -27,7 +27,7 @@ const FieldTemplate = ({
   registry,
 }: FieldTemplateProps) => {
   if (hidden) {
-    return children;
+    return <div style={{ display: "none" }}>{children}</div>;
   }
   return (
     <WrapIfAdditional

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -899,11 +899,19 @@ exports[`single fields hidden field 1`] = `
           }
         }
       >
-        <input
-          id="root_my-field"
-          type="hidden"
-          value=""
-        />
+        <div
+          style={
+            Object {
+              "display": "none",
+            }
+          }
+        >
+          <input
+            id="root_my-field"
+            type="hidden"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/packages/mui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/mui/src/FieldTemplate/FieldTemplate.tsx
@@ -27,7 +27,7 @@ const FieldTemplate = ({
   registry,
 }: FieldTemplateProps) => {
   if (hidden) {
-    return children;
+    return <div style={{ display: "none" }}>{children}</div>;
   }
   return (
     <WrapIfAdditional

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -3815,11 +3815,19 @@ exports[`single fields hidden field 1`] = `
           }
         }
       >
-        <input
-          id="root_my-field"
-          type="hidden"
-          value=""
-        />
+        <div
+          style={
+            Object {
+              "display": "none",
+            }
+          }
+        >
+          <input
+            id="root_my-field"
+            type="hidden"
+            value=""
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/packages/semantic-ui/src/FieldTemplate/FieldTemplate.js
+++ b/packages/semantic-ui/src/FieldTemplate/FieldTemplate.js
@@ -33,7 +33,7 @@ function FieldTemplate({
   );
 
   if (hidden) {
-    return children;
+    return <div style={{ display: "none" }}>{children}</div>;
   }
 
   return (

--- a/packages/semantic-ui/test/__snapshots__/Form.test.js.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.js.snap
@@ -684,11 +684,19 @@ exports[`single fields hidden field 1`] = `
       className="grouped equal width fields"
     >
       
-      <input
-        id="root_my-field"
-        type="hidden"
-        value=""
-      />
+      <div
+        style={
+          Object {
+            "display": "none",
+          }
+        }
+      >
+        <input
+          id="root_my-field"
+          type="hidden"
+          value=""
+        />
+      </div>
     </div>
   </div>
   <button

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,8 +18,7 @@
     "cs-format": "prettier \"{src,test}/**/*.ts?(x)\" --write",
     "lint": "eslint src test",
     "precommit": "lint-staged",
-    "test": "dts test",
-    "test:update": "dts test --u"
+    "test": "dts test"
   },
   "lint-staged": {
     "{src,test}/**/*.ts?(x)": [

--- a/packages/validator-ajv6/package.json
+++ b/packages/validator-ajv6/package.json
@@ -19,8 +19,7 @@
     "cs-format": "prettier \"{src,test}/**/*.ts?(x)\" --write",
     "lint": "eslint src test",
     "precommit": "lint-staged",
-    "test": "dts test",
-    "test:update": "dts test --u"
+    "test": "dts test"
   },
   "lint-staged": {
     "{src,test}/**/*.ts?(x)": [


### PR DESCRIPTION
### Reasons for making this change

Fixes (#2571) and (#2616)

- Updated the `FieldTemplate` in `chakra-ui`, `material-ui`, `mui` and `semantic-ui` to properly implement the hidden field
- Updated `SelectWidget` in `bootstrap-4` to fix missing `htmlFor` and the `disabled` state when `readonly`
- Updated snapshots to verify fixes
- Also removed the `test:update` script from `core`, `utils` and `validator-ajv6` because they are useless since those three packages do NOT have snapshots

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
