### PR TITLE
fix: #3104 by refactoring themes into new templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,26 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/antd
 - Only show description when there really IS a description, fixes (https://github.com/rjsf-team/react-jsonschema-form/issues/2779)
+- Refactored the `FieldErrorTemplate` from inside of `FieldTemplate`; fixes (https://github.com/rjsf-team/react-jsonschema-form/issues/3104)
+
+## @rjsf/bootstrap-4
+- Refactored the `FieldErrorTemplate` and `FieldHelpTemplate` from inside of `FieldTemplate`; fixes (https://github.com/rjsf-team/react-jsonschema-form/issues/3104)
+
+## @rjsf/chakra-ui
+- Refactored the `FieldErrorTemplate` and `FieldHelpTemplate` from inside of `FieldTemplate`; fixes (https://github.com/rjsf-team/react-jsonschema-form/issues/3104)
 
 ## @rjsf/core
 - Added new field `ArraySchemaField`, assigned to `SchemaField` by default, that is used by the `ArrayField` to render the `children` for each array field element
 - Refactored the internal `ErrorList` and `Help` components from inside of `SchemaField` to new templates: `FieldErrorTemplate` and `FieldHelpTemplate`; fixes (https://github.com/rjsf-team/react-jsonschema-form/issues/3104)
+
+## @rjsf/material-ui
+- Refactored the `FieldErrorTemplate` and `FieldHelpTemplate` from inside of `FieldTemplate`; fixes (https://github.com/rjsf-team/react-jsonschema-form/issues/3104)
+
+## @rjsf/mui
+- Refactored the `FieldErrorTemplate` and `FieldHelpTemplate` from inside of `FieldTemplate`; fixes (https://github.com/rjsf-team/react-jsonschema-form/issues/3104)
+
+## @rjsf/semantic-ui
+- Converted `RawErrors` and `HelpField` into `FieldErrorTemplate` and `FieldHelpTemplate`, removing their explicit calls from `FieldTemplate`; fixes (https://github.com/rjsf-team/react-jsonschema-form/issues/3104)
 
 ## @rjsf/utils
 - Added new `FieldErrorProps` and `FieldHelpProps` types

--- a/packages/antd/src/index.js
+++ b/packages/antd/src/index.js
@@ -11,6 +11,7 @@ import {
   MoveUpButton,
   RemoveButton,
 } from "./templates/IconButton";
+import FieldErrorTemplate from "./templates/FieldErrorTemplate";
 import FieldTemplate from "./templates/FieldTemplate";
 import ObjectFieldTemplate from "./templates/ObjectFieldTemplate";
 import SubmitButton from "./templates/SubmitButton";
@@ -56,6 +57,7 @@ export const Theme = {
     },
     DescriptionFieldTemplate: DescriptionField,
     ErrorListTemplate: ErrorList,
+    FieldErrorTemplate,
     FieldTemplate,
     ObjectFieldTemplate,
     TitleFieldTemplate: TitleField,

--- a/packages/antd/src/templates/FieldErrorTemplate/index.js
+++ b/packages/antd/src/templates/FieldErrorTemplate/index.js
@@ -1,0 +1,21 @@
+import React from "react";
+
+/** The `FieldErrorTemplate` component renders the errors local to the particular field
+ *
+ * @param props - The `FieldErrorProps` for the errors being rendered
+ */
+export default function FieldErrorTemplate(props) {
+  const { errors = [], idSchema } = props;
+  if (errors.length === 0) {
+    return null;
+  }
+  const id = `${idSchema.$id}__error`;
+
+  return (
+    <div id={id}>
+      {errors.map((error) => (
+        <div key={`field-${id}-error-${error}`}>{error}</div>
+      ))}
+    </div>
+  );
+}

--- a/packages/antd/src/templates/FieldTemplate/index.js
+++ b/packages/antd/src/templates/FieldTemplate/index.js
@@ -13,7 +13,7 @@ const FieldTemplate = ({
   description,
   disabled,
   displayLabel,
-  // errors,
+  errors,
   formContext,
   help,
   hidden,
@@ -40,11 +40,6 @@ const FieldTemplate = ({
     return <div className="field-hidden">{children}</div>;
   }
 
-  const renderFieldErrors = () =>
-    [...new Set(rawErrors)].map((error) => (
-      <div key={`field-${id}-error-${error}`}>{error}</div>
-    ));
-
   return (
     <WrapIfAdditional
       classNames={classNames}
@@ -66,9 +61,7 @@ const FieldTemplate = ({
           colon={colon}
           extra={description}
           hasFeedback={schema.type !== "array" && schema.type !== "object"}
-          help={
-            (!!rawHelp && help) || (!!rawErrors?.length && renderFieldErrors())
-          }
+          help={(!!rawHelp && help) || errors}
           htmlFor={id}
           label={displayLabel && label}
           labelCol={labelCol}

--- a/packages/bootstrap-4/src/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/bootstrap-4/src/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { FieldErrorProps } from "@rjsf/utils";
+import ListGroup from "react-bootstrap/ListGroup";
+
+/** The `FieldErrorTemplate` component renders the errors local to the particular field
+ *
+ * @param props - The `FieldErrorProps` for the errors being rendered
+ */
+export default function FieldErrorTemplate(props: FieldErrorProps) {
+  const { errors = [], idSchema } = props;
+  if (errors.length === 0) {
+    return null;
+  }
+  const id = `${idSchema.$id}__error`;
+
+  return (
+    <ListGroup as="ul" id={id}>
+      {errors.map((error: string) => {
+        return (
+          <ListGroup.Item as="li" key={error} className="border-0 m-0 p-0">
+            <small className="m-0 text-danger">{error}</small>
+          </ListGroup.Item>
+        );
+      })}
+    </ListGroup>
+  );
+}

--- a/packages/bootstrap-4/src/FieldErrorTemplate/index.ts
+++ b/packages/bootstrap-4/src/FieldErrorTemplate/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./FieldErrorTemplate";
+export * from "./FieldErrorTemplate";

--- a/packages/bootstrap-4/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/bootstrap-4/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { FieldHelpProps } from "@rjsf/utils";
+import Form from "react-bootstrap/Form";
+
+/** The `FieldHelpTemplate` component renders any help desired for a field
+ *
+ * @param props - The `FieldHelpProps` to be rendered
+ */
+export default function FieldHelpTemplate(props: FieldHelpProps) {
+  const { idSchema, help, hasErrors } = props;
+  if (!help) {
+    return null;
+  }
+  const id = `${idSchema.$id}__help`;
+  return (
+    <Form.Text className={hasErrors ? "text-danger" : "text-muted"} id={id}>
+      {help}
+    </Form.Text>
+  );
+}

--- a/packages/bootstrap-4/src/FieldHelpTemplate/index.ts
+++ b/packages/bootstrap-4/src/FieldHelpTemplate/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./FieldHelpTemplate";
+export * from "./FieldHelpTemplate";

--- a/packages/bootstrap-4/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/bootstrap-4/src/FieldTemplate/FieldTemplate.tsx
@@ -1,9 +1,6 @@
 import React from "react";
-
 import { FieldTemplateProps } from "@rjsf/utils";
-
 import Form from "react-bootstrap/Form";
-import ListGroup from "react-bootstrap/ListGroup";
 
 import WrapIfAdditional from "./WrapIfAdditional";
 
@@ -12,7 +9,8 @@ const FieldTemplate = ({
   children,
   displayLabel,
   rawErrors = [],
-  rawHelp,
+  errors,
+  help,
   rawDescription,
   classNames,
   disabled,
@@ -46,29 +44,8 @@ const FieldTemplate = ({
             {rawDescription}
           </Form.Text>
         )}
-        {rawErrors.length > 0 && (
-          <ListGroup as="ul">
-            {rawErrors.map((error: string) => {
-              return (
-                <ListGroup.Item
-                  as="li"
-                  key={error}
-                  className="border-0 m-0 p-0"
-                >
-                  <small className="m-0 text-danger">{error}</small>
-                </ListGroup.Item>
-              );
-            })}
-          </ListGroup>
-        )}
-        {rawHelp && (
-          <Form.Text
-            className={rawErrors.length > 0 ? "text-danger" : "text-muted"}
-            id={id}
-          >
-            {rawHelp}
-          </Form.Text>
-        )}
+        {errors}
+        {help}
       </Form.Group>
     </WrapIfAdditional>
   );

--- a/packages/bootstrap-4/src/Templates/Templates.ts
+++ b/packages/bootstrap-4/src/Templates/Templates.ts
@@ -5,6 +5,8 @@ import BaseInputTemplate from "../BaseInputTemplate/BaseInputTemplate";
 import DescriptionField from "../DescriptionField";
 import ErrorList from "../ErrorList";
 import { MoveDownButton, MoveUpButton, RemoveButton } from "../IconButton";
+import FieldErrorTemplate from "../FieldErrorTemplate";
+import FieldHelpTemplate from "../FieldHelpTemplate";
 import FieldTemplate from "../FieldTemplate";
 import ObjectFieldTemplate from "../ObjectFieldTemplate";
 import SubmitButton from "../SubmitButton";
@@ -23,6 +25,8 @@ export default {
   },
   DescriptionFieldTemplate: DescriptionField,
   ErrorListTemplate: ErrorList,
+  FieldErrorTemplate,
+  FieldHelpTemplate,
   FieldTemplate,
   ObjectFieldTemplate,
   TitleFieldTemplate: TitleField,

--- a/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
@@ -605,6 +605,7 @@ exports[`single fields help and error display 1`] = `
       
       <ul
         className="list-group"
+        id="root__error"
         onKeyDown={[Function]}
       >
         <li
@@ -622,7 +623,7 @@ exports[`single fields help and error display 1`] = `
       </ul>
       <small
         className="text-danger form-text"
-        id="root"
+        id="root__help"
       >
         help me!
       </small>

--- a/packages/chakra-ui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/chakra-ui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { FieldErrorProps } from "@rjsf/utils";
+import { FormErrorMessage, List, ListItem } from "@chakra-ui/react";
+
+/** The `FieldErrorTemplate` component renders the errors local to the particular field
+ *
+ * @param props - The `FieldErrorProps` for the errors being rendered
+ */
+export default function FieldErrorTemplate(props: FieldErrorProps) {
+  const { errors = [], idSchema } = props;
+  if (errors.length === 0) {
+    return null;
+  }
+  const id = `${idSchema.$id}__error`;
+
+  return (
+    <List>
+      {errors.map((error, i: number) => {
+        return (
+          <ListItem key={i}>
+            <FormErrorMessage id={id}>{error}</FormErrorMessage>
+          </ListItem>
+        );
+      })}
+    </List>
+  );
+}

--- a/packages/chakra-ui/src/FieldErrorTemplate/index.ts
+++ b/packages/chakra-ui/src/FieldErrorTemplate/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./FieldErrorTemplate";
+export * from "./FieldErrorTemplate";

--- a/packages/chakra-ui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/chakra-ui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { FieldHelpProps } from "@rjsf/utils";
+import { FormHelperText } from "@chakra-ui/react";
+
+/** The `FieldHelpTemplate` component renders any help desired for a field
+ *
+ * @param props - The `FieldHelpProps` to be rendered
+ */
+export default function FieldHelpTemplate(props: FieldHelpProps) {
+  const { idSchema, help } = props;
+  if (!help) {
+    return null;
+  }
+  const id = `${idSchema.$id}__help`;
+  return <FormHelperText id={id}>{help}</FormHelperText>;
+}

--- a/packages/chakra-ui/src/FieldHelpTemplate/index.ts
+++ b/packages/chakra-ui/src/FieldHelpTemplate/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./FieldHelpTemplate";
+export * from "./FieldHelpTemplate";

--- a/packages/chakra-ui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/chakra-ui/src/FieldTemplate/FieldTemplate.tsx
@@ -1,14 +1,6 @@
 import React from "react";
-
 import { FieldTemplateProps } from "@rjsf/utils";
-
-import {
-  Text,
-  FormControl,
-  FormHelperText,
-  FormErrorMessage,
-} from "@chakra-ui/react";
-import { List, ListItem } from "@chakra-ui/react";
+import { Text, FormControl } from "@chakra-ui/react";
 
 import WrapIfAdditional from "./WrapIfAdditional";
 
@@ -27,7 +19,8 @@ const FieldTemplate = (props: FieldTemplateProps) => {
     registry,
     required,
     rawErrors = [],
-    rawHelp,
+    errors,
+    help,
     rawDescription,
     schema,
   } = props;
@@ -57,18 +50,8 @@ const FieldTemplate = (props: FieldTemplateProps) => {
         {displayLabel && rawDescription ? (
           <Text mt={2}>{rawDescription}</Text>
         ) : null}
-        {rawErrors && rawErrors.length > 0 && (
-          <List>
-            {rawErrors.map((error, i: number) => {
-              return (
-                <ListItem key={i}>
-                  <FormErrorMessage id={id}>{error}</FormErrorMessage>
-                </ListItem>
-              );
-            })}
-          </List>
-        )}
-        {rawHelp && <FormHelperText id={id}>{rawHelp}</FormHelperText>}
+        {errors}
+        {help}
       </FormControl>
     </WrapIfAdditional>
   );

--- a/packages/chakra-ui/src/Templates/Templates.ts
+++ b/packages/chakra-ui/src/Templates/Templates.ts
@@ -5,6 +5,8 @@ import BaseInputTemplate from "../BaseInputTemplate/BaseInputTemplate";
 import DescriptionField from "../DescriptionField";
 import ErrorList from "../ErrorList";
 import { MoveDownButton, MoveUpButton, RemoveButton } from "../IconButton";
+import FieldErrorTemplate from "../FieldErrorTemplate";
+import FieldHelpTemplate from "../FieldHelpTemplate";
 import FieldTemplate from "../FieldTemplate";
 import ObjectFieldTemplate from "../ObjectFieldTemplate";
 import SubmitButton from "../SubmitButton";
@@ -23,6 +25,8 @@ export default {
   },
   DescriptionFieldTemplate: DescriptionField,
   ErrorListTemplate: ErrorList,
+  FieldErrorTemplate,
+  FieldHelpTemplate,
   FieldTemplate,
   ObjectFieldTemplate,
   TitleFieldTemplate: TitleField,

--- a/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
@@ -1351,7 +1351,7 @@ exports[`single fields help and error display 1`] = `
           <div
             aria-live="polite"
             className="chakra-form__error-message emotion-10"
-            id="root"
+            id="root__error"
           >
             an error
           </div>
@@ -1359,7 +1359,7 @@ exports[`single fields help and error display 1`] = `
       </ul>
       <div
         className="chakra-form__helper-text emotion-1"
-        id="root"
+        id="root__help"
       >
         help me!
       </div>

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -232,6 +232,7 @@ function SchemaFieldRender<T, F>(props: FieldProps<T, F>) {
       idSchema={idSchema}
       schema={schema}
       uiSchema={uiSchema}
+      hasErrors={!hideError && __errors && __errors.length > 0}
       registry={registry}
     />
   );

--- a/packages/fluent-ui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/fluent-ui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { FieldErrorProps } from "@rjsf/utils";
+import { List } from "@fluentui/react";
+
+/** The `FieldErrorTemplate` component renders the errors local to the particular field
+ *
+ * @param props - The `FieldErrorProps` for the errors being rendered
+ */
+export default function FieldErrorTemplate(props: FieldErrorProps) {
+  const { errors = [], idSchema } = props;
+  if (errors.length === 0) {
+    return null;
+  }
+  const id = `${idSchema.$id}__error`;
+
+  return <List id={id} items={errors} />;
+}

--- a/packages/fluent-ui/src/FieldErrorTemplate/index.ts
+++ b/packages/fluent-ui/src/FieldErrorTemplate/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./FieldErrorTemplate";
+export * from "./FieldErrorTemplate";

--- a/packages/fluent-ui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/fluent-ui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { FieldHelpProps } from "@rjsf/utils";
+import { Text } from "@fluentui/react";
+
+/** The `FieldHelpTemplate` component renders any help desired for a field
+ *
+ * @param props - The `FieldHelpProps` to be rendered
+ */
+export default function FieldHelpTemplate(props: FieldHelpProps) {
+  const { idSchema, help } = props;
+  if (!help) {
+    return null;
+  }
+  const id = `${idSchema.$id}__help`;
+  return <Text id={id}>{help}</Text>;
+}

--- a/packages/fluent-ui/src/FieldHelpTemplate/index.ts
+++ b/packages/fluent-ui/src/FieldHelpTemplate/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./FieldHelpTemplate";
+export * from "./FieldHelpTemplate";

--- a/packages/fluent-ui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/fluent-ui/src/FieldTemplate/FieldTemplate.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { FieldTemplateProps } from "@rjsf/utils";
-import { List, Text } from "@fluentui/react";
+import { Text } from "@fluentui/react";
 
 const FieldTemplate = ({
   id,
   children,
-  rawErrors = [],
-  rawHelp,
+  errors,
+  help,
   rawDescription,
   classNames = "",
   hidden,
@@ -15,13 +15,14 @@ const FieldTemplate = ({
   classNames = "ms-Grid-col ms-sm12 " + classNames.replace("form-group", "");
   return (
     <div
+      id={id}
       className={classNames}
       style={{ marginBottom: 15, display: hidden ? "none" : undefined }}
     >
       {children}
       {rawDescription && <Text>{rawDescription}</Text>}
-      {rawErrors.length > 0 && <List items={rawErrors} />}
-      {rawHelp && <Text id={id}>{rawHelp}</Text>}
+      {errors}
+      {help}
     </div>
   );
 };

--- a/packages/fluent-ui/src/Templates/Templates.ts
+++ b/packages/fluent-ui/src/Templates/Templates.ts
@@ -5,6 +5,8 @@ import BaseInputTemplate from "../BaseInputTemplate/BaseInputTemplate";
 import DescriptionField from "../DescriptionField";
 import ErrorList from "../ErrorList";
 import { MoveDownButton, MoveUpButton, RemoveButton } from "../IconButton";
+import FieldErrorTemplate from "../FieldErrorTemplate";
+import FieldHelpTemplate from "../FieldHelpTemplate";
 import FieldTemplate from "../FieldTemplate";
 import ObjectFieldTemplate from "../ObjectFieldTemplate";
 import SubmitButton from "../SubmitButton";
@@ -23,6 +25,8 @@ export default {
   },
   DescriptionFieldTemplate: DescriptionField,
   ErrorListTemplate: ErrorList,
+  FieldErrorTemplate,
+  FieldHelpTemplate,
   FieldTemplate,
   ObjectFieldTemplate,
   TitleFieldTemplate: TitleField,

--- a/packages/fluent-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Array.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`array fields array 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -114,6 +115,7 @@ exports[`array fields array icons 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -136,6 +138,7 @@ exports[`array fields array icons 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-string"
+              id="root_0"
               style={
                 Object {
                   "display": undefined,
@@ -290,6 +293,7 @@ exports[`array fields array icons 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-string"
+              id="root_1"
               style={
                 Object {
                   "display": undefined,
@@ -528,6 +532,7 @@ exports[`array fields checkboxes 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -623,6 +628,7 @@ exports[`array fields empty errors array 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -640,6 +646,7 @@ exports[`array fields empty errors array 1`] = `
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string"
+          id="root_name"
           style={
             Object {
               "display": undefined,
@@ -734,6 +741,7 @@ exports[`array fields fixed array 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -756,6 +764,7 @@ exports[`array fields fixed array 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-string"
+              id="root_0"
               style={
                 Object {
                   "display": undefined,
@@ -812,6 +821,7 @@ exports[`array fields fixed array 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-number"
+              id="root_1"
               style={
                 Object {
                   "display": undefined,
@@ -901,6 +911,7 @@ exports[`array fields no errors 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -918,6 +929,7 @@ exports[`array fields no errors 1`] = `
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string"
+          id="root_name"
           style={
             Object {
               "display": undefined,

--- a/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`single fields checkbox field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-boolean"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -94,6 +95,7 @@ exports[`single fields checkbox field 2`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-boolean"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -180,6 +182,7 @@ exports[`single fields checkboxes field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -405,6 +408,7 @@ exports[`single fields field with description 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -422,6 +426,7 @@ exports[`single fields field with description 1`] = `
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string"
+          id="root_my-field"
           style={
             Object {
               "display": undefined,
@@ -520,6 +525,7 @@ exports[`single fields field with description in uiSchema 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -537,6 +543,7 @@ exports[`single fields field with description in uiSchema 1`] = `
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string"
+          id="root_my-field"
           style={
             Object {
               "display": undefined,
@@ -635,6 +642,7 @@ exports[`single fields format color 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -996,6 +1004,7 @@ exports[`single fields format date 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -1101,6 +1110,7 @@ exports[`single fields format datetime 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -1212,6 +1222,7 @@ exports[`single fields help and error display 1`] = `
   </div>
   <div
     className="ms-Grid-col ms-sm12  field field-string field-error has-error has-danger"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -1257,6 +1268,7 @@ exports[`single fields help and error display 1`] = `
     
     <div
       className="ms-List"
+      id="root__error"
       role="list"
     >
       <div
@@ -1281,7 +1293,7 @@ exports[`single fields help and error display 1`] = `
     </div>
     <span
       className="css-153"
-      id="root"
+      id="root__help"
     >
       help me!
     </span>
@@ -1331,6 +1343,7 @@ exports[`single fields hidden field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -1348,6 +1361,7 @@ exports[`single fields hidden field 1`] = `
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string"
+          id="root_my-field"
           style={
             Object {
               "display": "none",
@@ -1411,6 +1425,7 @@ exports[`single fields hidden label 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -1492,6 +1507,7 @@ exports[`single fields null field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-null"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -1546,6 +1562,7 @@ exports[`single fields number field 0 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-number"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -1628,6 +1645,7 @@ exports[`single fields number field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-number"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -1710,6 +1728,7 @@ exports[`single fields password field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -1791,6 +1810,7 @@ exports[`single fields radio field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-boolean"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -1918,6 +1938,7 @@ exports[`single fields schema examples 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -2019,6 +2040,7 @@ exports[`single fields select field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -2113,6 +2135,7 @@ exports[`single fields slider field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-integer"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -2227,6 +2250,7 @@ exports[`single fields string field format data-url 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -2293,6 +2317,7 @@ exports[`single fields string field format email 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -2374,6 +2399,7 @@ exports[`single fields string field format uri 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -2455,6 +2481,7 @@ exports[`single fields string field regular 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -2536,6 +2563,7 @@ exports[`single fields string field with placeholder 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -2617,6 +2645,7 @@ exports[`single fields textarea field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -2698,6 +2727,7 @@ exports[`single fields title field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -2720,6 +2750,7 @@ exports[`single fields title field 1`] = `
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string"
+          id="root_title"
           style={
             Object {
               "display": undefined,
@@ -2814,6 +2845,7 @@ exports[`single fields unsupported field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-undefined"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -2890,6 +2922,7 @@ exports[`single fields up/down field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-number"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -3050,6 +3083,7 @@ exports[`single fields using custom tagName 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
     style={
       Object {
         "display": undefined,

--- a/packages/fluent-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Object.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`object fields additionalProperties 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -25,6 +26,7 @@ exports[`object fields additionalProperties 1`] = `
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string"
+          id="root_foo"
           style={
             Object {
               "display": undefined,
@@ -119,6 +121,7 @@ exports[`object fields object 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
     style={
       Object {
         "display": undefined,
@@ -136,6 +139,7 @@ exports[`object fields object 1`] = `
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string"
+          id="root_a"
           style={
             Object {
               "display": undefined,
@@ -183,6 +187,7 @@ exports[`object fields object 1`] = `
         </div>
         <div
           className="ms-Grid-col ms-sm12  field field-number"
+          id="root_b"
           style={
             Object {
               "display": undefined,

--- a/packages/material-ui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/material-ui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { FieldErrorProps } from "@rjsf/utils";
+import ListItem from "@material-ui/core/ListItem";
+import FormHelperText from "@material-ui/core/FormHelperText";
+import List from "@material-ui/core/List";
+
+/** The `FieldErrorTemplate` component renders the errors local to the particular field
+ *
+ * @param props - The `FieldErrorProps` for the errors being rendered
+ */
+export default function FieldErrorTemplate(props: FieldErrorProps) {
+  const { errors = [], idSchema } = props;
+  if (errors.length === 0) {
+    return null;
+  }
+  const id = `${idSchema.$id}__error`;
+
+  return (
+    <List dense={true} disablePadding={true}>
+      {errors.map((error, i: number) => {
+        return (
+          <ListItem key={i} disableGutters={true}>
+            <FormHelperText id={id}>{error}</FormHelperText>
+          </ListItem>
+        );
+      })}
+    </List>
+  );
+}

--- a/packages/material-ui/src/FieldErrorTemplate/index.ts
+++ b/packages/material-ui/src/FieldErrorTemplate/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./FieldErrorTemplate";
+export * from "./FieldErrorTemplate";

--- a/packages/material-ui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/material-ui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { FieldHelpProps } from "@rjsf/utils";
+import FormHelperText from "@material-ui/core/FormHelperText";
+
+/** The `FieldHelpTemplate` component renders any help desired for a field
+ *
+ * @param props - The `FieldHelpProps` to be rendered
+ */
+export default function FieldHelpTemplate(props: FieldHelpProps) {
+  const { idSchema, help } = props;
+  if (!help) {
+    return null;
+  }
+  const id = `${idSchema.$id}__help`;
+  return <FormHelperText id={id}>{help}</FormHelperText>;
+}

--- a/packages/material-ui/src/FieldHelpTemplate/index.ts
+++ b/packages/material-ui/src/FieldHelpTemplate/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./FieldHelpTemplate";
+export * from "./FieldHelpTemplate";

--- a/packages/material-ui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/material-ui/src/FieldTemplate/FieldTemplate.tsx
@@ -1,8 +1,5 @@
 import React from "react";
 import FormControl from "@material-ui/core/FormControl";
-import FormHelperText from "@material-ui/core/FormHelperText";
-import List from "@material-ui/core/List";
-import ListItem from "@material-ui/core/ListItem";
 import Typography from "@material-ui/core/Typography";
 import { FieldTemplateProps } from "@rjsf/utils";
 
@@ -21,7 +18,8 @@ const FieldTemplate = ({
   readonly,
   required,
   rawErrors = [],
-  rawHelp,
+  errors,
+  help,
   rawDescription,
   schema,
   registry,
@@ -53,18 +51,8 @@ const FieldTemplate = ({
             {rawDescription}
           </Typography>
         ) : null}
-        {rawErrors.length > 0 && (
-          <List dense={true} disablePadding={true}>
-            {rawErrors.map((error, i: number) => {
-              return (
-                <ListItem key={i} disableGutters={true}>
-                  <FormHelperText id={id}>{error}</FormHelperText>
-                </ListItem>
-              );
-            })}
-          </List>
-        )}
-        {rawHelp && <FormHelperText id={id}>{rawHelp}</FormHelperText>}
+        {errors}
+        {help}
       </FormControl>
     </WrapIfAdditional>
   );

--- a/packages/material-ui/src/Templates/Templates.ts
+++ b/packages/material-ui/src/Templates/Templates.ts
@@ -5,6 +5,8 @@ import BaseInputTemplate from "../BaseInputTemplate";
 import DescriptionField from "../DescriptionField";
 import ErrorList from "../ErrorList";
 import { MoveDownButton, MoveUpButton, RemoveButton } from "../IconButton";
+import FieldErrorTemplate from "../FieldErrorTemplate";
+import FieldHelpTemplate from "../FieldHelpTemplate";
 import FieldTemplate from "../FieldTemplate";
 import ObjectFieldTemplate from "../ObjectFieldTemplate";
 import SubmitButton from "../SubmitButton";
@@ -23,6 +25,8 @@ export default {
   },
   DescriptionFieldTemplate: DescriptionField,
   ErrorListTemplate: ErrorList,
+  FieldErrorTemplate,
+  FieldHelpTemplate,
   FieldTemplate,
   ObjectFieldTemplate,
   TitleFieldTemplate: TitleField,

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -968,7 +968,7 @@ exports[`single fields help and error display 1`] = `
         >
           <p
             className="MuiFormHelperText-root Mui-error"
-            id="root"
+            id="root__error"
           >
             an error
           </p>
@@ -976,7 +976,7 @@ exports[`single fields help and error display 1`] = `
       </ul>
       <p
         className="MuiFormHelperText-root Mui-error"
-        id="root"
+        id="root__help"
       >
         help me!
       </p>

--- a/packages/mui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/mui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { FieldErrorProps } from "@rjsf/utils";
+import ListItem from "@mui/material/ListItem";
+import FormHelperText from "@mui/material/FormHelperText";
+import List from "@mui/material/List";
+
+/** The `FieldErrorTemplate` component renders the errors local to the particular field
+ *
+ * @param props - The `FieldErrorProps` for the errors being rendered
+ */
+export default function FieldErrorTemplate(props: FieldErrorProps) {
+  const { errors = [], idSchema } = props;
+  if (errors.length === 0) {
+    return null;
+  }
+  const id = `${idSchema.$id}__error`;
+
+  return (
+    <List dense={true} disablePadding={true}>
+      {errors.map((error, i: number) => {
+        return (
+          <ListItem key={i} disableGutters={true}>
+            <FormHelperText id={id}>{error}</FormHelperText>
+          </ListItem>
+        );
+      })}
+    </List>
+  );
+}

--- a/packages/mui/src/FieldErrorTemplate/index.ts
+++ b/packages/mui/src/FieldErrorTemplate/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./FieldErrorTemplate";
+export * from "./FieldErrorTemplate";

--- a/packages/mui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/mui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { FieldHelpProps } from "@rjsf/utils";
+import FormHelperText from "@mui/material/FormHelperText";
+
+/** The `FieldHelpTemplate` component renders any help desired for a field
+ *
+ * @param props - The `FieldHelpProps` to be rendered
+ */
+export default function FieldHelpTemplate(props: FieldHelpProps) {
+  const { idSchema, help } = props;
+  if (!help) {
+    return null;
+  }
+  const id = `${idSchema.$id}__help`;
+  return <FormHelperText id={id}>{help}</FormHelperText>;
+}

--- a/packages/mui/src/FieldHelpTemplate/index.ts
+++ b/packages/mui/src/FieldHelpTemplate/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./FieldHelpTemplate";
+export * from "./FieldHelpTemplate";

--- a/packages/mui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/mui/src/FieldTemplate/FieldTemplate.tsx
@@ -1,8 +1,5 @@
 import React from "react";
 import FormControl from "@mui/material/FormControl";
-import FormHelperText from "@mui/material/FormHelperText";
-import List from "@mui/material/List";
-import ListItem from "@mui/material/ListItem";
 import Typography from "@mui/material/Typography";
 import { FieldTemplateProps } from "@rjsf/utils";
 
@@ -21,7 +18,8 @@ const FieldTemplate = ({
   readonly,
   required,
   rawErrors = [],
-  rawHelp,
+  errors,
+  help,
   rawDescription,
   schema,
   registry,
@@ -53,18 +51,8 @@ const FieldTemplate = ({
             {rawDescription}
           </Typography>
         ) : null}
-        {rawErrors.length > 0 && (
-          <List dense={true} disablePadding={true}>
-            {rawErrors.map((error, i: number) => {
-              return (
-                <ListItem key={i} disableGutters={true}>
-                  <FormHelperText id={id}>{error}</FormHelperText>
-                </ListItem>
-              );
-            })}
-          </List>
-        )}
-        {rawHelp && <FormHelperText id={id}>{rawHelp}</FormHelperText>}
+        {errors}
+        {help}
       </FormControl>
     </WrapIfAdditional>
   );

--- a/packages/mui/src/Templates/Templates.ts
+++ b/packages/mui/src/Templates/Templates.ts
@@ -5,6 +5,8 @@ import BaseInputTemplate from "../BaseInputTemplate";
 import DescriptionField from "../DescriptionField";
 import ErrorList from "../ErrorList";
 import { MoveDownButton, MoveUpButton, RemoveButton } from "../IconButton";
+import FieldErrorTemplate from "../FieldErrorTemplate";
+import FieldHelpTemplate from "../FieldHelpTemplate";
 import FieldTemplate from "../FieldTemplate";
 import ObjectFieldTemplate from "../ObjectFieldTemplate";
 import SubmitButton from "../SubmitButton";
@@ -23,6 +25,8 @@ export default {
   },
   DescriptionFieldTemplate: DescriptionField,
   ErrorListTemplate: ErrorList,
+  FieldErrorTemplate,
+  FieldHelpTemplate,
   FieldTemplate,
   ObjectFieldTemplate,
   TitleFieldTemplate: TitleField,

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -4276,7 +4276,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
         >
           <p
             className="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-contained emotion-17"
-            id="root"
+            id="root__error"
           >
             an error
           </p>
@@ -4284,7 +4284,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
       </ul>
       <p
         className="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-contained emotion-17"
-        id="root"
+        id="root__help"
       >
         help me!
       </p>

--- a/packages/semantic-ui/src/FieldErrorTemplate/FieldErrorTemplate.js
+++ b/packages/semantic-ui/src/FieldErrorTemplate/FieldErrorTemplate.js
@@ -4,6 +4,8 @@ import PropTypes from "prop-types";
 import { nanoid } from "nanoid";
 import { Label, List } from "semantic-ui-react";
 
+import { getSemanticErrorProps } from "../util";
+
 /**
  *
  * @param errors
@@ -12,11 +14,15 @@ import { Label, List } from "semantic-ui-react";
  * @constructor
  * @return {null}
  */
-function RawErrors({ errors, options }) {
+function FieldErrorTemplate({ errors, idSchema, uiSchema, registry }) {
+  const { formContext } = registry;
+  const options = getSemanticErrorProps({ formContext, uiSchema });
   const { pointing, size } = options;
   if (errors && errors.length > 0) {
+    const id = `${idSchema.$id}__error`;
     return (
       <Label
+        id={id}
         color="red"
         pointing={pointing || "above"}
         size={size || "small"}
@@ -33,16 +39,16 @@ function RawErrors({ errors, options }) {
   return null;
 }
 
-RawErrors.defaultProps = {
+FieldErrorTemplate.defaultProps = {
   options: {
     pointing: "above",
     size: "small",
   },
 };
 
-RawErrors.propTypes = {
+FieldErrorTemplate.propTypes = {
   options: PropTypes.object,
   errors: PropTypes.array,
 };
 
-export default RawErrors;
+export default FieldErrorTemplate;

--- a/packages/semantic-ui/src/FieldErrorTemplate/index.js
+++ b/packages/semantic-ui/src/FieldErrorTemplate/index.js
@@ -1,0 +1,3 @@
+/* eslint-disable import/export */
+export { default } from "./FieldErrorTemplate";
+export * from "./FieldErrorTemplate";

--- a/packages/semantic-ui/src/FieldHelpTemplate/FieldHelpTemplate.js
+++ b/packages/semantic-ui/src/FieldHelpTemplate/FieldHelpTemplate.js
@@ -6,16 +6,17 @@ import { Message } from "semantic-ui-react";
 /**
  * @return {null}
  */
-function HelpField({ helpText, id }) {
-  if (helpText) {
-    return <Message size="mini" info id={id} content={helpText} />;
+function FieldHelpTemplate({ help, idSchema }) {
+  if (help) {
+    const id = `${idSchema.$id}__help`;
+    return <Message size="mini" info id={id} content={help} />;
   }
   return null;
 }
 
-HelpField.propTypes = {
+FieldHelpTemplate.propTypes = {
   helpText: PropTypes.string,
   id: PropTypes.string,
 };
 
-export default HelpField;
+export default FieldHelpTemplate;

--- a/packages/semantic-ui/src/FieldHelpTemplate/index.js
+++ b/packages/semantic-ui/src/FieldHelpTemplate/index.js
@@ -1,0 +1,3 @@
+/* eslint-disable import/export */
+export { default } from "./FieldHelpTemplate";
+export * from "./FieldHelpTemplate";

--- a/packages/semantic-ui/src/FieldTemplate/FieldTemplate.js
+++ b/packages/semantic-ui/src/FieldTemplate/FieldTemplate.js
@@ -2,10 +2,8 @@
 import React from "react";
 import { getTemplate, getUiOptions } from "@rjsf/utils";
 import { Form } from "semantic-ui-react";
-import HelpField from "../HelpField";
-import RawErrors from "../RawErrors";
 import WrapIfAdditional from "./WrapIfAdditional";
-import { getSemanticProps, getSemanticErrorProps, MaybeWrap } from "../util";
+import { getSemanticProps, MaybeWrap } from "../util";
 
 function FieldTemplate({
   id,
@@ -14,8 +12,8 @@ function FieldTemplate({
   classNames,
   displayLabel,
   label,
-  rawErrors = [],
-  rawHelp,
+  errors,
+  help,
   hidden,
   rawDescription,
   registry,
@@ -24,7 +22,6 @@ function FieldTemplate({
 }) {
   const semanticProps = getSemanticProps(props);
   const { wrapLabel, wrapContent } = semanticProps;
-  const errorOptions = getSemanticErrorProps(props);
   const uiOptions = getUiOptions(uiSchema);
   const DescriptionFieldTemplate = getTemplate(
     "DescriptionFieldTemplate",
@@ -57,8 +54,8 @@ function FieldTemplate({
               )}
             </MaybeWrap>
           )}
-          <HelpField helpText={rawHelp} id={`${id}__help`} />
-          <RawErrors errors={rawErrors} options={errorOptions} />
+          {help}
+          {errors}
         </MaybeWrap>
       </Form.Group>
     </WrapIfAdditional>

--- a/packages/semantic-ui/src/HelpField/index.js
+++ b/packages/semantic-ui/src/HelpField/index.js
@@ -1,3 +1,0 @@
-/* eslint-disable import/export */
-export { default } from "./HelpField";
-export * from "./HelpField";

--- a/packages/semantic-ui/src/RawErrors/index.js
+++ b/packages/semantic-ui/src/RawErrors/index.js
@@ -1,3 +1,0 @@
-/* eslint-disable import/export */
-export { default } from "./RawErrors";
-export * from "./RawErrors";

--- a/packages/semantic-ui/src/Templates/Templates.js
+++ b/packages/semantic-ui/src/Templates/Templates.js
@@ -5,6 +5,8 @@ import BaseInputTemplate from "../BaseInputTemplate";
 import DescriptionField from "../DescriptionField";
 import ErrorList from "../ErrorList";
 import { MoveDownButton, MoveUpButton, RemoveButton } from "../IconButton";
+import FieldErrorTemplate from "../FieldErrorTemplate";
+import FieldHelpTemplate from "../FieldHelpTemplate";
 import FieldTemplate from "../FieldTemplate";
 import ObjectFieldTemplate from "../ObjectFieldTemplate";
 import SubmitButton from "../SubmitButton";
@@ -23,6 +25,8 @@ export default {
   },
   DescriptionFieldTemplate: DescriptionField,
   ErrorListTemplate: ErrorList,
+  FieldErrorTemplate,
+  FieldHelpTemplate,
   FieldTemplate,
   ObjectFieldTemplate,
   TitleFieldTemplate: TitleField,

--- a/packages/semantic-ui/test/__snapshots__/Form.test.js.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.js.snap
@@ -737,6 +737,7 @@ exports[`single fields help and error display 1`] = `
       </div>
       <div
         className="ui red pointing above small basic label"
+        id="root__error"
         onClick={[Function]}
       >
         <div

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -164,10 +164,12 @@ export type FieldHelpProps<T = any, F = any> = {
   help?: string | React.ReactElement;
   /** The tree of unique ids for every child field */
   idSchema: IdSchema<T>;
-  /** The schema that was passed to `Form` */
+  /** The schema that was passed to field */
   schema: RJSFSchema;
-  /** The uiSchema that was passed to `Form` */
+  /** The uiSchema that was passed to field */
   uiSchema?: UiSchema<T, F>;
+  /** Flag indicating whether there are errors associated with this field */
+  hasErrors?: boolean;
   /** The `registry` object */
   registry: Registry<T, F>;
 };


### PR DESCRIPTION
### Reasons for making this change

Continues fix for #3104 by refactoring existing code in themes to make their `FieldErrorTemplate` and `FieldHelpTemplate` templates.

- Updated the `FieldHelpProps` to add an optional `hasErrors` boolean flag needed by bootstrap-4
- In `antd`, refactored the `FieldErrorTemplate` out of the `FieldTemplate`
  - Updated the `templates` to add in the new `FieldErrorTemplate`
- In `bootstrap-4`, `chakra-ui`, `fluent-ui`, `material-ui` and `mui` refactored the `FieldErrorTemplate` and `FieldHelpTemplate` out of the `FieldTemplate`
  - In some cases, added a missing `id` (or added proper suffix) for one or both of the new templates
  - Updated the `templates` to add in the new `FieldErrorTemplate` and `FieldHelpTemplate`
  - Updated snapshots for those tests where missing `id`s were added
- In `semantic-ui`, renamed the `RawErrors` and `HelpField` to `FieldErrorTemplate` and `FieldHelpTemplate`
  - Updated both of those components to use the new properties from the interfaces and to render ids where appropriate
  - Changed `FieldTemplate` to simply render `errors` and `help` now that the templates are used
  - Updated the `templates` to add in the new `FieldErrorTemplate` and `FieldHelpTemplate`
  - Updated snapshots for tests where missing `id`s were added
- Updated the `CHANGELOG` accordingly

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
