### PR TITLE
Fix vite builds for dev

### DIFF
--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -6,6 +6,10 @@ import path from "path";
 export default defineConfig({
   // base needs to be changed for links to work in GitHub pages
   base: process.env.NODE_ENV === "production" ? "./" : "/",
+  server: {
+    port: 8080,
+    open: process.env.NODE_ENV !== "production",
+  }, // maintain the old webpack behavior in dev
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
### Reasons for making this change

- Restored old webpack port and open behavior on dev mode

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
