### PR TITLE
Reimplement #2778

### DIFF
--- a/.eslintrc-javascript
+++ b/.eslintrc-javascript
@@ -23,6 +23,7 @@
       "ignoreRestSiblings": true
     }],
     "no-console": [0],
+    "no-prototype-builtins": ["error"],
     "object-curly-spacing": [2, "always"],
     "keyword-spacing": ["error"]
   },

--- a/.eslintrc-typescript
+++ b/.eslintrc-typescript
@@ -30,7 +30,7 @@
     "no-console": [0],
     "object-curly-spacing": [2, "always"],
     "keyword-spacing": ["error"],
-    "no-prototype-builtins": "warn",
+    "no-prototype-builtins": "error",
     "@typescript-eslint/no-empty-function": "warn",
     "@typescript-eslint/no-var-requires": "warn"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # v5.0.0-beta.7
 
+## @rjsf/antd
+- Only show description when there really IS a description, fixes (https://github.com/rjsf-team/react-jsonschema-form/issues/2779)
+
 ## @rjsf/core
 - Added new field `ArraySchemaField`, assigned to `SchemaField` by default, that is used by the `ArrayField` to render the `children` for each array field element
 - Refactored the internal `ErrorList` and `Help` components from inside of `SchemaField` to new templates: `FieldErrorTemplate` and `FieldHelpTemplate`; fixes (https://github.com/rjsf-team/react-jsonschema-form/issues/3104)

--- a/packages/antd/src/templates/DescriptionField/index.js
+++ b/packages/antd/src/templates/DescriptionField/index.js
@@ -4,6 +4,6 @@ const DescriptionField = ({
   description,
   id,
   // registry,
-}) => <span id={id}>{description}</span>;
+}) => description && <span id={id}>{description}</span>;
 
 export default DescriptionField;

--- a/packages/antd/test/__snapshots__/Array.test.js.snap
+++ b/packages/antd/test/__snapshots__/Array.test.js.snap
@@ -212,11 +212,7 @@ exports[`array fields array icons 1`] = `
                       <div
                         className="ant-form-item-extra"
                       >
-                        <span
-                          id="root_0__description"
-                        >
-                          
-                        </span>
+                        
                       </div>
                     </div>
                   </div>
@@ -411,11 +407,7 @@ exports[`array fields array icons 1`] = `
                       <div
                         className="ant-form-item-extra"
                       >
-                        <span
-                          id="root_1__description"
-                        >
-                          
-                        </span>
+                        
                       </div>
                     </div>
                   </div>
@@ -823,11 +815,7 @@ exports[`array fields empty errors array 1`] = `
                   <div
                     className="ant-form-item-extra"
                   >
-                    <span
-                      id="root_name__description"
-                    >
-                      
-                    </span>
+                    
                   </div>
                 </div>
               </div>
@@ -953,11 +941,7 @@ exports[`array fields fixed array 1`] = `
                       <div
                         className="ant-form-item-extra"
                       >
-                        <span
-                          id="root_0__description"
-                        >
-                          
-                        </span>
+                        
                       </div>
                     </div>
                   </div>
@@ -1117,11 +1101,7 @@ exports[`array fields fixed array 1`] = `
                       <div
                         className="ant-form-item-extra"
                       >
-                        <span
-                          id="root_1__description"
-                        >
-                          
-                        </span>
+                        
                       </div>
                     </div>
                   </div>
@@ -1343,11 +1323,7 @@ exports[`array fields has errors 1`] = `
                   <div
                     className="ant-form-item-extra"
                   >
-                    <span
-                      id="root_name__description"
-                    >
-                      
-                    </span>
+                    
                   </div>
                 </div>
               </div>
@@ -1465,11 +1441,7 @@ exports[`array fields no errors 1`] = `
                   <div
                     className="ant-form-item-extra"
                   >
-                    <span
-                      id="root_name__description"
-                    >
-                      
-                    </span>
+                    
                   </div>
                 </div>
               </div>

--- a/packages/antd/test/__snapshots__/Form.test.js.snap
+++ b/packages/antd/test/__snapshots__/Form.test.js.snap
@@ -1921,11 +1921,7 @@ exports[`single fields title field 1`] = `
                   <div
                     className="ant-form-item-extra"
                   >
-                    <span
-                      id="root_title__description"
-                    >
-                      
-                    </span>
+                    
                   </div>
                 </div>
               </div>

--- a/packages/antd/test/__snapshots__/Object.test.js.snap
+++ b/packages/antd/test/__snapshots__/Object.test.js.snap
@@ -189,11 +189,7 @@ exports[`object fields additionalProperties 1`] = `
                       <div
                         className="ant-form-item-extra"
                       >
-                        <span
-                          id="root_foo__description"
-                        >
-                          
-                        </span>
+                        
                       </div>
                     </div>
                   </div>
@@ -407,11 +403,7 @@ exports[`object fields object 1`] = `
                   <div
                     className="ant-form-item-extra"
                   >
-                    <span
-                      id="root_a__description"
-                    >
-                      
-                    </span>
+                    
                   </div>
                 </div>
               </div>
@@ -572,11 +564,7 @@ exports[`object fields object 1`] = `
                   <div
                     className="ant-form-item-extra"
                   >
-                    <span
-                      id="root_b__description"
-                    >
-                      
-                    </span>
+                    
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
### Reasons for making this change

Reimplemented the intent of #2778 by making the `DescriptionField` only render when `description` is provided

- Updated the `antd` `DescriptionField` to only render `description` when provided
- Updated the test snapshots
- Updated the `CHANGELOG.md` accordingly
- Also made the `no-prototype-builtins` always lint as an error to prevent new code from doing this

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
