### PR TITLE
fix: Updated CHANGELOG.md for last PR that was missing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated the playground to add a new button for programmatically validating a form
 - Also updated the `validation.md` documentation to describe how to programmatically validate a form
 - Fixed the `chakra-ui` custom `uiSchema` documentation to make it clear they work on a per-field basis, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/2865)
+- Added `formElement` breaking-change documentation to the `5.x upgrade guide.md`
 
 # 5.0.0-beta.8
 


### PR DESCRIPTION
### Reasons for making this change

- fixed the documentation, but forgot to update the CHANGELOG

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
