### PR TITLE
fix: Rename WithThemeProps back to version 4.x ThemeProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,24 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/bootstrap
 - Updated the `FieldErrorTemplate` to remove the explicit typing of the `error` to string to support the two options
+- Updated `Theme` to use the renamed `ThemeProps` from `@rjsf/core`
+
+## @rjsf/chakra-ui
+- Updated `Theme` to use the renamed `ThemeProps` from `@rjsf/core`
 
 ## @rjsf/core
 - Updated the `FieldErrorTemplate` to remove the explicit typing of the `error` to string to support the two options 
 - Implemented programmatic validation via new `validateForm()` method on `Form`, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/2755, https://github.com/rjsf-team/react-jsonschema-form/issues/2552, https://github.com/rjsf-team/react-jsonschema-form/issues/2381, https://github.com/rjsf-team/react-jsonschema-form/issues/2343, https://github.com/rjsf-team/react-jsonschema-form/issues/1006, https://github.com/rjsf-team/react-jsonschema-form/issues/246)
+- Renamed `WithThemeProps` to `ThemeProps` to prevent another breaking-change by returning the type back to the name it had in version 4
+
+## @rjsf/fluent-ui
+- Updated `Theme` to use the renamed `ThemeProps` from `@rjsf/core`
+
+## @rjsf/material-ui
+- Updated `Theme` to use the renamed `ThemeProps` from `@rjsf/core`
+
+## @rjsf/mui
+- Updated `Theme` to use the renamed `ThemeProps` from `@rjsf/core`
 
 ## @rjsf/semantic-ui
 - Updated the `FieldErrorTemplate` to use the `children` variation of the `List.Item` that supports ReactElement

--- a/packages/bootstrap-4/src/Theme/Theme.tsx
+++ b/packages/bootstrap-4/src/Theme/Theme.tsx
@@ -1,9 +1,9 @@
+import { ThemeProps } from "@rjsf/core";
+
 import Templates from "../Templates";
 import Widgets from "../Widgets";
 
-import { WithThemeProps } from "@rjsf/core";
-
-const Theme: WithThemeProps = {
+const Theme: ThemeProps = {
   templates: Templates,
   widgets: Widgets,
 };

--- a/packages/chakra-ui/src/Theme/Theme.tsx
+++ b/packages/chakra-ui/src/Theme/Theme.tsx
@@ -1,9 +1,9 @@
-import { WithThemeProps } from "@rjsf/core";
+import { ThemeProps } from "@rjsf/core";
 
 import Templates from "../Templates";
 import Widgets from "../Widgets";
 
-const Theme: WithThemeProps = {
+const Theme: ThemeProps = {
   templates: Templates,
   widgets: Widgets,
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,8 +1,8 @@
 import Form, { FormProps, FormState, IChangeEvent } from "./components/Form";
-import withTheme, { WithThemeProps } from "./withTheme";
+import withTheme, { ThemeProps } from "./withTheme";
 import getDefaultRegistry from "./getDefaultRegistry";
 
-export type { FormProps, FormState, IChangeEvent, WithThemeProps };
+export type { FormProps, FormState, IChangeEvent, ThemeProps };
 
 export { withTheme, getDefaultRegistry };
 export default Form;

--- a/packages/core/src/withTheme.tsx
+++ b/packages/core/src/withTheme.tsx
@@ -5,14 +5,14 @@ import Form, { FormProps } from "./components/Form";
 /** The properties for the `withTheme` function, essentially a subset of properties from the `FormProps` that can be
  * overridden while creating a theme
  */
-export type WithThemeProps<T = any, F = any> = Pick<
+export type ThemeProps<T = any, F = any> = Pick<
   FormProps<T, F>,
   "fields" | "templates" | "widgets" | "_internalFormWrapper"
 >;
 
 /** A Higher-Order component that creates a wrapper around a `Form` with the overrides from the `WithThemeProps` */
 export default function withTheme<T = any, F = any>(
-  themeProps: WithThemeProps<T, F>
+  themeProps: ThemeProps<T, F>
 ) {
   return forwardRef(
     (

--- a/packages/fluent-ui/src/Theme/Theme.ts
+++ b/packages/fluent-ui/src/Theme/Theme.ts
@@ -1,9 +1,9 @@
+import { ThemeProps } from "@rjsf/core";
+
 import Templates from "../Templates";
 import Widgets from "../Widgets";
 
-import { WithThemeProps } from "@rjsf/core";
-
-const Theme: WithThemeProps = {
+const Theme: ThemeProps = {
   templates: Templates,
   widgets: Widgets,
 };

--- a/packages/material-ui/src/Theme/Theme.tsx
+++ b/packages/material-ui/src/Theme/Theme.tsx
@@ -1,9 +1,9 @@
-import { WithThemeProps } from "@rjsf/core";
+import { ThemeProps } from "@rjsf/core";
 
 import Templates from "../Templates";
 import Widgets from "../Widgets";
 
-const Theme: WithThemeProps = {
+const Theme: ThemeProps = {
   templates: Templates,
   widgets: Widgets,
 };

--- a/packages/mui/src/Theme/Theme.tsx
+++ b/packages/mui/src/Theme/Theme.tsx
@@ -1,9 +1,9 @@
-import { WithThemeProps } from "@rjsf/core";
+import { ThemeProps } from "@rjsf/core";
 
 import Templates from "../Templates";
 import Widgets from "../Widgets";
 
-const Theme: WithThemeProps = {
+const Theme: ThemeProps = {
   templates: Templates,
   widgets: Widgets,
 };


### PR DESCRIPTION
### Reasons for making this change

During my own migration to v5 beta I found one breaking-change that wasn't documented and need not have been made, so I reverted it

- Renamed the `WithThemeProps` type back to the name it had in version 4.x, `ThemeProps`
  - This avoids an unnecessary breaking-change
- Updated all Typescript based themes to use this renamed type
- Updated the `CHANGELOG.md` accordingly

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
