### PR TITLE
Adding properties should work when `additionalProperties` is `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Added support for `chakra-react-select` v4, fixing [#3152](https://github.com/rjsf-team/react-jsonschema-form/issues/3152).
 
 ## @rjsf/core
-- Extended `Form.onChange` to optionally return the `id` of the field that caused the change, fixing [#2768](https://github.com/rjsf-team/react-jsonschema-form/pull/2768)
+- Extended `Form.onChange` to optionally return the `id` of the field that caused the change, fixing [#2768](https://github.com/rjsf-team/react-jsonschema-form/issues/2768)
 - Fixed a regression in earlier v5 beta versions where additional properties could not be added when `additionalProperties` was `true` ([#3719](https://github.com/rjsf-team/react-jsonschema-form/pull/3719)).
 
 ## @rjsf/utils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 - Extended `Form.onChange` to optionally return the `id` of the field that caused the change, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/2768)
+- Fixed a regression in earlier v5 beta versions where additional properties could not be added when `additionalProperties` was `true` ([#3719](https://github.com/rjsf-team/react-jsonschema-form/pull/3719)).
 
 ## @rjsf/utils
 - Updated the `onChange` prop on `FieldProps` and `FieldTemplateProps` to add an optional `id` parameter to the callback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Added support for `chakra-react-select` v4, fixing [#3152](https://github.com/rjsf-team/react-jsonschema-form/issues/3152).
 
 ## @rjsf/core
-- Extended `Form.onChange` to optionally return the `id` of the field that caused the change, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/2768)
+- Extended `Form.onChange` to optionally return the `id` of the field that caused the change, fixing [#2768](https://github.com/rjsf-team/react-jsonschema-form/pull/2768)
 - Fixed a regression in earlier v5 beta versions where additional properties could not be added when `additionalProperties` was `true` ([#3719](https://github.com/rjsf-team/react-jsonschema-form/pull/3719)).
 
 ## @rjsf/utils

--- a/packages/core/src/components/fields/ObjectField.tsx
+++ b/packages/core/src/components/fields/ObjectField.tsx
@@ -189,21 +189,23 @@ class ObjectField<T = any, F = any> extends Component<
    * @param schema - The schema element to which the new property is being added
    */
   handleAddClick = (schema: RJSFSchema) => () => {
-    if (!isObject(schema.additionalProperties)) {
+    if (!schema.additionalProperties) {
       return;
     }
     const { formData, onChange, registry } = this.props;
-    let type = schema.additionalProperties.type;
     const newFormData = { ...formData };
 
-    if (REF_KEY in schema.additionalProperties) {
-      const { schemaUtils } = registry;
-      const refSchema = schemaUtils.retrieveSchema(
-        { $ref: schema.additionalProperties[REF_KEY] },
-        formData
-      );
-
-      type = refSchema.type;
+    let type: RJSFSchema["type"] = undefined;
+    if (isObject(schema.additionalProperties)) {
+      type = schema.additionalProperties.type;
+      if (REF_KEY in schema.additionalProperties) {
+        const { schemaUtils } = registry;
+        const refSchema = schemaUtils.retrieveSchema(
+          { $ref: schema.additionalProperties[REF_KEY] },
+          formData
+        );
+        type = refSchema.type;
+      }
     }
 
     const newKey = this.getAvailableKey("newKey", newFormData);

--- a/packages/core/test/ObjectField_test.js
+++ b/packages/core/test/ObjectField_test.js
@@ -875,6 +875,51 @@ describe("ObjectField", () => {
       });
     });
 
+    it("should add a property matching the additionalProperties schema", () => {
+      // Specify that additionalProperties must be an array of strings
+      const additionalPropertiesArraySchema = {
+        ...schema,
+        additionalProperties: {
+          type: "array",
+          items: {
+            type: "string",
+          },
+        },
+      };
+      const { node, onChange } = createFormComponent({
+        schema: additionalPropertiesArraySchema,
+        formData: {},
+      });
+
+      Simulate.click(node.querySelector(".object-property-expand button"));
+
+      sinon.assert.calledWithMatch(onChange.lastCall, {
+        formData: {
+          newKey: [],
+        },
+      });
+    });
+
+    it("should add a string item if additionalProperties is true", () => {
+      // Specify that additionalProperties must be an array of strings
+      const customSchema = {
+        ...schema,
+        additionalProperties: true,
+      };
+      const { node, onChange } = createFormComponent({
+        schema: customSchema,
+        formData: {},
+      });
+
+      Simulate.click(node.querySelector(".object-property-expand button"));
+
+      sinon.assert.calledWithMatch(onChange.lastCall, {
+        formData: {
+          newKey: "New Value",
+        },
+      });
+    });
+
     it("should not provide an expand button if length equals maxProperties", () => {
       const { node } = createFormComponent({
         schema: { maxProperties: 1, ...schema },

--- a/packages/core/test/ObjectField_test.js
+++ b/packages/core/test/ObjectField_test.js
@@ -901,7 +901,7 @@ describe("ObjectField", () => {
     });
 
     it("should add a string item if additionalProperties is true", () => {
-      // Specify that additionalProperties must be an array of strings
+      // Specify that additionalProperties is true
       const customSchema = {
         ...schema,
         additionalProperties: true,


### PR DESCRIPTION
Fixes #3179

Conversion of ObjectField to TypeScript caused a regression where `additionalProperties: true` was not properly evaluated when adding a property.
- Change ObjectField logic to handle `additionalProperties: true`.
- Add tests to validate some of the logic in handleAddClick, including the regression