### PR TITLE
fix: playground now builds to dist, made upload work properly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: dist
-        path: packages/playground/build
+        path: packages/playground/dist
     - run: npm test
 
 #  deploy_preview:


### PR DESCRIPTION
### Reasons for making this change

Fixed playground deploy [broken](https://github.com/rjsf-team/react-jsonschema-form/actions/runs/3102029048/jobs/5024085173) by #3115

- Updated `ci.yml` to change `packages/playground/build` to `packages/playground/dist`

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
