### PR TITLE
Reimplemented fix in #2198 in @rjsf/utils package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## Dev / docs / playground
 - Added two new validator selections, `AJV8` and `AJV8_es` to the list of available validators for the playground; Using the second one will translate error messages to spanish.
+- Updated the validation documentation to clarify the case of empty strings being stored as `null` in certain cases.
 
 # v5.0.0-beta.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # v5.0.0-beta.6
 
+## @rjsf/bootstrap-4
+- Change custom attribute to bsPrefix by @WillowP, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/2648)
+
 ## @rjsf/core
 - Added tests for the new `@rjsf/validator-ajv8` to the `validate_test.js` file to ensure the validation works with both validator implementations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,20 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 - Added tests for the new `@rjsf/validator-ajv8` to the `validate_test.js` file to ensure the validation works with both validator implementations
 
+## @rjsf/mui
+- Fixed the `README.md` to correct the package name in several places to match the actual package
+
 ## @rjsf/utils
 - Fixed the `README.md` to remove references to ajv6 validator, adding link to the `utility-functions.md` in the docs
+- Fixed the `README.md` to correct the package name in several places to match the actual package
+- Updated `getDefaultFormState()` so that oneOf and anyOf default values do not always use the first option when formData contains a better option, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/2183)
+
+## @rjsf/validator-ajv6
+- Fixed the `README.md` to correct the package name in several places to match the actual package
 
 ## @rjsf/validator-ajv8
 - Support for localization (L12n) on a customized validator using a `Localizer` function passed as a second parameter to `customizeValidator()`, fixing (https://github.com/rjsf-team/react-jsonschema-form/pull/846, and https://github.com/rjsf-team/react-jsonschema-form/issues/1195) 
+- Fixed the `README.md` to correct the package name in several places to match the actual package
 
 ## Dev / docs / playground
 - Added two new validator selections, `AJV8` and `AJV8_es` to the list of available validators for the playground; Using the second one will translate error messages to spanish.

--- a/packages/core/test/oneOf_test.js
+++ b/packages/core/test/oneOf_test.js
@@ -582,6 +582,43 @@ describe("oneOf", () => {
     expect(node.querySelector("input#root").value).eql("");
   });
 
+  it("should use only the selected option when generating default values", () => {
+    const schema = {
+      type: "object",
+      oneOf: [
+        {
+          additionalProperties: false,
+          properties: { lorem: { type: "object" } },
+        },
+        {
+          additionalProperties: false,
+          properties: { ipsum: { type: "object" } },
+        },
+        {
+          additionalProperties: false,
+          properties: { pyot: { type: "object" } },
+        },
+      ],
+    };
+
+    const { node, onChange } = createFormComponent({
+      schema,
+      formData: { lorem: {} },
+    });
+
+    const $select = node.querySelector("select");
+
+    Simulate.change($select, {
+      target: { value: $select.options[1].value },
+    });
+
+    expect($select.value).eql("1");
+
+    sinon.assert.calledWithMatch(onChange.lastCall, {
+      formData: { lorem: undefined, ipsum: {} },
+    });
+  });
+
   describe("Arrays", () => {
     it("should correctly render mixed types for oneOf inside array items", () => {
       const schema = {

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -1,4 +1,5 @@
 import get from "lodash/get";
+import isEmpty from "lodash/isEmpty";
 
 import {
   ANY_OF_KEY,
@@ -71,7 +72,7 @@ export function getInnerSchemaForArrayItem(
 }
 
 /** Computes the defaults for the current `schema` given the `rawFormData` and `parentDefaults` if any. This drills into
- * the each level of the schema, recursively, to fill out every level of defaults provided by the schema.
+ * each level of the schema, recursively, to fill out every level of defaults provided by the schema.
  *
  * @param validator - an implementation of the `ValidatorType` interface that will be used when necessary
  * @param schema - The schema for which the default state is desired
@@ -143,7 +144,7 @@ export function computeDefaults<T = any>(
     schema = schema.oneOf![
       getMatchingOption(
         validator,
-        undefined,
+        isEmpty(formData) ? undefined : formData,
         schema.oneOf as RJSFSchema[],
         rootSchema
       )
@@ -152,7 +153,7 @@ export function computeDefaults<T = any>(
     schema = schema.anyOf![
       getMatchingOption(
         validator,
-        undefined,
+        isEmpty(formData) ? undefined : formData,
         schema.anyOf as RJSFSchema[],
         rootSchema
       )

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -757,6 +757,26 @@ export default function getDefaultFormStateTest(
           grade: "A",
         });
       });
+      it("should populate defaults for oneOf second option", () => {
+        const schema: RJSFSchema = {
+          type: "object",
+          properties: {
+            test: {
+              oneOf: [
+                { properties: { a: { type: "string", default: "a" } } },
+                { properties: { b: { type: "string", default: "b" } } },
+              ],
+            },
+          },
+        };
+        // Mock errors so that getMatchingOption works as expected
+        testValidator.setReturnValues({ isValid: [false, true] });
+        expect(
+          getDefaultFormState(testValidator, schema, { test: { b: "b" } })
+        ).toEqual({
+          test: { b: "b" },
+        });
+      });
     });
     describe("defaults with anyOf", () => {
       it("should populate defaults for anyOf", () => {
@@ -835,6 +855,26 @@ export default function getDefaultFormStateTest(
         ).toEqual({
           name: "Name",
           grade: "A",
+        });
+      });
+      it("should populate defaults for anyOf second option", () => {
+        const schema: RJSFSchema = {
+          type: "object",
+          properties: {
+            test: {
+              anyOf: [
+                { properties: { a: { type: "string", default: "a" } } },
+                { properties: { b: { type: "string", default: "b" } } },
+              ],
+            },
+          },
+        };
+        // Mock errors so that getMatchingOption works as expected
+        testValidator.setReturnValues({ isValid: [false, true] });
+        expect(
+          getDefaultFormState(testValidator, schema, { test: { b: "b" } })
+        ).toEqual({
+          test: { b: "b" },
         });
       });
     });


### PR DESCRIPTION
### Reasons for making this change

The fix in #2198 is simple and fixes a pretty bad issue

- The fix in https://github.com/rjsf-team/react-jsonschema-form/pull/2198 needed to be refactored into the new `@rjsf/utils` package
- Replicated the fix into the `getDefaultFormState.ts` file
- Replicated the additional tests into `getDefaultFormStateTest.ts` and `oneOf_test.js`
- All of these change are identical to what is in the original PR with the addition of mocking return values for the utils tests
- Updated the `CHANGELOG.md` with the note for this fix along with the notes for PR https://github.com/rjsf-team/react-jsonschema-form/pull/3094

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/master/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
