### PR TITLE
rm "how to report"

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,9 +4,6 @@ This repository is governed by Mozilla's code of conduct and etiquette guideline
 For more details, please read the
 [Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/). 
 
-## How to Report
-For more information on how to report violations of the Community Participation Guidelines, please read our '[How to Report](https://www.mozilla.org/about/governance/policies/participation/reporting/)' page.
-
 <!--
 ## Project Specific Etiquette
 


### PR DESCRIPTION
Because we're no longer a Mozilla project, we shouldn't direct users to report to mozilla.