### PR TITLE
fix: Hopefully fix release process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "react-jsonschema-form",
-  "version": "5.0.0",
   "private": true,
   "description": "monorepo for react-jsonschema-form and its themes",
   "engines": {


### PR DESCRIPTION
### Reasons for making this change

The release process fails every time trying to publish the base package
```
lerna info lifecycle react-jsonschema-form@5.0.0~publish: react-jsonschema-form@5.0.0
lerna ERR! lifecycle "publish" errored in "react-jsonschema-form", exiting 1
```
After looking at the [sample repo](https://github.com/lerna/getting-started-example) provided by lerna I noticed that the base `package.json` did not contain a `version` number
- Updated the base `package.json` to remove the `"version": "5.0.0"` tag that appears to be causing the release issue

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
