### PR TITLE
fix: BooleanField component to not alter readOnly props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 - Extended `Form.onChange` to optionally return the `id` of the field that caused the change, fixing [#2768](https://github.com/rjsf-team/react-jsonschema-form/issues/2768)
 - Fixed a regression in earlier v5 beta versions where additional properties could not be added when `additionalProperties` was `true` ([#3719](https://github.com/rjsf-team/react-jsonschema-form/pull/3719)).
-
+- Fixed a regression in v5 beta version where BooleanField was altering readonly props ([#3188](https://github.com/rjsf-team/react-jsonschema-form/pull/3188).
+-
 ## @rjsf/utils
 - Updated the `onChange` prop on `FieldProps` and `FieldTemplateProps` to add an optional `id` parameter to the callback.
 
@@ -53,7 +54,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed `CheckboxesWidget` and `RadioWidget` to have unique `id`s for each radio element by appending the `option.value`, removing unnecessary casts to `any` and protecting against non-arrays
 
 ## @rjsf/core
-- Convert `WrapIfAdditional` to `WrapIfAdditionalTemplate` 
+- Convert `WrapIfAdditional` to `WrapIfAdditionalTemplate`
 - Added `name` to the `input` components that were missing it to support `remix`
 - Fixed `CheckboxesWidget` and `RadioWidget` to have unique `id`s for each radio element by appending the `option.value`
 - Updated the `validate()` method on `Form` to make `schemaUtils` an optional third parameter rather than a required first parameter, making the signature backwards compatible with what was provided in previous versions.
@@ -100,7 +101,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Pass `uiSchema` appropriately to all of the `IconButton`s, `ArrayFieldItemTemplate` and `WrapIfAdditional` components, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/3130)
 
 ## @rjsf/core
-- Updated the `FieldErrorTemplate` to remove the explicit typing of the `error` to string to support the two options 
+- Updated the `FieldErrorTemplate` to remove the explicit typing of the `error` to string to support the two options
 - Implemented programmatic validation via new `validateForm()` method on `Form`, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/2755, https://github.com/rjsf-team/react-jsonschema-form/issues/2552, https://github.com/rjsf-team/react-jsonschema-form/issues/2381, https://github.com/rjsf-team/react-jsonschema-form/issues/2343, https://github.com/rjsf-team/react-jsonschema-form/issues/1006, https://github.com/rjsf-team/react-jsonschema-form/issues/246)
 - Renamed `WithThemeProps` to `ThemeProps` to prevent another breaking-change by returning the type back to the name it had in version 4
 - Pass `uiSchema` appropriately to all of the `IconButton`s, `ArrayFieldItemTemplate` and `WrapIfAdditional` components, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/3130)
@@ -121,7 +122,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/semantic-ui
 - Updated the `FieldErrorTemplate` to use the `children` variation of the `List.Item` that supports ReactElement
 - Pass `uiSchema` appropriately to all of the `IconButton`s, `ArrayFieldItemTemplate` and `WrapIfAdditional` components, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/3130)
- 
+
 ## @rjsf/utils
 - Updated the `FieldErrorProps` type to make it support an array of string and ReactElement
 - Updated the `IconButtonProps` type to add `uiSchema`, adding the `<T = any, F = any>` generics to it and the associated `ButtonTemplates` in `TemplatesType` AND added `uiSchema` to `ArrayFieldTemplateItemType` as well, fixing (https://github.com/rjsf-team/react-jsonschema-form/issues/3130)
@@ -193,7 +194,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed the `README.md` to correct the package name in several places to match the actual package
 
 ## @rjsf/validator-ajv8
-- Support for localization (L12n) on a customized validator using a `Localizer` function passed as a second parameter to `customizeValidator()`, fixing (https://github.com/rjsf-team/react-jsonschema-form/pull/846, and https://github.com/rjsf-team/react-jsonschema-form/issues/1195) 
+- Support for localization (L12n) on a customized validator using a `Localizer` function passed as a second parameter to `customizeValidator()`, fixing (https://github.com/rjsf-team/react-jsonschema-form/pull/846, and https://github.com/rjsf-team/react-jsonschema-form/issues/1195)
 - Fixed the `README.md` to correct the package name in several places to match the actual package
 
 ## Dev / docs / playground

--- a/packages/core/src/components/fields/BooleanField.tsx
+++ b/packages/core/src/components/fields/BooleanField.tsx
@@ -56,26 +56,25 @@ function BooleanField<T = any, F = any>(props: FieldProps<T, F>) {
   } else {
     // We deprecated enumNames in v5. It's intentionally omitted from RSJFSchema type, so we need to cast here.
     const schemaWithEnumNames = schema as RJSFSchema & { enumNames?: string[] };
-    schema.enum = schema.enum ?? [true, false];
+    const enums = schema.enum ?? [true, false];
     if (
       !schemaWithEnumNames.enumNames &&
-      schema.enum &&
-      schema.enum.length === 2 &&
-      schema.enum.every((v) => typeof v === "boolean")
+      enums.length === 2 &&
+      enums.every((v) => typeof v === "boolean")
     ) {
       enumOptions = [
         {
-          value: schema.enum[0],
-          label: schema.enum[0] ? "Yes" : "No",
+          value: enums[0],
+          label: enums[0] ? "Yes" : "No",
         },
         {
-          value: schema.enum[1],
-          label: schema.enum[1] ? "Yes" : "No",
+          value: enums[1],
+          label: enums[1] ? "Yes" : "No",
         },
       ];
     } else {
       enumOptions = optionsList({
-        enum: schema.enum,
+        enum: enums,
         // NOTE: enumNames is deprecated, but still supported for now.
         enumNames: schemaWithEnumNames.enumNames,
       } as RJSFSchema);


### PR DESCRIPTION
### Reasons for making this change

Fixed the code for the BooleanField component to not alter the readonly props

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
