### PR TITLE
Reimplement #1755 and and #2460 in new Form.tsx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ should change the heading of the (upcoming) version to include a major version b
 - Added `ui:duplicateKeySuffixSeparator` to customize how duplicate object keys are renamed when using `additionalProperties`.
 - The `extraErrors` are now consistently appended onto the end of the schema validation-based `errors` information that is returned via the `onErrors()` callback when submit fails.
   - In addition, the extra information provided by AJV is no longer stripped from the `errors` during the merge process, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/1596).
+- Correctly call the `onChange` handler in the new set of props if it changed, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/1708).
+- Fixed race condition for `onChange` when `formData` is controlled prop, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/513),
 
 ## @rjsf/antd
 - Fix esm build to use `@rollup/plugin-replace` to replace `antd/lib` and `rc-picker/lib` with `antd/es` and `rc-picker/es` respectively, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/2962)

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -260,9 +260,9 @@ export default class Form<T = any, F = any> extends Component<
     if (
       !deepEquals(nextState.formData, nextProps.formData) &&
       !deepEquals(nextState.formData, this.state.formData) &&
-      this.props.onChange
+      nextProps.onChange
     ) {
-      this.props.onChange(nextState);
+      nextProps.onChange(nextState);
     }
     this.setState(nextState);
   }
@@ -562,7 +562,7 @@ export default class Form<T = any, F = any> extends Component<
     }
     this.setState(
       state as FormState<T, F>,
-      () => onChange && onChange(this.state)
+      () => onChange && onChange({ ...this.state, ...state })
     );
   };
 


### PR DESCRIPTION
### Reasons for making this change

Fixes #1708 and #513

- Reimplement two fixes related to `onChange` in the new `Form.tsx`
  - #1755 fixes the calling of the proper `onChange` during props update
  - #2460 fixes race condition on calling `onChange` after setState.
- Copied the tests as is from the original PR implementations

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
