### PR TITLE
Update issue templates to be assigned to `@rjsf-team/reviewers`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,10 +3,7 @@ description: File a bug/issue
 title: "<title>"
 labels: [bug, needs triage]
 assignees: 
-  - epicfaace
-  - jacqueswho
-  - heath-freenome
-  - nickgros
+  - @rjsf-team/reviewers
 body:
 - type: checkboxes
   attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,7 +3,7 @@ description: File a bug/issue
 title: "<title>"
 labels: [bug, needs triage]
 assignees: 
-  - @rjsf-team/reviewers
+  - rjsf-team/reviewers
 body:
 - type: checkboxes
   attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,7 +3,7 @@ description: File a Feature
 title: "<title>"
 labels: [feature, needs triage]
 assignees: 
-  - @rjsf-team/reviewers
+  - rjsf-team/reviewers
 body:
 - type: checkboxes
   attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,10 +3,7 @@ description: File a Feature
 title: "<title>"
 labels: [feature, needs triage]
 assignees: 
-  - epicfaace
-  - jacqueswho
-  - heath-freenome
-  - nickgros
+  - @rjsf-team/reviewers
 body:
 - type: checkboxes
   attributes:

--- a/.github/ISSUE_TEMPLATE/question_issue.yml
+++ b/.github/ISSUE_TEMPLATE/question_issue.yml
@@ -3,7 +3,7 @@ description: Ask a Question
 title: "<title>"
 labels: [question, needs triage]
 assignees: 
-  - @rjsf-team/reviewers
+  - rjsf-team/reviewers
 body:
 - type: checkboxes
   attributes:

--- a/.github/ISSUE_TEMPLATE/question_issue.yml
+++ b/.github/ISSUE_TEMPLATE/question_issue.yml
@@ -3,10 +3,7 @@ description: Ask a Question
 title: "<title>"
 labels: [question, needs triage]
 assignees: 
-  - epicfaace
-  - jacqueswho
-  - heath-freenome
-  - nickgros
+  - @rjsf-team/reviewers
 body:
 - type: checkboxes
   attributes:


### PR DESCRIPTION
See https://github.com/orgs/rjsf-team/teams/reviewers/

this makes it easier to add / remove people and also set up granular notifications for rjsf-specific reviews.

We could also do autoassignment in the future! https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team#about-auto-assignment
