### PR TITLE
fix: add formElement upgrade instructions

### DIFF
--- a/docs/5.x upgrade guide.md
+++ b/docs/5.x upgrade guide.md
@@ -95,6 +95,31 @@ render((
 ), document.getElementById("app"));
 ```
 
+##### `formElement` converted to RefObject
+The `formElement` variable that stored the ref to the inner `<form />` was converted from a simple variable assigned via a [callback ref](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs) (ala React < 16.3) to a React.RefObject created using the `React.createRef()` API.
+As a result, if you were using the `formElement` ref, you will need to update it to use `formElement.current`:
+
+```tsx
+import { RJSFSchema } from "@rjsf/utils";
+import Form from "@rjsf/core";
+import validator from "@rjsf/validator-ajv6";
+
+// Your schema
+const schema: RJSFSchema = { ... };
+
+const formRef = React.createRef();
+
+render((
+  <Form ref={formRef} schema={schema} validator={validator} />
+), document.getElementById("app"));
+
+...
+// Previously, to reset the form one would have called:
+//   formRef.current.formElement.reset();
+// Now one calls:
+formRef.current.formElement.current.reset();
+```
+
 ##### `validate` prop renamed
 Additionally, in version 5, the `validate` prop on `Form` was renamed to `customValidate` to avoid confusion with the new `validator` prop. 
 


### PR DESCRIPTION
### Reasons for making this change

- Updated the `5.x upgrade guide` to document the change from a simple variable to a `RefObject`

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
