### PR TITLE
fix: #2007 by reimplementing #2533

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # 5.0.0-beta.11
 
+## @rjsf/bootstrap-4
+- Make label generation consistent with other themes by refactoring the code into the `FieldTemplate` instead of having the widgets implementing the label, fixing [#2007](https://github.com/rjsf-team/react-jsonschema-form/issues/2007)
+
 ## @rjsf/chakra-ui
 - Added support for `chakra-react-select` v4, fixing [#3152](https://github.com/rjsf-team/react-jsonschema-form/issues/3152).
 

--- a/packages/bootstrap-4/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/bootstrap-4/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Form from "react-bootstrap/Form";
-import { getInputProps, getUiOptions, WidgetProps } from "@rjsf/utils";
+import { getInputProps, WidgetProps } from "@rjsf/utils";
 
 const BaseInputTemplate = ({
   id,
@@ -9,7 +9,6 @@ const BaseInputTemplate = ({
   readonly,
   disabled,
   type,
-  label,
   value,
   onChange,
   onBlur,
@@ -18,12 +17,10 @@ const BaseInputTemplate = ({
   options,
   schema,
   rawErrors = [],
-  uiSchema,
   children,
   extraProps,
 }: WidgetProps) => {
   const inputProps = { ...extraProps, ...getInputProps(schema, type, options) };
-  const uiOptions = getUiOptions(uiSchema);
   const _onChange = ({
     target: { value },
   }: React.ChangeEvent<HTMLInputElement>) =>
@@ -36,14 +33,7 @@ const BaseInputTemplate = ({
 
   // const classNames = [rawErrors.length > 0 ? "is-invalid" : "", type === 'file' ? 'custom-file-label': ""]
   return (
-    <Form.Group className="mb-0">
-      <Form.Label
-        htmlFor={id}
-        className={rawErrors.length > 0 ? "text-danger" : ""}
-      >
-        {uiOptions.title || label || schema.title}
-        {(label || uiOptions.title) && required ? "*" : null}
-      </Form.Label>
+    <>
       <Form.Control
         id={id}
         name={id}
@@ -70,7 +60,7 @@ const BaseInputTemplate = ({
             })}
         </datalist>
       ) : null}
-    </Form.Group>
+    </>
   );
 };
 

--- a/packages/bootstrap-4/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/bootstrap-4/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -16,8 +16,6 @@ const deselectValue = (value: any, selected: any) => {
 };
 
 const CheckboxesWidget = ({
-  schema,
-  label,
   id,
   disabled,
   options,
@@ -50,38 +48,35 @@ const CheckboxesWidget = ({
   }: React.FocusEvent<HTMLInputElement>) => onFocus(id, value);
 
   return (
-    <>
-      <Form.Label htmlFor={id}>{label || schema.title}</Form.Label>
-      <Form.Group>
-        {Array.isArray(enumOptions) &&
-          enumOptions.map((option, index: number) => {
-            const checked = value.indexOf(option.value) !== -1;
-            const itemDisabled =
-              Array.isArray(enumDisabled) &&
-              enumDisabled.indexOf(option.value) !== -1;
+    <Form.Group>
+      {Array.isArray(enumOptions) &&
+        enumOptions.map((option, index: number) => {
+          const checked = value.indexOf(option.value) !== -1;
+          const itemDisabled =
+            Array.isArray(enumDisabled) &&
+            enumDisabled.indexOf(option.value) !== -1;
 
-            return (
-              <Form.Check
-                key={option.value}
-                inline={inline}
-                custom
-                required={required}
-                checked={checked}
-                className="bg-transparent border-0"
-                type={"checkbox"}
-                id={`${id}-${option.value}`}
-                name={id}
-                label={option.label}
-                autoFocus={autofocus && index === 0}
-                onChange={_onChange(option)}
-                onBlur={_onBlur}
-                onFocus={_onFocus}
-                disabled={disabled || itemDisabled || readonly}
-              />
-            );
-          })}
-      </Form.Group>
-    </>
+          return (
+            <Form.Check
+              key={option.value}
+              inline={inline}
+              custom
+              required={required}
+              checked={checked}
+              className="bg-transparent border-0"
+              type={"checkbox"}
+              id={`${id}-${option.value}`}
+              name={id}
+              label={option.label}
+              autoFocus={autofocus && index === 0}
+              onChange={_onChange(option)}
+              onBlur={_onBlur}
+              onFocus={_onFocus}
+              disabled={disabled || itemDisabled || readonly}
+            />
+          );
+        })}
+    </Form.Group>
   );
 };
 

--- a/packages/bootstrap-4/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/bootstrap-4/src/FieldTemplate/FieldTemplate.tsx
@@ -13,6 +13,7 @@ const FieldTemplate = ({
   classNames,
   disabled,
   label,
+  hidden,
   onDropPropertyClick,
   onKeyChange,
   readonly,
@@ -27,6 +28,9 @@ const FieldTemplate = ({
     registry,
     uiOptions
   );
+  if (hidden) {
+    return <div className="hidden">{children}</div>;
+  }
   return (
     <WrapIfAdditionalTemplate
       classNames={classNames}
@@ -42,6 +46,15 @@ const FieldTemplate = ({
       registry={registry}
     >
       <Form.Group>
+        {displayLabel && (
+          <Form.Label
+            htmlFor={id}
+            className={rawErrors.length > 0 ? "text-danger" : ""}
+          >
+            {label}
+            {required ? "*" : null}
+          </Form.Label>
+        )}
         {children}
         {displayLabel && rawDescription && (
           <Form.Text

--- a/packages/bootstrap-4/src/RadioWidget/RadioWidget.tsx
+++ b/packages/bootstrap-4/src/RadioWidget/RadioWidget.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import Form from "react-bootstrap/Form";
 
-import { WidgetProps, getUiOptions } from "@rjsf/utils";
+import { WidgetProps } from "@rjsf/utils";
 
 const RadioWidget = ({
   id,
@@ -12,14 +12,11 @@ const RadioWidget = ({
   required,
   disabled,
   readonly,
-  label,
   onChange,
   onBlur,
   onFocus,
-  uiSchema,
 }: WidgetProps) => {
   const { enumOptions, enumDisabled } = options;
-  const uiOptions = getUiOptions(uiSchema);
 
   const _onChange = ({
     target: { value },
@@ -35,10 +32,6 @@ const RadioWidget = ({
 
   return (
     <Form.Group className="mb-0">
-      <Form.Label className="d-block">
-        {uiOptions.title || schema.title || label}
-        {(label || uiOptions.title || schema.title) && required ? "*" : null}
-      </Form.Label>
       {Array.isArray(enumOptions) &&
         enumOptions.map((option) => {
           const itemDisabled =

--- a/packages/bootstrap-4/src/SelectWidget/SelectWidget.tsx
+++ b/packages/bootstrap-4/src/SelectWidget/SelectWidget.tsx
@@ -8,7 +8,6 @@ const SelectWidget = ({
   schema,
   id,
   options,
-  label,
   required,
   disabled,
   readonly,
@@ -40,59 +39,50 @@ const SelectWidget = ({
   }
 
   return (
-    <Form.Group>
-      <Form.Label
-        className={rawErrors.length > 0 ? "text-danger" : ""}
-        htmlFor={id}
-      >
-        {label || schema.title}
-        {(label || schema.title) && required ? "*" : null}
-      </Form.Label>
-      <Form.Control
-        as="select"
-        bsPrefix="custom-select"
-        id={id}
-        name={id}
-        value={typeof value === "undefined" ? emptyValue : value}
-        required={required}
-        multiple={multiple}
-        disabled={disabled || readonly}
-        autoFocus={autofocus}
-        className={rawErrors.length > 0 ? "is-invalid" : ""}
-        onBlur={
-          onBlur &&
-          ((event: React.FocusEvent) => {
-            const newValue = getValue(event, multiple);
-            onBlur(id, processSelectValue(schema, newValue, options));
-          })
-        }
-        onFocus={
-          onFocus &&
-          ((event: React.FocusEvent) => {
-            const newValue = getValue(event, multiple);
-            onFocus(id, processSelectValue(schema, newValue, options));
-          })
-        }
-        onChange={(event: React.ChangeEvent) => {
+    <Form.Control
+      as="select"
+      bsPrefix="custom-select"
+      id={id}
+      name={id}
+      value={typeof value === "undefined" ? emptyValue : value}
+      required={required}
+      multiple={multiple}
+      disabled={disabled || readonly}
+      autoFocus={autofocus}
+      className={rawErrors.length > 0 ? "is-invalid" : ""}
+      onBlur={
+        onBlur &&
+        ((event: React.FocusEvent) => {
           const newValue = getValue(event, multiple);
-          onChange(processSelectValue(schema, newValue, options));
-        }}
-      >
-        {!multiple && schema.default === undefined && (
-          <option value="">{placeholder}</option>
-        )}
-        {(enumOptions as any).map(({ value, label }: any, i: number) => {
-          const disabled: any =
-            Array.isArray(enumDisabled) &&
-            (enumDisabled as any).indexOf(value) != -1;
-          return (
-            <option key={i} id={label} value={value} disabled={disabled}>
-              {label}
-            </option>
-          );
-        })}
-      </Form.Control>
-    </Form.Group>
+          onBlur(id, processSelectValue(schema, newValue, options));
+        })
+      }
+      onFocus={
+        onFocus &&
+        ((event: React.FocusEvent) => {
+          const newValue = getValue(event, multiple);
+          onFocus(id, processSelectValue(schema, newValue, options));
+        })
+      }
+      onChange={(event: React.ChangeEvent) => {
+        const newValue = getValue(event, multiple);
+        onChange(processSelectValue(schema, newValue, options));
+      }}
+    >
+      {!multiple && schema.default === undefined && (
+        <option value="">{placeholder}</option>
+      )}
+      {(enumOptions as any).map(({ value, label }: any, i: number) => {
+        const disabled: any =
+          Array.isArray(enumDisabled) &&
+          (enumDisabled as any).indexOf(value) != -1;
+        return (
+          <option key={i} id={label} value={value} disabled={disabled}>
+            {label}
+          </option>
+        );
+      })}
+    </Form.Control>
   );
 };
 

--- a/packages/bootstrap-4/src/TextareaWidget/TextareaWidget.tsx
+++ b/packages/bootstrap-4/src/TextareaWidget/TextareaWidget.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { getUiOptions, WidgetProps } from "@rjsf/utils";
+import { WidgetProps } from "@rjsf/utils";
 import FormControl from "react-bootstrap/FormControl";
 import InputGroup from "react-bootstrap/InputGroup";
 
@@ -15,17 +15,12 @@ const TextareaWidget = ({
   required,
   disabled,
   autofocus,
-  label,
   readonly,
   onBlur,
   onFocus,
   onChange,
   options,
-  schema,
-  rawErrors = [],
-  uiSchema,
 }: CustomWidgetProps) => {
-  const uiOptions = getUiOptions(uiSchema);
   const _onChange = ({
     target: { value },
   }: React.ChangeEvent<HTMLTextAreaElement>) =>
@@ -38,36 +33,23 @@ const TextareaWidget = ({
   }: React.FocusEvent<HTMLTextAreaElement>) => onFocus(id, value);
 
   return (
-    <>
-      <label htmlFor={id}>
-        {uiOptions.title || schema.title || label}
-        {required && (
-          <span
-            aria-hidden
-            className={rawErrors.length > 0 ? "text-danger ml-1" : "ml-1"}
-          >
-            &thinsp;{"*"}
-          </span>
-        )}
-      </label>
-      <InputGroup>
-        <FormControl
-          id={id}
-          name={id}
-          as="textarea"
-          placeholder={placeholder}
-          disabled={disabled}
-          readOnly={readonly}
-          value={value}
-          required={required}
-          autoFocus={autofocus}
-          rows={options.rows || 5}
-          onChange={_onChange}
-          onBlur={_onBlur}
-          onFocus={_onFocus}
-        />
-      </InputGroup>
-    </>
+    <InputGroup>
+      <FormControl
+        id={id}
+        name={id}
+        as="textarea"
+        placeholder={placeholder}
+        disabled={disabled}
+        readOnly={readonly}
+        value={value}
+        required={required}
+        autoFocus={autofocus}
+        rows={options.rows || 5}
+        onChange={_onChange}
+        onBlur={_onBlur}
+        onFocus={_onFocus}
+      />
+    </InputGroup>
   );
 };
 

--- a/packages/bootstrap-4/test/__snapshots__/AdditionalProperties.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/AdditionalProperties.test.tsx.snap
@@ -61,31 +61,27 @@ exports[`AdditionalProperties tests show add button and fields if additionalProp
                 <div
                   className="form-group"
                 >
-                  <div
-                    className="mb-0 form-group"
+                  <label
+                    className="form-label"
+                    htmlFor="root"
                   >
-                    <label
-                      className="form-label"
-                      htmlFor="root"
-                    >
-                      additionalProperty
-                    </label>
-                    <input
-                      autoFocus={false}
-                      className="form-control"
-                      disabled={false}
-                      id="root"
-                      name="root"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={false}
-                      type="text"
-                      value="should appear"
-                    />
-                  </div>
+                    additionalProperty
+                  </label>
+                  <input
+                    autoFocus={false}
+                    className="form-control"
+                    disabled={false}
+                    id="root"
+                    name="root"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    readOnly={false}
+                    required={false}
+                    type="text"
+                    value="should appear"
+                  />
                   
                 </div>
               </div>

--- a/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
@@ -128,29 +128,28 @@ exports[`array fields array icons 1`] = `
                       <div
                         className="form-group"
                       >
-                        <div
-                          className="mb-0 form-group"
+                        <label
+                          className="form-label"
+                          htmlFor="root_0"
                         >
-                          <label
-                            className="form-label"
-                            htmlFor="root_0"
-                          />
-                          <input
-                            autoFocus={false}
-                            className="form-control"
-                            disabled={false}
-                            id="root_0"
-                            name="root_0"
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            onFocus={[Function]}
-                            placeholder=""
-                            readOnly={false}
-                            required={true}
-                            type="text"
-                            value="a"
-                          />
-                        </div>
+                          
+                          *
+                        </label>
+                        <input
+                          autoFocus={false}
+                          className="form-control"
+                          disabled={false}
+                          id="root_0"
+                          name="root_0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          type="text"
+                          value="a"
+                        />
                         
                       </div>
                     </div>
@@ -292,29 +291,28 @@ exports[`array fields array icons 1`] = `
                       <div
                         className="form-group"
                       >
-                        <div
-                          className="mb-0 form-group"
+                        <label
+                          className="form-label"
+                          htmlFor="root_1"
                         >
-                          <label
-                            className="form-label"
-                            htmlFor="root_1"
-                          />
-                          <input
-                            autoFocus={false}
-                            className="form-control"
-                            disabled={false}
-                            id="root_1"
-                            name="root_1"
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            onFocus={[Function]}
-                            placeholder=""
-                            readOnly={false}
-                            required={true}
-                            type="text"
-                            value="b"
-                          />
-                        </div>
+                          
+                          *
+                        </label>
+                        <input
+                          autoFocus={false}
+                          className="form-control"
+                          disabled={false}
+                          id="root_1"
+                          name="root_1"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          type="text"
+                          value="b"
+                        />
                         
                       </div>
                     </div>
@@ -526,49 +524,47 @@ exports[`array fields checkboxes 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="form-group"
+      <label
+        className="form-label"
+        htmlFor="root"
       >
-        <label
-          className="form-label"
-          htmlFor="root"
-        />
-        <select
-          autoFocus={false}
-          className="custom-select"
+        
+      </label>
+      <select
+        autoFocus={false}
+        className="custom-select"
+        disabled={false}
+        id="root"
+        multiple={true}
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        required={false}
+        value={Array []}
+      >
+        <option
           disabled={false}
-          id="root"
-          multiple={true}
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          required={false}
-          value={Array []}
+          id="a"
+          value="a"
         >
-          <option
-            disabled={false}
-            id="a"
-            value="a"
-          >
-            a
-          </option>
-          <option
-            disabled={false}
-            id="b"
-            value="b"
-          >
-            b
-          </option>
-          <option
-            disabled={false}
-            id="c"
-            value="c"
-          >
-            c
-          </option>
-        </select>
-      </div>
+          a
+        </option>
+        <option
+          disabled={false}
+          id="b"
+          value="b"
+        >
+          b
+        </option>
+        <option
+          disabled={false}
+          id="c"
+          value="c"
+        >
+          c
+        </option>
+      </select>
       
     </div>
   </div>
@@ -618,31 +614,27 @@ exports[`array fields empty errors array 1`] = `
               <div
                 className="form-group"
               >
-                <div
-                  className="mb-0 form-group"
+                <label
+                  className="form-label"
+                  htmlFor="root_name"
                 >
-                  <label
-                    className="form-label"
-                    htmlFor="root_name"
-                  >
-                    name
-                  </label>
-                  <input
-                    autoFocus={false}
-                    className="form-control"
-                    disabled={false}
-                    id="root_name"
-                    name="root_name"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    placeholder=""
-                    readOnly={false}
-                    required={false}
-                    type="text"
-                    value=""
-                  />
-                </div>
+                  name
+                </label>
+                <input
+                  autoFocus={false}
+                  className="form-control"
+                  disabled={false}
+                  id="root_name"
+                  name="root_name"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
                 
               </div>
             </div>
@@ -698,29 +690,28 @@ exports[`array fields fixed array 1`] = `
                       <div
                         className="form-group"
                       >
-                        <div
-                          className="mb-0 form-group"
+                        <label
+                          className="form-label"
+                          htmlFor="root_0"
                         >
-                          <label
-                            className="form-label"
-                            htmlFor="root_0"
-                          />
-                          <input
-                            autoFocus={false}
-                            className="form-control"
-                            disabled={false}
-                            id="root_0"
-                            name="root_0"
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            onFocus={[Function]}
-                            placeholder=""
-                            readOnly={false}
-                            required={true}
-                            type="text"
-                            value=""
-                          />
-                        </div>
+                          
+                          *
+                        </label>
+                        <input
+                          autoFocus={false}
+                          className="form-control"
+                          disabled={false}
+                          id="root_0"
+                          name="root_0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          type="text"
+                          value=""
+                        />
                         
                       </div>
                     </div>
@@ -743,30 +734,29 @@ exports[`array fields fixed array 1`] = `
                       <div
                         className="form-group"
                       >
-                        <div
-                          className="mb-0 form-group"
+                        <label
+                          className="form-label"
+                          htmlFor="root_1"
                         >
-                          <label
-                            className="form-label"
-                            htmlFor="root_1"
-                          />
-                          <input
-                            autoFocus={false}
-                            className="form-control"
-                            disabled={false}
-                            id="root_1"
-                            name="root_1"
-                            onBlur={[Function]}
-                            onChange={[Function]}
-                            onFocus={[Function]}
-                            placeholder=""
-                            readOnly={false}
-                            required={true}
-                            step="any"
-                            type="number"
-                            value=""
-                          />
-                        </div>
+                          
+                          *
+                        </label>
+                        <input
+                          autoFocus={false}
+                          className="form-control"
+                          disabled={false}
+                          id="root_1"
+                          name="root_1"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          step="any"
+                          type="number"
+                          value=""
+                        />
                         
                       </div>
                     </div>
@@ -828,31 +818,27 @@ exports[`array fields no errors 1`] = `
               <div
                 className="form-group"
               >
-                <div
-                  className="mb-0 form-group"
+                <label
+                  className="form-label"
+                  htmlFor="root_name"
                 >
-                  <label
-                    className="form-label"
-                    htmlFor="root_name"
-                  >
-                    name
-                  </label>
-                  <input
-                    autoFocus={false}
-                    className="form-control"
-                    disabled={false}
-                    id="root_name"
-                    name="root_name"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    placeholder=""
-                    readOnly={false}
-                    required={false}
-                    type="text"
-                    value=""
-                  />
-                </div>
+                  name
+                </label>
+                <input
+                  autoFocus={false}
+                  className="form-control"
+                  disabled={false}
+                  id="root_name"
+                  name="root_name"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
                 
               </div>
             </div>

--- a/packages/bootstrap-4/test/__snapshots__/CheckboxesWidget.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/CheckboxesWidget.test.tsx.snap
@@ -1,79 +1,63 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CheckboxesWidget inline 1`] = `
-Array [
-  <label
-    className="form-label"
-    htmlFor="_id"
-  >
-    Some simple label
-  </label>,
+<div
+  className="form-group"
+>
   <div
-    className="form-group"
+    className="bg-transparent border-0 custom-control custom-checkbox custom-control-inline"
   >
-    <div
-      className="bg-transparent border-0 custom-control custom-checkbox custom-control-inline"
+    <input
+      autoFocus={true}
+      checked={true}
+      className="custom-control-input"
+      disabled={true}
+      id="_id-a"
+      name="_id"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      required={true}
+      type="checkbox"
+    />
+    <label
+      className="custom-control-label"
+      htmlFor="_id-a"
+      title=""
     >
-      <input
-        autoFocus={true}
-        checked={true}
-        className="custom-control-input"
-        disabled={true}
-        id="_id-a"
-        name="_id"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        required={true}
-        type="checkbox"
-      />
-      <label
-        className="custom-control-label"
-        htmlFor="_id-a"
-        title=""
-      >
-        A
-      </label>
-    </div>
-  </div>,
-]
+      A
+    </label>
+  </div>
+</div>
 `;
 
 exports[`CheckboxesWidget simple 1`] = `
-Array [
-  <label
-    className="form-label"
-    htmlFor="_id"
-  >
-    Some simple label
-  </label>,
+<div
+  className="form-group"
+>
   <div
-    className="form-group"
+    className="bg-transparent border-0 custom-control custom-checkbox"
   >
-    <div
-      className="bg-transparent border-0 custom-control custom-checkbox"
+    <input
+      autoFocus={true}
+      checked={true}
+      className="custom-control-input"
+      disabled={true}
+      id="_id-a"
+      name="_id"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      required={true}
+      type="checkbox"
+    />
+    <label
+      className="custom-control-label"
+      htmlFor="_id-a"
+      title=""
     >
-      <input
-        autoFocus={true}
-        checked={true}
-        className="custom-control-input"
-        disabled={true}
-        id="_id-a"
-        name="_id"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        required={true}
-        type="checkbox"
-      />
-      <label
-        className="custom-control-label"
-        htmlFor="_id-a"
-        title=""
-      >
-        A
-      </label>
-    </div>
-  </div>,
-]
+      A
+    </label>
+  </div>
+</div>
 `;

--- a/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
@@ -107,7 +107,9 @@ exports[`single fields checkboxes field 1`] = `
       <label
         className="form-label"
         htmlFor="root"
-      />
+      >
+        
+      </label>
       <div
         className="form-group"
       >
@@ -257,31 +259,27 @@ exports[`single fields field with description 1`] = `
               <div
                 className="form-group"
               >
-                <div
-                  className="mb-0 form-group"
+                <label
+                  className="form-label"
+                  htmlFor="root_my-field"
                 >
-                  <label
-                    className="form-label"
-                    htmlFor="root_my-field"
-                  >
-                    my-field
-                  </label>
-                  <input
-                    autoFocus={false}
-                    className="form-control"
-                    disabled={false}
-                    id="root_my-field"
-                    name="root_my-field"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    placeholder=""
-                    readOnly={false}
-                    required={false}
-                    type="text"
-                    value=""
-                  />
-                </div>
+                  my-field
+                </label>
+                <input
+                  autoFocus={false}
+                  className="form-control"
+                  disabled={false}
+                  id="root_my-field"
+                  name="root_my-field"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
                 <small
                   className="text-muted form-text"
                 >
@@ -340,31 +338,27 @@ exports[`single fields field with description in uiSchema 1`] = `
               <div
                 className="form-group"
               >
-                <div
-                  className="mb-0 form-group"
+                <label
+                  className="form-label"
+                  htmlFor="root_my-field"
                 >
-                  <label
-                    className="form-label"
-                    htmlFor="root_my-field"
-                  >
-                    my-field
-                  </label>
-                  <input
-                    autoFocus={false}
-                    className="form-control"
-                    disabled={false}
-                    id="root_my-field"
-                    name="root_my-field"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    placeholder=""
-                    readOnly={false}
-                    required={false}
-                    type="text"
-                    value=""
-                  />
-                </div>
+                  my-field
+                </label>
+                <input
+                  autoFocus={false}
+                  className="form-control"
+                  disabled={false}
+                  id="root_my-field"
+                  name="root_my-field"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
                 <small
                   className="text-muted form-text"
                 >
@@ -401,28 +395,26 @@ exports[`single fields format color 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="mb-0 form-group"
+      <label
+        className="form-label"
+        htmlFor="root"
       >
-        <label
-          className="form-label"
-          htmlFor="root"
-        />
-        <input
-          autoFocus={false}
-          className="form-control"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          readOnly={false}
-          type="color"
-          value=""
-        />
-      </div>
+        
+      </label>
+      <input
+        autoFocus={false}
+        className="form-control"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        type="color"
+        value=""
+      />
       
     </div>
   </div>
@@ -450,28 +442,26 @@ exports[`single fields format date 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="mb-0 form-group"
+      <label
+        className="form-label"
+        htmlFor="root"
       >
-        <label
-          className="form-label"
-          htmlFor="root"
-        />
-        <input
-          autoFocus={false}
-          className="form-control"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          readOnly={false}
-          type="date"
-          value=""
-        />
-      </div>
+        
+      </label>
+      <input
+        autoFocus={false}
+        className="form-control"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        type="date"
+        value=""
+      />
       
     </div>
   </div>
@@ -499,28 +489,26 @@ exports[`single fields format datetime 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="mb-0 form-group"
+      <label
+        className="form-label"
+        htmlFor="root"
       >
-        <label
-          className="form-label"
-          htmlFor="root"
-        />
-        <input
-          autoFocus={false}
-          className="form-control"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          readOnly={false}
-          type="datetime-local"
-          value=""
-        />
-      </div>
+        
+      </label>
+      <input
+        autoFocus={false}
+        className="form-control"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        type="datetime-local"
+        value=""
+      />
       
     </div>
   </div>
@@ -576,28 +564,26 @@ exports[`single fields help and error display 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="mb-0 form-group"
+      <label
+        className="text-danger form-label"
+        htmlFor="root"
       >
-        <label
-          className="text-danger form-label"
-          htmlFor="root"
-        />
-        <input
-          autoFocus={false}
-          className="is-invalid form-control"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          readOnly={false}
-          type="text"
-          value=""
-        />
-      </div>
+        
+      </label>
+      <input
+        autoFocus={false}
+        className="is-invalid form-control"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        type="text"
+        value=""
+      />
       
       <ul
         className="list-group"
@@ -666,19 +652,14 @@ exports[`single fields hidden field 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="hidden"
             >
-              <div
-                className="form-group"
-              >
-                <input
-                  id="root_my-field"
-                  name="root_my-field"
-                  type="hidden"
-                  value=""
-                />
-                
-              </div>
+              <input
+                id="root_my-field"
+                name="root_my-field"
+                type="hidden"
+                value=""
+              />
             </div>
           </div>
         </div>
@@ -709,28 +690,20 @@ exports[`single fields hidden label 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="mb-0 form-group"
-      >
-        <label
-          className="form-label"
-          htmlFor="root"
-        />
-        <input
-          autoFocus={false}
-          className="form-control"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          readOnly={false}
-          type="text"
-          value=""
-        />
-      </div>
+      <input
+        autoFocus={false}
+        className="form-control"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        type="text"
+        value=""
+      />
     </div>
   </div>
   <div>
@@ -757,6 +730,12 @@ exports[`single fields null field 1`] = `
     <div
       className="form-group"
     >
+      <label
+        className="form-label"
+        htmlFor="root"
+      >
+        
+      </label>
       
     </div>
   </div>
@@ -784,29 +763,27 @@ exports[`single fields number field 0 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="mb-0 form-group"
+      <label
+        className="form-label"
+        htmlFor="root"
       >
-        <label
-          className="form-label"
-          htmlFor="root"
-        />
-        <input
-          autoFocus={false}
-          className="form-control"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          readOnly={false}
-          step="any"
-          type="number"
-          value={0}
-        />
-      </div>
+        
+      </label>
+      <input
+        autoFocus={false}
+        className="form-control"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        step="any"
+        type="number"
+        value={0}
+      />
       
     </div>
   </div>
@@ -834,29 +811,27 @@ exports[`single fields number field 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="mb-0 form-group"
+      <label
+        className="form-label"
+        htmlFor="root"
       >
-        <label
-          className="form-label"
-          htmlFor="root"
-        />
-        <input
-          autoFocus={false}
-          className="form-control"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          readOnly={false}
-          step="any"
-          type="number"
-          value=""
-        />
-      </div>
+        
+      </label>
+      <input
+        autoFocus={false}
+        className="form-control"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        step="any"
+        type="number"
+        value=""
+      />
       
     </div>
   </div>
@@ -884,28 +859,26 @@ exports[`single fields password field 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="mb-0 form-group"
+      <label
+        className="form-label"
+        htmlFor="root"
       >
-        <label
-          className="form-label"
-          htmlFor="root"
-        />
-        <input
-          autoFocus={false}
-          className="form-control"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          readOnly={false}
-          type="password"
-          value=""
-        />
-      </div>
+        
+      </label>
+      <input
+        autoFocus={false}
+        className="form-control"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        type="password"
+        value=""
+      />
       
     </div>
   </div>
@@ -933,14 +906,15 @@ exports[`single fields radio field 1`] = `
     <div
       className="form-group"
     >
+      <label
+        className="form-label"
+        htmlFor="root"
+      >
+        
+      </label>
       <div
         className="mb-0 form-group"
       >
-        <label
-          className="d-block form-label"
-        >
-          
-        </label>
         <div
           className="form-check"
         >
@@ -1015,48 +989,46 @@ exports[`single fields schema examples 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="mb-0 form-group"
+      <label
+        className="form-label"
+        htmlFor="root"
       >
-        <label
-          className="form-label"
-          htmlFor="root"
+        
+      </label>
+      <input
+        autoFocus={false}
+        className="form-control"
+        disabled={false}
+        id="root"
+        list="examples_root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        type="text"
+        value=""
+      />
+      <datalist
+        id="examples_root"
+      >
+        <option
+          value="Firefox"
         />
-        <input
-          autoFocus={false}
-          className="form-control"
-          disabled={false}
-          id="root"
-          list="examples_root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          readOnly={false}
-          type="text"
-          value=""
+        <option
+          value="Chrome"
         />
-        <datalist
-          id="examples_root"
-        >
-          <option
-            value="Firefox"
-          />
-          <option
-            value="Chrome"
-          />
-          <option
-            value="Opera"
-          />
-          <option
-            value="Vivaldi"
-          />
-          <option
-            value="Safari"
-          />
-        </datalist>
-      </div>
+        <option
+          value="Opera"
+        />
+        <option
+          value="Vivaldi"
+        />
+        <option
+          value="Safari"
+        />
+      </datalist>
       
     </div>
   </div>
@@ -1084,45 +1056,43 @@ exports[`single fields select field 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="form-group"
+      <label
+        className="form-label"
+        htmlFor="root"
       >
-        <label
-          className="form-label"
-          htmlFor="root"
-        />
-        <select
-          autoFocus={false}
-          className="custom-select"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
+        
+      </label>
+      <select
+        autoFocus={false}
+        className="custom-select"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        value=""
+      >
+        <option
           value=""
         >
-          <option
-            value=""
-          >
-            
-          </option>
-          <option
-            disabled={false}
-            id="foo"
-            value="foo"
-          >
-            foo
-          </option>
-          <option
-            disabled={false}
-            id="bar"
-            value="bar"
-          >
-            bar
-          </option>
-        </select>
-      </div>
+          
+        </option>
+        <option
+          disabled={false}
+          id="foo"
+          value="foo"
+        >
+          foo
+        </option>
+        <option
+          disabled={false}
+          id="bar"
+          value="bar"
+        >
+          bar
+        </option>
+      </select>
       
     </div>
   </div>
@@ -1150,36 +1120,34 @@ exports[`single fields slider field 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="mb-0 form-group"
+      <label
+        className="form-label"
+        htmlFor="root"
       >
-        <label
-          className="form-label"
-          htmlFor="root"
-        />
-        <input
-          autoFocus={false}
-          className="form-control"
-          disabled={false}
-          id="root"
-          max={100}
-          min={42}
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          readOnly={false}
-          step={1}
-          type="number"
-          value={75}
-        />
-        <span
-          className="range-view"
-        >
-          75
-        </span>
-      </div>
+        
+      </label>
+      <input
+        autoFocus={false}
+        className="form-control"
+        disabled={false}
+        id="root"
+        max={100}
+        min={42}
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        step={1}
+        type="number"
+        value={75}
+      />
+      <span
+        className="range-view"
+      >
+        75
+      </span>
       
     </div>
   </div>
@@ -1207,28 +1175,26 @@ exports[`single fields string field format data-url 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="mb-0 form-group"
+      <label
+        className="form-label"
+        htmlFor="root"
       >
-        <label
-          className="form-label"
-          htmlFor="root"
-        />
-        <input
-          autoFocus={false}
-          className="form-control-file"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          readOnly={false}
-          type="file"
-          value=""
-        />
-      </div>
+        
+      </label>
+      <input
+        autoFocus={false}
+        className="form-control-file"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        type="file"
+        value=""
+      />
       
     </div>
   </div>
@@ -1256,28 +1222,26 @@ exports[`single fields string field format email 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="mb-0 form-group"
+      <label
+        className="form-label"
+        htmlFor="root"
       >
-        <label
-          className="form-label"
-          htmlFor="root"
-        />
-        <input
-          autoFocus={false}
-          className="form-control"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          readOnly={false}
-          type="email"
-          value=""
-        />
-      </div>
+        
+      </label>
+      <input
+        autoFocus={false}
+        className="form-control"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        type="email"
+        value=""
+      />
       
     </div>
   </div>
@@ -1305,28 +1269,26 @@ exports[`single fields string field format uri 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="mb-0 form-group"
+      <label
+        className="form-label"
+        htmlFor="root"
       >
-        <label
-          className="form-label"
-          htmlFor="root"
-        />
-        <input
-          autoFocus={false}
-          className="form-control"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          readOnly={false}
-          type="url"
-          value=""
-        />
-      </div>
+        
+      </label>
+      <input
+        autoFocus={false}
+        className="form-control"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        type="url"
+        value=""
+      />
       
     </div>
   </div>
@@ -1354,28 +1316,26 @@ exports[`single fields string field regular 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="mb-0 form-group"
+      <label
+        className="form-label"
+        htmlFor="root"
       >
-        <label
-          className="form-label"
-          htmlFor="root"
-        />
-        <input
-          autoFocus={false}
-          className="form-control"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          readOnly={false}
-          type="text"
-          value=""
-        />
-      </div>
+        
+      </label>
+      <input
+        autoFocus={false}
+        className="form-control"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        type="text"
+        value=""
+      />
       
     </div>
   </div>
@@ -1403,28 +1363,26 @@ exports[`single fields string field with placeholder 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="mb-0 form-group"
+      <label
+        className="form-label"
+        htmlFor="root"
       >
-        <label
-          className="form-label"
-          htmlFor="root"
-        />
-        <input
-          autoFocus={false}
-          className="form-control"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder="placeholder"
-          readOnly={false}
-          type="text"
-          value=""
-        />
-      </div>
+        
+      </label>
+      <input
+        autoFocus={false}
+        className="form-control"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder="placeholder"
+        readOnly={false}
+        type="text"
+        value=""
+      />
       
     </div>
   </div>
@@ -1453,6 +1411,7 @@ exports[`single fields textarea field 1`] = `
       className="form-group"
     >
       <label
+        className="form-label"
         htmlFor="root"
       >
         
@@ -1538,31 +1497,27 @@ exports[`single fields title field 1`] = `
               <div
                 className="form-group"
               >
-                <div
-                  className="mb-0 form-group"
+                <label
+                  className="form-label"
+                  htmlFor="root_title"
                 >
-                  <label
-                    className="form-label"
-                    htmlFor="root_title"
-                  >
-                    Titre 2
-                  </label>
-                  <input
-                    autoFocus={false}
-                    className="form-control"
-                    disabled={false}
-                    id="root_title"
-                    name="root_title"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    placeholder=""
-                    readOnly={false}
-                    required={false}
-                    type="text"
-                    value=""
-                  />
-                </div>
+                  Titre 2
+                </label>
+                <input
+                  autoFocus={false}
+                  className="form-control"
+                  disabled={false}
+                  id="root_title"
+                  name="root_title"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
                 
               </div>
             </div>
@@ -1595,6 +1550,12 @@ exports[`single fields unsupported field 1`] = `
     <div
       className="form-group"
     >
+      <label
+        className="form-label"
+        htmlFor="root"
+      >
+        
+      </label>
       <div
         className="unsupported-field"
       >
@@ -1644,28 +1605,26 @@ exports[`single fields up/down field 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="mb-0 form-group"
+      <label
+        className="form-label"
+        htmlFor="root"
       >
-        <label
-          className="form-label"
-          htmlFor="root"
-        />
-        <input
-          autoFocus={false}
-          className="form-control"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          readOnly={false}
-          type="number"
-          value=""
-        />
-      </div>
+        
+      </label>
+      <input
+        autoFocus={false}
+        className="form-control"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        type="number"
+        value=""
+      />
       
     </div>
   </div>
@@ -1693,28 +1652,26 @@ exports[`single fields using custom tagName 1`] = `
     <div
       className="form-group"
     >
-      <div
-        className="mb-0 form-group"
+      <label
+        className="form-label"
+        htmlFor="root"
       >
-        <label
-          className="form-label"
-          htmlFor="root"
-        />
-        <input
-          autoFocus={false}
-          className="form-control"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder=""
-          readOnly={false}
-          type="text"
-          value=""
-        />
-      </div>
+        
+      </label>
+      <input
+        autoFocus={false}
+        className="form-control"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        type="text"
+        value=""
+      />
       
     </div>
   </div>

--- a/packages/bootstrap-4/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Object.test.tsx.snap
@@ -61,31 +61,27 @@ exports[`object fields additionalProperties 1`] = `
                 <div
                   className="form-group"
                 >
-                  <div
-                    className="mb-0 form-group"
+                  <label
+                    className="form-label"
+                    htmlFor="root_foo"
                   >
-                    <label
-                      className="form-label"
-                      htmlFor="root_foo"
-                    >
-                      foo
-                    </label>
-                    <input
-                      autoFocus={false}
-                      className="form-control"
-                      disabled={false}
-                      id="root_foo"
-                      name="root_foo"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={false}
-                      type="text"
-                      value="foo"
-                    />
-                  </div>
+                    foo
+                  </label>
+                  <input
+                    autoFocus={false}
+                    className="form-control"
+                    disabled={false}
+                    id="root_foo"
+                    name="root_foo"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    readOnly={false}
+                    required={false}
+                    type="text"
+                    value="foo"
+                  />
                   
                 </div>
               </div>
@@ -217,31 +213,27 @@ exports[`object fields object 1`] = `
               <div
                 className="form-group"
               >
-                <div
-                  className="mb-0 form-group"
+                <label
+                  className="form-label"
+                  htmlFor="root_a"
                 >
-                  <label
-                    className="form-label"
-                    htmlFor="root_a"
-                  >
-                    A
-                  </label>
-                  <input
-                    autoFocus={false}
-                    className="form-control"
-                    disabled={false}
-                    id="root_a"
-                    name="root_a"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    placeholder=""
-                    readOnly={false}
-                    required={false}
-                    type="text"
-                    value=""
-                  />
-                </div>
+                  A
+                </label>
+                <input
+                  autoFocus={false}
+                  className="form-control"
+                  disabled={false}
+                  id="root_a"
+                  name="root_a"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
                 
               </div>
             </div>
@@ -265,32 +257,28 @@ exports[`object fields object 1`] = `
               <div
                 className="form-group"
               >
-                <div
-                  className="mb-0 form-group"
+                <label
+                  className="form-label"
+                  htmlFor="root_b"
                 >
-                  <label
-                    className="form-label"
-                    htmlFor="root_b"
-                  >
-                    B
-                  </label>
-                  <input
-                    autoFocus={false}
-                    className="form-control"
-                    disabled={false}
-                    id="root_b"
-                    name="root_b"
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    placeholder=""
-                    readOnly={false}
-                    required={false}
-                    step="any"
-                    type="number"
-                    value=""
-                  />
-                </div>
+                  B
+                </label>
+                <input
+                  autoFocus={false}
+                  className="form-control"
+                  disabled={false}
+                  id="root_b"
+                  name="root_b"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  step="any"
+                  type="number"
+                  value=""
+                />
                 
               </div>
             </div>

--- a/packages/bootstrap-4/test/__snapshots__/TextAreaWidget.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/TextAreaWidget.test.tsx.snap
@@ -1,102 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TextareaWidget simple with errors 1`] = `
-Array [
-  <label
-    htmlFor="_id"
-  >
-    Some simple label
-    <span
-      aria-hidden={true}
-      className="text-danger ml-1"
-    >
-       
-      *
-    </span>
-  </label>,
-  <div
-    className="input-group"
-  >
-    <textarea
-      autoFocus={true}
-      className="form-control"
-      disabled={false}
-      id="_id"
-      name="_id"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      placeholder=""
-      readOnly={true}
-      required={true}
-      rows={5}
-      value="value"
-    />
-  </div>,
-]
+<div
+  className="input-group"
+>
+  <textarea
+    autoFocus={true}
+    className="form-control"
+    disabled={false}
+    id="_id"
+    name="_id"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    placeholder=""
+    readOnly={true}
+    required={true}
+    rows={5}
+    value="value"
+  />
+</div>
 `;
 
 exports[`TextareaWidget simple without errors 1`] = `
-Array [
-  <label
-    htmlFor="_id"
-  >
-    Some simple label
-    <span
-      aria-hidden={true}
-      className="text-danger ml-1"
-    >
-       
-      *
-    </span>
-  </label>,
-  <div
-    className="input-group"
-  >
-    <textarea
-      autoFocus={true}
-      className="form-control"
-      disabled={false}
-      id="_id"
-      name="_id"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      placeholder=""
-      readOnly={true}
-      required={true}
-      rows={5}
-      value="value"
-    />
-  </div>,
-]
+<div
+  className="input-group"
+>
+  <textarea
+    autoFocus={true}
+    className="form-control"
+    disabled={false}
+    id="_id"
+    name="_id"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    placeholder=""
+    readOnly={true}
+    required={true}
+    rows={5}
+    value="value"
+  />
+</div>
 `;
 
 exports[`TextareaWidget simple without required 1`] = `
-Array [
-  <label
-    htmlFor="_id"
-  >
-    Some simple label
-  </label>,
-  <div
-    className="input-group"
-  >
-    <textarea
-      autoFocus={true}
-      className="form-control"
-      disabled={false}
-      id="_id"
-      name="_id"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      placeholder=""
-      readOnly={true}
-      required={false}
-      rows={5}
-      value="value"
-    />
-  </div>,
-]
+<div
+  className="input-group"
+>
+  <textarea
+    autoFocus={true}
+    className="form-control"
+    disabled={false}
+    id="_id"
+    name="_id"
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    placeholder=""
+    readOnly={true}
+    required={false}
+    rows={5}
+    value="value"
+  />
+</div>
 `;


### PR DESCRIPTION
### Reasons for making this change

Fixed #2007 by reimplementing #2533

The current code for FieldTemplate and TextWidget in bootstrap 4 is incompatible with the core package. This breaks the external facing API for customizing field template. According to the core package implementation and documents, FieldTemplate is responsible for layout of labels, description, errors and help while the input widget along with the state is to be managed by the Field Component themselves (and Widgets) If a user, uses custom field template with the bootstrap 4 form, the label is displayed multiple times, once by the custom field template (as intended in the API) and second time by the TextWidget (breaks from the core package convention) This fixes the problem and updates the tests to catch any future regressions.

- Updated `FieldTemplate` to output `Label` generation, adding an additional check to simply render `children` when the component is `hidden`
- Updated `BaseInputTemplate`, `CheckboxesWidget`, `RadioWidget`, `SelectWidget` and `TextareaWidget`, removing the `Label` generation
- Updated the test snapshots
- Updated the `CHANGELOG.md` accordingly

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
