### PR TITLE
docs: fix playground sample links

### DIFF
--- a/docs/advanced-customization/custom-templates.md
+++ b/docs/advanced-customization/custom-templates.md
@@ -82,7 +82,7 @@ const uiSchema = {
 }
 ```
 
-Please see [customArray.js](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/playground/src/samples/customArray.js) for another example.
+Please see the [customArray.jsx sample](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/playground/src/samples/customArray.jsx) from the [playground](https://rjsf-team.github.io/react-jsonschema-form/) for another example.
 
 The following props are passed to each `ArrayFieldTemplate`:
 
@@ -645,7 +645,7 @@ const uiSchema = {
 };
 ```
 
-Please see [customObject.js](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/playground/src/samples/customObject.js) for a better example.
+Please see the [customObject.jsx sample](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/playground/src/samples/customObject.jsx) from the [playground](https://rjsf-team.github.io/react-jsonschema-form/) for a better example.
 
 The following props are passed to each `ObjectFieldTemplate` as defined by the `ObjectFieldTemplateProps` in `@rjsf/utils`:
 


### PR DESCRIPTION
### Reasons for making this change
The links in advanced customization -> custom templates to samples for ArrayFieldTemplate and ObjectFieldTemplate were still pointing to the .js files. I also added a link to the playground itself.

### Checklist
* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added