### PR TITLE
Fixed playground controls not functioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 - Added a `requestSubmit()` call to the `Form.submit()` function, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/2104, https://github.com/rjsf-team/react-jsonschema-form/issues/3023)
 - Added missing `children` property on the `FormProps` type for `Form`
+- Throw an error when the required `validator` prop has not been provided to the `Form`
 
 ## @rjsf/antd
 - Do not show errors if `extraErrors` has `[]` (https://github.com/rjsf-team/react-jsonschema-form/pull/2576).
@@ -46,6 +47,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed up the incorrectly formatted `5.x Migration Guide`
 - Added a `Programmatic Submit` button on the playground form to allow users to test the ability to programmatically submit a form
 - Regenerated the `package-lock.json` files using clean `node_modules` directories
+- Fixed issue with playground controls in top right corner not functioning properly due to missing validator
 
 # v5.0.0-beta.2
 - Added peer dependencies to new `@rjsf/utils` library now that it is published on npm

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -241,6 +241,10 @@ export default class Form<T = any, F = any> extends Component<
   constructor(props: FormProps<T, F>) {
     super(props);
 
+    if (!props.validator) {
+      throw new Error("A validator is required for Form functionality to work");
+    }
+
     this.state = this.getStateFromProps(props, props.formData);
     if (
       this.props.onChange &&

--- a/packages/core/test/Form_test.js
+++ b/packages/core/test/Form_test.js
@@ -28,6 +28,15 @@ describeRepeated("Form common", (createFormComponent) => {
   });
 
   describe("Empty schema", () => {
+    it("Should throw error when Form is missing validator", () => {
+      expect(() =>
+        createFormComponent({ schema: {}, validator: undefined })
+      ).to.Throw(
+        Error,
+        "A validator is required for Form functionality to work"
+      );
+    });
+
     it("should render a form tag", () => {
       const { node } = createFormComponent({ schema: {} });
 
@@ -3478,6 +3487,7 @@ describe("Form omitExtraData and liveOmit", () => {
     const props = {
       schema,
       uiSchema,
+      validator,
     };
 
     class Container extends React.Component {

--- a/packages/core/test/withTheme_test.js
+++ b/packages/core/test/withTheme_test.js
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import React, { Component, createRef } from "react";
+import validator from "@rjsf/validator-ajv6";
 
 import { withTheme } from "../src";
 import { createComponent, createSandbox } from "./test_utils";
@@ -7,6 +8,7 @@ import { createComponent, createSandbox } from "./test_utils";
 const WrapperClassComponent = (...args) => {
   return class extends Component {
     render() {
+      console.log(this.props);
       const Cmp = withTheme(...args);
       return <Cmp {...this.props} />;
     }
@@ -46,6 +48,7 @@ describe("withTheme", () => {
       let { node } = createComponent(WrapperClassComponent({ fields }), {
         schema,
         uiSchema,
+        validator,
       });
       expect(node.querySelectorAll(".string-field")).to.have.length.of(2);
     });
@@ -79,6 +82,7 @@ describe("withTheme", () => {
           schema,
           uiSchema,
           fields: userFields,
+          validator,
         }
       );
       expect(node.querySelectorAll(".string-field")).to.have.length.of(1);
@@ -114,6 +118,7 @@ describe("withTheme", () => {
           schema,
           uiSchema,
           fields: userFields,
+          validator,
         }
       );
       expect(node.querySelectorAll(".string-field")).to.have.length.of(0);
@@ -133,6 +138,7 @@ describe("withTheme", () => {
       let { node } = createComponent(WrapperClassComponent({ widgets }), {
         schema,
         uiSchema,
+        validator,
       });
       expect(node.querySelectorAll("#test")).to.have.length.of(1);
     });
@@ -163,6 +169,7 @@ describe("withTheme", () => {
           schema,
           uiSchema,
           widgets: userWidgets,
+          validator,
         }
       );
       expect(node.querySelectorAll("#test-theme-widget")).to.have.length.of(1);
@@ -191,6 +198,7 @@ describe("withTheme", () => {
           schema,
           uiSchema,
           widgets: userWidgets,
+          validator,
         }
       );
       expect(node.querySelectorAll("#test-theme-widget")).to.have.length.of(0);
@@ -222,6 +230,7 @@ describe("withTheme", () => {
         {
           schema,
           uiSchema,
+          validator,
         }
       );
       expect(
@@ -250,6 +259,7 @@ describe("withTheme", () => {
         {
           schema,
           templates: userTemplates,
+          validator,
         }
       );
       expect(
@@ -289,6 +299,7 @@ describe("withTheme", () => {
         {
           schema,
           uiSchema,
+          validator,
         }
       );
       expect(
@@ -325,6 +336,7 @@ describe("withTheme", () => {
         {
           schema,
           templates: userTemplates,
+          validator,
         }
       );
       expect(
@@ -344,6 +356,7 @@ describe("withTheme", () => {
     createComponent(withTheme({}), {
       schema,
       uiSchema,
+      validator,
       ref,
     });
 

--- a/packages/core/test/withTheme_test.js
+++ b/packages/core/test/withTheme_test.js
@@ -8,7 +8,6 @@ import { createComponent, createSandbox } from "./test_utils";
 const WrapperClassComponent = (...args) => {
   return class extends Component {
     render() {
-      console.log(this.props);
       const Cmp = withTheme(...args);
       return <Cmp {...this.props} />;
     }

--- a/packages/playground/src/app.js
+++ b/packages/playground/src/app.js
@@ -5,6 +5,7 @@ import "react-app-polyfill/ie11";
 import Form, { withTheme } from "@rjsf/core";
 import { shouldRender } from "@rjsf/utils";
 import DemoFrame from "./DemoFrame";
+import localValidator from "@rjsf/validator-ajv6";
 
 const log = (type) => console.log.bind(console, type);
 const toJson = (val) => JSON.stringify(val, null, 2);
@@ -17,6 +18,7 @@ const liveSettingsSchema = {
     readonly: { type: "boolean", title: "Readonly whole form" },
     omitExtraData: { type: "boolean", title: "Omit extra data" },
     liveOmit: { type: "boolean", title: "Live omit" },
+    noValidate: { type: "boolean", title: "Disable validation" },
   },
 };
 
@@ -185,6 +187,7 @@ function ThemeSelector({ theme, themes, select }) {
       schema={schema}
       uiSchema={uiSchema}
       formData={theme}
+      validator={localValidator}
       onChange={({ formData }) =>
         formData && select(formData, themes[formData])
       }
@@ -209,6 +212,7 @@ function SubthemeSelector({ subtheme, subthemes, select }) {
       schema={schema}
       uiSchema={uiSchema}
       formData={subtheme}
+      validator={localValidator}
       onChange={({ formData }) =>
         formData && select(formData, subthemes[formData])
       }
@@ -233,6 +237,7 @@ function ValidatorSelector({ validator, validators, select }) {
       schema={schema}
       uiSchema={uiSchema}
       formData={validator}
+      validator={localValidator}
       onChange={({ formData }) => formData && select(formData)}
     >
       <div />
@@ -458,6 +463,7 @@ class Playground extends Component {
                 idPrefix="rjsf_options"
                 schema={liveSettingsSchema}
                 formData={liveSettings}
+                validator={localValidator}
                 onChange={this.setLiveSettings}
               >
                 <div />
@@ -482,11 +488,7 @@ class Playground extends Component {
                 select={this.onValidatorSelected}
               />
               <CopyLink shareURL={this.state.shareURL} onShare={this.onShare} />
-            </div>
-          </div>
-          <div className="row">
-            <div className="col-sm-10" />
-            <div className="col-sm-2">
+              <span> </span>
               <button
                 title="Click me to submit the form programmatically."
                 className="btn btn-default"
@@ -567,6 +569,7 @@ class Playground extends Component {
                 readonly={liveSettings.readonly}
                 omitExtraData={liveSettings.omitExtraData}
                 liveOmit={liveSettings.liveOmit}
+                noValidate={liveSettings.noValidate}
                 schema={schema}
                 uiSchema={uiSchema}
                 formData={formData}
@@ -577,7 +580,7 @@ class Playground extends Component {
                   console.log("submit event", e);
                 }}
                 fields={{ geo: GeoPosition }}
-                validate={validate}
+                customValidate={validate}
                 validator={validators[validator]}
                 onBlur={(id, value) =>
                   console.log(`Touched ${id} with value ${value}`)


### PR DESCRIPTION
### Reasons for making this change

- Updated `CHANGELOG.md` appropriately
- Updated `Form` to throw an `Error` when the `validator` prop is missing
  - Updated tests to verify change and to add missing validator props where needed
- Updated the `app.js` in the playground to add a local `validator` prop to all of the `Form` components used to generate the playground controls
  - Added the ability to select `noValidate` on the `Form` as well
  - Renamed the `validate` prop on the `Form` to be the new `customValidate` prop so that it works properly
  - Also moved the `Programmatic Submit` button along side the `Share` button to reduce vertical space

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
