### PR TITLE
Updated package.json build scripts to rollup typescript

### DIFF
--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -6,7 +6,7 @@
   "module": "dist/antd.esm.js",
   "scripts": {
     "start": "dts watch",
-    "build": "rimraf dist && dts build --format cjs,esm,umd",
+    "build": "rimraf dist && dts build --rollupTypes --format cjs,esm,umd",
     "cs-check": "prettier -l \"{src,test}/**/*.js\"",
     "cs-format": "prettier \"{src,test}/**/*.js\" --write",
     "lint": "eslint src test",

--- a/packages/bootstrap-4/package.json
+++ b/packages/bootstrap-4/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "start": "dts watch",
-    "build": "rimraf dist && dts build --format cjs,esm,umd",
+    "build": "rimraf dist && dts build --rollupTypes --format cjs,esm,umd",
     "cs-check": "prettier -l \"{src,test}/**/*.ts?(x)\"",
     "cs-format": "prettier \"{src,test}/**/*.ts?(x)\" --write",
     "lint": "eslint src test",

--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "start": "dts watch",
-    "build": "rimraf dist && dts build --format cjs,esm,umd",
+    "build": "rimraf dist && dts build --rollupTypes --format cjs,esm,umd",
     "cs-check": "prettier -l \"{src,test}/**/*.ts?(x)\"",
     "cs-format": "prettier \"{src,test}/**/*.ts?(x)\" --write",
     "lint": "eslint src test",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.0-beta.2",
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
-    "build": "rimraf dist && dts build --format cjs,esm,umd",
+    "build": "rimraf dist && dts build --rollupTypes --format cjs,esm,umd",
     "cs-check": "prettier -l \"{src,test}/**/*.[jt]s?(x)\"",
     "cs-format": "prettier \"{src,test}/**/*.[jt]s?(x)\" --write",
     "lint": "eslint src test",

--- a/packages/fluent-ui/package.json
+++ b/packages/fluent-ui/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "start": "dts watch",
-    "build": "rimraf dist && dts build --format cjs,esm,umd",
+    "build": "rimraf dist && dts build --rollupTypes --format cjs,esm,umd",
     "cs-check": "prettier -l \"{src,test}/**/*.ts?(x)\"",
     "cs-format": "prettier \"{src,test}/**/*.ts?(x)\" --write",
     "lint": "eslint src test",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "start": "dts watch",
-    "build": "rimraf dist && dts build --format cjs,esm,umd",
+    "build": "rimraf dist && dts build --rollupTypes --format cjs,esm,umd",
     "cs-check": "prettier -l \"{src,test}/**/*.ts?(x)\"",
     "cs-format": "prettier \"{src,test}/**/*.ts?(x)\" --write",
     "lint": "eslint src test",

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "start": "dts watch",
-    "build": "rimraf dist && dts build --format cjs,esm,umd",
+    "build": "rimraf dist && dts build --rollupTypes --format cjs,esm,umd",
     "cs-check": "prettier -l \"{src,test}/**/*.ts?(x)\"",
     "cs-format": "prettier \"{src,test}/**/*.ts?(x)\" --write",
     "lint": "eslint src test",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -12,7 +12,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "build": "rimraf dist && tsdx build --format cjs,es,umd",
+    "build": "rimraf dist && tsdx build --rollupTypes --format cjs,es,umd",
     "cs-check": "prettier -l \"{src,test}/**/*.js\"",
     "cs-format": "prettier \"{src,test}/**/*.js\" --write",
     "lint": "eslint src test",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,7 +13,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "build": "rimraf dist && dts build --format cjs,esm,umd",
+    "build": "rimraf dist && dts build --rollupTypes --format cjs,esm,umd",
     "cs-check": "prettier -l \"{src,test}/**/*.ts?(x)\"",
     "cs-format": "prettier \"{src,test}/**/*.ts?(x)\" --write",
     "lint": "eslint src test",

--- a/packages/validator-ajv6/package.json
+++ b/packages/validator-ajv6/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "start": "dts watch",
-    "build": "rimraf dist && dts build --format cjs,esm,umd",
+    "build": "rimraf dist && dts build --rollupTypes --format cjs,esm,umd",
     "cs-check": "prettier -l \"{src,test}/**/*.ts?(x)\"",
     "cs-format": "prettier \"{src,test}/**/*.ts?(x)\" --write",
     "lint": "eslint src test",


### PR DESCRIPTION
### Reasons for making this change

- Added the `--rollupTypes` flag on the build script so that types are also rolled up like the source

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

Before:
<img width="347" alt="image" src="https://user-images.githubusercontent.com/3852574/187320341-075c3e5b-040f-4299-bf06-9d546f6025e3.png">

After:
<img width="233" alt="Screen Shot 2022-08-29 at 10 26 33 PM" src="https://user-images.githubusercontent.com/51679588/187356568-f6792a1b-3a4f-4dec-aa22-e9129227c563.png">