### PR TITLE
fix: Release build now runs out of memory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
           node-version: 16.x
       - run: npm ci
       - run: npm run build
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
       - run: npm test
       - run: npm run lint
       - run: npm run cs-check


### PR DESCRIPTION
### Reasons for making this change

- Updated the `release.yml` to add the `NODE_OPTIONS` to increase memory for the `npm run build` the same way we did in the `ci.yml`

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
