### PR TITLE
fix: Add programmatic form validation support

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: main
     - name: Setup Python
       uses: actions/setup-python@v3
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated the `FieldErrorTemplate` to remove the explicit typing of the `error` to string to support the two options
 
 ## @rjsf/core
-- Implemented programmatic validation via new `validateForm()` method on `Form`, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/2755, https://github.com/rjsf-team/react-jsonschema-form/issues/2552, https://github.com/rjsf-team/react-jsonschema-form/issues/2381, https://github.com/rjsf-team/react-jsonschema-form/issues/2343, https://github.com/rjsf-team/react-jsonschema-form/issues/1006, https://github.com/rjsf-team/react-jsonschema-form/issues/246)
 - Updated the `FieldErrorTemplate` to remove the explicit typing of the `error` to string to support the two options 
+- Implemented programmatic validation via new `validateForm()` method on `Form`, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/2755, https://github.com/rjsf-team/react-jsonschema-form/issues/2552, https://github.com/rjsf-team/react-jsonschema-form/issues/2381, https://github.com/rjsf-team/react-jsonschema-form/issues/2343, https://github.com/rjsf-team/react-jsonschema-form/issues/1006, https://github.com/rjsf-team/react-jsonschema-form/issues/246)
 
 ## @rjsf/semantic-ui
 - Updated the `FieldErrorTemplate` to use the `children` variation of the `List.Item` that supports ReactElement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated the `FieldErrorTemplate` to remove the explicit typing of the `error` to string to support the two options
 
 ## @rjsf/core
+- Implemented programmatic validation via new `validateForm()` method on `Form`, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/2755, https://github.com/rjsf-team/react-jsonschema-form/issues/2552, https://github.com/rjsf-team/react-jsonschema-form/issues/2381, https://github.com/rjsf-team/react-jsonschema-form/issues/2343, https://github.com/rjsf-team/react-jsonschema-form/issues/1006, https://github.com/rjsf-team/react-jsonschema-form/issues/246)
 - Updated the `FieldErrorTemplate` to remove the explicit typing of the `error` to string to support the two options 
 
 ## @rjsf/semantic-ui
@@ -31,6 +32,8 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## Dev / docs / playground
 - Updated the `custom-templates.md` file to add the missing asterisk to the new `FieldErrorTemplate` and `FieldHelpTemplate`
+- Updated the playground to add a new button for programmatically validating a form
+- Also updated the `validation.md` documentation to describe how to programmatically validate a form
 
 # 5.0.0-beta.8
 

--- a/docs/usage/validation.md
+++ b/docs/usage/validation.md
@@ -34,6 +34,33 @@ render((
 ), document.getElementById("app"));
 ```
 
+## Validate form programmatically
+
+It is possible to programmatically validate a form using the `validateForm()` function on `Form`.
+Add a `ref` to your `Form` component and call the `validateForm()` method to validate the form programmatically.
+The `validateForm()` method returns true if the form is valid, false otherwise.
+If you have provided an `onError` callback it will be called with the list of errors when the `validatorForm()` method returns false.
+
+```jsx
+import { createRef } from "react"
+import validator from "@rjsf/validator-ajv6";
+
+const formRef = createRef();
+const onError = (errors) => alert(errors);
+
+const schema = {
+    type: "string"
+};
+
+render((
+  <Form schema={schema} validator={validator} onError={onError} ref={formRef}/>
+), document.getElementById("app"));
+
+if (formRef.current.validateForm()) {
+  alert("Form is valid");
+}
+```
+
 ## HTML5 Validation
 
 By default, the form uses HTML5 validation. This may cause unintuitive results because the HTML5 validation errors (such as when a field is `required`) may be displayed before the form is submitted, and thus these errors will display differently from the react-jsonschema-form validation errors. You can turn off HTML validation by setting the `noHtml5Validate` to `true`.

--- a/packages/playground/src/app.js
+++ b/packages/playground/src/app.js
@@ -487,16 +487,28 @@ class Playground extends Component {
                 validator={validator}
                 select={this.onValidatorSelected}
               />
-              <CopyLink shareURL={this.state.shareURL} onShare={this.onShare} />
-              <span> </span>
               <button
                 title="Click me to submit the form programmatically."
                 className="btn btn-default"
                 type="button"
                 onClick={() => this.playGroundForm.current.submit()}
               >
-                Programmatic Submit
+                Prog. Submit
               </button>
+              <span> </span>
+              <button
+                title="Click me to validate the form programmatically."
+                className="btn btn-default"
+                type="button"
+                onClick={() => {
+                  const valid = this.playGroundForm.current.validateForm();
+                  alert(valid ? "Form is valid" : "Form has errors");
+                }}
+              >
+                Prog. Validate
+              </button>
+              <div style={{ marginTop: "5px" }} />
+              <CopyLink shareURL={this.state.shareURL} onShare={this.onShare} />
             </div>
           </div>
         </div>
@@ -578,6 +590,7 @@ class Playground extends Component {
                 onSubmit={({ formData }, e) => {
                   console.log("submitted formData", formData);
                   console.log("submit event", e);
+                  window.alert("Form submitted");
                 }}
                 fields={{ geo: GeoPosition }}
                 customValidate={validate}


### PR DESCRIPTION
### Reasons for making this change

Fixes https://github.com/rjsf-team/react-jsonschema-form/issues/2755, https://github.com/rjsf-team/react-jsonschema-form/issues/2552, https://github.com/rjsf-team/react-jsonschema-form/issues/2381, https://github.com/rjsf-team/react-jsonschema-form/issues/2343, https://github.com/rjsf-team/react-jsonschema-form/issues/1006, https://github.com/rjsf-team/react-jsonschema-form/issues/246

- Updated the `Form` to add a new `validateForm()` function by refactoring that portion of the code out of the `onSubmit()` callback
- Updated the playground to add a new `Prog. Validate` button to programmatically validate a form
  - Moved the `Share` button onto the next line and changed `Programmatically Submit` button to `Prog. Submit`
  - Added an alert when the form is submitted
- Updated the `validation.md` documentation with this new capability
- Updated the `CHANGELOG.md` file accordingly

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature

<img width="571" alt="Screenshot 2022-09-16 at 10 31 49 AM" src="https://user-images.githubusercontent.com/51679588/190698777-7d0d7a3c-1db7-4de0-b1d0-83785994b006.png">
