### PR TITLE
make Semantic-UI's AddButton not show an empty label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/semantic-ui
 - Updated the `FieldErrorTemplate` to use the `children` variation of the `List.Item` that supports ReactElement
 - Pass `uiSchema` appropriately to all of the `IconButton`s, `ArrayFieldItemTemplate` and `WrapIfAdditional` components, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/3130)
+- Fixed `ArrayFieldTemplate` and `ObjectFieldTemplate`'s `AddButton` to show the non-labeled version. (https://github.com/rjsf-team/react-jsonschema-form/pull/3142)
  
 ## @rjsf/utils
 - Updated the `FieldErrorProps` type to make it support an array of string and ReactElement

--- a/packages/semantic-ui/src/AddButton/AddButton.js
+++ b/packages/semantic-ui/src/AddButton/AddButton.js
@@ -3,7 +3,7 @@ import { Button, Icon } from "semantic-ui-react";
 
 function AddButton({ uiSchema, ...props }) {
   return (
-    <Button title="Add Item" {...props} icon size="tiny" labelPosition="left">
+    <Button title="Add Item" {...props} icon size="tiny">
       <Icon name="plus" />
     </Button>
   );

--- a/packages/semantic-ui/test/__snapshots__/Array.test.js.snap
+++ b/packages/semantic-ui/test/__snapshots__/Array.test.js.snap
@@ -29,7 +29,7 @@ exports[`array fields array 1`] = `
             }
           >
             <button
-              className="ui tiny icon left labeled button"
+              className="ui tiny icon button"
               onClick={[Function]}
               title="Add Item"
             >
@@ -268,7 +268,7 @@ exports[`array fields array icons 1`] = `
             }
           >
             <button
-              className="ui tiny icon left labeled button"
+              className="ui tiny icon button"
               onClick={[Function]}
               title="Add Item"
             >

--- a/packages/semantic-ui/test/__snapshots__/Object.test.js.snap
+++ b/packages/semantic-ui/test/__snapshots__/Object.test.js.snap
@@ -125,7 +125,7 @@ exports[`object fields additionalProperties 1`] = `
             }
           >
             <button
-              className="ui tiny icon left labeled button"
+              className="ui tiny icon button"
               onClick={[Function]}
               title="Add Item"
             >


### PR DESCRIPTION
### Reasons for making this change

The Semantic-UI theme's AddButton, which is used for ObjectFieldTemplate and ArrayFieldTemplate, currently displays an empty slot for a non-existent label:
![image](https://user-images.githubusercontent.com/61185219/191940189-c01365bb-9188-4c79-bc1d-2ce1632fb56e.png)
This makes it show a square button:
![image](https://user-images.githubusercontent.com/61185219/191940277-684bf85d-37fe-4363-9bf4-d2017bfd9eed.png)

### Checklist
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR

~~I cannot run/update the tests as the build fails for me. I assume it's somehow a me issue though:~~
```
[@rjsf/core     ] > @rjsf/core@5.0.0-beta.9 build
[@rjsf/core     ] > rimraf dist && dts build --rollupTypes --format cjs,esm,umd
[@rjsf/core     ] 
[@rjsf/core     ] node:internal/modules/cjs/loader:936
[@rjsf/core     ]   throw err;
[@rjsf/core     ]   ^
[@rjsf/core     ] 
[@rjsf/core     ] Error: Cannot find module './templates.js'
[@rjsf/core     ] Require stack:
[@rjsf/core     ] - [...]/packages/core/node_modules/@babel/highlight/node_modules/chalk/index.js
```
~~the `./templates.js` file is present in `node_modules/chalk/`, but not in `packages/core/node_modules/@babel/highlight/node_modules/chalk/` (and all other dependencies depending on it). I'd appreciate guidance on this. Should I open a separate issue?~~

EDIT: ignore the above. Deleting the `node_modules` folders and re-running `npm install` fixed it. I assume the `node_modules` folders ended up in an invalid state after my first run of `npm run build` failed.
For the record, this is what I ran:
```
rm --recursive --force --verbose packages/*/node_modules
rm -rfv node_modules/
npm install
```