### PR TITLE
Fixed #1596 by adapting the fix from #2002 into rjsf v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@ should change the heading of the (upcoming) version to include a major version b
 - clear errors on formData change when liveOmit=true when "additionalProperties: false" [issue 1507](https://github.com/rjsf-team/react-jsonschema-form/issues/1507) (https://github.com/rjsf-team/react-jsonschema-form/pull/2631)
 
 ## @rjsf/validator-ajv6
-- A **BREAKING CHANGE** to `toErrorList()` was made so that it takes `fieldPath: string[]` rather than `fieldName='root'` as part of the fix (https://github.com/rjsf-team/react-jsonschema-form/issues/1596)
-  - The returned `errors` also now adds `property` from the `fieldPath` along with the proper path from the `property` to the `stack` message, making it consistent with the AJV errors
-  - In addition, the extra information provided by AJV is no longer stripped from the `errors` when merged with custom validation, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/1596).
+- A **BREAKING CHANGE** to `toErrorList()` was made so that it takes `fieldPath: string[]` rather than `fieldName='root'` as part of the fix to (https://github.com/rjsf-team/react-jsonschema-form/issues/1596)
+  - The returned `errors` also now adds `property` from the `fieldPath` along with the proper path from the `property` to the `stack` message, making it consistent with the AJV errors.
+    - Previously the `stack` attribute would say `root: error message`; now it says `. error message`
+  - In addition, the extra information provided by AJV is no longer lost from the `errors` when merged with custom validation, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/1596).
 
 ## @rjsf/core
 - **BREAKING CHANGE** Fix overriding core submit button className (https://github.com/rjsf-team/react-jsonschema-form/issues/2979)
@@ -30,7 +31,7 @@ should change the heading of the (upcoming) version to include a major version b
 - **BREAKING CHANGE** Fixed `anyOf` and `oneOf` getting incorrect, potentially duplicate ids when combined with array (https://github.com/rjsf-team/react-jsonschema-form/issues/2197)
 - `formContext` is now passed properly to `SchemaField`, fixes (https://github.com/rjsf-team/react-jsonschema-form/issues/2394, https://github.com/rjsf-team/react-jsonschema-form/issues/2274) 
 - Added `ui:duplicateKeySuffixSeparator` to customize how duplicate object keys are renamed when using `additionalProperties`.
-- The `extraErrors` are now appended onto the end of the schema validation-based `errors` information that is returned via the `onErrors()` callback when submit fails, rather than being merged into the hierarchy.
+- The `extraErrors` are now consistently appended onto the end of the schema validation-based `errors` information that is returned via the `onErrors()` callback when submit fails.
   - In addition, the extra information provided by AJV is no longer stripped from the `errors` during the merge process, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/1596).
 
 ## @rjsf/antd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,19 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/utils
 - clear errors on formData change when liveOmit=true when "additionalProperties: false" [issue 1507](https://github.com/rjsf-team/react-jsonschema-form/issues/1507) (https://github.com/rjsf-team/react-jsonschema-form/pull/2631)
 
+## @rjsf/validator-ajv6
+- A **BREAKING CHANGE** to `toErrorList()` was made so that it takes `fieldPath: string[]` rather than `fieldName='root'` as part of the fix (https://github.com/rjsf-team/react-jsonschema-form/issues/1596)
+  - The returned `errors` also now adds `property` from the `fieldPath` along with the proper path from the `property` to the `stack` message, making it consistent with the AJV errors
+  - In addition, the extra information provided by AJV is no longer stripped from the `errors` when merged with custom validation, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/1596).
+
 ## @rjsf/core
 - **BREAKING CHANGE** Fix overriding core submit button className (https://github.com/rjsf-team/react-jsonschema-form/issues/2979)
 - Fix `ui:field` with anyOf or oneOf no longer rendered twice (#2890)
 - **BREAKING CHANGE** Fixed `anyOf` and `oneOf` getting incorrect, potentially duplicate ids when combined with array (https://github.com/rjsf-team/react-jsonschema-form/issues/2197)
 - `formContext` is now passed properly to `SchemaField`, fixes (https://github.com/rjsf-team/react-jsonschema-form/issues/2394, https://github.com/rjsf-team/react-jsonschema-form/issues/2274) 
 - Added `ui:duplicateKeySuffixSeparator` to customize how duplicate object keys are renamed when using `additionalProperties`.
+- The `extraErrors` are now appended onto the end of the schema validation-based `errors` information that is returned via the `onErrors()` callback when submit fails, rather than being merged into the hierarchy.
+  - In addition, the extra information provided by AJV is no longer stripped from the `errors` during the merge process, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/1596).
 
 ## @rjsf/antd
 - Fix esm build to use `@rollup/plugin-replace` to replace `antd/lib` and `rc-picker/lib` with `antd/es` and `rc-picker/es` respectively, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/2962)

--- a/docs/5.x upgrade guide.md
+++ b/docs/5.x upgrade guide.md
@@ -87,10 +87,10 @@ render((
 ), document.getElementById("app"));
 ```
 
-#### validate renamed
+##### validate renamed
 In version 5, the `validate` prop on `Form` was renamed to `customValidate` to avoid confusion with the new `validator` prop. 
 
-#### utils
+#### utils.js
 In version 5, all the utility functions that were previously accessed via `import { utils } from '@rjsf/core';` are now available via `import utils from '@rjsf/utils';`.
 Because of the decoupling of validation from `@rjsf/core` there is a breaking change for all the [validator-based utility functions](https://react-jsonschema-form.readthedocs.io/en/stable/api-reference/utiltity-functions#validator-based-utility-functions), since they now require an additional `ValidatorType` parameter.
 
@@ -129,6 +129,93 @@ function YourWidget(props: WidgetProps) {
   
 ...  
 }
+```
+
+#### validator.js
+Because of the decoupling of validation from `@rjsf/core` this file was refactored into its own `@rjsf/validator-ajv` package.
+During that refactor a few **breaking changes** were made to how it works related to custom validation and `ErrorSchema` conversion.
+
+##### toErrorList param changed
+In previous versions, the `toErrorList()` function used to take a `fieldName` string defaulted to `root`, and use it to format the `stack` message.
+In version 5, `fieldName` was changed to `fieldPath` string array defaulted to an empty array, and is used to recursively add the field name to the errors as the `property` object along with the raw `message`.
+The result is that if you had an `ErrorSchema` that looks like:
+
+```tsx
+const errorSchema: ErrorSchema = {
+  __error: [ "error message 1"],
+  password: { __error: "passwords do not match" }
+}
+```
+
+The returned result from calling `toErrorList(errorSchema)` has changed as follows:
+
+```tsx
+// version 4 result
+[
+  { stack: "root: error message 1" },
+  { stack: "password: passwords do not match" }
+]
+
+// version 5 result
+[
+  { property: ".", message: "error message 1", stack: ". error message 1" },
+  { property: ".password", message: "passwords do not match", stack: ".password passwords do not match" }
+]
+```
+
+##### Custom validation and extraErrors
+In previous versions, when using a custom validator on the `Form`, any errors that were generated were inconsistently inserted into the validations `errors` list.
+In addition, there was an [issue](https://github.com/rjsf-team/react-jsonschema-form/issues/1596) with the additional AJV error information besides the `stack` being lost when custom validation generated errors, which has been fixed.
+Also, when `extraErrors` were provided, they were being inconsistently inserted into the `errors` list and the additional AJV error information besides the `stack` was also lost.
+In version 5, all of these errors will be consistently appended onto the end of the validation `errors` list, and the additional AJV error information is maintained.
+
+In other words, if custom validation or `extraErrors` produced the following `ErrorSchema`:
+
+```tsx
+{
+  __error: [ "Please correct your password"],
+  password2: { __error: "passwords do not match" }
+}
+```
+
+And the AJV validation produced the following `ErrorSchema`:
+
+```tsx
+{
+  __error: [{
+    message: "should NOT be shorter than 3 characters",
+    name: "minLength",
+    params: { limit: 3 },
+    property: ".password2",
+    schemaPath: "#/properties/password2/minLength",
+    stack: ".password2 should NOT be shorter than 3 characters",
+  }]
+}
+```
+
+The resulting `errors` list has changed as follows:
+
+```tsx
+// version 4
+[
+  { stack: "root: Please correct your password" },
+  { stack: "password2: passwords do not match" },
+  { stack: "password2: should NOT be shorter than 3 characters" }
+]
+
+// version 5
+[
+  {
+    message: "should NOT be shorter than 3 characters",
+    name: "minLength",
+    params: { limit: 3 },
+    property: ".password2",
+    schemaPath: "#/properties/password2/minLength",
+    stack: ".password2 should NOT be shorter than 3 characters",
+  },
+  { property: ".", message: "Please correct your password", stack: ". Please correct your password" },
+  { property: ".", message: "passwords do not match", stack: ".password2 passwords do not match" }
+]
 ```
 
 #### Generate correct ids when arrays are combined with `anyOf`/`oneOf`

--- a/docs/5.x upgrade guide.md
+++ b/docs/5.x upgrade guide.md
@@ -23,7 +23,8 @@ Unfortunately, there is required work pending to properly support React 18, so u
 ### New packages
 
 There are three new packages added in RJSF version 5:
-- `@rjsf/utils`: All of the [utility functions](https://react-jsonschema-form.readthedocs.io/en/stable/api-reference/utiltity-functions) previously imported from `@rjsf/core/utils` as well as the Typescript types for RJSV version 5.
+- `@rjsf/utils`: All of the [utility functions](https://react-jsonschema-form.readthedocs.io/en/stable/api-reference/utiltity-functions) previously imported from `@rjsf/core/utils` as well as the Typescript types for RJSF version 5.
+  - The following new utility functions were added: `createSchemaUtils()`, `getInputProps()`, `mergeValidationData()` and `processSelectValue()`
 - `@rjsf/validator-ajv6`: The [ajv](https://github.com/ajv-validator/ajv)-v6-based validator refactored out of `@rjsf/core@4.x`, that implements the `ValidatorType` interface defined in `@rjsf/utils`.
 - `@rjsf/mui`: Previously `@rjsf/material-ui/v5`, now provided as its own theme.
 

--- a/docs/api-reference/utility-functions.md
+++ b/docs/api-reference/utility-functions.md
@@ -385,7 +385,7 @@ Converts a UTC date string into a local Date format
 Returns the superset of `formData` that includes the given set updated to include any missing fields that have computed to have defaults provided in the `schema`.
 
 #### Parameters
-- validator: ValidatorType - An implementation of the `ValidatorType` interface that will be used when necessary
+- validator: ValidatorType<T> - An implementation of the `ValidatorType` interface that will be used when necessary
 - theSchema: RJSFSchema - The schema for which the default state is desired
 - [formData]: T - The current formData, if any, onto which to provide any missing defaults
 - [rootSchema]: RJSFSchema - The root schema, used to primarily to look up `$ref`s
@@ -398,7 +398,7 @@ Returns the superset of `formData` that includes the given set updated to includ
 Determines whether the combination of `schema` and `uiSchema` properties indicates that the label for the `schema` should be displayed in a UI.
 
 #### Parameters
-- validator: ValidatorType - An implementation of the `ValidatorType` interface that will be used when necessary
+- validator: ValidatorType<T> - An implementation of the `ValidatorType` interface that will be used when necessary
 - schema: RJSFSchema - The schema for which the display label flag is desired
 - [uiSchema={}]: UiSchema<T, F> - The UI schema from which to derive potentially displayable information
 - [rootSchema]: RJSFSchema - The root schema, used to primarily to look up `$ref`s
@@ -410,7 +410,7 @@ Determines whether the combination of `schema` and `uiSchema` properties indicat
 Given the `formData` and list of `options`, attempts to find the index of the option that best matches the data.
 
 #### Parameters
-- validator: ValidatorType - An implementation of the `ValidatorType` interface that will be used when necessary
+- validator: ValidatorType<T> - An implementation of the `ValidatorType` interface that will be used when necessary
 - formData: T | undefined - The current formData, if any, used to figure out a match
 - options: RJSFSchema[] - The list of options to find a matching options from
 - rootSchema: RJSFSchema - The root schema, used to primarily to look up `$ref`s
@@ -422,7 +422,7 @@ Given the `formData` and list of `options`, attempts to find the index of the op
 Checks to see if the `schema` and `uiSchema` combination represents an array of files
 
 #### Parameters
-- validator: ValidatorType - An implementation of the `ValidatorType` interface that will be used when necessary
+- validator: ValidatorType<T> - An implementation of the `ValidatorType` interface that will be used when necessary
 - schema: RJSFSchema - The schema for which check for array of files flag is desired
 - [uiSchema={}]: UiSchema<T, F> - The UI schema from which to check the widget
 - [rootSchema]: RJSFSchema - The root schema, used to primarily to look up `$ref`s
@@ -434,7 +434,7 @@ Checks to see if the `schema` and `uiSchema` combination represents an array of 
 Checks to see if the `schema` combination represents a multi-select
 
 #### Parameters
-- validator: ValidatorType - An implementation of the `ValidatorType` interface that will be used when necessary
+- validator: ValidatorType<T> - An implementation of the `ValidatorType` interface that will be used when necessary
 - schema: RJSFSchema - The schema for which check for a multi-select flag is desired
 - [rootSchema]: RJSFSchema - The root schema, used to primarily to look up `$ref`s
 
@@ -445,12 +445,24 @@ Checks to see if the `schema` combination represents a multi-select
 Checks to see if the `schema` combination represents a select
 
 #### Parameters
-- validator: ValidatorType - An implementation of the `ValidatorType` interface that will be used when necessary
+- validator: ValidatorType<T> - An implementation of the `ValidatorType` interface that will be used when necessary
 - theSchema: RJSFSchema - The schema for which check for a select flag is desired
 - [rootSchema]: RJSFSchema - The root schema, used to primarily to look up `$ref`s
 
 #### Returns
 - boolean: True if schema contains a select, otherwise false
+
+### mergeValidationData<T=any>()
+Merges the errors in `additionalErrorSchema` into the existing `validationData` by combining the hierarchies in the two `ErrorSchema`s and then appending the error list from the `additionalErrorSchema` obtained by calling `validator.toErrorList()` onto the `errors` in the `validationData`.
+If no `additionalErrorSchema` is passed, then `validationData` is returned.
+
+#### Parameters
+- validator: ValidatorType<T> - An implementation of the `ValidatorType` interface that will be used to convert an ErrorSchema to a list of errors
+- validationData: ValidationData<T> - The current `ValidationData` into which to merge the additional errors
+- [additionalErrorSchema]: ErrorSchema<T> - The additional set of errors in an `ErrorSchema`
+
+#### Returns
+- ValidationData<T>: The `validationData` with the additional errors from `additionalErrorSchema` merged into it, if provided.
 
 ### retrieveSchema<T = any>()
 Retrieves an expanded schema that has had all of its conditions, additional properties, references and dependencies
@@ -458,7 +470,7 @@ resolved and merged into the `schema` given a `validator`, `rootSchema` and `raw
 potentially recursive resolution.
 
 #### Parameters
-- validator: ValidatorType - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
+- validator: ValidatorType<T> - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
 - schema: RJSFSchema - The schema for which retrieving a schema is desired
 - [rootSchema={}]: RJSFSchema - The root schema that will be forwarded to all the APIs
 - [rawFormData]: T - The current formData, if any, to assist retrieving a schema
@@ -470,7 +482,7 @@ potentially recursive resolution.
 Generates an `IdSchema` object for the `schema`, recursively
 
 #### Parameters
-- validator: ValidatorType - An implementation of the `ValidatorType` interface that will be used when necessary
+- validator: ValidatorType<T> - An implementation of the `ValidatorType` interface that will be used when necessary
 - schema: RJSFSchema - The schema for which the `IdSchema` is desired
 - [id]: string | null - The base id for the schema
 - [rootSchema]: RJSFSchema - The root schema, used to primarily to look up `$ref`s
@@ -485,7 +497,7 @@ Generates an `IdSchema` object for the `schema`, recursively
 Generates an `PathSchema` object for the `schema`, recursively
 
 #### Parameters
-- validator: ValidatorType - An implementation of the `ValidatorType` interface that will be used when necessary
+- validator: ValidatorType<T> - An implementation of the `ValidatorType` interface that will be used when necessary
 - schema: RJSFSchema - The schema for which the `PathSchema` is desired
 - [name='']: string - The base name for the schema
 - [rootSchema]: RJSFSchema - The root schema, used to primarily to look up `$ref`s
@@ -501,7 +513,7 @@ Creates a `SchemaUtilsType` interface that is based around the given `validator`
 The resulting interface implementation will forward the `validator` and `rootSchema` to all the wrapped APIs.
 
 #### Parameters
-- validator: ValidatorType - an implementation of the `ValidatorType` interface that will be forwarded to all the APIs
+- validator: ValidatorType<T> - an implementation of the `ValidatorType` interface that will be forwarded to all the APIs
 - rootSchema: RJSFSchema - The root schema that will be forwarded to all the APIs
 
 #### Returns

--- a/docs/usage/validation.md
+++ b/docs/usage/validation.md
@@ -123,11 +123,11 @@ render((
 
 Each element in the `errors` list passed to `transformErrors` is a `RJSFValidationError` interface (in `@rjsf/utils`) and has the following properties:
 
-- `name`: name of the error, for example, "required" or "minLength"
-- `message`: message, for example, "is a required property" or "should NOT be shorter than 3 characters"
-- `params`: an object with the error params returned by ajv ([see doc](https://github.com/ajv-validator/ajv/tree/6a671057ea6aae690b5967ee26a0ddf8452c6297#error-parameters) for more info).
-- `property`: a string in Javascript property accessor notation to the data path of the field with the error. For example, `.name` or `['first-name']`.
-- `schemaPath`: JSON pointer to the schema of the keyword that failed validation. For example, `#/fields/firstName/required`. (Note: this may sometimes be wrong due to a [bug in ajv](https://github.com/ajv-validator/ajv/issues/512)).
+- `name`: optional name of the error, for example, "required" or "minLength"
+- `message`: optional message, for example, "is a required property" or "should NOT be shorter than 3 characters"
+- `params`: optional object with the error params returned by ajv ([see doc](https://github.com/ajv-validator/ajv/tree/6a671057ea6aae690b5967ee26a0ddf8452c6297#error-parameters) for more info).
+- `property`: optional string in Javascript property accessor notation to the data path of the field with the error. For example, `.name` or `.first-name`.
+- `schemaPath`: optional JSON pointer to the schema of the keyword that failed validation. For example, `#/fields/firstName/required`. (Note: this may sometimes be wrong due to a [bug in ajv](https://github.com/ajv-validator/ajv/issues/512)).
 - `stack`: full error name, for example ".name is a required property".
 
 ## Error List Display
@@ -135,7 +135,7 @@ Each element in the `errors` list passed to `transformErrors` is a `RJSFValidati
 To take control over how the form errors are displayed, you can define an *error list template* for your form.
 This list is the form global error list that appears at the top of your forms.
 
-An error list template is basically a React stateless component being passed errors as props so you can render them as you like:
+An error list template is basically a React stateless component being passed errors as props, so you can render them as you like:
 
 ```tsx
 import validator from "@rjsf/validator-ajv6";
@@ -167,7 +167,7 @@ render((
         showErrorList={true}
         formData={""}
         liveValidate
-        ErrorList={ErrorListTemplate} />
+        templates: {{ ErrorListTemplate }} />
 ), document.getElementById("app"));
 ```
 
@@ -180,7 +180,6 @@ The following props are passed to `ErrorList` as defined by the `ErrorListProps`
 - `schema`: The schema that was passed to `Form`.
 - `uiSchema`: The uiSchema that was passed to `Form`.
 - `formContext`: The `formContext` object that you passed to `Form`.
-
 
 ## The case of empty strings
 

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -334,12 +334,12 @@ export default class Form<T = any, F = any> extends Component<
       errorSchema = currentErrors.errorSchema;
     }
     if (props.extraErrors) {
-      errorSchema = mergeObjects(
-        errorSchema,
-        props.extraErrors,
-        true
-      ) as ErrorSchema<T>;
-      errors = schemaUtils.getValidator().toErrorList(errorSchema);
+      const merged = schemaUtils.mergeValidationData(
+        { errorSchema, errors },
+        props.extraErrors
+      );
+      errorSchema = merged.errorSchema;
+      errors = merged.errors;
     }
     const idSchema = schemaUtils.toIdSchema(
       retrievedSchema,
@@ -536,12 +536,12 @@ export default class Form<T = any, F = any> extends Component<
       const schemaValidationErrors = errors;
       const schemaValidationErrorSchema = errorSchema;
       if (extraErrors) {
-        errorSchema = mergeObjects(
-          errorSchema,
-          extraErrors,
-          true
-        ) as ErrorSchema<T>;
-        errors = schemaUtils.getValidator().toErrorList(errorSchema);
+        const merged = schemaUtils.mergeValidationData(
+          schemaValidation,
+          extraErrors
+        );
+        errorSchema = merged.errorSchema;
+        errors = merged.errors;
       }
       state = {
         formData: newFormData,
@@ -633,12 +633,12 @@ export default class Form<T = any, F = any> extends Component<
       const schemaValidationErrorSchema = errorSchema;
       if (errors.length > 0) {
         if (extraErrors) {
-          errorSchema = mergeObjects(
-            errorSchema,
-            extraErrors,
-            true
-          ) as ErrorSchema<T>;
-          errors = schemaUtils.getValidator().toErrorList(errorSchema);
+          const merged = schemaUtils.mergeValidationData(
+            schemaValidation,
+            extraErrors
+          );
+          errorSchema = merged.errorSchema;
+          errors = merged.errors;
         }
         this.setState(
           {

--- a/packages/core/test/validate_test.js
+++ b/packages/core/test/validate_test.js
@@ -133,7 +133,7 @@ describe("Validation", () => {
 
         submitForm(node);
         sinon.assert.calledWithMatch(onError.lastCall, [
-          { stack: "root: Invalid" },
+          { property: ".", stack: ".: Invalid" },
         ]);
       });
 
@@ -160,7 +160,7 @@ describe("Validation", () => {
 
         sinon.assert.calledWithMatch(onChange.lastCall, {
           errorSchema: { __errors: ["Invalid"] },
-          errors: [{ stack: "root: Invalid" }],
+          errors: [{ property: ".", stack: ".: Invalid" }],
           formData: "1234",
         });
       });
@@ -242,8 +242,15 @@ describe("Validation", () => {
         });
         submitForm(node);
         sinon.assert.calledWithMatch(onError.lastCall, [
-          { stack: "pass2: should NOT be shorter than 3 characters" },
-          { stack: "pass2: Passwords don't match" },
+          {
+            message: "should NOT be shorter than 3 characters",
+            name: "minLength",
+            params: { limit: 3 },
+            property: ".pass2",
+            schemaPath: "#/properties/pass2/minLength",
+            stack: ".pass2 should NOT be shorter than 3 characters",
+          },
+          { property: ".pass2", stack: ".pass2: Passwords don't match" },
         ]);
       });
 
@@ -281,7 +288,7 @@ describe("Validation", () => {
 
         submitForm(node);
         sinon.assert.calledWithMatch(onError.lastCall, [
-          { stack: "pass2: Passwords don't match" },
+          { property: ".0.pass2", stack: ".0.pass2: Passwords don't match" },
         ]);
       });
 
@@ -309,7 +316,7 @@ describe("Validation", () => {
         });
         submitForm(node);
         sinon.assert.calledWithMatch(onError.lastCall, [
-          { stack: "root: Forbidden value: bbb" },
+          { property: ".", stack: ".: Forbidden value: bbb" },
         ]);
       });
     });

--- a/packages/core/test/validate_test.js
+++ b/packages/core/test/validate_test.js
@@ -133,7 +133,7 @@ describe("Validation", () => {
 
         submitForm(node);
         sinon.assert.calledWithMatch(onError.lastCall, [
-          { property: ".", stack: ".: Invalid" },
+          { property: ".", message: "Invalid", stack: ". Invalid" },
         ]);
       });
 
@@ -160,7 +160,7 @@ describe("Validation", () => {
 
         sinon.assert.calledWithMatch(onChange.lastCall, {
           errorSchema: { __errors: ["Invalid"] },
-          errors: [{ property: ".", stack: ".: Invalid" }],
+          errors: [{ property: ".", message: "Invalid", stack: ". Invalid" }],
           formData: "1234",
         });
       });
@@ -250,7 +250,11 @@ describe("Validation", () => {
             schemaPath: "#/properties/pass2/minLength",
             stack: ".pass2 should NOT be shorter than 3 characters",
           },
-          { property: ".pass2", stack: ".pass2: Passwords don't match" },
+          {
+            property: ".pass2",
+            message: "Passwords don't match",
+            stack: ".pass2 Passwords don't match",
+          },
         ]);
       });
 
@@ -288,7 +292,11 @@ describe("Validation", () => {
 
         submitForm(node);
         sinon.assert.calledWithMatch(onError.lastCall, [
-          { property: ".0.pass2", stack: ".0.pass2: Passwords don't match" },
+          {
+            property: ".0.pass2",
+            message: "Passwords don't match",
+            stack: ".0.pass2 Passwords don't match",
+          },
         ]);
       });
 
@@ -316,7 +324,11 @@ describe("Validation", () => {
         });
         submitForm(node);
         sinon.assert.calledWithMatch(onError.lastCall, [
-          { property: ".", stack: ".: Forbidden value: bbb" },
+          {
+            property: ".",
+            message: "Forbidden value: bbb",
+            stack: ". Forbidden value: bbb",
+          },
         ]);
       });
     });

--- a/packages/utils/src/createSchemaUtils.ts
+++ b/packages/utils/src/createSchemaUtils.ts
@@ -1,10 +1,12 @@
 import deepEquals from "./deepEquals";
 import {
+  ErrorSchema,
   IdSchema,
   PathSchema,
   RJSFSchema,
   SchemaUtilsType,
   UiSchema,
+  ValidationData,
   ValidatorType,
 } from "./types";
 import {
@@ -14,6 +16,7 @@ import {
   isFilesArray,
   isMultiSelect,
   isSelect,
+  mergeValidationData,
   retrieveSchema,
   toIdSchema,
   toPathSchema,
@@ -150,6 +153,26 @@ class SchemaUtils<T = any> implements SchemaUtilsType<T> {
    */
   isSelect(schema: RJSFSchema) {
     return isSelect<T>(this.validator, schema, this.rootSchema);
+  }
+
+  /** Merges the errors in `additionalErrorSchema` into the existing `validationData` by combining the hierarchies in
+   * the two `ErrorSchema`s and then appending the error list from the `additionalErrorSchema` obtained by calling
+   * `getValidator().toErrorList()` onto the `errors` in the `validationData`. If no `additionalErrorSchema` is passed,
+   * then `validationData` is returned.
+   *
+   * @param validationData - The current `ValidationData` into which to merge the additional errors
+   * @param [additionalErrorSchema] - The additional set of errors
+   * @returns - The `validationData` with the additional errors from `additionalErrorSchema` merged into it, if provided.
+   */
+  mergeValidationData(
+    validationData: ValidationData<T>,
+    additionalErrorSchema?: ErrorSchema<T>
+  ): ValidationData<T> {
+    return mergeValidationData<T>(
+      this.validator,
+      validationData,
+      additionalErrorSchema
+    );
   }
 
   /** Retrieves an expanded schema that has had all of its conditions, additional properties, references and

--- a/packages/utils/src/schema/index.ts
+++ b/packages/utils/src/schema/index.ts
@@ -4,6 +4,7 @@ import getMatchingOption from "./getMatchingOption";
 import isFilesArray from "./isFilesArray";
 import isMultiSelect from "./isMultiSelect";
 import isSelect from "./isSelect";
+import mergeValidationData from "./mergeValidationData";
 import retrieveSchema from "./retrieveSchema";
 import toIdSchema from "./toIdSchema";
 import toPathSchema from "./toPathSchema";
@@ -15,6 +16,7 @@ export {
   isFilesArray,
   isMultiSelect,
   isSelect,
+  mergeValidationData,
   retrieveSchema,
   toIdSchema,
   toPathSchema,

--- a/packages/utils/src/schema/mergeValidationData.ts
+++ b/packages/utils/src/schema/mergeValidationData.ts
@@ -1,0 +1,36 @@
+import isEmpty from "lodash/isEmpty";
+
+import mergeObjects from "../mergeObjects";
+import { ErrorSchema, ValidationData, ValidatorType } from "../types";
+
+/** Merges the errors in `additionalErrorSchema` into the existing `validationData` by combining the hierarchies in the
+ * two `ErrorSchema`s and then appending the error list from the `additionalErrorSchema` obtained by calling
+ * `validator.toErrorList()` onto the `errors` in the `validationData`. If no `additionalErrorSchema` is passed, then
+ * `validationData` is returned.
+ *
+ * @param validator - The validator used to convert an ErrorSchema to a list of errors
+ * @param validationData - The current `ValidationData` into which to merge the additional errors
+ * @param [additionalErrorSchema] - The additional set of errors in an `ErrorSchema`
+ * @returns - The `validationData` with the additional errors from `additionalErrorSchema` merged into it, if provided.
+ */
+export default function mergeValidationData<T = any>(
+  validator: ValidatorType<T>,
+  validationData: ValidationData<T>,
+  additionalErrorSchema?: ErrorSchema<T>
+): ValidationData<T> {
+  if (!additionalErrorSchema) {
+    return validationData;
+  }
+  const { errors: oldErrors, errorSchema: oldErrorSchema } = validationData;
+  let errors = validator.toErrorList(additionalErrorSchema);
+  let errorSchema = additionalErrorSchema;
+  if (!isEmpty(oldErrorSchema)) {
+    errorSchema = mergeObjects(
+      oldErrorSchema,
+      additionalErrorSchema,
+      true
+    ) as ErrorSchema<T>;
+    errors = [...oldErrors].concat(errors);
+  }
+  return { errorSchema, errors };
+}

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -714,11 +714,11 @@ export interface ValidatorType<T = any> {
   /** Converts an `errorSchema` into a list of `RJSFValidationErrors`
    *
    * @param errorSchema - The `ErrorSchema` instance to convert
-   * @param [fieldName='root'] - The current field name, defaults to `root` if not specified
+   * @param [fieldPath=[]] - The current field path, defaults to [] if not specified
    */
   toErrorList(
     errorSchema?: ErrorSchema<T>,
-    fieldName?: string
+    fieldPath?: string[]
   ): RJSFValidationError[];
   /** Validates data against a schema, returning true if the data is valid, or
    * false otherwise. If the schema is invalid, then this function will return
@@ -804,6 +804,20 @@ export interface SchemaUtilsType<T = any> {
    * @returns - True if schema contains a select, otherwise false
    */
   isSelect(schema: RJSFSchema): boolean;
+  /** Merges the errors in `additionalErrorSchema` into the existing `validationData` by combining the hierarchies in the
+   * two `ErrorSchema`s and then appending the error list from the `additionalErrorSchema` obtained by calling
+   * `validator.toErrorList()` onto the `errors` in the `validationData`. If no `additionalErrorSchema` is passed, then
+   * `validationData` is returned.
+   *
+   * @param validator - The validator used to convert an ErrorSchema to a list of errors
+   * @param validationData - The current `ValidationData` into which to merge the additional errors
+   * @param [additionalErrorSchema] - The additional set of errors
+   * @returns - The `validationData` with the additional errors from `additionalErrorSchema` merged into it, if provided.
+   */
+  mergeValidationData(
+    validationData: ValidationData<T>,
+    additionalErrorSchema?: ErrorSchema<T>
+  ): ValidationData<T>;
   /** Retrieves an expanded schema that has had all of its conditions, additional properties, references and
    * dependencies resolved and merged into the `schema` given a `rawFormData` that is used to do the potentially
    * recursive resolution.

--- a/packages/utils/test/schema.test.ts
+++ b/packages/utils/test/schema.test.ts
@@ -6,6 +6,7 @@ import {
   isFilesArrayTest,
   isMultiSelectTest,
   isSelectTest,
+  mergeValidationDataTest,
   retrieveSchemaTest,
   toIdSchemaTest,
   toPathSchemaTest,
@@ -19,6 +20,7 @@ getMatchingOptionTest(testValidator);
 isFilesArrayTest(testValidator);
 isMultiSelectTest(testValidator);
 isSelectTest(testValidator);
+mergeValidationDataTest(testValidator);
 retrieveSchemaTest(testValidator);
 toIdSchemaTest(testValidator);
 toPathSchemaTest(testValidator);

--- a/packages/utils/test/schema/index.ts
+++ b/packages/utils/test/schema/index.ts
@@ -4,6 +4,7 @@ import getMatchingOptionTest from "./getMatchingOptionTest";
 import isFilesArrayTest from "./isFilesArrayTest";
 import isMultiSelectTest from "./isMultiSelectTest";
 import isSelectTest from "./isSelectTest";
+import mergeValidationDataTest from "./mergeValidationDataTest";
 import retrieveSchemaTest from "./retrieveSchemaTest";
 import toIdSchemaTest from "./toIdSchemaTest";
 import toPathSchemaTest from "./toPathSchemaTest";
@@ -17,6 +18,7 @@ export {
   isFilesArrayTest,
   isMultiSelectTest,
   isSelectTest,
+  mergeValidationDataTest,
   retrieveSchemaTest,
   toIdSchemaTest,
   toPathSchemaTest,

--- a/packages/utils/test/schema/mergeValidationDataTest.ts
+++ b/packages/utils/test/schema/mergeValidationDataTest.ts
@@ -26,7 +26,9 @@ export default function mergeValidationDataTest(
         errors: [],
       };
       const errors = ["custom errors"];
-      const customErrors = [{ property: ".", stack: `.: ${errors[0]}` }];
+      const customErrors = [
+        { property: ".", message: errors[0], stack: `. ${errors[0]}` },
+      ];
       testValidator.setReturnValues({ errorList: [customErrors] });
       const errorSchema: ErrorSchema = { [ERRORS_KEY]: errors } as ErrorSchema;
       const expected = {
@@ -45,7 +47,9 @@ export default function mergeValidationDataTest(
         errors: [{ stack: oldError, name: "foo", schemaPath: ".foo" }],
       };
       const errors = ["custom errors"];
-      const customErrors = [{ property: ".", stack: `.: ${errors[0]}` }];
+      const customErrors = [
+        { property: ".", message: errors[0], stack: `. ${errors[0]}` },
+      ];
       testValidator.setReturnValues({ errorList: [customErrors] });
       const errorSchema: ErrorSchema = { [ERRORS_KEY]: errors } as ErrorSchema;
       const expected = {

--- a/packages/utils/test/schema/mergeValidationDataTest.ts
+++ b/packages/utils/test/schema/mergeValidationDataTest.ts
@@ -1,0 +1,60 @@
+import {
+  ERRORS_KEY,
+  mergeValidationData,
+  createSchemaUtils,
+  ErrorSchema,
+  ValidationData,
+} from "../../src";
+import { TestValidatorType } from "./types";
+
+export default function mergeValidationDataTest(
+  testValidator: TestValidatorType
+) {
+  describe("mergeValidationDataTest()", () => {
+    it("Returns validationData when no additionalErrorSchema is passed", () => {
+      const validationData: ValidationData<any> = {
+        errorSchema: {},
+        errors: [],
+      };
+      expect(mergeValidationData(testValidator, validationData)).toBe(
+        validationData
+      );
+    });
+    it("Returns only additionalErrorSchema when additionalErrorSchema is passed and no validationData", () => {
+      const validationData: ValidationData<any> = {
+        errorSchema: {},
+        errors: [],
+      };
+      const errors = ["custom errors"];
+      const customErrors = [{ property: ".", stack: `.: ${errors[0]}` }];
+      testValidator.setReturnValues({ errorList: [customErrors] });
+      const errorSchema: ErrorSchema = { [ERRORS_KEY]: errors } as ErrorSchema;
+      const expected = {
+        errorSchema,
+        errors: customErrors,
+      };
+      expect(
+        mergeValidationData(testValidator, validationData, errorSchema)
+      ).toEqual(expected);
+    });
+    it("Returns merged data when additionalErrorSchema is passed", () => {
+      const schemaUtils = createSchemaUtils(testValidator, {});
+      const oldError = "ajv error";
+      const validationData: ValidationData<any> = {
+        errorSchema: { [ERRORS_KEY]: [oldError] } as ErrorSchema,
+        errors: [{ stack: oldError, name: "foo", schemaPath: ".foo" }],
+      };
+      const errors = ["custom errors"];
+      const customErrors = [{ property: ".", stack: `.: ${errors[0]}` }];
+      testValidator.setReturnValues({ errorList: [customErrors] });
+      const errorSchema: ErrorSchema = { [ERRORS_KEY]: errors } as ErrorSchema;
+      const expected = {
+        errorSchema: { [ERRORS_KEY]: [oldError, ...errors] },
+        errors: [...validationData.errors, ...customErrors],
+      };
+      expect(
+        schemaUtils.mergeValidationData(validationData, errorSchema)
+      ).toEqual(expected);
+    });
+  });
+}

--- a/packages/utils/test/schema/types.ts
+++ b/packages/utils/test/schema/types.ts
@@ -1,8 +1,9 @@
-import { ValidationData, ValidatorType } from "../../src";
+import { RJSFValidationError, ValidationData, ValidatorType } from "../../src";
 
 export interface TestValidatorParams<T = any> {
   isValid?: boolean[];
   data?: ValidationData<T>[];
+  errorList?: RJSFValidationError[][];
 }
 
 export interface TestValidatorType extends ValidatorType {

--- a/packages/utils/test/testUtils/getTestValidator.ts
+++ b/packages/utils/test/testUtils/getTestValidator.ts
@@ -1,17 +1,20 @@
-import { ValidationData } from "../../src";
+import { RJSFValidationError, ValidationData } from "../../src";
 import { TestValidatorParams, TestValidatorType } from "../schema/types";
 
 export default function getTestValidator<T = any>({
   isValid = [],
   data = [],
+  errorList = [],
 }: TestValidatorParams): TestValidatorType {
   const testValidator: {
     _data: ValidationData<T>[];
     _isValid: boolean[];
+    _errorList: RJSFValidationError[][];
     validator: TestValidatorType;
   } = {
     _data: data,
     _isValid: isValid,
+    _errorList: errorList,
     validator: {
       validateFormData: jest.fn().mockImplementation(() => {
         if (
@@ -32,13 +35,25 @@ export default function getTestValidator<T = any>({
         }
         return true;
       }),
-      toErrorList: jest.fn().mockImplementation(() => []),
-      setReturnValues({ isValid, data }: TestValidatorParams) {
+      toErrorList: jest.fn().mockImplementation(() => {
+        // console.warn('isValid',  JSON.stringify(args));
+        if (
+          Array.isArray(testValidator._errorList) &&
+          testValidator._errorList.length > 0
+        ) {
+          return testValidator._errorList.shift();
+        }
+        return [];
+      }),
+      setReturnValues({ isValid, data, errorList }: TestValidatorParams) {
         if (isValid !== undefined) {
           testValidator._isValid = isValid;
         }
         if (data !== undefined) {
           testValidator._data = data;
+        }
+        if (errorList !== undefined) {
+          testValidator._errorList = errorList;
         }
       },
     },

--- a/packages/validator-ajv6/src/validator.ts
+++ b/packages/validator-ajv6/src/validator.ts
@@ -116,11 +116,12 @@ export default class AJV6Validator<T = any> implements ValidatorType<T> {
     let errorList: RJSFValidationError[] = [];
     if (ERRORS_KEY in errorSchema) {
       errorList = errorList.concat(
-        errorSchema.__errors!.map((stack: string) => {
-          const property = "." + fieldPath.join(".");
+        errorSchema.__errors!.map((message: string) => {
+          const property = `.${fieldPath.join(".")}`;
           return {
             property,
-            stack: `${property}: ${stack}`,
+            message,
+            stack: `${property} ${message}`,
           };
         })
       );

--- a/packages/validator-ajv6/test/utilsTests/getTestValidator.ts
+++ b/packages/validator-ajv6/test/utilsTests/getTestValidator.ts
@@ -30,9 +30,9 @@ export default function getTestValidator<T = any>(
     },
     toErrorList(
       errorSchema?: ErrorSchema<T>,
-      fieldName?: string
+      fieldPath?: string[]
     ): RJSFValidationError[] {
-      return validator.toErrorList(errorSchema, fieldName);
+      return validator.toErrorList(errorSchema, fieldPath);
     },
     isValid(schema: RJSFSchema, formData: T, rootSchema: RJSFSchema): boolean {
       return validator.isValid(schema, formData, rootSchema);

--- a/packages/validator-ajv6/test/utilsTests/schema.test.ts
+++ b/packages/validator-ajv6/test/utilsTests/schema.test.ts
@@ -6,6 +6,7 @@ import {
   isFilesArrayTest,
   isMultiSelectTest,
   isSelectTest,
+  mergeValidationDataTest,
   retrieveSchemaTest,
   toIdSchemaTest,
   toPathSchemaTest,
@@ -20,6 +21,7 @@ getMatchingOptionTest(testValidator);
 isFilesArrayTest(testValidator);
 isMultiSelectTest(testValidator);
 isSelectTest(testValidator);
+mergeValidationDataTest(testValidator);
 retrieveSchemaTest(testValidator);
 toIdSchemaTest(testValidator);
 toPathSchemaTest(testValidator);

--- a/packages/validator-ajv6/test/validator.test.ts
+++ b/packages/validator-ajv6/test/validator.test.ts
@@ -123,11 +123,11 @@ describe("AJV6Validator", () => {
           } as ErrorSchema,
         } as unknown as ErrorSchema;
         expect(validator.toErrorList(errorSchema)).toEqual([
-          { stack: "root: err1" },
-          { stack: "root: err2" },
-          { stack: "b: err3" },
-          { stack: "b: err4" },
-          { stack: "c: err5" },
+          { property: ".", stack: ".: err1" },
+          { property: ".", stack: ".: err2" },
+          { property: ".a.b", stack: ".a.b: err3" },
+          { property: ".a.b", stack: ".a.b: err4" },
+          { property: ".c", stack: ".c: err5" },
         ]);
       });
     });
@@ -284,7 +284,7 @@ describe("AJV6Validator", () => {
           });
           it("should return an error list", () => {
             expect(errors).toHaveLength(1);
-            expect(errors[0].stack).toEqual("pass2: passwords don`t match.");
+            expect(errors[0].stack).toEqual(".pass2: passwords don`t match.");
           });
           it("should return an errorSchema", () => {
             expect(errorSchema.pass2!.__errors).toHaveLength(1);
@@ -319,7 +319,7 @@ describe("AJV6Validator", () => {
           });
           it("should return an error list", () => {
             expect(errors).toHaveLength(1);
-            expect(errors[0].stack).toEqual("pass2: passwords don`t match.");
+            expect(errors[0].stack).toEqual(".pass2: passwords don`t match.");
           });
           it("should return an errorSchema", () => {
             expect(errorSchema.pass2!.__errors).toHaveLength(1);

--- a/packages/validator-ajv6/test/validator.test.ts
+++ b/packages/validator-ajv6/test/validator.test.ts
@@ -123,11 +123,11 @@ describe("AJV6Validator", () => {
           } as ErrorSchema,
         } as unknown as ErrorSchema;
         expect(validator.toErrorList(errorSchema)).toEqual([
-          { property: ".", stack: ".: err1" },
-          { property: ".", stack: ".: err2" },
-          { property: ".a.b", stack: ".a.b: err3" },
-          { property: ".a.b", stack: ".a.b: err4" },
-          { property: ".c", stack: ".c: err5" },
+          { property: ".", message: "err1", stack: ". err1" },
+          { property: ".", message: "err2", stack: ". err2" },
+          { property: ".a.b", message: "err3", stack: ".a.b err3" },
+          { property: ".a.b", message: "err4", stack: ".a.b err4" },
+          { property: ".c", message: "err5", stack: ".c err5" },
         ]);
       });
     });
@@ -284,7 +284,7 @@ describe("AJV6Validator", () => {
           });
           it("should return an error list", () => {
             expect(errors).toHaveLength(1);
-            expect(errors[0].stack).toEqual(".pass2: passwords don`t match.");
+            expect(errors[0].stack).toEqual(".pass2 passwords don`t match.");
           });
           it("should return an errorSchema", () => {
             expect(errorSchema.pass2!.__errors).toHaveLength(1);
@@ -319,7 +319,7 @@ describe("AJV6Validator", () => {
           });
           it("should return an error list", () => {
             expect(errors).toHaveLength(1);
-            expect(errors[0].stack).toEqual(".pass2: passwords don`t match.");
+            expect(errors[0].stack).toEqual(".pass2 passwords don`t match.");
           });
           it("should return an errorSchema", () => {
             expect(errorSchema.pass2!.__errors).toHaveLength(1);


### PR DESCRIPTION
### Reasons for making this change

Fixed #1596 by adapting the fix from #2002

- Added a new `mergeValidationData()` method in `@rjsf/utils` to handle the appending of errors onto the end of the validationData from an additional error schema
  - Added this to the `schema` directory `index.ts` along with exposing it on the `SchemaUtils` type and implementation
  - Also fixed the type of `toErrorList()` in `ValidatorType` to change from `fieldName: string` to `fieldPath: string[]`
  - Added reusable `mergeValidationDataTest.ts`, calling it in the utils
- Update the `@rjsf/validator-ajv6` to pick up the breaking change from #2002 around `AJV6Validator.toErrorList()`
  - Also modified the `validateFormData()` function to return the result of `mergeValidationData()` when the user has a custom validator
  - Updated tests for the new structure of the `toErrorList()` data
  - Also updated the `schema.tests` to add the new `mergeValidationDataTest()`
- Updated `Form` to use the `mergeValidationData()` function in the few places where `extraErrors` was being merged into the schema validation
  - Updated tests for the new structor of the `toErrorList()` data
- Updated the `CHANGELOG.md` to describe this fix
- Updated the `5.x upgrade guide.md` to describe all the new utility functions added
- Updated the `utility-functions.md` documentation for the new method, also adding missing generic to `ValidatorType`
- Updated the `validation.md` documentation for the `ErrorListTemplate` change along with making the `RJSFValidationError` interface describe the optional properties

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
