### PR TITLE
Restored uiSchema.classNames with deprecation warning

### DIFF
--- a/docs/5.x upgrade guide.md
+++ b/docs/5.x upgrade guide.md
@@ -262,8 +262,33 @@ From v5, the child fields will correctly use the parent id when generating its o
 
 ##### Non-standard `enumNames` property
 
-`enumNames` is a non-standard JSON Schema field that was deprecated in version 5. `enumNames` could be included in the schema to apply labels that differed from an enumeration value. This behavior can still be accomplished with `oneOf` or `anyOf` containing `const` values, so this behavior may be removed from a future major version of RJSF. For more information, see [#532](https://github.com/rjsf-team/react-jsonschema-form/issues/532).
+`enumNames` is a non-standard JSON Schema field that was deprecated in version 5.
+`enumNames` could be included in the schema to apply labels that differed from an enumeration value.
+This behavior can still be accomplished with `oneOf` or `anyOf` containing `const` values, so `enumNames` support may be removed from a future major version of RJSF.
+For more information, see [#532](https://github.com/rjsf-team/react-jsonschema-form/issues/532).
 
+##### uiSchema.classNames
+
+In versions previous to 5, `uiSchema.classNames` was the only property that did not require the `ui:` prefix.
+Additionally, it did not support being added into the `ui:options` object.
+This was fixed in version 5 to be consistent with all the other properties in the `uiSchema`, so the `uiSchema.classNames` support may be removed from a future major version of RJSF.
+
+If you are using `classNames` as follows, simply add the `ui:` prefix to it to remove the deprecation warning that will be displayed for each `uiSchema.classNames` you have:
+
+```jsx
+// This uiSchema will log a deprecation warning to the console
+const uiSchema = {
+  title: {
+    "classNames": "myClass" 
+  }
+};
+// This uiSchema will not
+const uiSchema = {
+  title: {
+    "ui:classNames": "myClass"
+  }
+};
+```
 
 ### `@rjsf/material-ui` BREAKING CHANGES
 

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -258,7 +258,7 @@ function SchemaFieldRender<T, F>(props: FieldProps<T, F>) {
   if (uiSchema?.classNames) {
     if (process.env.NODE_ENV !== "production") {
       console.warn(
-        "WARNING: 'uiSchema.classNames' is deprecated and will be removed in the next major release; Use 'ui:classNames' instead."
+        "WARNING: 'uiSchema.classNames' is deprecated and may be removed in a major release; Use 'ui:classNames' instead."
       );
     }
     classNames.push(uiSchema.classNames);

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -209,7 +209,7 @@ function SchemaFieldRender<T, F>(props: FieldProps<T, F>) {
 
   const { __errors, ...fieldErrorSchema } = errorSchema || {};
   // See #439: uiSchema: Don't pass consumed class names to child components
-  const fieldUiSchema = omit(uiSchema, ["ui:classNames"]);
+  const fieldUiSchema = omit(uiSchema, ["ui:classNames", "classNames"]);
   if ("ui:options" in fieldUiSchema) {
     fieldUiSchema["ui:options"] = omit(fieldUiSchema["ui:options"], [
       "classNames",
@@ -254,6 +254,12 @@ function SchemaFieldRender<T, F>(props: FieldProps<T, F>) {
   const classNames = ["form-group", "field", `field-${schema.type}`];
   if (!hideError && errors && errors.length > 0) {
     classNames.push("field-error has-error has-danger");
+  }
+  if (uiSchema?.classNames) {
+    console.warn(
+      "WARNING: 'uiSchema.classNames' is deprecated and will be removed in the next major release; Use 'ui:classNames' instead."
+    );
+    classNames.push(uiSchema.classNames);
   }
   if (uiOptions.classNames) {
     classNames.push(uiOptions.classNames);

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -256,9 +256,11 @@ function SchemaFieldRender<T, F>(props: FieldProps<T, F>) {
     classNames.push("field-error has-error has-danger");
   }
   if (uiSchema?.classNames) {
-    console.warn(
-      "WARNING: 'uiSchema.classNames' is deprecated and will be removed in the next major release; Use 'ui:classNames' instead."
-    );
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(
+        "WARNING: 'uiSchema.classNames' is deprecated and will be removed in the next major release; Use 'ui:classNames' instead."
+      );
+    }
     classNames.push(uiSchema.classNames);
   }
   if (uiOptions.classNames) {

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -258,7 +258,7 @@ function SchemaFieldRender<T, F>(props: FieldProps<T, F>) {
   if (uiSchema?.classNames) {
     if (process.env.NODE_ENV !== "production") {
       console.warn(
-        "WARNING: 'uiSchema.classNames' is deprecated and may be removed in a major release; Use 'ui:classNames' instead."
+        "'uiSchema.classNames' is deprecated and may be removed in a major release; Use 'ui:classNames' instead."
       );
     }
     classNames.push(uiSchema.classNames);

--- a/packages/core/test/uiSchema_test.js
+++ b/packages/core/test/uiSchema_test.js
@@ -31,6 +31,9 @@ describe("uiSchema", () => {
         bar: {
           type: "string",
         },
+        baz: {
+          type: "string",
+        },
       },
     };
 
@@ -43,15 +46,26 @@ describe("uiSchema", () => {
           classNames: "class-for-bar another-for-bar",
         },
       },
+      baz: {
+        classNames: "class-for-baz",
+      },
     };
 
     it("should apply custom class names to target widgets", () => {
+      sandbox.stub(console, "warn");
+
       const { node } = createFormComponent({ schema, uiSchema });
-      const [foo, bar] = node.querySelectorAll(".field-string");
+      const [foo, bar, baz] = node.querySelectorAll(".field-string");
 
       expect(foo.classList.contains("class-for-foo")).eql(true);
       expect(bar.classList.contains("class-for-bar")).eql(true);
       expect(bar.classList.contains("another-for-bar")).eql(true);
+      expect(baz.classList.contains("class-for-baz")).eql(true);
+      expect(
+        console.warn.calledWithMatch(
+          /WARNING: 'uiSchema.classNames' is deprecated/
+        )
+      ).to.be.true;
     });
   });
 

--- a/packages/core/test/uiSchema_test.js
+++ b/packages/core/test/uiSchema_test.js
@@ -62,9 +62,7 @@ describe("uiSchema", () => {
       expect(bar.classList.contains("another-for-bar")).eql(true);
       expect(baz.classList.contains("class-for-baz")).eql(true);
       expect(
-        console.warn.calledWithMatch(
-          /WARNING: 'uiSchema.classNames' is deprecated/
-        )
+        console.warn.calledWithMatch(/'uiSchema.classNames' is deprecated/)
       ).to.be.true;
     });
   });


### PR DESCRIPTION
### Reasons for making this change

- Updated `SchemaField` to restore support for `uiSchema.classNames` with big fat deprecation warning
- Updated the existing `classNames` test to verify restored code and deprecation warning
- NOTE: Will fix up the documentation in the other PR

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
