### PR TITLE
Fixed the 5.x migration guide formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ should change the heading of the (upcoming) version to include a major version b
 - Upgraded from the `1.x` to `2.x` version of `semantic-ui-react`
 - Added support for `schema.examples` in the material ui theme fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/2368, https://github.com/rjsf-team/react-jsonschema-form/issues/2557)
 
+## Dev / docs / playground
+- Fixed missing `playground` import error by adding `source-map-loader`
+- Fixed up the incorrectly formatted `5.x Migration Guide`
+
 # v5.0.0-beta.2
 - Added peer dependencies to new `@rjsf/utils` library now that it is published on npm
 

--- a/docs/5.x upgrade guide.md
+++ b/docs/5.x upgrade guide.md
@@ -4,17 +4,9 @@
 
 There were several significant **breaking changes** in RJSF version 5 that were necessary in order to support the following new features:
 
-- Schema validation was decoupled from `@rjsf/core` to resolve issue [#2693](https://github.com/rjsf-team/react-jsonschema-form/issues/2693).
-  - Additionally, in order to break a circular dependency in the validation refactor, the `@rjsf/core/utils.js` file was split out into its own `@rjsf/utils` package as was suggested in [#1655](https://github.com/rjsf-team/react-jsonschema-form/issues/1655).
-- The theme for Material UI version 5 (i.e. `@rjsf/mui`) was split out of the theme for version 4 (i.e. `@rjsf/material-ui`) to resolve the following issues:
-  - [#2762](https://github.com/rjsf-team/react-jsonschema-form/issues/2762)
-  - [#2858](https://github.com/rjsf-team/react-jsonschema-form/issues/2858)
-  - [#2905](https://github.com/rjsf-team/react-jsonschema-form/issues/2905)
-  - [#2945](https://github.com/rjsf-team/react-jsonschema-form/issues/2945)
-- As part of the fix for [#2526](https://github.com/rjsf-team/react-jsonschema-form/issues/2526) all the existing templates in the previous version were moved into a new `templates` dictionary, similar to how `widgets` and `fields` work
-  - This `templates` dictionary was added to the `Registry` and also the `Form` props, replacing the `ArrayFieldTemplate`, `FieldTemplate`, `ObjectFieldTemplate` and `ErrorList` props.
-  - In addition, several of the `fields` and `widgets` based components were moved into the `templates` dictionary as they were more like templates than true `Field`s or `Widget`s.
-  - [#2945](https://github.com/rjsf-team/react-jsonschema-form/issues/2945)
+- Schema validation was decoupled from `@rjsf/core` to resolve issue [#2693](https://github.com/rjsf-team/react-jsonschema-form/issues/2693). Additionally, in order to break a circular dependency in the validation refactor, the `@rjsf/core/utils.js` file was split out into its own `@rjsf/utils` package as was suggested in [#1655](https://github.com/rjsf-team/react-jsonschema-form/issues/1655).
+- The theme for Material UI version 5 (i.e. `@rjsf/mui`) was split out of the theme for version 4 (i.e. `@rjsf/material-ui`) to resolve the following issues: [#2762](https://github.com/rjsf-team/react-jsonschema-form/issues/2762), [#2858](https://github.com/rjsf-team/react-jsonschema-form/issues/2858), [#2905](https://github.com/rjsf-team/react-jsonschema-form/issues/2905), [#2945](https://github.com/rjsf-team/react-jsonschema-form/issues/2945)
+- As part of the fix for [#2526](https://github.com/rjsf-team/react-jsonschema-form/issues/2526) all the existing templates in the previous version were moved into a new `templates` dictionary, similar to how `widgets` and `fields` work. This `templates` dictionary was added to the `Registry` and also the `Form` props, replacing the `ArrayFieldTemplate`, `FieldTemplate`, `ObjectFieldTemplate` and `ErrorList` props. In addition, several of the `fields` and `widgets` based components were moved into the `templates` dictionary as they were more like templates than true `Field`s or `Widget`s. Also fixes [#2945](https://github.com/rjsf-team/react-jsonschema-form/issues/2945)
 - Fixed `anyOf` and `oneOf` getting incorrect, potentially duplicate ids when combined with array (https://github.com/rjsf-team/react-jsonschema-form/issues/2197)
 
 ### Node support
@@ -33,6 +25,7 @@ Unfortunately, there is required work pending to properly support React 18, so u
 ### New packages
 
 There are three new packages added in RJSF version 5:
+
 - `@rjsf/utils`: All of the [utility functions](https://react-jsonschema-form.readthedocs.io/en/stable/api-reference/utiltity-functions) previously imported from `@rjsf/core/utils` as well as the Typescript types for RJSF version 5.
   - The following new utility functions were added: `createSchemaUtils()`, `getInputProps()`, `mergeValidationData()` and `processSelectValue()`
 - `@rjsf/validator-ajv6`: The [ajv](https://github.com/ajv-validator/ajv)-v6-based validator refactored out of `@rjsf/core@4.x`, that implements the `ValidatorType` interface defined in `@rjsf/utils`.
@@ -47,6 +40,7 @@ All the rest of the types for RJSF are now exported from the new `@rjsf/utils` p
 
 NOTE: The types in `@rjsf/utils` have been improved significantly from those in version 4.
 Some of the most notable changes are:
+
 - `RJSFSchema` has replaced the use of `JSON7Schema` for future compatibility reasons.
   - Currently `RJSFSchema` is simply an alias to `JSON7Schema` so this change is purely a naming one.
   - It is highly recommended to update your use of `JSON7Schema` with `RJSFSchema` so that when the RJSF begins supporting a newer JSON Schema version out-of-the-box, your code won't be affected. 


### PR DESCRIPTION
### Reasons for making this change

- Fixed the formatting for the `5.x migration guide` by adding well placed blank lines and consolidating sub-bullets into the main bullet
- Updated the `CHANGELOG.md` with these changes

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ 
] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

Sub-bullets aren't being subbed
<img width="709" alt="Screen Shot 2022-08-29 at 2 04 01 PM" src="https://user-images.githubusercontent.com/51679588/187298616-4268d36e-a10b-4e9a-a2c2-618b8899a8ed.png">

These bullets aren't bullets
<img width="708" alt="Screen Shot 2022-08-29 at 2 00 19 PM" src="https://user-images.githubusercontent.com/51679588/187298088-8380c975-93aa-42c6-b938-d3ec8de1d1c2.png">
Same, these bullets aren't bullets
<img width="729" alt="Screen Shot 2022-08-29 at 2 01 21 PM" src="https://user-images.githubusercontent.com/51679588/187298187-e1d3b3be-d4de-4134-84b1-998c049f1b17.png">
