### PR TITLE
fix: Partially fix #3189

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/chakra-ui
 - Automatically close single-choice Select widget on selection
 
+## @rjsf/core
+- Added the new generic, `S extends StrictRJSFSchema = RJSFSchema`, for `schema`/`rootSchema` to every component that needed it.
+
+## @rjsf/utils
+- Beta-only potentially BREAKING CHANGE: Changed all types that directly or indirectly defined `schema`/`rootSchema` to add the generic `S extends StrictRJSFSchema = RJSFSchema` and use `S` as the type for them.
+  - `StrictRJSFSchema` was added as the alias to `JSON7Schema` and `RJSFSchema` was modified to be `StrictRJSFSchema & GenericObjectType`
+  - This new generic was added BEFORE the newly added `F = any` generic because it is assumed that more people will want to change the schema than the formContext types
+  - This provides future support for the newer draft versions of the schema
+
+## @rjsf/validator-ajv6
+- Fixed a few type casts given the new expanded definition of the `RJSFSchema` type change
+
+## @rjsf/validator-ajv8
+- Updated the typing to add the new `S extends StrictRJSFSchema = RJSFSchema` generic and fixed up type casts
+
+## Dev / docs / playground
+- Updated the `5.x upgrade guide` to document the new `StrictRJSFSchema` and `S` generic
+
 # 5.0.0-beta.11
 
 ## @rjsf/antd

--- a/docs/5.x upgrade guide.md
+++ b/docs/5.x upgrade guide.md
@@ -42,11 +42,11 @@ All the rest of the types for RJSF are now exported from the new `@rjsf/utils` p
 NOTE: The types in `@rjsf/utils` have been improved significantly from those in version 4.
 Some of the most notable changes are:
 
-- `RJSFSchema` has replaced the use of `JSON7Schema` for future compatibility reasons.
-  - Currently `RJSFSchema` is simply an alias to `JSON7Schema` so this change is purely a naming one.
-  - It is highly recommended to update your use of `JSON7Schema` with `RJSFSchema` so that when the RJSF begins supporting a newer JSON Schema version out-of-the-box, your code won't be affected. 
-- `RJSFSchemaDefinition` has replaced the use of `JSONSchema7Definition` for the same reasons.
 - The use of the generic `T` (defaulting to `any`) for the `formData` type has been expanded to cover all type hierarchies that use `formData`.
+- `StrictRJSFSchema` and `RJSFSchema` have replaced the use of `JSON7Schema` for future compatibility reasons.
+  - `RJSFSchema` is `StrictRJSFSchema` joined with the `GenericObjectType` (i.e. `{ [key: string]: any }`) to allow for additional syntax related to newer draft versions
+  - All definitions of `schema` and `rootSchema` elements have been replaced with a generic that is defined as `S extends StrictRJSFSchema = RJSFSchema`
+  - It is highly recommended to update your use of `JSON7Schema` with `RJSFSchema` since that is the default for the new generic used for `schema` and `rootSchema` 
 - A new generic `F` (defaulting to `any`) was added for the `formContext` type, and all types in the hierarchy that use `formContext` have had that generic added to them.
 - The new `CustomValidator`, `ErrorTransformer`, `ValidationData`, `ValidatorType` and `SchemaUtilsType` types were added to support the decoupling of the validation implementation.
 - The new `TemplatesType`, `ArrayFieldDescriptionProps`, `ArrayFieldTitleProps`, `UnsupportedFieldProps`, `IconButtonProps`, `SubmitButtonProps` and `UIOptionsBaseType` were added to support the consolidation (and expansion) of `templates` in the `Registry` and `Form`.
@@ -362,21 +362,21 @@ For example, given a schema such as:
           {
             "properties": {
               "foo": {
-                "type": "string",
-              },
-            },
+                "type": "string"
+              }
+            }
           },
           {
             "properties": {
               "bar": {
-                "type": "string",
-              },
-            },
-          },
-        ],
-      },
-    },
-  },
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
 }
 ```
 

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -7,6 +7,7 @@ import {
   IdSchema,
   PathSchema,
   RJSFSchema,
+  StrictRJSFSchema,
   RJSFValidationError,
   Registry,
   RegistryWidgetsType,
@@ -33,15 +34,19 @@ import _isEmpty from "lodash/isEmpty";
 import getDefaultRegistry from "../getDefaultRegistry";
 
 /** The properties that are passed to the `Form` */
-export interface FormProps<T = any, F = any> {
+export interface FormProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> {
   /** The JSON schema object for the form */
-  schema: RJSFSchema;
+  schema: S;
   /** An implementation of the `ValidatorType` interface that is needed for form validation to work */
-  validator: ValidatorType<T>;
+  validator: ValidatorType<T, S>;
   /** The optional children for the form, if provided, it will replace the default `SubmitButton` */
   children?: React.ReactNode;
   /** The uiSchema for the form */
-  uiSchema?: UiSchema<T, F>;
+  uiSchema?: UiSchema<T, S, F>;
   /** The data for the form, used to prefill a form with existing data */
   formData?: T;
   // Form presentation and behavior modifiers
@@ -71,19 +76,19 @@ export interface FormProps<T = any, F = any> {
   readonly?: boolean;
   // Form registry
   /** The dictionary of registered fields in the form */
-  fields?: RegistryFieldsType<T, F>;
+  fields?: RegistryFieldsType<T, S, F>;
   /** The dictionary of registered templates in the form; Partial allows a subset to be provided beyond the defaults */
-  templates?: Partial<Omit<TemplatesType<T, F>, "ButtonTemplates">> & {
-    ButtonTemplates?: Partial<TemplatesType<T, F>["ButtonTemplates"]>;
+  templates?: Partial<Omit<TemplatesType<T, S, F>, "ButtonTemplates">> & {
+    ButtonTemplates?: Partial<TemplatesType<T, S, F>["ButtonTemplates"]>;
   };
   /** The dictionary of registered widgets in the form */
-  widgets?: RegistryWidgetsType<T, F>;
+  widgets?: RegistryWidgetsType<T, S, F>;
   // Callbacks
   /** If you plan on being notified every time the form data are updated, you can pass an `onChange` handler, which will
    * receive the same args as `onSubmit` any time a value is updated in the form. Can also return the `id` of the field
    * that caused the change
    */
-  onChange?: (data: IChangeEvent<T, F>, id?: string) => void;
+  onChange?: (data: IChangeEvent<T, S, F>, id?: string) => void;
   /** To react when submitted form data are invalid, pass an `onError` handler. It will be passed the list of
    * encountered errors
    */
@@ -92,7 +97,7 @@ export interface FormProps<T = any, F = any> {
    * and its data are valid. It will be passed a result object having a `formData` attribute, which is the valid form
    * data you're usually after. The original event will also be passed as a second parameter
    */
-  onSubmit?: (data: IChangeEvent<T, F>, event: React.FormEvent<any>) => void;
+  onSubmit?: (data: IChangeEvent<T, S, F>, event: React.FormEvent<any>) => void;
   /** Sometimes you may want to trigger events or modify external state when a field has been touched, so you can pass
    * an `onBlur` handler, which will receive the id of the input that was blurred and the field value
    */
@@ -184,17 +189,21 @@ export interface FormProps<T = any, F = any> {
 }
 
 /** The data that is contained within the state for the `Form` */
-export interface FormState<T = any, F = any> {
+export interface FormState<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> {
   /** The JSON schema object for the form */
-  schema: RJSFSchema;
+  schema: S;
   /** The uiSchema for the form */
-  uiSchema: UiSchema<T, F>;
+  uiSchema: UiSchema<T, S, F>;
   /** The `IdSchema` for the form, computed from the `schema`, the `rootFieldId`, the `formData` and the `idPrefix` and
    * `idSeparator` props.
    */
   idSchema: IdSchema<T>;
   /** The schemaUtils implementation used by the `Form`, created from the `validator` and the `schema` */
-  schemaUtils: SchemaUtilsType<T>;
+  schemaUtils: SchemaUtilsType<T, S, F>;
   /** The current data for the form, computed from the `formData` prop and the changes made by the user */
   formData: T;
   /** Flag indicating whether the form is in edit mode, true when `formData` is passed to the form, otherwise false */
@@ -214,9 +223,12 @@ export interface FormState<T = any, F = any> {
 /** The event data passed when changes have been made to the form, includes everything from the `FormState` except
  * the schema validation errors. An additional `status` is added when returned from `onSubmit`
  */
-export interface IChangeEvent<T = any, F = any>
-  extends Omit<
-    FormState<T, F>,
+export interface IChangeEvent<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> extends Omit<
+    FormState<T, S, F>,
     "schemaValidationErrors" | "schemaValidationErrorSchema"
   > {
   /** The status of the form when submitted */
@@ -224,10 +236,11 @@ export interface IChangeEvent<T = any, F = any>
 }
 
 /** The `Form` component renders the outer form and all the fields defined in the `schema` */
-export default class Form<T = any, F = any> extends Component<
-  FormProps<T, F>,
-  FormState<T, F>
-> {
+export default class Form<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> extends Component<FormProps<T, S, F>, FormState<T, S, F>> {
   /** The ref used to hold the `form` element, this needs to be `any` because `tagName` or `_internalFormWrapper` can
    * provide any possible type here
    */
@@ -239,7 +252,7 @@ export default class Form<T = any, F = any> extends Component<
    *
    * @param props - The initial props for the `Form`
    */
-  constructor(props: FormProps<T, F>) {
+  constructor(props: FormProps<T, S, F>) {
     super(props);
 
     if (!props.validator) {
@@ -262,7 +275,7 @@ export default class Form<T = any, F = any> extends Component<
    *
    * @param nextProps - The new set of props about to be applied to the `Form`
    */
-  UNSAFE_componentWillReceiveProps(nextProps: FormProps<T, F>) {
+  UNSAFE_componentWillReceiveProps(nextProps: FormProps<T, S, F>) {
     const nextState = this.getStateFromProps(nextProps, nextProps.formData);
     if (
       !deepEquals(nextState.formData, nextProps.formData) &&
@@ -283,24 +296,24 @@ export default class Form<T = any, F = any> extends Component<
    * @returns - The new state for the `Form`
    */
   getStateFromProps(
-    props: FormProps<T, F>,
+    props: FormProps<T, S, F>,
     inputFormData?: T
-  ): FormState<T, F> {
-    const state: FormState<T, F> = this.state || {};
+  ): FormState<T, S, F> {
+    const state: FormState<T, S, F> = this.state || {};
     const schema = "schema" in props ? props.schema : this.props.schema;
-    const uiSchema: UiSchema<T, F> =
+    const uiSchema: UiSchema<T, S, F> =
       ("uiSchema" in props ? props.uiSchema! : this.props.uiSchema!) || {};
     const edit = typeof inputFormData !== "undefined";
     const liveValidate =
       "liveValidate" in props ? props.liveValidate : this.props.liveValidate;
     const mustValidate = edit && !props.noValidate && liveValidate;
     const rootSchema = schema;
-    let schemaUtils: SchemaUtilsType<T> = state.schemaUtils;
+    let schemaUtils: SchemaUtilsType<T, S> = state.schemaUtils;
     if (
       !schemaUtils ||
       schemaUtils.doesSchemaUtilsDiffer(props.validator, rootSchema)
     ) {
-      schemaUtils = createSchemaUtils<T>(props.validator, rootSchema);
+      schemaUtils = createSchemaUtils<T, S, F>(props.validator, rootSchema);
     }
     const formData: T = schemaUtils.getDefaultFormState(
       schema,
@@ -355,7 +368,7 @@ export default class Form<T = any, F = any> extends Component<
       props.idPrefix,
       props.idSeparator
     );
-    const nextState: FormState<T, F> = {
+    const nextState: FormState<T, S, F> = {
       schemaUtils,
       schema,
       uiSchema,
@@ -377,8 +390,8 @@ export default class Form<T = any, F = any> extends Component<
    * @returns - True if the component should be updated, false otherwise
    */
   shouldComponentUpdate(
-    nextProps: FormProps<T, F>,
-    nextState: FormState<T, F>
+    nextProps: FormProps<T, S, F>,
+    nextState: FormState<T, S, F>
   ): boolean {
     return shouldRender(this, nextProps, nextState);
   }
@@ -393,7 +406,7 @@ export default class Form<T = any, F = any> extends Component<
   validate(
     formData: T,
     schema = this.props.schema,
-    altSchemaUtils?: SchemaUtilsType<T>
+    altSchemaUtils?: SchemaUtilsType<T, S>
   ): ValidationData<T> {
     const schemaUtils = altSchemaUtils
       ? altSchemaUtils
@@ -411,11 +424,11 @@ export default class Form<T = any, F = any> extends Component<
   }
 
   /** Renders any errors contained in the `state` in using the `ErrorList`, if not disabled by `showErrorList`. */
-  renderErrors(registry: Registry<T, F>) {
+  renderErrors(registry: Registry<T, S, F>) {
     const { errors, errorSchema, schema, uiSchema } = this.state;
     const { showErrorList, formContext } = this.props;
-    const options = getUiOptions<T, F>(uiSchema);
-    const ErrorListTemplate = getTemplate<"ErrorListTemplate", T, F>(
+    const options = getUiOptions<T, S, F>(uiSchema);
+    const ErrorListTemplate = getTemplate<"ErrorListTemplate", T, S, F>(
       "ErrorListTemplate",
       registry,
       options
@@ -522,7 +535,7 @@ export default class Form<T = any, F = any> extends Component<
     }
 
     const mustValidate = !noValidate && liveValidate;
-    let state: Partial<FormState<T, F>> = { formData, schema };
+    let state: Partial<FormState<T, S, F>> = { formData, schema };
     let newFormData = formData;
 
     if (omitExtraData === true && liveOmit === true) {
@@ -573,7 +586,7 @@ export default class Form<T = any, F = any> extends Component<
       };
     }
     this.setState(
-      state as FormState<T, F>,
+      state as FormState<T, S, F>,
       () => onChange && onChange({ ...this.state, ...state }, id)
     );
   };
@@ -664,9 +677,13 @@ export default class Form<T = any, F = any> extends Component<
   };
 
   /** Returns the registry for the form */
-  getRegistry(): Registry<T, F> {
+  getRegistry(): Registry<T, S, F> {
     const { schemaUtils } = this.state;
-    const { fields, templates, widgets, formContext } = getDefaultRegistry();
+    const { fields, templates, widgets, formContext } = getDefaultRegistry<
+      T,
+      S,
+      F
+    >();
     return {
       fields: { ...fields, ...this.props.fields },
       templates: {
@@ -769,7 +786,7 @@ export default class Form<T = any, F = any> extends Component<
     const { SchemaField: _SchemaField } = registry.fields;
     const { SubmitButton } = registry.templates.ButtonTemplates;
     // The `semantic-ui` and `material-ui` themes have `_internalFormWrapper`s that take an `as` prop that is the
-    // PropTypes.elementType to use for the inner tag so we'll need to pass `tagName` along if it is provided.
+    // PropTypes.elementType to use for the inner tag, so we'll need to pass `tagName` along if it is provided.
     // NOTE, the `as` prop is native to `semantic-ui` and is emulated in the `material-ui` theme
     const as = _internalFormWrapper ? tagName : undefined;
     const FormTag = _internalFormWrapper || tagName || "form";

--- a/packages/core/src/components/fields/MultiSchemaField.tsx
+++ b/packages/core/src/components/fields/MultiSchemaField.tsx
@@ -6,6 +6,7 @@ import {
   deepEquals,
   FieldProps,
   RJSFSchema,
+  StrictRJSFSchema,
 } from "@rjsf/utils";
 import unset from "lodash/unset";
 
@@ -20,15 +21,16 @@ type AnyOfFieldState = {
  *
  * @param props - The `FieldProps` for this template
  */
-class AnyOfField<T = any, F = any> extends Component<
-  FieldProps<T, F>,
-  AnyOfFieldState
-> {
+class AnyOfField<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> extends Component<FieldProps<T, S, F>, AnyOfFieldState> {
   /** Constructs an `AnyOfField` with the given `props` to initialize the initially selected option in state
    *
    * @param props - The `FieldProps` for this template
    */
-  constructor(props: FieldProps<T, F>) {
+  constructor(props: FieldProps<T, S, F>) {
     super(props);
 
     const { formData, options } = this.props;
@@ -45,7 +47,7 @@ class AnyOfField<T = any, F = any> extends Component<
    * @param prevState - The previous `AnyOfFieldState` for this template
    */
   componentDidUpdate(
-    prevProps: Readonly<FieldProps<T, F>>,
+    prevProps: Readonly<FieldProps<T, S, F>>,
     prevState: Readonly<AnyOfFieldState>
   ) {
     const { formData, options, idSchema } = this.props;
@@ -76,11 +78,7 @@ class AnyOfField<T = any, F = any> extends Component<
    * @param options - The list of options to choose from
    * @return - The index of the `option` that best matches the `formData`
    */
-  getMatchingOption(
-    selectedOption: number,
-    formData: T,
-    options: RJSFSchema[]
-  ) {
+  getMatchingOption(selectedOption: number, formData: T, options: S[]) {
     const { schemaUtils } = this.props.registry;
 
     const option = schemaUtils.getMatchingOption(formData, options);
@@ -178,8 +176,8 @@ class AnyOfField<T = any, F = any> extends Component<
     const { widgets, fields } = registry;
     const { SchemaField: _SchemaField } = fields;
     const { selectedOption } = this.state;
-    const { widget = "select", ...uiOptions } = getUiOptions<T, F>(uiSchema);
-    const Widget = getWidget<T, F>({ type: "number" }, widget, widgets);
+    const { widget = "select", ...uiOptions } = getUiOptions<T, S, F>(uiSchema);
+    const Widget = getWidget<T, S, F>({ type: "number" }, widget, widgets);
 
     const option = options[selectedOption] || null;
     let optionSchema;
@@ -202,7 +200,7 @@ class AnyOfField<T = any, F = any> extends Component<
         <div className="form-group">
           <Widget
             id={this.getFieldId()}
-            schema={{ type: "number", default: 0 }}
+            schema={{ type: "number", default: 0 } as S}
             onChange={this.onOptionChange}
             onBlur={onBlur}
             onFocus={onFocus}

--- a/packages/core/src/components/fields/NullField.tsx
+++ b/packages/core/src/components/fields/NullField.tsx
@@ -1,12 +1,14 @@
 import { useEffect } from "react";
-import { FieldProps } from "@rjsf/utils";
+import { FieldProps, RJSFSchema, StrictRJSFSchema } from "@rjsf/utils";
 
 /** The `NullField` component is used to render a field in the schema is null. It also ensures that the `formData` is
  * also set to null if it has no value.
  *
  * @param props - The `FieldProps` for this template
  */
-function NullField<T = any, F = any>(props: FieldProps<T, F>) {
+function NullField<T = any, S extends StrictRJSFSchema = RJSFSchema, F = any>(
+  props: FieldProps<T, S, F>
+) {
   const { formData, onChange } = props;
   useEffect(() => {
     if (formData === undefined) {

--- a/packages/core/src/components/fields/NumberField.tsx
+++ b/packages/core/src/components/fields/NumberField.tsx
@@ -1,5 +1,10 @@
 import React, { useState, useCallback } from "react";
-import { asNumber, FieldProps } from "@rjsf/utils";
+import {
+  asNumber,
+  FieldProps,
+  RJSFSchema,
+  StrictRJSFSchema,
+} from "@rjsf/utils";
 
 // Matches a string that ends in a . character, optionally followed by a sequence of
 // digits followed by any number of 0 characters up until the end of the line.
@@ -30,7 +35,9 @@ const trailingCharMatcher = /[0.]0*$/;
  *    value cached in the state. If it matches the cached value, the cached
  *    value is passed to the input instead of the formData value
  */
-function NumberField<T = any, F = any>(props: FieldProps<T, F>) {
+function NumberField<T = any, S extends StrictRJSFSchema = RJSFSchema, F = any>(
+  props: FieldProps<T, S, F>
+) {
   const { registry, onChange, formData, value: initialValue } = props;
   const [lastValue, setLastValue] = useState(initialValue);
   const { StringField } = registry.fields;
@@ -42,7 +49,7 @@ function NumberField<T = any, F = any>(props: FieldProps<T, F>) {
    * @param value - The current value for the change occurring
    */
   const handleChange = useCallback(
-    (value: FieldProps<T, F>["value"]) => {
+    (value: FieldProps<T, S, F>["value"]) => {
       // Cache the original value in component state
       setLastValue(value);
 

--- a/packages/core/src/components/fields/ObjectField.tsx
+++ b/packages/core/src/components/fields/ObjectField.tsx
@@ -8,6 +8,7 @@ import {
   GenericObjectType,
   IdSchema,
   RJSFSchema,
+  StrictRJSFSchema,
   ADDITIONAL_PROPERTY_FLAG,
   PROPERTIES_KEY,
   REF_KEY,
@@ -31,10 +32,11 @@ type ObjectFieldState = {
  *
  * @param props - The `FieldProps` for this template
  */
-class ObjectField<T = any, F = any> extends Component<
-  FieldProps<T, F>,
-  ObjectFieldState
-> {
+class ObjectField<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> extends Component<FieldProps<T, S, F>, ObjectFieldState> {
   /** Set up the initial state */
   state = {
     wasPropertyKeyModified: false,
@@ -112,7 +114,9 @@ class ObjectField<T = any, F = any> extends Component<
    */
   getAvailableKey = (preferredKey: string, formData: T) => {
     const { uiSchema } = this.props;
-    const { duplicateKeySuffixSeparator = "-" } = getUiOptions<T, F>(uiSchema);
+    const { duplicateKeySuffixSeparator = "-" } = getUiOptions<T, S, F>(
+      uiSchema
+    );
 
     let index = 0;
     let newKey = preferredKey;
@@ -188,7 +192,7 @@ class ObjectField<T = any, F = any> extends Component<
    *
    * @param schema - The schema element to which the new property is being added
    */
-  handleAddClick = (schema: RJSFSchema) => () => {
+  handleAddClick = (schema: S) => () => {
     if (!schema.additionalProperties) {
       return;
     }
@@ -201,7 +205,7 @@ class ObjectField<T = any, F = any> extends Component<
       if (REF_KEY in schema.additionalProperties) {
         const { schemaUtils } = registry;
         const refSchema = schemaUtils.retrieveSchema(
-          { $ref: schema.additionalProperties[REF_KEY] },
+          { $ref: schema.additionalProperties[REF_KEY] } as S,
           formData
         );
         type = refSchema.type;
@@ -238,8 +242,8 @@ class ObjectField<T = any, F = any> extends Component<
 
     const { fields, formContext, schemaUtils } = registry;
     const { SchemaField } = fields;
-    const schema = schemaUtils.retrieveSchema(rawSchema, formData);
-    const uiOptions = getUiOptions<T, F>(uiSchema);
+    const schema: S = schemaUtils.retrieveSchema(rawSchema, formData);
+    const uiOptions = getUiOptions<T, S, F>(uiSchema);
     const { properties: schemaProperties = {} } = schema;
 
     const title = schema.title === undefined ? name : schema.title;
@@ -260,7 +264,7 @@ class ObjectField<T = any, F = any> extends Component<
       );
     }
 
-    const Template = getTemplate<"ObjectFieldTemplate", T, F>(
+    const Template = getTemplate<"ObjectFieldTemplate", T, S, F>(
       "ObjectFieldTemplate",
       registry,
       uiOptions
@@ -278,7 +282,7 @@ class ObjectField<T = any, F = any> extends Component<
         const fieldUiSchema = addedByAdditionalProperties
           ? uiSchema.additionalProperties
           : uiSchema[name];
-        const hidden = getUiOptions<T, F>(fieldUiSchema).widget === "hidden";
+        const hidden = getUiOptions<T, S, F>(fieldUiSchema).widget === "hidden";
         const fieldIdSchema: IdSchema<T> = get(idSchema, [name], {});
 
         return {

--- a/packages/core/src/components/fields/StringField.tsx
+++ b/packages/core/src/components/fields/StringField.tsx
@@ -5,13 +5,17 @@ import {
   optionsList,
   hasWidget,
   FieldProps,
+  RJSFSchema,
+  StrictRJSFSchema,
 } from "@rjsf/utils";
 
 /** The `StringField` component is used to render a schema field that represents a string type
  *
  * @param props - The `FieldProps` for this template
  */
-function StringField<T = any, F = any>(props: FieldProps<T, F>) {
+function StringField<T = any, S extends StrictRJSFSchema = RJSFSchema, F = any>(
+  props: FieldProps<T, S, F>
+) {
   const {
     schema,
     name,
@@ -34,15 +38,15 @@ function StringField<T = any, F = any>(props: FieldProps<T, F>) {
     ? optionsList(schema)
     : undefined;
   let defaultWidget = enumOptions ? "select" : "text";
-  if (format && hasWidget<T, F>(schema, format, widgets)) {
+  if (format && hasWidget<T, S, F>(schema, format, widgets)) {
     defaultWidget = format;
   }
   const {
     widget = defaultWidget,
     placeholder = "",
     ...options
-  } = getUiOptions<T, F>(uiSchema);
-  const Widget = getWidget<T, F>(schema, widget, widgets);
+  } = getUiOptions<T, S, F>(uiSchema);
+  const Widget = getWidget<T, S, F>(schema, widget, widgets);
   return (
     <Widget
       options={{ ...options, enumOptions }}

--- a/packages/core/src/components/fields/index.ts
+++ b/packages/core/src/components/fields/index.ts
@@ -1,4 +1,9 @@
-import { RegistryFieldsType } from "@rjsf/utils";
+import {
+  Field,
+  RegistryFieldsType,
+  RJSFSchema,
+  StrictRJSFSchema,
+} from "@rjsf/utils";
 
 import ArrayField from "./ArrayField";
 import BooleanField from "./BooleanField";
@@ -9,17 +14,23 @@ import SchemaField from "./SchemaField";
 import StringField from "./StringField";
 import NullField from "./NullField";
 
-const fields: RegistryFieldsType = {
-  AnyOfField: MultiSchemaField,
-  ArrayField,
-  // ArrayField falls back to SchemaField if ArraySchemaField is not defined, which it isn't by default
-  BooleanField,
-  NumberField,
-  ObjectField,
-  OneOfField: MultiSchemaField,
-  SchemaField,
-  StringField,
-  NullField,
-};
+function fields<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(): RegistryFieldsType<T, S, F> {
+  return {
+    AnyOfField: MultiSchemaField,
+    ArrayField: ArrayField as unknown as Field<T, S, F>,
+    // ArrayField falls back to SchemaField if ArraySchemaField is not defined, which it isn't by default
+    BooleanField,
+    NumberField,
+    ObjectField,
+    OneOfField: MultiSchemaField,
+    SchemaField,
+    StringField,
+    NullField,
+  };
+}
 
 export default fields;

--- a/packages/core/src/components/templates/ArrayFieldDescriptionTemplate.tsx
+++ b/packages/core/src/components/templates/ArrayFieldDescriptionTemplate.tsx
@@ -3,6 +3,8 @@ import {
   getTemplate,
   getUiOptions,
   ArrayFieldDescriptionProps,
+  RJSFSchema,
+  StrictRJSFSchema,
 } from "@rjsf/utils";
 
 /** The `ArrayFieldDescriptionTemplate` component renders a `DescriptionFieldTemplate` with an `id` derived from
@@ -10,11 +12,13 @@ import {
  *
  * @param props - The `ArrayFieldDescriptionProps` for the component
  */
-export default function ArrayFieldDescriptionTemplate<T = any, F = any>(
-  props: ArrayFieldDescriptionProps
-) {
+export default function ArrayFieldDescriptionTemplate<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: ArrayFieldDescriptionProps<T, S, F>) {
   const { idSchema, description, registry, schema, uiSchema } = props;
-  const options = getUiOptions<T, F>(uiSchema);
+  const options = getUiOptions<T, S, F>(uiSchema);
   const { label: displayLabel = true } = options;
   if (!description || !displayLabel) {
     return null;
@@ -22,6 +26,7 @@ export default function ArrayFieldDescriptionTemplate<T = any, F = any>(
   const DescriptionFieldTemplate = getTemplate<
     "DescriptionFieldTemplate",
     T,
+    S,
     F
   >("DescriptionFieldTemplate", registry, options);
   const id = `${idSchema.$id}__description`;

--- a/packages/core/src/components/templates/ArrayFieldItemTemplate.tsx
+++ b/packages/core/src/components/templates/ArrayFieldItemTemplate.tsx
@@ -1,13 +1,19 @@
 import React, { CSSProperties } from "react";
-import { ArrayFieldTemplateItemType } from "@rjsf/utils";
+import {
+  ArrayFieldTemplateItemType,
+  RJSFSchema,
+  StrictRJSFSchema,
+} from "@rjsf/utils";
 
 /** The `ArrayFieldItemTemplate` component is the template used to render an items of an array.
  *
  * @param props - The `ArrayFieldTemplateItemType` props for the component
  */
-export default function ArrayFieldItemTemplate<T = any, F = any>(
-  props: ArrayFieldTemplateItemType<T, F>
-) {
+export default function ArrayFieldItemTemplate<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: ArrayFieldTemplateItemType<T, S, F>) {
   const {
     children,
     className,

--- a/packages/core/src/components/templates/ArrayFieldTemplate.tsx
+++ b/packages/core/src/components/templates/ArrayFieldTemplate.tsx
@@ -4,15 +4,19 @@ import {
   getUiOptions,
   ArrayFieldTemplateProps,
   ArrayFieldTemplateItemType,
+  RJSFSchema,
+  StrictRJSFSchema,
 } from "@rjsf/utils";
 
 /** The `ArrayFieldTemplate` component is the template used to render all items in an array.
  *
  * @param props - The `ArrayFieldTemplateItemType` props for the component
  */
-export default function ArrayFieldTemplate<T = any, F = any>(
-  props: ArrayFieldTemplateProps<T, F>
-) {
+export default function ArrayFieldTemplate<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: ArrayFieldTemplateProps<T, S, F>) {
   const {
     canAdd,
     className,
@@ -27,22 +31,24 @@ export default function ArrayFieldTemplate<T = any, F = any>(
     schema,
     title,
   } = props;
-  const uiOptions = getUiOptions<T, F>(uiSchema);
+  const uiOptions = getUiOptions<T, S, F>(uiSchema);
   const ArrayFieldDescriptionTemplate = getTemplate<
     "ArrayFieldDescriptionTemplate",
     T,
+    S,
     F
   >("ArrayFieldDescriptionTemplate", registry, uiOptions);
-  const ArrayFieldItemTemplate = getTemplate<"ArrayFieldItemTemplate", T, F>(
+  const ArrayFieldItemTemplate = getTemplate<"ArrayFieldItemTemplate", T, S, F>(
     "ArrayFieldItemTemplate",
     registry,
     uiOptions
   );
-  const ArrayFieldTitleTemplate = getTemplate<"ArrayFieldTitleTemplate", T, F>(
+  const ArrayFieldTitleTemplate = getTemplate<
     "ArrayFieldTitleTemplate",
-    registry,
-    uiOptions
-  );
+    T,
+    S,
+    F
+  >("ArrayFieldTitleTemplate", registry, uiOptions);
   // Button templates are not overridden in the uiSchema
   const {
     ButtonTemplates: { AddButton },
@@ -66,9 +72,11 @@ export default function ArrayFieldTemplate<T = any, F = any>(
       />
       <div className="row array-item-list">
         {items &&
-          items.map(({ key, ...itemProps }: ArrayFieldTemplateItemType) => (
-            <ArrayFieldItemTemplate key={key} {...itemProps} />
-          ))}
+          items.map(
+            ({ key, ...itemProps }: ArrayFieldTemplateItemType<T, S, F>) => (
+              <ArrayFieldItemTemplate key={key} {...itemProps} />
+            )
+          )}
       </div>
       {canAdd && (
         <AddButton

--- a/packages/core/src/components/templates/ArrayFieldTitleTemplate.tsx
+++ b/packages/core/src/components/templates/ArrayFieldTitleTemplate.tsx
@@ -4,6 +4,8 @@ import {
   getUiOptions,
   ArrayFieldTitleProps,
   TemplatesType,
+  RJSFSchema,
+  StrictRJSFSchema,
 } from "@rjsf/utils";
 
 /** The `ArrayFieldTitleTemplate` component renders a `TitleFieldTemplate` with an `id` derived from
@@ -11,17 +13,19 @@ import {
  *
  * @param props - The `ArrayFieldTitleProps` for the component
  */
-export default function ArrayFieldTitleTemplate<T = any, F = any>(
-  props: ArrayFieldTitleProps
-) {
+export default function ArrayFieldTitleTemplate<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: ArrayFieldTitleProps<T, S, F>) {
   const { idSchema, title, schema, uiSchema, required, registry } = props;
-  const options = getUiOptions<T, F>(uiSchema);
+  const options = getUiOptions<T, S, F>(uiSchema);
   const { label: displayLabel = true } = options;
   if (!title || !displayLabel) {
     return null;
   }
-  const TitleFieldTemplate: TemplatesType<T, F>["TitleFieldTemplate"] =
-    getTemplate<"TitleFieldTemplate", T, F>(
+  const TitleFieldTemplate: TemplatesType<T, S, F>["TitleFieldTemplate"] =
+    getTemplate<"TitleFieldTemplate", T, S, F>(
       "TitleFieldTemplate",
       registry,
       options

--- a/packages/core/src/components/templates/BaseInputTemplate.tsx
+++ b/packages/core/src/components/templates/BaseInputTemplate.tsx
@@ -1,5 +1,10 @@
 import React, { useCallback } from "react";
-import { getInputProps, WidgetProps } from "@rjsf/utils";
+import {
+  getInputProps,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps,
+} from "@rjsf/utils";
 
 /** The `BaseInputTemplate` is the template to use to render the basic `<input>` component for the `core` theme.
  * It is used as the template for rendering many of the <input> based widgets that differ by `type` and callbacks only.
@@ -7,9 +12,11 @@ import { getInputProps, WidgetProps } from "@rjsf/utils";
  *
  * @param props - The `WidgetProps` for this template
  */
-export default function BaseInputTemplate<T = any, F = any>(
-  props: WidgetProps<T, F>
-) {
+export default function BaseInputTemplate<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: WidgetProps<T, S, F>) {
   const {
     id,
     value,
@@ -35,7 +42,10 @@ export default function BaseInputTemplate<T = any, F = any>(
     console.log("No id for", props);
     throw new Error(`no id for props ${JSON.stringify(props)}`);
   }
-  const inputProps = { ...rest, ...getInputProps<T, F>(schema, type, options) };
+  const inputProps = {
+    ...rest,
+    ...getInputProps<T, S, F>(schema, type, options),
+  };
 
   let inputValue;
   if (inputProps.type === "number" || inputProps.type === "integer") {

--- a/packages/core/src/components/templates/ButtonTemplates/AddButton.tsx
+++ b/packages/core/src/components/templates/ButtonTemplates/AddButton.tsx
@@ -1,15 +1,15 @@
 import React from "react";
-import { IconButtonProps } from "@rjsf/utils";
+import { IconButtonProps, RJSFSchema, StrictRJSFSchema } from "@rjsf/utils";
 
 import IconButton from "./IconButton";
 
 /** The `AddButton` renders a button that represent the `Add` action on a form
  */
-export default function AddButton({
-  className,
-  onClick,
-  disabled,
-}: IconButtonProps) {
+export default function AddButton<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>({ className, onClick, disabled }: IconButtonProps<T, S, F>) {
   return (
     <div className="row">
       <p className={`col-xs-3 col-xs-offset-9 text-right ${className}`}>

--- a/packages/core/src/components/templates/ButtonTemplates/IconButton.tsx
+++ b/packages/core/src/components/templates/ButtonTemplates/IconButton.tsx
@@ -1,7 +1,11 @@
 import React from "react";
-import { IconButtonProps } from "@rjsf/utils";
+import { IconButtonProps, RJSFSchema, StrictRJSFSchema } from "@rjsf/utils";
 
-export default function IconButton(props: IconButtonProps) {
+export default function IconButton<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: IconButtonProps<T, S, F>) {
   const {
     iconType = "default",
     icon,
@@ -20,7 +24,11 @@ export default function IconButton(props: IconButtonProps) {
   );
 }
 
-export function MoveDownButton(props: IconButtonProps) {
+export function MoveDownButton<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: IconButtonProps<T, S, F>) {
   return (
     <IconButton
       title="Move down"
@@ -31,7 +39,11 @@ export function MoveDownButton(props: IconButtonProps) {
   );
 }
 
-export function MoveUpButton(props: IconButtonProps) {
+export function MoveUpButton<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: IconButtonProps<T, S, F>) {
   return (
     <IconButton
       title="Move up"
@@ -42,7 +54,11 @@ export function MoveUpButton(props: IconButtonProps) {
   );
 }
 
-export function RemoveButton(props: IconButtonProps) {
+export function RemoveButton<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: IconButtonProps<T, S, F>) {
   return (
     <IconButton
       title="Remove"

--- a/packages/core/src/components/templates/ButtonTemplates/SubmitButton.tsx
+++ b/packages/core/src/components/templates/ButtonTemplates/SubmitButton.tsx
@@ -1,11 +1,18 @@
 import React from "react";
-import { getSubmitButtonOptions, SubmitButtonProps } from "@rjsf/utils";
+import {
+  getSubmitButtonOptions,
+  RJSFSchema,
+  StrictRJSFSchema,
+  SubmitButtonProps,
+} from "@rjsf/utils";
 
 /** The `SubmitButton` renders a button that represent the `Submit` action on a form
  */
-export default function SubmitButton<T, F>({
-  uiSchema,
-}: SubmitButtonProps<T, F>) {
+export default function SubmitButton<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>({ uiSchema }: SubmitButtonProps<T, S, F>) {
   const {
     submitText,
     norender,

--- a/packages/core/src/components/templates/ButtonTemplates/index.ts
+++ b/packages/core/src/components/templates/ButtonTemplates/index.ts
@@ -1,15 +1,21 @@
-import { TemplatesType } from "@rjsf/utils";
+import { RJSFSchema, StrictRJSFSchema, TemplatesType } from "@rjsf/utils";
 
 import SubmitButton from "./SubmitButton";
 import AddButton from "./AddButton";
 import { RemoveButton, MoveDownButton, MoveUpButton } from "./IconButton";
 
-const buttonTemplates: TemplatesType["ButtonTemplates"] = {
-  SubmitButton,
-  AddButton,
-  MoveDownButton,
-  MoveUpButton,
-  RemoveButton,
-};
+function buttonTemplates<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(): TemplatesType<T, S, F>["ButtonTemplates"] {
+  return {
+    SubmitButton,
+    AddButton,
+    MoveDownButton,
+    MoveUpButton,
+    RemoveButton,
+  };
+}
 
 export default buttonTemplates;

--- a/packages/core/src/components/templates/DescriptionField.tsx
+++ b/packages/core/src/components/templates/DescriptionField.tsx
@@ -1,13 +1,19 @@
 import React from "react";
-import { DescriptionFieldProps } from "@rjsf/utils";
+import {
+  DescriptionFieldProps,
+  RJSFSchema,
+  StrictRJSFSchema,
+} from "@rjsf/utils";
 
 /** The `DescriptionField` is the template to use to render the description of a field
  *
  * @param props - The `DescriptionFieldProps` for this component
  */
-export default function DescriptionField<T = any, F = any>(
-  props: DescriptionFieldProps<T, F>
-) {
+export default function DescriptionField<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: DescriptionFieldProps<T, S, F>) {
   const { id, description } = props;
   if (!description) {
     return null;

--- a/packages/core/src/components/templates/ErrorList.tsx
+++ b/packages/core/src/components/templates/ErrorList.tsx
@@ -1,11 +1,20 @@
 import React from "react";
-import { ErrorListProps, RJSFValidationError } from "@rjsf/utils";
+import {
+  ErrorListProps,
+  RJSFValidationError,
+  RJSFSchema,
+  StrictRJSFSchema,
+} from "@rjsf/utils";
 
 /** The `ErrorList` component is the template that renders the all the errors associated with the fields in the `Form`
  *
  * @param props - The `ErrorListProps` for this component
  */
-export default function ErrorList<T = any>({ errors }: ErrorListProps<T>) {
+export default function ErrorList<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>({ errors }: ErrorListProps<T, S, F>) {
   return (
     <div className="panel panel-danger errors">
       <div className="panel-heading">

--- a/packages/core/src/components/templates/FieldErrorTemplate.tsx
+++ b/packages/core/src/components/templates/FieldErrorTemplate.tsx
@@ -1,13 +1,15 @@
 import React from "react";
-import { FieldErrorProps } from "@rjsf/utils";
+import { FieldErrorProps, RJSFSchema, StrictRJSFSchema } from "@rjsf/utils";
 
 /** The `FieldErrorTemplate` component renders the errors local to the particular field
  *
  * @param props - The `FieldErrorProps` for the errors being rendered
  */
-export default function FieldErrorTemplate<T = any, F = any>(
-  props: FieldErrorProps<T, F>
-) {
+export default function FieldErrorTemplate<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: FieldErrorProps<T, S, F>) {
   const { errors = [], idSchema } = props;
   if (errors.length === 0) {
     return null;

--- a/packages/core/src/components/templates/FieldHelpTemplate.tsx
+++ b/packages/core/src/components/templates/FieldHelpTemplate.tsx
@@ -1,13 +1,15 @@
 import React from "react";
-import { FieldHelpProps } from "@rjsf/utils";
+import { FieldHelpProps, RJSFSchema, StrictRJSFSchema } from "@rjsf/utils";
 
 /** The `FieldHelpTemplate` component renders any help desired for a field
  *
  * @param props - The `FieldHelpProps` to be rendered
  */
-export default function FieldHelpTemplate<T = any, F = any>(
-  props: FieldHelpProps<T, F>
-) {
+export default function FieldHelpTemplate<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: FieldHelpProps<T, S, F>) {
   const { idSchema, help } = props;
   if (!help) {
     return null;

--- a/packages/core/src/components/templates/FieldTemplate/FieldTemplate.tsx
+++ b/packages/core/src/components/templates/FieldTemplate/FieldTemplate.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { FieldTemplateProps, getTemplate, getUiOptions } from "@rjsf/utils";
+import {
+  FieldTemplateProps,
+  RJSFSchema,
+  StrictRJSFSchema,
+  getTemplate,
+  getUiOptions,
+} from "@rjsf/utils";
 
 import Label from "./Label";
 
@@ -8,9 +14,11 @@ import Label from "./Label";
  *
  * @param props - The `FieldTemplateProps` for this component
  */
-export default function FieldTemplate<T = any, F = any>(
-  props: FieldTemplateProps<T, F>
-) {
+export default function FieldTemplate<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: FieldTemplateProps<T, S, F>) {
   const {
     id,
     label,
@@ -25,11 +33,12 @@ export default function FieldTemplate<T = any, F = any>(
     uiSchema,
   } = props;
   const uiOptions = getUiOptions(uiSchema);
-  const WrapIfAdditionalTemplate = getTemplate<"WrapIfAdditionalTemplate">(
+  const WrapIfAdditionalTemplate = getTemplate<
     "WrapIfAdditionalTemplate",
-    registry,
-    uiOptions
-  );
+    T,
+    S,
+    F
+  >("WrapIfAdditionalTemplate", registry, uiOptions);
   if (hidden) {
     return <div className="hidden">{children}</div>;
   }

--- a/packages/core/src/components/templates/ObjectFieldTemplate.tsx
+++ b/packages/core/src/components/templates/ObjectFieldTemplate.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import {
   ObjectFieldTemplatePropertyType,
   ObjectFieldTemplateProps,
+  RJSFSchema,
+  StrictRJSFSchema,
   canExpand,
   getTemplate,
   getUiOptions,
@@ -13,9 +15,11 @@ import {
  *
  * @param props - The `ObjectFieldTemplateProps` for this component
  */
-export default function ObjectFieldTemplate<T = any, F = any>(
-  props: ObjectFieldTemplateProps<T, F>
-) {
+export default function ObjectFieldTemplate<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: ObjectFieldTemplateProps<T, S, F>) {
   const {
     description,
     disabled,
@@ -30,8 +34,8 @@ export default function ObjectFieldTemplate<T = any, F = any>(
     title,
     uiSchema,
   } = props;
-  const options = getUiOptions<T, F>(uiSchema);
-  const TitleFieldTemplate = getTemplate<"TitleFieldTemplate", T, F>(
+  const options = getUiOptions<T, S, F>(uiSchema);
+  const TitleFieldTemplate = getTemplate<"TitleFieldTemplate", T, S, F>(
     "TitleFieldTemplate",
     registry,
     options
@@ -39,6 +43,7 @@ export default function ObjectFieldTemplate<T = any, F = any>(
   const DescriptionFieldTemplate = getTemplate<
     "DescriptionFieldTemplate",
     T,
+    S,
     F
   >("DescriptionFieldTemplate", registry, options);
   // Button templates are not overridden in the uiSchema

--- a/packages/core/src/components/templates/TitleField.tsx
+++ b/packages/core/src/components/templates/TitleField.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TitleFieldProps } from "@rjsf/utils";
+import { TitleFieldProps, RJSFSchema, StrictRJSFSchema } from "@rjsf/utils";
 
 const REQUIRED_FIELD_SYMBOL = "*";
 
@@ -7,9 +7,11 @@ const REQUIRED_FIELD_SYMBOL = "*";
  *
  * @param props - The `TitleFieldProps` for this component
  */
-export default function TitleField<T = any, F = any>(
-  props: TitleFieldProps<T, F>
-) {
+export default function TitleField<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: TitleFieldProps<T, S, F>) {
   const { id, title, required } = props;
   return (
     <legend id={id}>

--- a/packages/core/src/components/templates/UnsupportedField.tsx
+++ b/packages/core/src/components/templates/UnsupportedField.tsx
@@ -1,14 +1,20 @@
 import React from "react";
-import { UnsupportedFieldProps } from "@rjsf/utils";
+import {
+  UnsupportedFieldProps,
+  RJSFSchema,
+  StrictRJSFSchema,
+} from "@rjsf/utils";
 
 /** The `UnsupportedField` component is used to render a field in the schema is one that is not supported by
  * react-jsonschema-form.
  *
  * @param props - The `FieldProps` for this template
  */
-function UnsupportedField<T = any, F = any>(
-  props: UnsupportedFieldProps<T, F>
-) {
+function UnsupportedField<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: UnsupportedFieldProps<T, S, F>) {
   const { schema, idSchema, reason } = props;
   return (
     <div className="unsupported-field">

--- a/packages/core/src/components/templates/WrapIfAdditionalTemplate.tsx
+++ b/packages/core/src/components/templates/WrapIfAdditionalTemplate.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import {
   ADDITIONAL_PROPERTY_FLAG,
+  RJSFSchema,
+  StrictRJSFSchema,
   WrapIfAdditionalTemplateProps,
 } from "@rjsf/utils";
 
@@ -11,9 +13,11 @@ import Label from "./FieldTemplate/Label";
  *
  * @param props - The `WrapIfAdditionalProps` for this component
  */
-export default function WrapIfAdditionalTemplate<T = any, F = any>(
-  props: WrapIfAdditionalTemplateProps<T, F>
-) {
+export default function WrapIfAdditionalTemplate<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: WrapIfAdditionalTemplateProps<T, S, F>) {
   const {
     id,
     classNames,

--- a/packages/core/src/components/templates/index.ts
+++ b/packages/core/src/components/templates/index.ts
@@ -1,4 +1,4 @@
-import { TemplatesType } from "@rjsf/utils";
+import { RJSFSchema, StrictRJSFSchema, TemplatesType } from "@rjsf/utils";
 
 import ArrayFieldDescriptionTemplate from "./ArrayFieldDescriptionTemplate";
 import ArrayFieldItemTemplate from "./ArrayFieldItemTemplate";
@@ -16,22 +16,28 @@ import TitleField from "./TitleField";
 import UnsupportedField from "./UnsupportedField";
 import WrapIfAdditionalTemplate from "./WrapIfAdditionalTemplate";
 
-const templates: TemplatesType = {
-  ArrayFieldDescriptionTemplate,
-  ArrayFieldItemTemplate,
-  ArrayFieldTemplate,
-  ArrayFieldTitleTemplate,
-  ButtonTemplates,
-  BaseInputTemplate,
-  DescriptionFieldTemplate: DescriptionField,
-  ErrorListTemplate: ErrorList,
-  FieldTemplate,
-  FieldErrorTemplate,
-  FieldHelpTemplate,
-  ObjectFieldTemplate,
-  TitleFieldTemplate: TitleField,
-  UnsupportedFieldTemplate: UnsupportedField,
-  WrapIfAdditionalTemplate,
-};
+function templates<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(): TemplatesType<T, S, F> {
+  return {
+    ArrayFieldDescriptionTemplate,
+    ArrayFieldItemTemplate,
+    ArrayFieldTemplate,
+    ArrayFieldTitleTemplate,
+    ButtonTemplates: ButtonTemplates<T, S, F>(),
+    BaseInputTemplate,
+    DescriptionFieldTemplate: DescriptionField,
+    ErrorListTemplate: ErrorList,
+    FieldTemplate,
+    FieldErrorTemplate,
+    FieldHelpTemplate,
+    ObjectFieldTemplate,
+    TitleFieldTemplate: TitleField,
+    UnsupportedFieldTemplate: UnsupportedField,
+    WrapIfAdditionalTemplate,
+  };
+}
 
 export default templates;

--- a/packages/core/src/components/widgets/AltDateTimeWidget.tsx
+++ b/packages/core/src/components/widgets/AltDateTimeWidget.tsx
@@ -1,4 +1,4 @@
-import { WidgetProps } from "@rjsf/utils";
+import { RJSFSchema, StrictRJSFSchema, WidgetProps } from "@rjsf/utils";
 import React from "react";
 
 /** The `AltDateTimeWidget` is an alternative widget for rendering datetime properties.
@@ -6,10 +6,11 @@ import React from "react";
  *
  * @param props - The `WidgetProps` for this component
  */
-function AltDateTimeWidget<T = any, F = any>({
-  time = true,
-  ...props
-}: WidgetProps<T, F>) {
+function AltDateTimeWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>({ time = true, ...props }: WidgetProps<T, S, F>) {
   const { AltDateWidget } = props.registry.widgets;
   return <AltDateWidget time={time} {...props} />;
 }

--- a/packages/core/src/components/widgets/AltDateWidget.tsx
+++ b/packages/core/src/components/widgets/AltDateWidget.tsx
@@ -4,8 +4,10 @@ import {
   parseDateString,
   toDateString,
   pad,
-  WidgetProps,
   DateObject,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps,
 } from "@rjsf/utils";
 
 function rangeOptions(start: number, stop: number) {
@@ -45,8 +47,12 @@ function dateElementProps(
   return data;
 }
 
-type DateElementProps<T, F> = Pick<
-  WidgetProps<T, F>,
+type DateElementProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = Pick<
+  WidgetProps<T, S, F>,
   | "value"
   | "disabled"
   | "readonly"
@@ -61,7 +67,11 @@ type DateElementProps<T, F> = Pick<
   range: [number, number];
 };
 
-function DateElement<T, F>({
+function DateElement<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>({
   type,
   range,
   value,
@@ -73,12 +83,12 @@ function DateElement<T, F>({
   registry,
   onBlur,
   onFocus,
-}: DateElementProps<T, F>) {
+}: DateElementProps<T, S, F>) {
   const id = rootId + "_" + type;
   const { SelectWidget } = registry.widgets;
   return (
     <SelectWidget
-      schema={{ type: "integer" }}
+      schema={{ type: "integer" } as S}
       id={id}
       className="form-control"
       options={{ enumOptions: rangeOptions(range[0], range[1]) }}
@@ -99,7 +109,11 @@ function DateElement<T, F>({
 /** The `AltDateWidget` is an alternative widget for rendering date properties.
  * @param props - The `WidgetProps` for this component
  */
-function AltDateWidget<T = any, F = any>({
+function AltDateWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>({
   time = false,
   disabled = false,
   readonly = false,
@@ -111,7 +125,7 @@ function AltDateWidget<T = any, F = any>({
   onFocus,
   onChange,
   value,
-}: WidgetProps<T, F>) {
+}: WidgetProps<T, S, F>) {
   const [state, setState] = useReducer(
     (state: DateObject, action: Partial<DateObject>) => {
       return { ...state, ...action };

--- a/packages/core/src/components/widgets/CheckboxWidget.tsx
+++ b/packages/core/src/components/widgets/CheckboxWidget.tsx
@@ -1,12 +1,22 @@
 import React, { useCallback } from "react";
-import { getTemplate, schemaRequiresTrueValue, WidgetProps } from "@rjsf/utils";
+import {
+  getTemplate,
+  schemaRequiresTrueValue,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps,
+} from "@rjsf/utils";
 
 /** The `CheckBoxWidget` is a widget for rendering boolean properties.
  *  It is typically used to represent a boolean.
  *
  * @param props - The `WidgetProps` for this component
  */
-function CheckboxWidget<T = any, F = any>({
+function CheckboxWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>({
   schema,
   uiSchema,
   options,
@@ -20,10 +30,11 @@ function CheckboxWidget<T = any, F = any>({
   onFocus,
   onChange,
   registry,
-}: WidgetProps<T, F>) {
+}: WidgetProps<T, S, F>) {
   const DescriptionFieldTemplate = getTemplate<
     "DescriptionFieldTemplate",
     T,
+    S,
     F
   >("DescriptionFieldTemplate", registry, options);
   // Because an unchecked checkbox will cause html5 validation to fail, only add

--- a/packages/core/src/components/widgets/CheckboxesWidget.tsx
+++ b/packages/core/src/components/widgets/CheckboxesWidget.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent } from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { WidgetProps, RJSFSchema, StrictRJSFSchema } from "@rjsf/utils";
 
 function selectValue(value: any, selected: any[], all: any[]) {
   const at = all.indexOf(value);
@@ -18,7 +18,11 @@ function deselectValue(value: any, selected: any[]) {
  *
  * @param props - The `WidgetProps` for this component
  */
-function CheckboxesWidget<T = any, F = any>({
+function CheckboxesWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>({
   id,
   disabled,
   options: { inline = false, enumOptions, enumDisabled },
@@ -26,7 +30,7 @@ function CheckboxesWidget<T = any, F = any>({
   autofocus = false,
   readonly,
   onChange,
-}: WidgetProps<T, F>) {
+}: WidgetProps<T, S, F>) {
   return (
     <div className="checkboxes" id={id}>
       {Array.isArray(enumOptions) &&

--- a/packages/core/src/components/widgets/ColorWidget.tsx
+++ b/packages/core/src/components/widgets/ColorWidget.tsx
@@ -1,16 +1,23 @@
 import React from "react";
-import { getTemplate, WidgetProps } from "@rjsf/utils";
+import {
+  getTemplate,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps,
+} from "@rjsf/utils";
 
 /** The `ColorWidget` component uses the `BaseInputTemplate` changing the type to `color` and disables it when it is
  * either disabled or readonly.
  *
  * @param props - The `WidgetProps` for this component
  */
-export default function ColorWidget<T = any, F = any>(
-  props: WidgetProps<T, F>
-) {
+export default function ColorWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: WidgetProps<T, S, F>) {
   const { disabled, readonly, options, registry } = props;
-  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, F>(
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, S, F>(
     "BaseInputTemplate",
     registry,
     options

--- a/packages/core/src/components/widgets/DateTimeWidget.tsx
+++ b/packages/core/src/components/widgets/DateTimeWidget.tsx
@@ -1,16 +1,25 @@
 import React from "react";
-import { getTemplate, localToUTC, utcToLocal, WidgetProps } from "@rjsf/utils";
+import {
+  getTemplate,
+  localToUTC,
+  utcToLocal,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps,
+} from "@rjsf/utils";
 
 /** The `DateTimeWidget` component uses the `BaseInputTemplate` changing the type to `datetime-local` and transforms
  * the value to/from utc using the appropriate utility functions.
  *
  * @param props - The `WidgetProps` for this component
  */
-export default function DateTimeWidget<T = any, F = any>(
-  props: WidgetProps<T, F>
-) {
+export default function DateTimeWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: WidgetProps<T, S, F>) {
   const { onChange, value, options, registry } = props;
-  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, F>(
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, S, F>(
     "BaseInputTemplate",
     registry,
     options

--- a/packages/core/src/components/widgets/DateWidget.tsx
+++ b/packages/core/src/components/widgets/DateWidget.tsx
@@ -1,14 +1,23 @@
 import React, { useCallback } from "react";
-import { getTemplate, WidgetProps } from "@rjsf/utils";
+import {
+  getTemplate,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps,
+} from "@rjsf/utils";
 
 /** The `DateWidget` component uses the `BaseInputTemplate` changing the type to `date` and transforms
  * the value to undefined when it is falsy during the `onChange` handling.
  *
  * @param props - The `WidgetProps` for this component
  */
-export default function DateWidget<T = any, F = any>(props: WidgetProps<T, F>) {
+export default function DateWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: WidgetProps<T, S, F>) {
   const { onChange, options, registry } = props;
-  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, F>(
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, S, F>(
     "BaseInputTemplate",
     registry,
     options

--- a/packages/core/src/components/widgets/EmailWidget.tsx
+++ b/packages/core/src/components/widgets/EmailWidget.tsx
@@ -1,15 +1,22 @@
 import React from "react";
-import { getTemplate, WidgetProps } from "@rjsf/utils";
+import {
+  getTemplate,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps,
+} from "@rjsf/utils";
 
 /** The `EmailWidget` component uses the `BaseInputTemplate` changing the type to `email`.
  *
  * @param props - The `WidgetProps` for this component
  */
-export default function EmailWidget<T = any, F = any>(
-  props: WidgetProps<T, F>
-) {
+export default function EmailWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: WidgetProps<T, S, F>) {
   const { options, registry } = props;
-  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, F>(
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, S, F>(
     "BaseInputTemplate",
     registry,
     options

--- a/packages/core/src/components/widgets/FileWidget.tsx
+++ b/packages/core/src/components/widgets/FileWidget.tsx
@@ -1,6 +1,11 @@
 import React, { ChangeEvent, useCallback, useMemo, useState } from "react";
 
-import { dataURItoBlob, WidgetProps } from "@rjsf/utils";
+import {
+  dataURItoBlob,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps,
+} from "@rjsf/utils";
 
 function addNameToDataURL(dataURL: string, name: string) {
   if (dataURL === null) {
@@ -85,7 +90,7 @@ function extractFileInfo(dataURLs: string[]) {
  *  The `FileWidget` is a widget for rendering file upload fields.
  *  It is typically used with a string property with data-url format.
  */
-function FileWidget<T, F>({
+function FileWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F = any>({
   multiple,
   id,
   readonly,
@@ -94,7 +99,7 @@ function FileWidget<T, F>({
   value,
   autofocus = false,
   options,
-}: WidgetProps<T, F>) {
+}: WidgetProps<T, S, F>) {
   const extractedFilesInfo = useMemo(
     () =>
       Array.isArray(value) ? extractFileInfo(value) : extractFileInfo([value]),

--- a/packages/core/src/components/widgets/HiddenWidget.tsx
+++ b/packages/core/src/components/widgets/HiddenWidget.tsx
@@ -1,12 +1,16 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { RJSFSchema, StrictRJSFSchema, WidgetProps } from "@rjsf/utils";
 
 /** The `HiddenWidget` is a widget for rendering a hidden input field.
  *  It is typically used by setting type to "hidden".
  *
  * @param props - The `WidgetProps` for this component
  */
-function HiddenWidget<T = any, F = any>({ id, value }: WidgetProps<T, F>) {
+function HiddenWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>({ id, value }: WidgetProps<T, S, F>) {
   return (
     <input
       type="hidden"

--- a/packages/core/src/components/widgets/PasswordWidget.tsx
+++ b/packages/core/src/components/widgets/PasswordWidget.tsx
@@ -1,15 +1,22 @@
 import React from "react";
-import { getTemplate, WidgetProps } from "@rjsf/utils";
+import {
+  getTemplate,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps,
+} from "@rjsf/utils";
 
 /** The `PasswordWidget` component uses the `BaseInputTemplate` changing the type to `password`.
  *
  * @param props - The `WidgetProps` for this component
  */
-export default function PasswordWidget<T = any, F = any>(
-  props: WidgetProps<T, F>
-) {
+export default function PasswordWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: WidgetProps<T, S, F>) {
   const { options, registry } = props;
-  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, F>(
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, S, F>(
     "BaseInputTemplate",
     registry,
     options

--- a/packages/core/src/components/widgets/RadioWidget.tsx
+++ b/packages/core/src/components/widgets/RadioWidget.tsx
@@ -1,12 +1,16 @@
 import React, { FocusEvent, useCallback } from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { RJSFSchema, StrictRJSFSchema, WidgetProps } from "@rjsf/utils";
 
 /** The `RadioWidget` is a widget for rendering a radio group.
  *  It is typically used with a string property constrained with enum options.
  *
  * @param props - The `WidgetProps` for this component
  */
-function RadioWidget<T = any, F = any>({
+function RadioWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>({
   options,
   value,
   required,
@@ -17,7 +21,7 @@ function RadioWidget<T = any, F = any>({
   onFocus,
   onChange,
   id,
-}: WidgetProps<T, F>) {
+}: WidgetProps<T, S, F>) {
   // Generating a unique field name to identify this set of radio buttons
   const name = Math.random().toString();
   const { enumOptions, enumDisabled, inline } = options;

--- a/packages/core/src/components/widgets/RangeWidget.tsx
+++ b/packages/core/src/components/widgets/RangeWidget.tsx
@@ -1,14 +1,16 @@
 import React from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { RJSFSchema, StrictRJSFSchema, WidgetProps } from "@rjsf/utils";
 
 /** The `RangeWidget` component uses the `BaseInputTemplate` changing the type to `range` and wrapping the result
  * in a div, with the value along side it.
  *
  * @param props - The `WidgetProps` for this component
  */
-export default function RangeWidget<T = any, F = any>(
-  props: WidgetProps<T, F>
-) {
+export default function RangeWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: WidgetProps<T, S, F>) {
   const {
     value,
     registry: {

--- a/packages/core/src/components/widgets/SelectWidget.tsx
+++ b/packages/core/src/components/widgets/SelectWidget.tsx
@@ -1,5 +1,10 @@
 import React, { ChangeEvent, FocusEvent, useCallback } from "react";
-import { processSelectValue, WidgetProps } from "@rjsf/utils";
+import {
+  processSelectValue,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps,
+} from "@rjsf/utils";
 
 function getValue(
   event: React.SyntheticEvent<HTMLSelectElement>,
@@ -19,7 +24,11 @@ function getValue(
  *
  * @param props - The `WidgetProps` for this component
  */
-function SelectWidget<T = any, F = any>({
+function SelectWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>({
   schema,
   id,
   options,
@@ -33,7 +42,7 @@ function SelectWidget<T = any, F = any>({
   onBlur,
   onFocus,
   placeholder,
-}: WidgetProps<T, F>) {
+}: WidgetProps<T, S, F>) {
   const { enumOptions, enumDisabled } = options;
   const emptyValue = multiple ? [] : "";
 

--- a/packages/core/src/components/widgets/TextWidget.tsx
+++ b/packages/core/src/components/widgets/TextWidget.tsx
@@ -1,13 +1,22 @@
 import React from "react";
-import { getTemplate, WidgetProps } from "@rjsf/utils";
+import {
+  getTemplate,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps,
+} from "@rjsf/utils";
 
 /** The `TextWidget` component uses the `BaseInputTemplate`.
  *
  * @param props - The `WidgetProps` for this component
  */
-export default function TextWidget<T = any, F = any>(props: WidgetProps<T, F>) {
+export default function TextWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: WidgetProps<T, S, F>) {
   const { options, registry } = props;
-  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, F>(
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, S, F>(
     "BaseInputTemplate",
     registry,
     options

--- a/packages/core/src/components/widgets/TextareaWidget.tsx
+++ b/packages/core/src/components/widgets/TextareaWidget.tsx
@@ -1,11 +1,15 @@
 import React, { FocusEvent, useCallback } from "react";
-import { WidgetProps } from "@rjsf/utils";
+import { RJSFSchema, StrictRJSFSchema, WidgetProps } from "@rjsf/utils";
 
 /** The `TextareaWidget` is a widget for rendering input fields as textarea.
  *
  * @param props - The `WidgetProps` for this component
  */
-function TextareaWidget<T = any, F = any>({
+function TextareaWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>({
   id,
   options = {},
   placeholder,
@@ -17,7 +21,7 @@ function TextareaWidget<T = any, F = any>({
   onChange,
   onBlur,
   onFocus,
-}: WidgetProps<T, F>) {
+}: WidgetProps<T, S, F>) {
   const handleChange = useCallback(
     ({ target: { value } }: React.ChangeEvent<HTMLTextAreaElement>) =>
       onChange(value === "" ? options.emptyValue : value),

--- a/packages/core/src/components/widgets/URLWidget.tsx
+++ b/packages/core/src/components/widgets/URLWidget.tsx
@@ -1,13 +1,22 @@
 import React from "react";
-import { getTemplate, WidgetProps } from "@rjsf/utils";
+import {
+  getTemplate,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps,
+} from "@rjsf/utils";
 
 /** The `URLWidget` component uses the `BaseInputTemplate` changing the type to `url`.
  *
  * @param props - The `WidgetProps` for this component
  */
-export default function URLWidget<T = any, F = any>(props: WidgetProps<T, F>) {
+export default function URLWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: WidgetProps<T, S, F>) {
   const { options, registry } = props;
-  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, F>(
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, S, F>(
     "BaseInputTemplate",
     registry,
     options

--- a/packages/core/src/components/widgets/UpDownWidget.tsx
+++ b/packages/core/src/components/widgets/UpDownWidget.tsx
@@ -1,15 +1,22 @@
 import React from "react";
-import { getTemplate, WidgetProps } from "@rjsf/utils";
+import {
+  getTemplate,
+  RJSFSchema,
+  StrictRJSFSchema,
+  WidgetProps,
+} from "@rjsf/utils";
 
 /** The `UpDownWidget` component uses the `BaseInputTemplate` changing the type to `number`.
  *
  * @param props - The `WidgetProps` for this component
  */
-export default function UpDownWidget<T = any, F = any>(
-  props: WidgetProps<T, F>
-) {
+export default function UpDownWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(props: WidgetProps<T, S, F>) {
   const { options, registry } = props;
-  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, F>(
+  const BaseInputTemplate = getTemplate<"BaseInputTemplate", T, S, F>(
     "BaseInputTemplate",
     registry,
     options

--- a/packages/core/src/components/widgets/index.ts
+++ b/packages/core/src/components/widgets/index.ts
@@ -1,4 +1,4 @@
-import { RegistryWidgetsType } from "@rjsf/utils";
+import { RegistryWidgetsType, RJSFSchema, StrictRJSFSchema } from "@rjsf/utils";
 
 import AltDateWidget from "./AltDateWidget";
 import AltDateTimeWidget from "./AltDateTimeWidget";
@@ -19,25 +19,31 @@ import TextWidget from "./TextWidget";
 import URLWidget from "./URLWidget";
 import UpDownWidget from "./UpDownWidget";
 
-const widgets: RegistryWidgetsType = {
-  PasswordWidget,
-  RadioWidget,
-  UpDownWidget,
-  RangeWidget,
-  SelectWidget,
-  TextWidget,
-  DateWidget,
-  DateTimeWidget,
-  AltDateWidget,
-  AltDateTimeWidget,
-  EmailWidget,
-  URLWidget,
-  TextareaWidget,
-  HiddenWidget,
-  ColorWidget,
-  FileWidget,
-  CheckboxWidget,
-  CheckboxesWidget,
-};
+function widgets<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(): RegistryWidgetsType<T, S, F> {
+  return {
+    PasswordWidget,
+    RadioWidget,
+    UpDownWidget,
+    RangeWidget,
+    SelectWidget,
+    TextWidget,
+    DateWidget,
+    DateTimeWidget,
+    AltDateWidget,
+    AltDateTimeWidget,
+    EmailWidget,
+    URLWidget,
+    TextareaWidget,
+    HiddenWidget,
+    ColorWidget,
+    FileWidget,
+    CheckboxWidget,
+    CheckboxesWidget,
+  };
+}
 
 export default widgets;

--- a/packages/core/src/getDefaultRegistry.ts
+++ b/packages/core/src/getDefaultRegistry.ts
@@ -1,4 +1,4 @@
-import { Registry } from "@rjsf/utils";
+import { Registry, RJSFSchema, StrictRJSFSchema } from "@rjsf/utils";
 
 import fields from "./components/fields";
 import templates from "./components/templates";
@@ -8,15 +8,16 @@ import widgets from "./components/widgets";
  * plus an empty `rootSchema` and `formContext. We omit schemaUtils here because it cannot be defaulted without a
  * rootSchema and validator. It will be added into the computed registry later in the Form.
  */
-export default function getDefaultRegistry<T = any, F = any>(): Omit<
-  Registry<T, F>,
-  "schemaUtils"
-> {
+export default function getDefaultRegistry<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(): Omit<Registry<T, S, F>, "schemaUtils"> {
   return {
-    fields,
-    templates,
-    widgets,
-    rootSchema: {},
+    fields: fields<T, S, F>(),
+    templates: templates<T, S, F>(),
+    widgets: widgets<T, S, F>(),
+    rootSchema: {} as S,
     formContext: {} as F,
   };
 }

--- a/packages/core/src/withTheme.tsx
+++ b/packages/core/src/withTheme.tsx
@@ -1,23 +1,30 @@
 import React, { ForwardedRef, forwardRef } from "react";
 
 import Form, { FormProps } from "./components/Form";
+import { RJSFSchema, StrictRJSFSchema } from "@rjsf/utils";
 
 /** The properties for the `withTheme` function, essentially a subset of properties from the `FormProps` that can be
  * overridden while creating a theme
  */
-export type ThemeProps<T = any, F = any> = Pick<
-  FormProps<T, F>,
+export type ThemeProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = Pick<
+  FormProps<T, S, F>,
   "fields" | "templates" | "widgets" | "_internalFormWrapper"
 >;
 
 /** A Higher-Order component that creates a wrapper around a `Form` with the overrides from the `WithThemeProps` */
-export default function withTheme<T = any, F = any>(
-  themeProps: ThemeProps<T, F>
-) {
+export default function withTheme<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(themeProps: ThemeProps<T, S, F>) {
   return forwardRef(
     (
-      { fields, widgets, templates, ...directProps }: FormProps<T, F>,
-      ref: ForwardedRef<Form<T, F>>
+      { fields, widgets, templates, ...directProps }: FormProps<T, S, F>,
+      ref: ForwardedRef<Form<T, S, F>>
     ) => {
       fields = { ...themeProps.fields, ...fields };
       widgets = { ...themeProps.widgets, ...widgets };
@@ -31,7 +38,7 @@ export default function withTheme<T = any, F = any>(
       };
 
       return (
-        <Form<T, F>
+        <Form<T, S, F>
           {...themeProps}
           {...directProps}
           fields={fields}

--- a/packages/fluent-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/fluent-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { WrapIfAdditionalTemplateProps } from "@rjsf/utils";
 
-export default function WrapIfAdditionalTemplate<T = any, F = any>(
-  props: WrapIfAdditionalTemplateProps<T, F>
+export default function WrapIfAdditionalTemplate(
+  props: WrapIfAdditionalTemplateProps
 ) {
   const { children } = props;
   // TODO Implement WrapIfAdditionalTemplate features in FluentUI (#2777)

--- a/packages/utils/src/allowAdditionalItems.ts
+++ b/packages/utils/src/allowAdditionalItems.ts
@@ -1,5 +1,5 @@
 import isObject from "./isObject";
-import { RJSFSchema } from "./types";
+import { RJSFSchema, StrictRJSFSchema } from "./types";
 
 /** Checks the schema to see if it is allowing additional items, by verifying that `schema.additionalItems` is an
  * object. The user is warned in the console if `schema.additionalItems` has the value `true`.
@@ -7,7 +7,9 @@ import { RJSFSchema } from "./types";
  * @param schema - The schema object to check
  * @returns - True if additional items is allowed, otherwise false
  */
-export default function allowAdditionalItems(schema: RJSFSchema) {
+export default function allowAdditionalItems<
+  S extends StrictRJSFSchema = RJSFSchema
+>(schema: S) {
   if (schema.additionalItems === true) {
     console.warn("additionalItems=true is currently not supported");
   }

--- a/packages/utils/src/canExpand.ts
+++ b/packages/utils/src/canExpand.ts
@@ -1,4 +1,4 @@
-import { RJSFSchema, UiSchema } from "./types";
+import { RJSFSchema, StrictRJSFSchema, UiSchema } from "./types";
 import getUiOptions from "./getUiOptions";
 
 /** Checks whether the field described by `schema`, having the `uiSchema` and `formData` supports expanding. The UI for
@@ -10,15 +10,15 @@ import getUiOptions from "./getUiOptions";
  * @param [formData] - The formData for the field
  * @returns - True if the schema element has additionalProperties, is expandable, and not at the maxProperties limit
  */
-export default function canExpand<T = any, F = any>(
-  schema: RJSFSchema,
-  uiSchema: UiSchema<T, F> = {},
-  formData?: T
-) {
+export default function canExpand<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(schema: RJSFSchema, uiSchema: UiSchema<T, S, F> = {}, formData?: T) {
   if (!schema.additionalProperties) {
     return false;
   }
-  const { expandable = true } = getUiOptions<T, F>(uiSchema);
+  const { expandable = true } = getUiOptions<T, S, F>(uiSchema);
   if (expandable === false) {
     return expandable;
   }

--- a/packages/utils/src/createSchemaUtils.ts
+++ b/packages/utils/src/createSchemaUtils.ts
@@ -5,6 +5,7 @@ import {
   PathSchema,
   RJSFSchema,
   SchemaUtilsType,
+  StrictRJSFSchema,
   UiSchema,
   ValidationData,
   ValidatorType,
@@ -27,16 +28,18 @@ import {
  * and `rootSchema` generally does not change across a `Form`, this allows for providing a simplified set of APIs to the
  * `@rjsf/core` components and the various themes as well. This class implements the `SchemaUtilsType` interface.
  */
-class SchemaUtils<T = any> implements SchemaUtilsType<T> {
-  rootSchema: RJSFSchema;
-  validator: ValidatorType;
+class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F = any>
+  implements SchemaUtilsType<T, S>
+{
+  rootSchema: S;
+  validator: ValidatorType<T, S>;
 
   /** Constructs the `SchemaUtils` instance with the given `validator` and `rootSchema` stored as instance variables
    *
    * @param validator - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
    * @param rootSchema - The root schema that will be forwarded to all the APIs
    */
-  constructor(validator: ValidatorType, rootSchema: RJSFSchema) {
+  constructor(validator: ValidatorType<T, S>, rootSchema: S) {
     this.rootSchema = rootSchema;
     this.validator = validator;
   }
@@ -58,8 +61,8 @@ class SchemaUtils<T = any> implements SchemaUtilsType<T> {
    * @returns - True if the `SchemaUtilsType` differs from the given `validator` or `rootSchema`
    */
   doesSchemaUtilsDiffer(
-    validator: ValidatorType,
-    rootSchema: RJSFSchema
+    validator: ValidatorType<T, S>,
+    rootSchema: S
   ): boolean {
     if (!validator || !rootSchema) {
       return false;
@@ -78,11 +81,11 @@ class SchemaUtils<T = any> implements SchemaUtilsType<T> {
    * @returns - The resulting `formData` with all the defaults provided
    */
   getDefaultFormState(
-    schema: RJSFSchema,
+    schema: S,
     formData?: T,
     includeUndefinedValues = false
   ): T | T[] | undefined {
-    return getDefaultFormState<T>(
+    return getDefaultFormState<T, S>(
       this.validator,
       schema,
       formData,
@@ -98,8 +101,8 @@ class SchemaUtils<T = any> implements SchemaUtilsType<T> {
    * @param [uiSchema] - The UI schema from which to derive potentially displayable information
    * @returns - True if the label should be displayed or false if it should not
    */
-  getDisplayLabel<F = any>(schema: RJSFSchema, uiSchema?: UiSchema<T, F>) {
-    return getDisplayLabel<T, F>(
+  getDisplayLabel(schema: S, uiSchema?: UiSchema<T, S, F>) {
+    return getDisplayLabel<T, S, F>(
       this.validator,
       schema,
       uiSchema,
@@ -113,8 +116,8 @@ class SchemaUtils<T = any> implements SchemaUtilsType<T> {
    * @param options - The list of options to find a matching options from
    * @returns - The index of the matched option or 0 if none is available
    */
-  getMatchingOption(formData: T, options: RJSFSchema[]) {
-    return getMatchingOption<T>(
+  getMatchingOption(formData: T, options: S[]) {
+    return getMatchingOption<T, S>(
       this.validator,
       formData,
       options,
@@ -128,8 +131,8 @@ class SchemaUtils<T = any> implements SchemaUtilsType<T> {
    * @param [uiSchema] - The UI schema from which to check the widget
    * @returns - True if schema/uiSchema contains an array of files, otherwise false
    */
-  isFilesArray<F = any>(schema: RJSFSchema, uiSchema?: UiSchema<T, F>) {
-    return isFilesArray<T, F>(
+  isFilesArray(schema: S, uiSchema?: UiSchema<T, S, F>) {
+    return isFilesArray<T, S, F>(
       this.validator,
       schema,
       uiSchema,
@@ -142,8 +145,8 @@ class SchemaUtils<T = any> implements SchemaUtilsType<T> {
    * @param schema - The schema for which check for a multi-select flag is desired
    * @returns - True if schema contains a multi-select, otherwise false
    */
-  isMultiSelect(schema: RJSFSchema) {
-    return isMultiSelect<T>(this.validator, schema, this.rootSchema);
+  isMultiSelect(schema: S) {
+    return isMultiSelect<T, S>(this.validator, schema, this.rootSchema);
   }
 
   /** Checks to see if the `schema` combination represents a select
@@ -151,8 +154,8 @@ class SchemaUtils<T = any> implements SchemaUtilsType<T> {
    * @param schema - The schema for which check for a select flag is desired
    * @returns - True if schema contains a select, otherwise false
    */
-  isSelect(schema: RJSFSchema) {
-    return isSelect<T>(this.validator, schema, this.rootSchema);
+  isSelect(schema: S) {
+    return isSelect<T, S>(this.validator, schema, this.rootSchema);
   }
 
   /** Merges the errors in `additionalErrorSchema` into the existing `validationData` by combining the hierarchies in
@@ -168,7 +171,7 @@ class SchemaUtils<T = any> implements SchemaUtilsType<T> {
     validationData: ValidationData<T>,
     additionalErrorSchema?: ErrorSchema<T>
   ): ValidationData<T> {
-    return mergeValidationData<T>(
+    return mergeValidationData<T, S>(
       this.validator,
       validationData,
       additionalErrorSchema
@@ -183,8 +186,8 @@ class SchemaUtils<T = any> implements SchemaUtilsType<T> {
    * @param [rawFormData] - The current formData, if any, to assist retrieving a schema
    * @returns - The schema having its conditions, additional properties, references and dependencies resolved
    */
-  retrieveSchema(schema: RJSFSchema, rawFormData: T) {
-    return retrieveSchema<T>(
+  retrieveSchema(schema: S, rawFormData: T) {
+    return retrieveSchema<T, S>(
       this.validator,
       schema,
       this.rootSchema,
@@ -202,13 +205,13 @@ class SchemaUtils<T = any> implements SchemaUtilsType<T> {
    * @returns - The `IdSchema` object for the `schema`
    */
   toIdSchema(
-    schema: RJSFSchema,
+    schema: S,
     id?: string | null,
     formData?: T,
     idPrefix = "root",
     idSeparator = "_"
   ): IdSchema<T> {
-    return toIdSchema<T>(
+    return toIdSchema<T, S>(
       this.validator,
       schema,
       id,
@@ -226,8 +229,8 @@ class SchemaUtils<T = any> implements SchemaUtilsType<T> {
    * @param [formData] - The current formData, if any, onto which to provide any missing defaults
    * @returns - The `PathSchema` object for the `schema`
    */
-  toPathSchema(schema: RJSFSchema, name?: string, formData?: T): PathSchema<T> {
-    return toPathSchema<T>(
+  toPathSchema(schema: S, name?: string, formData?: T): PathSchema<T> {
+    return toPathSchema<T, S>(
       this.validator,
       schema,
       name,
@@ -244,9 +247,10 @@ class SchemaUtils<T = any> implements SchemaUtilsType<T> {
  * @param rootSchema - The root schema that will be forwarded to all the APIs
  * @returns - An implementation of a `SchemaUtilsType` interface
  */
-export default function createSchemaUtils<T = any>(
-  validator: ValidatorType,
-  rootSchema: RJSFSchema
-): SchemaUtilsType<T> {
-  return new SchemaUtils<T>(validator, rootSchema);
+export default function createSchemaUtils<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(validator: ValidatorType<T, S>, rootSchema: S): SchemaUtilsType<T, S, F> {
+  return new SchemaUtils<T, S, F>(validator, rootSchema);
 }

--- a/packages/utils/src/getInputProps.ts
+++ b/packages/utils/src/getInputProps.ts
@@ -1,5 +1,10 @@
 import rangeSpec from "./rangeSpec";
-import { InputPropsType, RJSFSchema, UIOptionsType } from "./types";
+import {
+  InputPropsType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  UIOptionsType,
+} from "./types";
 
 /** Using the `schema`, `defaultType` and `options`, extract out the props for the <input> element that make sense.
  *
@@ -9,10 +14,14 @@ import { InputPropsType, RJSFSchema, UIOptionsType } from "./types";
  * @param [autoDefaultStepAny=true] - Determines whether to auto-default step=any when the type is number and no step
  * @returns - The extracted `InputPropsType` object
  */
-export default function getInputProps<T = any, F = any>(
+export default function getInputProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(
   schema: RJSFSchema,
   defaultType?: string,
-  options: UIOptionsType<T, F> = {},
+  options: UIOptionsType<T, S, F> = {},
   autoDefaultStepAny = true
 ): InputPropsType {
   const inputProps: InputPropsType = {

--- a/packages/utils/src/getSchemaType.ts
+++ b/packages/utils/src/getSchemaType.ts
@@ -1,5 +1,5 @@
 import guessType from "./guessType";
-import { RJSFSchema } from "./types";
+import { RJSFSchema, StrictRJSFSchema } from "./types";
 
 /** Gets the type of a given `schema`. If the type is not explicitly defined, then an attempt is made to infer it from
  * other elements of the schema as follows:
@@ -12,8 +12,8 @@ import { RJSFSchema } from "./types";
  * @param schema - The schema for which to get the type
  * @returns - The type of the schema
  */
-export default function getSchemaType(
-  schema: RJSFSchema
+export default function getSchemaType<S extends StrictRJSFSchema = RJSFSchema>(
+  schema: S
 ): string | string[] | undefined {
   let { type } = schema;
 

--- a/packages/utils/src/getSubmitButtonOptions.ts
+++ b/packages/utils/src/getSubmitButtonOptions.ts
@@ -1,6 +1,11 @@
 import { SUBMIT_BTN_OPTIONS_KEY } from "./constants";
 import getUiOptions from "./getUiOptions";
-import { UiSchema, UISchemaSubmitButtonOptions } from "./types";
+import {
+  RJSFSchema,
+  StrictRJSFSchema,
+  UiSchema,
+  UISchemaSubmitButtonOptions,
+} from "./types";
 
 /** The default submit button options, exported for testing purposes
  */
@@ -17,10 +22,12 @@ export const DEFAULT_OPTIONS: UISchemaSubmitButtonOptions = {
  * @param [uiSchema={}] - the UI Schema from which to extract submit button props
  * @returns - The merging of the `DEFAULT_OPTIONS` with any custom ones
  */
-export default function getSubmitButtonOptions<T = any, F = any>(
-  uiSchema: UiSchema<T, F> = {}
-): UISchemaSubmitButtonOptions {
-  const uiOptions = getUiOptions<T, F>(uiSchema);
+export default function getSubmitButtonOptions<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(uiSchema: UiSchema<T, S, F> = {}): UISchemaSubmitButtonOptions {
+  const uiOptions = getUiOptions<T, S, F>(uiSchema);
   if (uiOptions && uiOptions[SUBMIT_BTN_OPTIONS_KEY]) {
     const options = uiOptions[
       SUBMIT_BTN_OPTIONS_KEY

--- a/packages/utils/src/getTemplate.ts
+++ b/packages/utils/src/getTemplate.ts
@@ -1,4 +1,10 @@
-import { TemplatesType, Registry, UIOptionsType } from "./types";
+import {
+  TemplatesType,
+  Registry,
+  UIOptionsType,
+  StrictRJSFSchema,
+  RJSFSchema,
+} from "./types";
 
 /** Returns the template with the given `name` from either the `uiSchema` if it is defined or from the `registry`
  * otherwise. NOTE, since `ButtonTemplates` are not overridden in `uiSchema` only those in the `registry` are returned.
@@ -9,14 +15,15 @@ import { TemplatesType, Registry, UIOptionsType } from "./types";
  * @returns - The template from either the `uiSchema` or `registry` for the `name`
  */
 export default function getTemplate<
-  Name extends keyof TemplatesType<T, F>,
+  Name extends keyof TemplatesType<T, S, F>,
   T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
   F = any
 >(
   name: Name,
-  registry: Registry<T, F>,
-  uiOptions: UIOptionsType<T, F> = {}
-): TemplatesType<T, F>[Name] {
+  registry: Registry<T, S, F>,
+  uiOptions: UIOptionsType<T, S, F> = {}
+): TemplatesType<T, S, F>[Name] {
   const { templates } = registry;
   if (name === "ButtonTemplates") {
     return templates[name];
@@ -24,6 +31,7 @@ export default function getTemplate<
   return (
     // Evaluating uiOptions[name] results in TS2590: Expression produces a union type that is too complex to represent
     // To avoid that, we cast uiOptions to `any` before accessing the name field
-    ((uiOptions as any)[name] as TemplatesType<T, F>[Name]) || templates[name]
+    ((uiOptions as any)[name] as TemplatesType<T, S, F>[Name]) ||
+    templates[name]
   );
 }

--- a/packages/utils/src/getUiOptions.ts
+++ b/packages/utils/src/getUiOptions.ts
@@ -1,16 +1,18 @@
 import { UI_OPTIONS_KEY, UI_WIDGET_KEY } from "./constants";
 import isObject from "./isObject";
-import { UIOptionsType, UiSchema } from "./types";
+import { RJSFSchema, StrictRJSFSchema, UIOptionsType, UiSchema } from "./types";
 
 /** Get all passed options from ui:options, and ui:<optionName>, returning them in an object with the `ui:`
  * stripped off.
  *
  * @param [uiSchema={}] - The UI Schema from which to get any `ui:xxx` options
- * @returns - An object containing all of the `ui:xxx` options with the stripped off
+ * @returns - An object containing all the `ui:xxx` options with the stripped off
  */
-export default function getUiOptions<T = any, F = any>(
-  uiSchema: UiSchema<T, F> = {}
-): UIOptionsType<T, F> {
+export default function getUiOptions<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(uiSchema: UiSchema<T, S, F> = {}): UIOptionsType<T, S, F> {
   return Object.keys(uiSchema)
     .filter((key) => key.indexOf("ui:") === 0)
     .reduce((options, key) => {

--- a/packages/utils/src/getWidget.tsx
+++ b/packages/utils/src/getWidget.tsx
@@ -3,7 +3,12 @@ import ReactIs from "react-is";
 import get from "lodash/get";
 import set from "lodash/set";
 
-import { RJSFSchema, Widget, RegistryWidgetsType } from "./types";
+import {
+  RJSFSchema,
+  Widget,
+  RegistryWidgetsType,
+  StrictRJSFSchema,
+} from "./types";
 import getSchemaType from "./getSchemaType";
 
 /** The map of schema types to widget type to widget name
@@ -67,8 +72,12 @@ const widgetMap: { [k: string]: { [j: string]: string } } = {
  * @param AWidget - A widget that will be wrapped or one that is already wrapped
  * @returns - The wrapper widget
  */
-function mergeWidgetOptions<T = any, F = any>(AWidget: Widget<T, F>) {
-  let MergedWidget: Widget<T, F> = get(AWidget, "MergedWidget");
+function mergeWidgetOptions<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(AWidget: Widget<T, S, F>) {
+  let MergedWidget: Widget<T, S, F> = get(AWidget, "MergedWidget");
   // cache return value as property of widget for proper react reconciliation
   if (!MergedWidget) {
     const defaultOptions =
@@ -92,11 +101,15 @@ function mergeWidgetOptions<T = any, F = any>(AWidget: Widget<T, F>) {
  * @returns - The `Widget` component to use
  * @throws - An error if there is no `Widget` component that can be returned
  */
-export default function getWidget<T = any, F = any>(
+export default function getWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(
   schema: RJSFSchema,
-  widget?: Widget<T, F> | string,
-  registeredWidgets: RegistryWidgetsType<T, F> = {}
-): Widget<T, F> {
+  widget?: Widget<T, S, F> | string,
+  registeredWidgets: RegistryWidgetsType<T, S, F> = {}
+): Widget<T, S, F> {
   const type = getSchemaType(schema);
 
   if (
@@ -104,7 +117,7 @@ export default function getWidget<T = any, F = any>(
     (widget && ReactIs.isForwardRef(React.createElement(widget))) ||
     ReactIs.isMemo(widget)
   ) {
-    return mergeWidgetOptions<T, F>(widget as Widget<T, F>);
+    return mergeWidgetOptions<T, S, F>(widget as Widget<T, S, F>);
   }
 
   if (typeof widget !== "string") {
@@ -113,7 +126,7 @@ export default function getWidget<T = any, F = any>(
 
   if (widget in registeredWidgets) {
     const registeredWidget = registeredWidgets[widget];
-    return getWidget<T, F>(schema, registeredWidget, registeredWidgets);
+    return getWidget<T, S, F>(schema, registeredWidget, registeredWidgets);
   }
 
   if (typeof type === "string") {
@@ -123,7 +136,7 @@ export default function getWidget<T = any, F = any>(
 
     if (widget in widgetMap[type]) {
       const registeredWidget = registeredWidgets[widgetMap[type][widget]];
-      return getWidget<T, F>(schema, registeredWidget, registeredWidgets);
+      return getWidget<T, S, F>(schema, registeredWidget, registeredWidgets);
     }
   }
 

--- a/packages/utils/src/hasWidget.ts
+++ b/packages/utils/src/hasWidget.ts
@@ -1,5 +1,10 @@
 import getWidget from "./getWidget";
-import { RegistryWidgetsType, RJSFSchema, Widget } from "./types";
+import {
+  RegistryWidgetsType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  Widget,
+} from "./types";
 
 /** Detects whether the `widget` exists for the `schema` with the associated `registryWidgets` and returns true if it
  * does, or false if it doesn't.
@@ -9,10 +14,14 @@ import { RegistryWidgetsType, RJSFSchema, Widget } from "./types";
  * @param [registeredWidgets={}] - A registry of widget name to `Widget` implementation
  * @returns - True if the widget exists, false otherwise
  */
-export default function hasWidget<T = any, F = any>(
+export default function hasWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(
   schema: RJSFSchema,
-  widget: Widget<T, F> | string,
-  registeredWidgets: RegistryWidgetsType<T, F> = {}
+  widget: Widget<T, S, F> | string,
+  registeredWidgets: RegistryWidgetsType<T, S, F> = {}
 ) {
   try {
     getWidget(schema, widget, registeredWidgets);

--- a/packages/utils/src/isConstant.ts
+++ b/packages/utils/src/isConstant.ts
@@ -1,5 +1,5 @@
 import { CONST_KEY } from "./constants";
-import { RJSFSchema } from "./types";
+import { RJSFSchema, StrictRJSFSchema } from "./types";
 
 /** This function checks if the given `schema` matches a single constant value. This happens when either the schema has
  * an `enum` array with a single value or there is a `const` defined.
@@ -7,7 +7,9 @@ import { RJSFSchema } from "./types";
  * @param schema - The schema for a field
  * @returns - True if the `schema` has a single constant value, false otherwise
  */
-export default function isConstant(schema: RJSFSchema) {
+export default function isConstant<S extends StrictRJSFSchema = RJSFSchema>(
+  schema: S
+) {
   return (
     (Array.isArray(schema.enum) && schema.enum.length === 1) ||
     CONST_KEY in schema

--- a/packages/utils/src/isCustomWidget.ts
+++ b/packages/utils/src/isCustomWidget.ts
@@ -1,18 +1,20 @@
 import getUiOptions from "./getUiOptions";
-import { UiSchema } from "./types";
+import { RJSFSchema, StrictRJSFSchema, UiSchema } from "./types";
 
 /** Checks to see if the `uiSchema` contains the `widget` field and that the widget is not `hidden`
  *
  * @param uiSchema - The UI Schema from which to detect if it is customized
  * @returns - True if the `uiSchema` describes a custom widget, false otherwise
  */
-export default function isCustomWidget<T = any, F = any>(
-  uiSchema: UiSchema<T, F> = {}
-) {
+export default function isCustomWidget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(uiSchema: UiSchema<T, S, F> = {}) {
   return (
     // TODO: Remove the `&& uiSchema['ui:widget'] !== 'hidden'` once we support hidden widgets for arrays.
     // https://react-jsonschema-form.readthedocs.io/en/latest/usage/widgets/#hidden-widgets
-    "widget" in getUiOptions<T, F>(uiSchema) &&
-    getUiOptions<T, F>(uiSchema)["widget"] !== "hidden"
+    "widget" in getUiOptions<T, S, F>(uiSchema) &&
+    getUiOptions<T, S, F>(uiSchema)["widget"] !== "hidden"
   );
 }

--- a/packages/utils/src/isFixedItems.ts
+++ b/packages/utils/src/isFixedItems.ts
@@ -1,5 +1,5 @@
 import isObject from "./isObject";
-import { RJSFSchema } from "./types";
+import { RJSFSchema, StrictRJSFSchema } from "./types";
 
 /** Detects whether the given `schema` contains fixed items. This is the case when `schema.items` is a non-empty array
  * that only contains objects.
@@ -7,7 +7,9 @@ import { RJSFSchema } from "./types";
  * @param schema - The schema in which to check for fixed items
  * @returns - True if there are fixed items in the schema, false otherwise
  */
-export default function isFixedItems(schema: RJSFSchema) {
+export default function isFixedItems<S extends StrictRJSFSchema = RJSFSchema>(
+  schema: S
+) {
   return (
     Array.isArray(schema.items) &&
     schema.items.length > 0 &&

--- a/packages/utils/src/mergeDefaultsWithFormData.ts
+++ b/packages/utils/src/mergeDefaultsWithFormData.ts
@@ -1,6 +1,7 @@
 import get from "lodash/get";
 
 import isObject from "./isObject";
+import { GenericObjectType } from "../src";
 
 /** Merges the `defaults` object of type `T` into the `formData` of type `T`
  *
@@ -31,9 +32,8 @@ export default function mergeDefaultsWithFormData<T = any>(
     return mapped as unknown as T;
   }
   if (isObject(formData)) {
-    // eslint-disable-next-line no-unused-vars
     const acc: { [key in keyof T]: any } = Object.assign({}, defaults); // Prevent mutation of source object.
-    return Object.keys(formData).reduce((acc, key) => {
+    return Object.keys(formData as GenericObjectType).reduce((acc, key) => {
       acc[key as keyof T] = mergeDefaultsWithFormData<T>(
         defaults ? get(defaults, key) : {},
         get(formData, key)

--- a/packages/utils/src/optionsList.ts
+++ b/packages/utils/src/optionsList.ts
@@ -1,5 +1,5 @@
 import toConstant from "./toConstant";
-import { RJSFSchema, EnumOptionsType } from "./types";
+import { RJSFSchema, EnumOptionsType, StrictRJSFSchema } from "./types";
 
 /** Gets the list of options from the schema. If the schema has an enum list, then those enum values are returned. The
  * labels for the options will be extracted from the non-standard, RJSF-deprecated `enumNames` if it exists, otherwise
@@ -9,12 +9,12 @@ import { RJSFSchema, EnumOptionsType } from "./types";
  * @param schema - The schema from which to extract the options list
  * @returns - The list of options from the schema
  */
-export default function optionsList(
-  schema: RJSFSchema
-): EnumOptionsType[] | undefined {
+export default function optionsList<S extends StrictRJSFSchema = RJSFSchema>(
+  schema: S
+): EnumOptionsType<S>[] | undefined {
   // enumNames was deprecated in v5 and is intentionally omitted from the RJSFSchema type.
   // Cast the type to include enumNames so the feature still works.
-  const schemaWithEnumNames = schema as RJSFSchema & { enumNames?: string[] };
+  const schemaWithEnumNames = schema as S & { enumNames?: string[] };
   if (schemaWithEnumNames.enumNames && process.env.NODE_ENV !== "production") {
     console.warn(
       "The enumNames property is deprecated and may be removed in a future major release."
@@ -32,7 +32,7 @@ export default function optionsList(
   return (
     altSchemas &&
     altSchemas.map((aSchemaDef) => {
-      const aSchema = aSchemaDef as RJSFSchema;
+      const aSchema = aSchemaDef as S;
       const value = toConstant(aSchema);
       const label = aSchema.title || String(value);
       return {

--- a/packages/utils/src/processSelectValue.ts
+++ b/packages/utils/src/processSelectValue.ts
@@ -1,6 +1,6 @@
 import get from "lodash/get";
 
-import { RJSFSchema, UIOptionsType } from "./types";
+import { RJSFSchema, StrictRJSFSchema, UIOptionsType } from "./types";
 import asNumber from "./asNumber";
 import guessType from "./guessType";
 
@@ -15,11 +15,11 @@ const nums = new Set<any>(["number", "integer"]);
  * @param [options] - The UIOptionsType from which to potentially extract the emptyValue
  * @returns - The `value` converted to the proper type
  */
-export default function processSelectValue<T = any, F = any>(
-  schema: RJSFSchema,
-  value?: any,
-  options?: UIOptionsType<T, F>
-) {
+export default function processSelectValue<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(schema: S, value?: any, options?: UIOptionsType<T, S, F>) {
   const { enum: schemaEnum, type, items } = schema;
   if (value === "") {
     return options && options.emptyValue !== undefined

--- a/packages/utils/src/rangeSpec.ts
+++ b/packages/utils/src/rangeSpec.ts
@@ -1,4 +1,4 @@
-import { RangeSpecType } from "./types";
+import { RangeSpecType, StrictRJSFSchema } from "./types";
 import { RJSFSchema } from "./types";
 
 /** Extracts the range spec information `{ step?: number, min?: number, max?: number }` that can be spread onto an HTML
@@ -7,7 +7,9 @@ import { RJSFSchema } from "./types";
  * @param schema - The schema from which to extract the range spec
  * @returns - A range specification from the schema
  */
-export default function rangeSpec(schema: RJSFSchema) {
+export default function rangeSpec<S extends StrictRJSFSchema = RJSFSchema>(
+  schema: S
+) {
   const spec: RangeSpecType = {};
   if (schema.multipleOf) {
     spec.step = schema.multipleOf;

--- a/packages/utils/src/schema/getDisplayLabel.ts
+++ b/packages/utils/src/schema/getDisplayLabel.ts
@@ -2,7 +2,12 @@ import { UI_FIELD_KEY, UI_WIDGET_KEY } from "../constants";
 import getSchemaType from "../getSchemaType";
 import getUiOptions from "../getUiOptions";
 import isCustomWidget from "../isCustomWidget";
-import { RJSFSchema, UiSchema, ValidatorType } from "../types";
+import {
+  RJSFSchema,
+  StrictRJSFSchema,
+  UiSchema,
+  ValidatorType,
+} from "../types";
 import isFilesArray from "./isFilesArray";
 import isMultiSelect from "./isMultiSelect";
 
@@ -15,21 +20,25 @@ import isMultiSelect from "./isMultiSelect";
  * @param [rootSchema] - The root schema, used to primarily to look up `$ref`s
  * @returns - True if the label should be displayed or false if it should not
  */
-export default function getDisplayLabel<T = any, F = any>(
-  validator: ValidatorType,
-  schema: RJSFSchema,
-  uiSchema: UiSchema<T, F> = {},
-  rootSchema?: RJSFSchema
+export default function getDisplayLabel<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(
+  validator: ValidatorType<T, S>,
+  schema: S,
+  uiSchema: UiSchema<T, S, F> = {},
+  rootSchema?: S
 ): boolean {
-  const uiOptions = getUiOptions<T, F>(uiSchema);
+  const uiOptions = getUiOptions<T, S, F>(uiSchema);
   const { label = true } = uiOptions;
   let displayLabel = !!label;
   const schemaType = getSchemaType(schema);
 
   if (schemaType === "array") {
     displayLabel =
-      isMultiSelect<T>(validator, schema, rootSchema) ||
-      isFilesArray<T, F>(validator, schema, uiSchema, rootSchema) ||
+      isMultiSelect<T, S>(validator, schema, rootSchema) ||
+      isFilesArray<T, S, F>(validator, schema, uiSchema, rootSchema) ||
       isCustomWidget(uiSchema);
   }
 

--- a/packages/utils/src/schema/getMatchingOption.ts
+++ b/packages/utils/src/schema/getMatchingOption.ts
@@ -1,4 +1,4 @@
-import { RJSFSchema, ValidatorType } from "../types";
+import { RJSFSchema, StrictRJSFSchema, ValidatorType } from "../types";
 
 /** Given the `formData` and list of `options`, attempts to find the index of the option that best matches the data.
  *
@@ -8,11 +8,14 @@ import { RJSFSchema, ValidatorType } from "../types";
  * @param rootSchema - The root schema, used to primarily to look up `$ref`s
  * @returns - The index of the matched option or 0 if none is available
  */
-export default function getMatchingOption<T = any>(
-  validator: ValidatorType,
+export default function getMatchingOption<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema
+>(
+  validator: ValidatorType<T, S>,
   formData: T | undefined,
-  options: RJSFSchema[],
-  rootSchema: RJSFSchema
+  options: S[],
+  rootSchema: S
 ): number {
   // For performance, skip validating subschemas if formData is undefined. We just
   // want to get the first option in that case.

--- a/packages/utils/src/schema/isFilesArray.ts
+++ b/packages/utils/src/schema/isFilesArray.ts
@@ -1,5 +1,10 @@
 import { UI_WIDGET_KEY } from "../constants";
-import { RJSFSchema, UiSchema, ValidatorType } from "../types";
+import {
+  RJSFSchema,
+  StrictRJSFSchema,
+  UiSchema,
+  ValidatorType,
+} from "../types";
 import retrieveSchema from "./retrieveSchema";
 
 /** Checks to see if the `schema` and `uiSchema` combination represents an array of files
@@ -10,19 +15,23 @@ import retrieveSchema from "./retrieveSchema";
  * @param [rootSchema] - The root schema, used to primarily to look up `$ref`s
  * @returns - True if schema/uiSchema contains an array of files, otherwise false
  */
-export default function isFilesArray<T = any, F = any>(
-  validator: ValidatorType,
-  schema: RJSFSchema,
-  uiSchema: UiSchema<T, F> = {},
-  rootSchema?: RJSFSchema
+export default function isFilesArray<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+>(
+  validator: ValidatorType<T, S>,
+  schema: S,
+  uiSchema: UiSchema<T, S, F> = {},
+  rootSchema?: S
 ) {
   if (uiSchema[UI_WIDGET_KEY] === "files") {
     return true;
   }
   if (schema.items) {
-    const itemsSchema = retrieveSchema<T>(
+    const itemsSchema = retrieveSchema<T, S>(
       validator,
-      schema.items as RJSFSchema,
+      schema.items as S,
       rootSchema
     );
     return itemsSchema.type === "string" && itemsSchema.format === "data-url";

--- a/packages/utils/src/schema/isMultiSelect.ts
+++ b/packages/utils/src/schema/isMultiSelect.ts
@@ -1,4 +1,4 @@
-import { RJSFSchema, ValidatorType } from "../types";
+import { RJSFSchema, StrictRJSFSchema, ValidatorType } from "../types";
 
 import isSelect from "./isSelect";
 
@@ -9,11 +9,10 @@ import isSelect from "./isSelect";
  * @param [rootSchema] - The root schema, used to primarily to look up `$ref`s
  * @returns - True if schema contains a multi-select, otherwise false
  */
-export default function isMultiSelect<T = any>(
-  validator: ValidatorType,
-  schema: RJSFSchema,
-  rootSchema?: RJSFSchema
-) {
+export default function isMultiSelect<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema
+>(validator: ValidatorType<T, S>, schema: S, rootSchema?: S) {
   if (
     !schema.uniqueItems ||
     !schema.items ||
@@ -21,5 +20,5 @@ export default function isMultiSelect<T = any>(
   ) {
     return false;
   }
-  return isSelect<T>(validator, schema.items as RJSFSchema, rootSchema);
+  return isSelect<T, S>(validator, schema.items as S, rootSchema);
 }

--- a/packages/utils/src/schema/isSelect.ts
+++ b/packages/utils/src/schema/isSelect.ts
@@ -1,5 +1,5 @@
 import isConstant from "../isConstant";
-import { RJSFSchema, ValidatorType } from "../types";
+import { RJSFSchema, StrictRJSFSchema, ValidatorType } from "../types";
 import retrieveSchema from "./retrieveSchema";
 
 /** Checks to see if the `schema` combination represents a select
@@ -9,12 +9,16 @@ import retrieveSchema from "./retrieveSchema";
  * @param [rootSchema] - The root schema, used to primarily to look up `$ref`s
  * @returns - True if schema contains a select, otherwise false
  */
-export default function isSelect<T = any>(
-  validator: ValidatorType,
-  theSchema: RJSFSchema,
-  rootSchema: RJSFSchema = {}
-) {
-  const schema = retrieveSchema<T>(validator, theSchema, rootSchema, undefined);
+export default function isSelect<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema
+>(validator: ValidatorType<T, S>, theSchema: S, rootSchema: S = {} as S) {
+  const schema = retrieveSchema<T, S>(
+    validator,
+    theSchema,
+    rootSchema,
+    undefined
+  );
   const altSchemas = schema.oneOf || schema.anyOf;
   if (Array.isArray(schema.enum)) {
     return true;

--- a/packages/utils/src/schema/mergeValidationData.ts
+++ b/packages/utils/src/schema/mergeValidationData.ts
@@ -1,7 +1,13 @@
 import isEmpty from "lodash/isEmpty";
 
 import mergeObjects from "../mergeObjects";
-import { ErrorSchema, ValidationData, ValidatorType } from "../types";
+import {
+  ErrorSchema,
+  RJSFSchema,
+  StrictRJSFSchema,
+  ValidationData,
+  ValidatorType,
+} from "../types";
 
 /** Merges the errors in `additionalErrorSchema` into the existing `validationData` by combining the hierarchies in the
  * two `ErrorSchema`s and then appending the error list from the `additionalErrorSchema` obtained by calling
@@ -13,8 +19,11 @@ import { ErrorSchema, ValidationData, ValidatorType } from "../types";
  * @param [additionalErrorSchema] - The additional set of errors in an `ErrorSchema`
  * @returns - The `validationData` with the additional errors from `additionalErrorSchema` merged into it, if provided.
  */
-export default function mergeValidationData<T = any>(
-  validator: ValidatorType<T>,
+export default function mergeValidationData<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema
+>(
+  validator: ValidatorType<T, S>,
   validationData: ValidationData<T>,
   additionalErrorSchema?: ErrorSchema<T>
 ): ValidationData<T> {

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -18,7 +18,7 @@ import mergeSchemas from "../mergeSchemas";
 import {
   GenericObjectType,
   RJSFSchema,
-  RJSFSchemaDefinition,
+  StrictRJSFSchema,
   ValidatorType,
 } from "../types";
 import getMatchingOption from "./getMatchingOption";
@@ -26,18 +26,16 @@ import getMatchingOption from "./getMatchingOption";
 /** Resolves a conditional block (if/else/then) by removing the condition and merging the appropriate conditional branch
  * with the rest of the schema
  *
- * @param validator - An implementation of the `ValidatorType` interface that is used to detect valid schema conditions
+ * @param validator - An implementation of the `ValidatorType<T, S>` interface that is used to detect valid schema conditions
  * @param schema - The schema for which resolving a condition is desired
  * @param rootSchema - The root schema that will be forwarded to all the APIs
  * @param formData - The current formData to assist retrieving a schema
  * @returns - A schema with the appropriate condition resolved
  */
-export function resolveCondition<T = any>(
-  validator: ValidatorType,
-  schema: RJSFSchema,
-  rootSchema: RJSFSchema,
-  formData: T
-) {
+export function resolveCondition<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema
+>(validator: ValidatorType<T, S>, schema: S, rootSchema: S, formData: T) {
   const {
     if: expression,
     then,
@@ -46,7 +44,7 @@ export function resolveCondition<T = any>(
   } = schema;
 
   const conditionalSchema = validator.isValid(
-    expression as RJSFSchema,
+    expression as S,
     formData,
     rootSchema
   )
@@ -54,19 +52,19 @@ export function resolveCondition<T = any>(
     : otherwise;
 
   if (conditionalSchema && typeof conditionalSchema !== "boolean") {
-    return retrieveSchema<T>(
+    return retrieveSchema<T, S>(
       validator,
       mergeSchemas(
         resolvedSchemaLessConditional,
         retrieveSchema(validator, conditionalSchema, rootSchema, formData)
-      ),
+      ) as S,
       rootSchema,
       formData
     );
   }
-  return retrieveSchema<T>(
+  return retrieveSchema<T, S>(
     validator,
-    resolvedSchemaLessConditional,
+    resolvedSchemaLessConditional as S,
     rootSchema,
     formData
   );
@@ -75,37 +73,42 @@ export function resolveCondition<T = any>(
 /** Resolves references and dependencies within a schema and its 'allOf' children.
  * Called internally by retrieveSchema.
  *
- * @param validator - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
+ * @param validator - An implementation of the `ValidatorType<T, S>` interface that will be forwarded to all the APIs
  * @param schema - The schema for which resolving a schema is desired
  * @param [rootSchema={}] - The root schema that will be forwarded to all the APIs
  * @param [formData] - The current formData, if any, to assist retrieving a schema
  * @returns - The schema having its references and dependencies resolved
  */
-export function resolveSchema<T = any>(
-  validator: ValidatorType,
-  schema: RJSFSchema,
-  rootSchema: RJSFSchema = {},
+export function resolveSchema<T = any, S extends StrictRJSFSchema = RJSFSchema>(
+  validator: ValidatorType<T, S>,
+  schema: S,
+  rootSchema: S = {} as S,
   formData?: T
-): RJSFSchema {
+): S {
   if (REF_KEY in schema) {
-    return resolveReference<T>(validator, schema, rootSchema, formData);
+    return resolveReference<T, S>(validator, schema, rootSchema, formData);
   }
   if (DEPENDENCIES_KEY in schema) {
-    const resolvedSchema = resolveDependencies<T>(
+    const resolvedSchema = resolveDependencies<T, S>(
       validator,
       schema,
       rootSchema,
       formData
     );
-    return retrieveSchema<T>(validator, resolvedSchema, rootSchema, formData);
+    return retrieveSchema<T, S>(
+      validator,
+      resolvedSchema,
+      rootSchema,
+      formData
+    );
   }
   if (ALL_OF_KEY in schema) {
     return {
       ...schema,
       allOf: schema.allOf!.map((allOfSubschema) =>
-        retrieveSchema<T>(
+        retrieveSchema<T, S>(
           validator,
-          allOfSubschema as RJSFSchema,
+          allOfSubschema as S,
           rootSchema,
           formData
         )
@@ -118,24 +121,22 @@ export function resolveSchema<T = any>(
 
 /** Resolves references within a schema and its 'allOf' children.
  *
- * @param validator - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
+ * @param validator - An implementation of the `ValidatorType<T, S>` interface that will be forwarded to all the APIs
  * @param schema - The schema for which resolving a reference is desired
  * @param rootSchema - The root schema that will be forwarded to all the APIs
  * @param [formData] - The current formData, if any, to assist retrieving a schema
  * @returns - The schema having its references resolved
  */
-export function resolveReference<T = any>(
-  validator: ValidatorType,
-  schema: RJSFSchema,
-  rootSchema: RJSFSchema,
-  formData?: T
-): RJSFSchema {
+export function resolveReference<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema
+>(validator: ValidatorType<T, S>, schema: S, rootSchema: S, formData?: T): S {
   // Retrieve the referenced schema definition.
-  const $refSchema = findSchemaDefinition(schema.$ref, rootSchema);
+  const $refSchema = findSchemaDefinition<S>(schema.$ref, rootSchema);
   // Drop the $ref property of the source schema.
   const { $ref, ...localSchema } = schema;
   // Update referenced schema definition with local schema properties.
-  return retrieveSchema<T>(
+  return retrieveSchema<T, S>(
     validator,
     { ...$refSchema, ...localSchema },
     rootSchema,
@@ -145,18 +146,21 @@ export function resolveReference<T = any>(
 
 /** Creates new 'properties' items for each key in the `formData`
  *
- * @param validator - An implementation of the `ValidatorType` interface that will be used when necessary
+ * @param validator - An implementation of the `ValidatorType<T, S>` interface that will be used when necessary
  * @param theSchema - The schema for which the existing additional properties is desired
  * @param [rootSchema] - The root schema, used to primarily to look up `$ref`s * @param validator
  * @param [aFormData] - The current formData, if any, to assist retrieving a schema
  * @returns - The updated schema with additional properties stubbed
  */
-export function stubExistingAdditionalProperties<T = any>(
-  validator: ValidatorType,
-  theSchema: RJSFSchema,
-  rootSchema?: RJSFSchema,
+export function stubExistingAdditionalProperties<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema
+>(
+  validator: ValidatorType<T, S>,
+  theSchema: S,
+  rootSchema?: S,
   aFormData?: T
-): RJSFSchema {
+): S {
   // Clone the schema so we don't ruin the consumer's original
   const schema = {
     ...theSchema,
@@ -172,12 +176,12 @@ export function stubExistingAdditionalProperties<T = any>(
       return;
     }
 
-    let additionalProperties: RJSFSchema = {};
+    let additionalProperties: S["additionalProperties"] = {};
     if (typeof schema.additionalProperties !== "boolean") {
       if (REF_KEY in schema.additionalProperties!) {
-        additionalProperties = retrieveSchema<T>(
+        additionalProperties = retrieveSchema<T, S>(
           validator,
-          { $ref: get(schema.additionalProperties, [REF_KEY]) },
+          { $ref: get(schema.additionalProperties, [REF_KEY]) } as S,
           rootSchema,
           formData as T
         );
@@ -203,22 +207,25 @@ export function stubExistingAdditionalProperties<T = any>(
  * resolved and merged into the `schema` given a `validator`, `rootSchema` and `rawFormData` that is used to do the
  * potentially recursive resolution.
  *
- * @param validator - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
+ * @param validator - An implementation of the `ValidatorType<T, S>` interface that will be forwarded to all the APIs
  * @param schema - The schema for which retrieving a schema is desired
  * @param [rootSchema={}] - The root schema that will be forwarded to all the APIs
  * @param [rawFormData] - The current formData, if any, to assist retrieving a schema
  * @returns - The schema having its conditions, additional properties, references and dependencies resolved
  */
-export default function retrieveSchema<T = any>(
-  validator: ValidatorType,
-  schema: RJSFSchema,
-  rootSchema: RJSFSchema = {},
+export default function retrieveSchema<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema
+>(
+  validator: ValidatorType<T, S>,
+  schema: S,
+  rootSchema: S = {} as S,
   rawFormData?: T
-): RJSFSchema {
+): S {
   if (!isObject(schema)) {
-    return {};
+    return {} as S;
   }
-  let resolvedSchema = resolveSchema<T>(
+  let resolvedSchema = resolveSchema<T, S>(
     validator,
     schema,
     rootSchema,
@@ -226,7 +233,12 @@ export default function retrieveSchema<T = any>(
   );
 
   if ("if" in schema) {
-    return resolveCondition<T>(validator, schema, rootSchema, rawFormData as T);
+    return resolveCondition<T, S>(
+      validator,
+      schema,
+      rootSchema,
+      rawFormData as T
+    );
   }
 
   const formData: GenericObjectType = rawFormData || {};
@@ -237,10 +249,10 @@ export default function retrieveSchema<T = any>(
 
     Object.entries(resolvedSchema.properties).forEach((entries) => {
       const propName = entries[0];
-      const propSchema = entries[1] as RJSFSchema;
+      const propSchema = entries[1] as S;
       const rawPropData = formData[propName];
       const propData = isObject(rawPropData) ? rawPropData : {};
-      const resolvedPropSchema = retrieveSchema<T>(
+      const resolvedPropSchema = retrieveSchema<T, S>(
         validator,
         propSchema,
         rootSchema,
@@ -263,18 +275,18 @@ export default function retrieveSchema<T = any>(
       resolvedSchema = mergeAllOf({
         ...resolvedSchema,
         allOf: resolvedSchema.allOf,
-      });
+      }) as S;
     } catch (e) {
       console.warn("could not merge subschemas in allOf:\n" + e);
       const { allOf, ...resolvedSchemaWithoutAllOf } = resolvedSchema;
-      return resolvedSchemaWithoutAllOf;
+      return resolvedSchemaWithoutAllOf as S;
     }
   }
   const hasAdditionalProperties =
     ADDITIONAL_PROPERTIES_KEY in resolvedSchema &&
     resolvedSchema.additionalProperties !== false;
   if (hasAdditionalProperties) {
-    return stubExistingAdditionalProperties<T>(
+    return stubExistingAdditionalProperties<T, S>(
       validator,
       resolvedSchema,
       rootSchema,
@@ -286,41 +298,39 @@ export default function retrieveSchema<T = any>(
 
 /** Resolves dependencies within a schema and its 'allOf' children.
  *
- * @param validator - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
+ * @param validator - An implementation of the `ValidatorType<T, S>` interface that will be forwarded to all the APIs
  * @param schema - The schema for which resolving a dependency is desired
  * @param rootSchema - The root schema that will be forwarded to all the APIs
  * @param [formData] - The current formData, if any, to assist retrieving a schema
  * @returns - The schema with its dependencies resolved
  */
-export function resolveDependencies<T = any>(
-  validator: ValidatorType,
-  schema: RJSFSchema,
-  rootSchema: RJSFSchema,
-  formData?: T
-): RJSFSchema {
+export function resolveDependencies<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema
+>(validator: ValidatorType<T, S>, schema: S, rootSchema: S, formData?: T): S {
   // Drop the dependencies from the source schema.
   const { dependencies, ...remainingSchema } = schema;
-  let resolvedSchema = remainingSchema;
+  let resolvedSchema: S = remainingSchema as S;
   if (Array.isArray(resolvedSchema.oneOf)) {
     resolvedSchema = resolvedSchema.oneOf[
-      getMatchingOption<T>(
+      getMatchingOption<T, S>(
         validator,
         formData,
-        resolvedSchema.oneOf as RJSFSchema[],
+        resolvedSchema.oneOf as S[],
         rootSchema
       )
-    ] as RJSFSchema;
+    ] as S;
   } else if (Array.isArray(resolvedSchema.anyOf)) {
     resolvedSchema = resolvedSchema.anyOf[
-      getMatchingOption<T>(
+      getMatchingOption<T, S>(
         validator,
         formData,
-        resolvedSchema.anyOf as RJSFSchema[],
+        resolvedSchema.anyOf as S[],
         rootSchema
       )
-    ] as RJSFSchema;
+    ] as S;
   }
-  return processDependencies<T>(
+  return processDependencies<T, S>(
     validator,
     dependencies,
     resolvedSchema,
@@ -331,20 +341,23 @@ export function resolveDependencies<T = any>(
 
 /** Processes all the `dependencies` recursively into the `resolvedSchema` as needed
  *
- * @param validator - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
+ * @param validator - An implementation of the `ValidatorType<T, S>` interface that will be forwarded to all the APIs
  * @param dependencies - The set of dependencies that needs to be processed
  * @param resolvedSchema - The schema for which processing dependencies is desired
  * @param rootSchema - The root schema that will be forwarded to all the APIs
  * @param [formData] - The current formData, if any, to assist retrieving a schema
  * @returns - The schema with the `dependencies` resolved into it
  */
-export function processDependencies<T = any>(
-  validator: ValidatorType,
-  dependencies: RJSFSchema["dependencies"],
-  resolvedSchema: RJSFSchema,
-  rootSchema: RJSFSchema,
+export function processDependencies<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema
+>(
+  validator: ValidatorType<T, S>,
+  dependencies: S["dependencies"],
+  resolvedSchema: S,
+  rootSchema: S,
   formData?: T
-): RJSFSchema {
+): S {
   let schema = resolvedSchema;
   // Process dependencies updating the local schema properties as appropriate.
   for (const dependencyKey in dependencies) {
@@ -363,16 +376,16 @@ export function processDependencies<T = any>(
     if (Array.isArray(dependencyValue)) {
       schema = withDependentProperties(schema, dependencyValue);
     } else if (isObject(dependencyValue)) {
-      schema = withDependentSchema<T>(
+      schema = withDependentSchema<T, S>(
         validator,
         schema,
         rootSchema,
         dependencyKey,
-        dependencyValue as RJSFSchema,
+        dependencyValue as S,
         formData
       );
     }
-    return processDependencies<T>(
+    return processDependencies<T, S>(
       validator,
       remainingDependencies,
       schema,
@@ -389,10 +402,9 @@ export function processDependencies<T = any>(
  * @param [additionallyRequired] - An optional array of additionally required names
  * @returns - The schema with the additional required values merged in
  */
-export function withDependentProperties(
-  schema: RJSFSchema,
-  additionallyRequired?: string[]
-) {
+export function withDependentProperties<
+  S extends StrictRJSFSchema = RJSFSchema
+>(schema: S, additionallyRequired?: string[]) {
   if (!additionallyRequired) {
     return schema;
   }
@@ -404,7 +416,7 @@ export function withDependentProperties(
 
 /** Merges a dependent schema into the `schema` dealing with oneOfs and references
  *
- * @param validator - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
+ * @param validator - An implementation of the `ValidatorType<T, S>` interface that will be forwarded to all the APIs
  * @param schema - The schema for which resolving a dependent schema is desired
  * @param rootSchema - The root schema that will be forwarded to all the APIs
  * @param dependencyKey - The key name of the dependency
@@ -412,21 +424,24 @@ export function withDependentProperties(
  * @param formData- The current formData to assist retrieving a schema
  * @returns - The schema with the dependent schema resolved into it
  */
-export function withDependentSchema<T>(
-  validator: ValidatorType,
-  schema: RJSFSchema,
-  rootSchema: RJSFSchema,
+export function withDependentSchema<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema
+>(
+  validator: ValidatorType<T, S>,
+  schema: S,
+  rootSchema: S,
   dependencyKey: string,
-  dependencyValue: RJSFSchema,
+  dependencyValue: S,
   formData?: T
 ) {
-  const { oneOf, ...dependentSchema } = retrieveSchema<T>(
+  const { oneOf, ...dependentSchema } = retrieveSchema<T, S>(
     validator,
     dependencyValue,
     rootSchema,
     formData
   );
-  schema = mergeSchemas(schema, dependentSchema);
+  schema = mergeSchemas(schema, dependentSchema) as S;
   // Since it does not contain oneOf, we return the original schema.
   if (oneOf === undefined) {
     return schema;
@@ -436,14 +451,14 @@ export function withDependentSchema<T>(
     if (typeof subschema === "boolean" || !(REF_KEY in subschema)) {
       return subschema;
     }
-    return resolveReference<T>(
+    return resolveReference<T, S>(
       validator,
-      subschema as RJSFSchema,
+      subschema as S,
       rootSchema,
       formData
     );
   });
-  return withExactlyOneSubschema<T>(
+  return withExactlyOneSubschema<T, S>(
     validator,
     schema,
     rootSchema,
@@ -455,47 +470,50 @@ export function withDependentSchema<T>(
 
 /** Returns a `schema` with the best choice from the `oneOf` options merged into it
  *
- * @param validator - An implementation of the `ValidatorType` interface that will be used to validate oneOf options
+ * @param validator - An implementation of the `ValidatorType<T, S>` interface that will be used to validate oneOf options
  * @param schema - The schema for which resolving a oneOf subschema is desired
  * @param rootSchema - The root schema that will be forwarded to all the APIs
  * @param dependencyKey - The key name of the oneOf dependency
  * @param oneOf - The list of schemas representing the oneOf options
  * @param [formData] - The current formData to assist retrieving a schema
- * @returns  The schema with best choice of oneOf schemas merged into
+ * @returns  The schema with the best choice of oneOf schemas merged into
  */
-export function withExactlyOneSubschema<T = any>(
-  validator: ValidatorType,
-  schema: RJSFSchema,
-  rootSchema: RJSFSchema,
+export function withExactlyOneSubschema<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema
+>(
+  validator: ValidatorType<T, S>,
+  schema: S,
+  rootSchema: S,
   dependencyKey: string,
-  oneOf: RJSFSchemaDefinition[],
+  oneOf: S["oneOf"],
   formData?: T
-) {
-  const validSubschemas = oneOf.filter((subschema) => {
-    if (typeof subschema === "boolean" || !subschema.properties) {
+): S {
+  const validSubschemas = oneOf!.filter((subschema) => {
+    if (typeof subschema === "boolean" || !subschema || !subschema.properties) {
       return false;
     }
     const { [dependencyKey]: conditionPropertySchema } = subschema.properties;
     if (conditionPropertySchema) {
-      const conditionSchema: RJSFSchema = {
+      const conditionSchema: S = {
         type: "object",
         properties: {
           [dependencyKey]: conditionPropertySchema,
         },
-      };
+      } as S;
       const { errors } = validator.validateFormData(formData, conditionSchema);
       return errors.length === 0;
     }
     return false;
   });
 
-  if (validSubschemas.length !== 1) {
+  if (validSubschemas!.length !== 1) {
     console.warn(
       "ignoring oneOf in dependencies because there isn't exactly one subschema that is valid"
     );
     return schema;
   }
-  const subschema: RJSFSchema = validSubschemas[0] as RJSFSchema;
+  const subschema: S = validSubschemas[0] as S;
   const [dependentSubschema] = splitKeyElementFromObject(
     dependencyKey,
     subschema.properties as GenericObjectType
@@ -503,6 +521,6 @@ export function withExactlyOneSubschema<T = any>(
   const dependentSchema = { ...subschema, properties: dependentSubschema };
   return mergeSchemas(
     schema,
-    retrieveSchema<T>(validator, dependentSchema, rootSchema, formData)
-  );
+    retrieveSchema<T, S>(validator, dependentSchema, rootSchema, formData)
+  ) as S;
 }

--- a/packages/utils/src/schemaRequiresTrueValue.ts
+++ b/packages/utils/src/schemaRequiresTrueValue.ts
@@ -1,4 +1,4 @@
-import { RJSFSchema, RJSFSchemaDefinition } from "./types";
+import { RJSFSchema, StrictRJSFSchema } from "./types";
 
 /** Check to see if a `schema` specifies that a value must be true. This happens when:
  * - `schema.const` is truthy
@@ -9,7 +9,9 @@ import { RJSFSchema, RJSFSchemaDefinition } from "./types";
  * @param schema - The schema to check
  * @returns - True if the schema specifies a value that must be true, false otherwise
  */
-export default function schemaRequiresTrueValue(schema: RJSFSchema): boolean {
+export default function schemaRequiresTrueValue<
+  S extends StrictRJSFSchema = RJSFSchema
+>(schema: S): boolean {
   // Check if const is a truthy value
   if (schema.const) {
     return true;
@@ -22,18 +24,18 @@ export default function schemaRequiresTrueValue(schema: RJSFSchema): boolean {
 
   // If anyOf has a single value, evaluate the subschema
   if (schema.anyOf && schema.anyOf.length === 1) {
-    return schemaRequiresTrueValue(schema.anyOf[0] as RJSFSchema);
+    return schemaRequiresTrueValue(schema.anyOf[0] as S);
   }
 
   // If oneOf has a single value, evaluate the subschema
   if (schema.oneOf && schema.oneOf.length === 1) {
-    return schemaRequiresTrueValue(schema.oneOf[0] as RJSFSchema);
+    return schemaRequiresTrueValue(schema.oneOf[0] as S);
   }
 
   // Evaluate each subschema in allOf, to see if one of them requires a true value
   if (schema.allOf) {
-    const schemaSome = (subSchema: RJSFSchemaDefinition) =>
-      schemaRequiresTrueValue(subSchema as RJSFSchema);
+    const schemaSome = (subSchema: S["additionalProperties"]) =>
+      schemaRequiresTrueValue(subSchema as S);
     return schema.allOf.some(schemaSome);
   }
 

--- a/packages/utils/src/toConstant.ts
+++ b/packages/utils/src/toConstant.ts
@@ -1,5 +1,5 @@
 import { CONST_KEY, ENUM_KEY } from "./constants";
-import { RJSFSchema } from "./types";
+import { RJSFSchema, StrictRJSFSchema } from "./types";
 
 /** Returns the constant value from the schema when it is either a single value enum or has a const key. Otherwise
  * throws an error.
@@ -8,7 +8,9 @@ import { RJSFSchema } from "./types";
  * @returns - The constant value for the schema
  * @throws - Error when the schema does not have a constant value
  */
-export default function toConstant(schema: RJSFSchema) {
+export default function toConstant<S extends StrictRJSFSchema = RJSFSchema>(
+  schema: S
+) {
   if (
     ENUM_KEY in schema &&
     Array.isArray(schema.enum) &&

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1,5 +1,5 @@
 import React from "react";
-import { JSONSchema7, JSONSchema7Definition } from "json-schema";
+import { JSONSchema7 } from "json-schema";
 
 /** The representation of any generic object type, usually used as an intersection on other types to make them more
  * flexible in the properties they support (i.e. anything else)
@@ -11,12 +11,11 @@ export type GenericObjectType = {
 /** Map the JSONSchema7 to our own type so that we can easily bump to JSONSchema8 at some future date and only have to
  * update this one type.
  */
-export type RJSFSchema = JSONSchema7;
+export type StrictRJSFSchema = JSONSchema7;
 
-/** Map the JSONSchema7Definition to our own type so that we can easily bump to JSONSchema8Definition at some future
- * date and only have to update this one type.
+/** Allow for more flexible schemas (i.e. draft-2019) than the strict JSONSchema7
  */
-export type RJSFSchemaDefinition = JSONSchema7Definition;
+export type RJSFSchema = StrictRJSFSchema & GenericObjectType;
 
 /** The interface representing a Date object that contains an optional time */
 export interface DateObject {
@@ -129,7 +128,11 @@ export type FormValidation<T = any> = FieldValidation & {
 };
 
 /** The properties that are passed to an `ErrorListTemplate` implementation */
-export type ErrorListProps<T = any, F = any> = {
+export type ErrorListProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = {
   /** The errorSchema constructed by `Form` */
   errorSchema: ErrorSchema<T>;
   /** An array of the errors */
@@ -137,13 +140,17 @@ export type ErrorListProps<T = any, F = any> = {
   /** The `formContext` object that was passed to `Form` */
   formContext?: F;
   /** The schema that was passed to `Form` */
-  schema: RJSFSchema;
+  schema: S;
   /** The uiSchema that was passed to `Form` */
-  uiSchema?: UiSchema<T, F>;
+  uiSchema?: UiSchema<T, S, F>;
 };
 
 /** The properties that are passed to an `FieldErrorTemplate` implementation */
-export type FieldErrorProps<T = any, F = any> = {
+export type FieldErrorProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = {
   /** The errorSchema constructed by `Form` */
   errorSchema?: ErrorSchema<T>;
   /** An array of the errors */
@@ -151,119 +158,144 @@ export type FieldErrorProps<T = any, F = any> = {
   /** The tree of unique ids for every child field */
   idSchema: IdSchema<T>;
   /** The schema that was passed to field */
-  schema: RJSFSchema;
+  schema: S;
   /** The uiSchema that was passed to field */
-  uiSchema?: UiSchema<T, F>;
+  uiSchema?: UiSchema<T, S, F>;
   /** The `registry` object */
-  registry: Registry<T, F>;
+  registry: Registry<T, S, F>;
 };
 
 /** The properties that are passed to an `FieldHelpTemplate` implementation */
-export type FieldHelpProps<T = any, F = any> = {
+export type FieldHelpProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = {
   /** The help information to be rendered */
   help?: string | React.ReactElement;
   /** The tree of unique ids for every child field */
   idSchema: IdSchema<T>;
   /** The schema that was passed to field */
-  schema: RJSFSchema;
+  schema: S;
   /** The uiSchema that was passed to field */
-  uiSchema?: UiSchema<T, F>;
+  uiSchema?: UiSchema<T, S, F>;
   /** Flag indicating whether there are errors associated with this field */
   hasErrors?: boolean;
   /** The `registry` object */
-  registry: Registry<T, F>;
+  registry: Registry<T, S, F>;
 };
 
 /** The set of `Fields` stored in the `Registry` */
-export type RegistryFieldsType<T = any, F = any> = {
+export type RegistryFieldsType<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = {
   /** A `Field` indexed by `name` */
-  [name: string]: Field<T, F>;
+  [name: string]: Field<T, S, F>;
 };
 
 /** The set of `Widgets` stored in the `Registry` */
-export type RegistryWidgetsType<T = any, F = any> = {
+export type RegistryWidgetsType<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = {
   /** A `Widget` indexed by `name` */
-  [name: string]: Widget<T, F>;
+  [name: string]: Widget<T, S, F>;
 };
 
 /** The set of RJSF templates that can be overridden by themes or users */
-export interface TemplatesType<T = any, F = any> {
+export interface TemplatesType<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> {
   /** The template to use while rendering normal or fixed array fields */
-  ArrayFieldTemplate: React.ComponentType<ArrayFieldTemplateProps<T, F>>;
+  ArrayFieldTemplate: React.ComponentType<ArrayFieldTemplateProps<T, S, F>>;
   /** The template to use while rendering the description for an array field */
   ArrayFieldDescriptionTemplate: React.ComponentType<
-    ArrayFieldDescriptionProps<T, F>
+    ArrayFieldDescriptionProps<T, S, F>
   >;
   /** The template to use while rendering an item in an array field */
-  ArrayFieldItemTemplate: React.ComponentType<ArrayFieldTemplateItemType<T, F>>;
+  ArrayFieldItemTemplate: React.ComponentType<
+    ArrayFieldTemplateItemType<T, S, F>
+  >;
   /** The template to use while rendering the title for an array field */
-  ArrayFieldTitleTemplate: React.ComponentType<ArrayFieldTitleProps<T, F>>;
+  ArrayFieldTitleTemplate: React.ComponentType<ArrayFieldTitleProps<T, S, F>>;
   /** The template to use while rendering the standard html input */
-  BaseInputTemplate: React.ComponentType<WidgetProps<T, F>>;
+  BaseInputTemplate: React.ComponentType<WidgetProps<T, S, F>>;
   /** The template to use for rendering the description of a field */
-  DescriptionFieldTemplate: React.ComponentType<DescriptionFieldProps<T, F>>;
+  DescriptionFieldTemplate: React.ComponentType<DescriptionFieldProps<T, S, F>>;
   /** The template to use while rendering the errors for the whole form */
-  ErrorListTemplate: React.ComponentType<ErrorListProps<T, F>>;
+  ErrorListTemplate: React.ComponentType<ErrorListProps<T, S, F>>;
   /** The template to use while rendering the errors for a single field */
-  FieldErrorTemplate: React.ComponentType<FieldErrorProps<T, F>>;
+  FieldErrorTemplate: React.ComponentType<FieldErrorProps<T, S, F>>;
   /** The template to use while rendering the errors for a single field */
-  FieldHelpTemplate: React.ComponentType<FieldHelpProps<T, F>>;
+  FieldHelpTemplate: React.ComponentType<FieldHelpProps<T, S, F>>;
   /** The template to use while rendering a field */
-  FieldTemplate: React.ComponentType<FieldTemplateProps<T, F>>;
+  FieldTemplate: React.ComponentType<FieldTemplateProps<T, S, F>>;
   /** The template to use while rendering an object */
-  ObjectFieldTemplate: React.ComponentType<ObjectFieldTemplateProps<T, F>>;
+  ObjectFieldTemplate: React.ComponentType<ObjectFieldTemplateProps<T, S, F>>;
   /** The template to use for rendering the title of a field */
-  TitleFieldTemplate: React.ComponentType<TitleFieldProps<T, F>>;
+  TitleFieldTemplate: React.ComponentType<TitleFieldProps<T, S, F>>;
   /** The template to use for rendering information about an unsupported field type in the schema */
-  UnsupportedFieldTemplate: React.ComponentType<UnsupportedFieldProps<T, F>>;
+  UnsupportedFieldTemplate: React.ComponentType<UnsupportedFieldProps<T, S, F>>;
   /** The template to use for rendering a field that allows a user to add additional properties */
   WrapIfAdditionalTemplate: React.ComponentType<
-    WrapIfAdditionalTemplateProps<T, F>
+    WrapIfAdditionalTemplateProps<T, S, F>
   >;
   /** The set of templates associated with buttons in the form */
   ButtonTemplates: {
     /** The template to use for the main `Submit` button  */
-    SubmitButton: React.ComponentType<SubmitButtonProps<T, F>>;
+    SubmitButton: React.ComponentType<SubmitButtonProps<T, S, F>>;
     /** The template to use for the Add button used for AdditionalProperties and Array items */
-    AddButton: React.ComponentType<IconButtonProps<T, F>>;
+    AddButton: React.ComponentType<IconButtonProps<T, S, F>>;
     /** The template to use for the Move Down button used for Array items */
-    MoveDownButton: React.ComponentType<IconButtonProps<T, F>>;
+    MoveDownButton: React.ComponentType<IconButtonProps<T, S, F>>;
     /** The template to use for the Move Up button used for Array items */
-    MoveUpButton: React.ComponentType<IconButtonProps<T, F>>;
+    MoveUpButton: React.ComponentType<IconButtonProps<T, S, F>>;
     /** The template to use for the Remove button used for AdditionalProperties and Array items */
-    RemoveButton: React.ComponentType<IconButtonProps<T, F>>;
+    RemoveButton: React.ComponentType<IconButtonProps<T, S, F>>;
   };
 }
 
 /** The object containing the registered core, theme and custom fields and widgets as well as the root schema, form
  * context, schema utils and templates.
  */
-export interface Registry<T = any, F = any> {
+export interface Registry<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> {
   /** The set of all fields used by the `Form`. Includes fields from `core`, theme-specific fields and any custom
    * registered fields
    */
-  fields: RegistryFieldsType<T, F>;
+  fields: RegistryFieldsType<T, S, F>;
   /** The set of templates used by the `Form`. Includes templates from `core`, theme-specific fields and any custom
    * registered templates
    */
-  templates: TemplatesType<T, F>;
+  templates: TemplatesType<T, S, F>;
   /** The set of all widgets used by the `Form`. Includes widgets from `core`, theme-specific widgets and any custom
    * registered widgets
    */
-  widgets: RegistryWidgetsType<T, F>;
+  widgets: RegistryWidgetsType<T, S, F>;
   /** The `formContext` object that was passed to `Form` */
   formContext: F;
   /** The root schema, as passed to the `Form`, which can contain referenced definitions */
-  rootSchema: RJSFSchema;
+  rootSchema: S;
   /** The current implementation of the `SchemaUtilsType` (from `@rjsf/utils`) in use by the `Form`.  Used to call any
    * of the validation-schema-based utility functions
    */
-  schemaUtils: SchemaUtilsType<T>;
+  schemaUtils: SchemaUtilsType<T, S>;
 }
 
 /** The properties that are passed to a Field implementation */
-export interface FieldProps<T = any, F = any>
-  extends GenericObjectType,
+export interface FieldProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> extends GenericObjectType,
     Pick<
       React.HTMLAttributes<HTMLElement>,
       Exclude<
@@ -272,9 +304,9 @@ export interface FieldProps<T = any, F = any>
       >
     > {
   /** The JSON subschema object for this field */
-  schema: RJSFSchema;
+  schema: S;
   /** The uiSchema for this field */
-  uiSchema?: UiSchema<T, F>;
+  uiSchema?: UiSchema<T, S, F>;
   /** The tree of unique ids for every child field */
   idSchema: IdSchema<T>;
   /** The data for this field */
@@ -302,14 +334,22 @@ export interface FieldProps<T = any, F = any>
   /** The unique name of the field, usually derived from the name of the property in the JSONSchema */
   name: string;
   /** The `registry` object */
-  registry: Registry<T, F>;
+  registry: Registry<T, S, F>;
 }
 
 /** The definition of a React-based Field component */
-export type Field<T = any, F = any> = React.ComponentType<FieldProps<T, F>>;
+export type Field<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = React.ComponentType<FieldProps<T, S, F>>;
 
 /** The properties that are passed to a FieldTemplate implementation */
-export type FieldTemplateProps<T = any, F = any> = {
+export type FieldTemplateProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = {
   /** The id of the field in the hierarchy. You can use it to render a label targeting the wrapped widget */
   id: string;
   /** A string containing the base CSS classes, merged with any custom ones defined in your uiSchema */
@@ -349,9 +389,9 @@ export type FieldTemplateProps<T = any, F = any> = {
    */
   displayLabel?: boolean;
   /** The schema object for this field */
-  schema: RJSFSchema;
+  schema: S;
   /** The uiSchema object for this field */
-  uiSchema?: UiSchema<T, F>;
+  uiSchema?: UiSchema<T, S, F>;
   /** The `formContext` object that was passed to `Form` */
   formContext?: F;
   /** The formData for this field */
@@ -363,56 +403,69 @@ export type FieldTemplateProps<T = any, F = any> = {
   /** The property drop/removal event handler; Called when a field is removed in an additionalProperty context */
   onDropPropertyClick: (value: string) => () => void;
   /** The `registry` object */
-  registry: Registry<T, F>;
+  registry: Registry<T, S, F>;
 };
 
 /** The properties that are passed to the `UnsupportedFieldTemplate` implementation */
-export type UnsupportedFieldProps<T = any, F = any> = {
+export type UnsupportedFieldProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = {
   /** The schema object for this field */
-  schema: RJSFSchema;
+  schema: S;
   /** The tree of unique ids for every child field */
   idSchema?: IdSchema<T>;
   /** The reason why the schema field has an unsupported type */
   reason: string;
   /** The `registry` object */
-  registry: Registry<T, F>;
+  registry: Registry<T, S, F>;
 };
 
 /** The properties that are passed to a `TitleFieldTemplate` implementation */
-export type TitleFieldProps<T = any, F = any> = {
+export type TitleFieldProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = {
   /** The id of the field title in the hierarchy */
   id: string;
   /** The title for the field being rendered */
   title: string;
   /** The schema object for the field being titled */
-  schema: RJSFSchema;
+  schema: S;
   /** The uiSchema object for this title field */
-  uiSchema?: UiSchema<T, F>;
+  uiSchema?: UiSchema<T, S, F>;
   /** A boolean value stating if the field is required */
   required?: boolean;
   /** The `registry` object */
-  registry: Registry<T, F>;
+  registry: Registry<T, S, F>;
 };
 
 /** The properties that are passed to a `DescriptionFieldTemplate` implementation */
-export type DescriptionFieldProps<T = any, F = any> = {
+export type DescriptionFieldProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = {
   /** The id of the field description in the hierarchy */
   id: string;
   /** The schema object for the field being described */
-  schema: RJSFSchema;
+  schema: S;
   /** The uiSchema object for this description field */
-  uiSchema?: UiSchema<T, F>;
+  uiSchema?: UiSchema<T, S, F>;
   /** The description of the field being rendered */
   description: string | React.ReactElement;
   /** The `registry` object */
-  registry: Registry<T, F>;
+  registry: Registry<T, S, F>;
 };
 
 /** The properties that are passed to a `ArrayFieldTitleTemplate` implementation */
-export type ArrayFieldTitleProps<T = any, F = any> = Omit<
-  TitleFieldProps<T, F>,
-  "id" | "title"
-> & {
+export type ArrayFieldTitleProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = Omit<TitleFieldProps<T, S, F>, "id" | "title"> & {
   /** The title for the field being rendered */
   title?: string;
   /** The idSchema of the field in the hierarchy */
@@ -420,10 +473,11 @@ export type ArrayFieldTitleProps<T = any, F = any> = Omit<
 };
 
 /** The properties that are passed to a `ArrayFieldDescriptionTemplate` implementation */
-export type ArrayFieldDescriptionProps<T = any, F = any> = Omit<
-  DescriptionFieldProps<T, F>,
-  "id" | "description"
-> & {
+export type ArrayFieldDescriptionProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = Omit<DescriptionFieldProps<T, S, F>, "id" | "description"> & {
   /** The description of the field being rendered */
   description?: string | React.ReactElement;
   /** The idSchema of the field in the hierarchy */
@@ -431,7 +485,11 @@ export type ArrayFieldDescriptionProps<T = any, F = any> = Omit<
 };
 
 /** The properties of each element in the ArrayFieldTemplateProps.items array */
-export type ArrayFieldTemplateItemType<T = any, F = any> = {
+export type ArrayFieldTemplateItemType<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = {
   /** The html for the item's content */
   children: React.ReactElement;
   /** The className string */
@@ -459,13 +517,17 @@ export type ArrayFieldTemplateItemType<T = any, F = any> = {
   /** A stable, unique key for the array item */
   key: string;
   /** The uiSchema object for this field */
-  uiSchema?: UiSchema<T, F>;
+  uiSchema?: UiSchema<T, S, F>;
   /** The `registry` object */
-  registry: Registry<T, F>;
+  registry: Registry<T, S, F>;
 };
 
 /** The properties that are passed to an ArrayFieldTemplate implementation */
-export type ArrayFieldTemplateProps<T = any, F = any> = {
+export type ArrayFieldTemplateProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = {
   /** A boolean value stating whether new elements can be added to the array */
   canAdd?: boolean;
   /** The className string */
@@ -475,7 +537,7 @@ export type ArrayFieldTemplateProps<T = any, F = any> = {
   /** An object containing the id for this object & ids for its properties */
   idSchema: IdSchema<T>;
   /** An array of objects representing the items in the array */
-  items: ArrayFieldTemplateItemType<T, F>[];
+  items: ArrayFieldTemplateItemType<T, S, F>[];
   /** A function that adds a new item to the array */
   onAddClick: (event?: any) => void;
   /** A boolean value stating if the array is read-only */
@@ -485,9 +547,9 @@ export type ArrayFieldTemplateProps<T = any, F = any> = {
   /** A boolean value stating if the field is hiding its errors */
   hideError?: boolean;
   /** The schema object for this array */
-  schema: RJSFSchema;
+  schema: S;
   /** The uiSchema object for this array field */
-  uiSchema?: UiSchema<T, F>;
+  uiSchema?: UiSchema<T, S, F>;
   /** A string value containing the title for the array */
   title: string;
   /** The `formContext` object that was passed to Form */
@@ -497,7 +559,7 @@ export type ArrayFieldTemplateProps<T = any, F = any> = {
   /** An array of strings listing all generated error messages from encountered errors for this widget */
   rawErrors?: string[];
   /** The `registry` object */
-  registry: Registry<T, F>;
+  registry: Registry<T, S, F>;
 };
 
 /** The properties of each element in the ObjectFieldTemplateProps.properties array */
@@ -515,7 +577,11 @@ export type ObjectFieldTemplatePropertyType = {
 };
 
 /** The properties that are passed to an ObjectFieldTemplate implementation */
-export type ObjectFieldTemplateProps<T = any, F = any> = {
+export type ObjectFieldTemplateProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = {
   /** A string value containing the title for the object */
   title: string;
   /** A string value containing the description for the object */
@@ -525,7 +591,7 @@ export type ObjectFieldTemplateProps<T = any, F = any> = {
   /** An array of objects representing the properties in the object */
   properties: ObjectFieldTemplatePropertyType[];
   /** Returns a function that adds a new property to the object (to be used with additionalProperties) */
-  onAddClick: (schema: RJSFSchema) => () => void;
+  onAddClick: (schema: S) => () => void;
   /** A boolean value stating if the object is read-only */
   readonly?: boolean;
   /** A boolean value stating if the object is required */
@@ -533,9 +599,9 @@ export type ObjectFieldTemplateProps<T = any, F = any> = {
   /** A boolean value stating if the field is hiding its errors */
   hideError?: boolean;
   /** The schema object for this object */
-  schema: RJSFSchema;
+  schema: S;
   /** The uiSchema object for this object field */
-  uiSchema?: UiSchema<T, F>;
+  uiSchema?: UiSchema<T, S, F>;
   /** An object containing the id for this object & ids for its properties */
   idSchema: IdSchema<T>;
   /** The form data for the object */
@@ -543,15 +609,19 @@ export type ObjectFieldTemplateProps<T = any, F = any> = {
   /** The `formContext` object that was passed to Form */
   formContext?: F;
   /** The `registry` object */
-  registry: Registry<T, F>;
+  registry: Registry<T, S, F>;
 };
 
 /** The properties that are passed to a WrapIfAdditionalTemplate implementation */
-export type WrapIfAdditionalTemplateProps<T = any, F = any> = {
+export type WrapIfAdditionalTemplateProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = {
   /** The field or widget component instance for this field row */
   children: React.ReactNode;
 } & Pick<
-  FieldTemplateProps<T, F>,
+  FieldTemplateProps<T, S, F>,
   | "id"
   | "classNames"
   | "label"
@@ -566,8 +636,11 @@ export type WrapIfAdditionalTemplateProps<T = any, F = any> = {
 >;
 
 /** The properties that are passed to a Widget implementation */
-export interface WidgetProps<T = any, F = any>
-  extends GenericObjectType,
+export interface WidgetProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> extends GenericObjectType,
     Pick<
       React.HTMLAttributes<HTMLElement>,
       Exclude<keyof React.HTMLAttributes<HTMLElement>, "onBlur" | "onFocus">
@@ -575,9 +648,9 @@ export interface WidgetProps<T = any, F = any>
   /** The generated id for this widget */
   id: string;
   /** The JSONSchema subschema object for this widget */
-  schema: RJSFSchema;
+  schema: S;
   /** The uiSchema for this widget */
-  uiSchema?: UiSchema<T, F>;
+  uiSchema?: UiSchema<T, S, F>;
   /** The current value for this widget */
   value: any;
   /** The required status of this widget */
@@ -595,7 +668,7 @@ export interface WidgetProps<T = any, F = any>
   /** A map of UI Options passed as a prop to the component, including the optional `enumOptions`
    * which is a special case on top of `UIOptionsType` needed only by widgets
    */
-  options: NonNullable<UIOptionsType<T, F>> & {
+  options: NonNullable<UIOptionsType<T, S, F>> & {
     /** The enum options list for a type that supports them */
     enumOptions?: EnumOptionsType[];
   };
@@ -614,21 +687,30 @@ export interface WidgetProps<T = any, F = any>
   /** An array of strings listing all generated error messages from encountered errors for this widget */
   rawErrors?: string[];
   /** The `registry` object */
-  registry: Registry<T, F>;
+  registry: Registry<T, S, F>;
 }
 
 /** The definition of a React-based Widget component */
-export type Widget<T = any, F = any> = React.ComponentType<WidgetProps<T, F>>;
+export type Widget<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = React.ComponentType<WidgetProps<T, S, F>>;
 
 /** The type that defines the props used by the Submit button */
-export type SubmitButtonProps<T = any, F = any> = {
+export type SubmitButtonProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = {
   /** The uiSchema for this widget */
-  uiSchema?: UiSchema<T, F>;
+  uiSchema?: UiSchema<T, S, F>;
 };
 
 /** The type that defines the props for an Icon button, extending from a basic HTML button attributes */
 export type IconButtonProps<
   T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
   F = any
 > = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   /** An alternative specification for the type of the icon button */
@@ -636,7 +718,7 @@ export type IconButtonProps<
   /** The name representation or actual react element implementation for the icon */
   icon?: string | React.ReactElement;
   /** The uiSchema for this widget */
-  uiSchema?: UiSchema<T, F>;
+  uiSchema?: UiSchema<T, S, F>;
 };
 
 /** The type that defines how to change the behavior of the submit button for the form */
@@ -655,13 +737,13 @@ export type UISchemaSubmitButtonOptions = {
 };
 
 /** This type represents an element used to render an enum option */
-export type EnumOptionsType = {
+export type EnumOptionsType<S extends StrictRJSFSchema = RJSFSchema> = {
   /** The value for the enum option */
   value: any;
   /** The label for the enum options */
   label: string;
   /** The schema associated with the enum option when the option represents a `oneOf` or `anyOf` choice */
-  schema?: RJSFSchema;
+  schema?: S;
 };
 
 /** This type remaps the keys of `Type` to prepend `ui:` onto them. As a result it does not need to be exported */
@@ -672,9 +754,11 @@ type MakeUIType<Type> = {
 /** This type represents all the known supported options in the `ui:options` property, kept separate in order to
  * remap the keys. It also contains all the properties, optionally, of `TemplatesType` except "ButtonTemplates"
  */
-type UIOptionsBaseType<T = any, F = any> = Partial<
-  Omit<TemplatesType<T, F>, "ButtonTemplates">
-> & {
+type UIOptionsBaseType<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = Partial<Omit<TemplatesType<T, S, F>, "ButtonTemplates">> & {
   /** Any classnames that the user wants to be applied to a field in the ui */
   classNames?: string;
   /** We know that for title, it will be a string, if it is provided */
@@ -722,7 +806,7 @@ type UIOptionsBaseType<T = any, F = any> = Partial<
   /** Allows RJSF to override the default widget implementation by specifying either the name of a widget that is used
    * to look up an implementation from the `widgets` list or an actual one-off widget implementation itself
    */
-  widget?: Widget<T, F> | string;
+  widget?: Widget<T, S, F> | string;
   /** When using `additionalProperties`, key collision is prevented by appending a unique integer to the duplicate key.
    * This option allows you to change the separator between the original key name and the integer. Default is "-"
    */
@@ -730,7 +814,11 @@ type UIOptionsBaseType<T = any, F = any> = Partial<
 };
 
 /** The type that represents the Options potentially provided by `ui:options` */
-export type UIOptionsType<T = any, F = any> = UIOptionsBaseType<T, F> & {
+export type UIOptionsType<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = UIOptionsBaseType<T, S, F> & {
   /** Anything else will be one of these types */
   [key: string]: boolean | number | string | object | any[] | null | undefined;
 };
@@ -738,16 +826,20 @@ export type UIOptionsType<T = any, F = any> = UIOptionsBaseType<T, F> & {
 /** Type describing the well-known properties of the `UiSchema` while also supporting all user defined properties,
  * starting with `ui:`.
  */
-export type UiSchema<T = any, F = any> = GenericObjectType &
-  MakeUIType<UIOptionsBaseType<T, F>> & {
+export type UiSchema<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> = GenericObjectType &
+  MakeUIType<UIOptionsBaseType<T, S, F>> & {
     /** Allows the form to generate a unique prefix for the `Form`'s root prefix */
     "ui:rootFieldId"?: string;
     /** Allows RJSF to override the default field implementation by specifying either the name of a field that is used
      * to look up an implementation from the `fields` list or an actual one-off `Field` component implementation itself
      */
-    "ui:field"?: Field<T, F> | string;
-    /** An object that contains all of the potential UI options in a single object */
-    "ui:options"?: UIOptionsType<T, F>;
+    "ui:field"?: Field<T, S, F> | string;
+    /** An object that contains all the potential UI options in a single object */
+    "ui:options"?: UIOptionsType<T, S, F>;
   };
 
 /** A `CustomValidator` function takes in a `formData` and `errors` object and returns the given `errors` object back,
@@ -776,7 +868,10 @@ export type ValidationData<T> = {
 /** The interface that describes the validation functions that are provided by a Validator implementation used by the
  * schema utilities.
  */
-export interface ValidatorType<T = any> {
+export interface ValidatorType<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema
+> {
   /** This function processes the `formData` with an optional user contributed `customValidate` function, which receives
    * the form data and a `errorHandler` function that will be used to add custom validation errors for each field. Also
    * supports a `transformErrors` function that will take the raw AJV validation errors, prior to custom validation and
@@ -788,8 +883,8 @@ export interface ValidatorType<T = any> {
    * @param [transformErrors] - An optional function that is used to transform errors after AJV validation
    */
   validateFormData(
-    formData: T,
-    schema: RJSFSchema,
+    formData: T | undefined,
+    schema: S,
     customValidate?: CustomValidator<T>,
     transformErrors?: ErrorTransformer
   ): ValidationData<T>;
@@ -810,7 +905,7 @@ export interface ValidatorType<T = any> {
    * @param formData- - The form data to validate
    * @param rootSchema - The root schema used to provide $ref resolutions
    */
-  isValid(schema: RJSFSchema, formData: T, rootSchema: RJSFSchema): boolean;
+  isValid(schema: S, formData: T, rootSchema: S): boolean;
 }
 
 /** The `SchemaUtilsType` interface provides a wrapper around the publicly exported APIs in the `@rjsf/utils/schema`
@@ -818,12 +913,16 @@ export interface ValidatorType<T = any> {
  * the `validator` and `rootSchema` generally does not change across a `Form`, this allows for providing a simplified
  * set of APIs to the `@rjsf/core` components and the various themes as well.
  */
-export interface SchemaUtilsType<T = any> {
+export interface SchemaUtilsType<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F = any
+> {
   /** Returns the `ValidatorType` in the `SchemaUtilsType`
    *
    * @returns - The `ValidatorType`
    */
-  getValidator(): ValidatorType<T>;
+  getValidator(): ValidatorType<T, S>;
   /** Determines whether either the `validator` and `rootSchema` differ from the ones associated with this instance of
    * the `SchemaUtilsType`. If either `validator` or `rootSchema` are falsy, then return false to prevent the creation
    * of a new `SchemaUtilsType` with incomplete properties.
@@ -832,10 +931,7 @@ export interface SchemaUtilsType<T = any> {
    * @param rootSchema - The root schema that will be compared against the current one
    * @returns - True if the `SchemaUtilsType` differs from the given `validator` or `rootSchema`
    */
-  doesSchemaUtilsDiffer(
-    validator: ValidatorType,
-    rootSchema: RJSFSchema
-  ): boolean;
+  doesSchemaUtilsDiffer(validator: ValidatorType<T, S>, rootSchema: S): boolean;
   /** Returns the superset of `formData` that includes the given set updated to include any missing fields that have
    * computed to have defaults provided in the `schema`.
    *
@@ -845,7 +941,7 @@ export interface SchemaUtilsType<T = any> {
    * @returns - The resulting `formData` with all the defaults provided
    */
   getDefaultFormState(
-    schema: RJSFSchema,
+    schema: S,
     formData?: T,
     includeUndefinedValues?: boolean
   ): T | T[] | undefined;
@@ -856,42 +952,38 @@ export interface SchemaUtilsType<T = any> {
    * @param [uiSchema] - The UI schema from which to derive potentially displayable information
    * @returns - True if the label should be displayed or false if it should not
    */
-  getDisplayLabel<F = any>(
-    schema: RJSFSchema,
-    uiSchema?: UiSchema<T, F>
-  ): boolean;
+  getDisplayLabel(schema: S, uiSchema?: UiSchema<T, S, F>): boolean;
   /** Given the `formData` and list of `options`, attempts to find the index of the option that best matches the data.
    *
    * @param formData - The current formData, if any, onto which to provide any missing defaults
    * @param options - The list of options to find a matching options from
    * @returns - The index of the matched option or 0 if none is available
    */
-  getMatchingOption(formData: T, options: RJSFSchema[]): number;
+  getMatchingOption(formData: T, options: S[]): number;
   /** Checks to see if the `schema` and `uiSchema` combination represents an array of files
    *
    * @param schema - The schema for which check for array of files flag is desired
    * @param [uiSchema] - The UI schema from which to check the widget
    * @returns - True if schema/uiSchema contains an array of files, otherwise false
    */
-  isFilesArray<F = any>(schema: RJSFSchema, uiSchema?: UiSchema<T, F>): boolean;
+  isFilesArray(schema: S, uiSchema?: UiSchema<T, S, F>): boolean;
   /** Checks to see if the `schema` combination represents a multi-select
    *
    * @param schema - The schema for which check for a multi-select flag is desired
    * @returns - True if schema contains a multi-select, otherwise false
    */
-  isMultiSelect(schema: RJSFSchema): boolean;
+  isMultiSelect(schema: S): boolean;
   /** Checks to see if the `schema` combination represents a select
    *
    * @param schema - The schema for which check for a select flag is desired
    * @returns - True if schema contains a select, otherwise false
    */
-  isSelect(schema: RJSFSchema): boolean;
+  isSelect(schema: S): boolean;
   /** Merges the errors in `additionalErrorSchema` into the existing `validationData` by combining the hierarchies in the
    * two `ErrorSchema`s and then appending the error list from the `additionalErrorSchema` obtained by calling
    * `validator.toErrorList()` onto the `errors` in the `validationData`. If no `additionalErrorSchema` is passed, then
    * `validationData` is returned.
    *
-   * @param validator - The validator used to convert an ErrorSchema to a list of errors
    * @param validationData - The current `ValidationData` into which to merge the additional errors
    * @param [additionalErrorSchema] - The additional set of errors
    * @returns - The `validationData` with the additional errors from `additionalErrorSchema` merged into it, if provided.
@@ -905,10 +997,10 @@ export interface SchemaUtilsType<T = any> {
    * recursive resolution.
    *
    * @param schema - The schema for which retrieving a schema is desired
-   * @param [rawFormData] - The current formData, if any, to assist retrieving a schema
+   * @param [formData] - The current formData, if any, to assist retrieving a schema
    * @returns - The schema having its conditions, additional properties, references and dependencies resolved
    */
-  retrieveSchema(schema: RJSFSchema, formData?: T): RJSFSchema;
+  retrieveSchema(schema: S, formData?: T): S;
   /** Generates an `IdSchema` object for the `schema`, recursively
    *
    * @param schema - The schema for which the display label flag is desired
@@ -919,7 +1011,7 @@ export interface SchemaUtilsType<T = any> {
    * @returns - The `IdSchema` object for the `schema`
    */
   toIdSchema(
-    schema: RJSFSchema,
+    schema: S,
     id?: string,
     formData?: T,
     idPrefix?: string,
@@ -932,5 +1024,5 @@ export interface SchemaUtilsType<T = any> {
    * @param [formData] - The current formData, if any, onto which to provide any missing defaults
    * @returns - The `PathSchema` object for the `schema`
    */
-  toPathSchema(schema: RJSFSchema, name?: string, formData?: T): PathSchema<T>;
+  toPathSchema(schema: S, name?: string, formData?: T): PathSchema<T>;
 }

--- a/packages/utils/test/getTemplate.test.ts
+++ b/packages/utils/test/getTemplate.test.ts
@@ -1,6 +1,7 @@
 import {
   createSchemaUtils,
   getTemplate,
+  RJSFSchema,
   Registry,
   TemplatesType,
   UIOptionsType,
@@ -13,7 +14,7 @@ const CustomTemplate = () => undefined;
 
 const registry: Registry = {
   formContext: {},
-  rootSchema: {},
+  rootSchema: {} as RJSFSchema,
   schemaUtils: createSchemaUtils(getTestValidator({}), {}),
   templates: {
     ArrayFieldDescriptionTemplate: FakeTemplate,

--- a/packages/utils/test/schema/retrieveSchemaTest.ts
+++ b/packages/utils/test/schema/retrieveSchemaTest.ts
@@ -3,7 +3,6 @@ import {
   RJSFSchema,
   createSchemaUtils,
   ADDITIONAL_PROPERTY_FLAG,
-  RJSFSchemaDefinition,
 } from "../../src";
 import {
   resolveSchema,
@@ -1433,7 +1432,7 @@ export default function retrieveSchemaTest(testValidator: TestValidatorType) {
         const schema: RJSFSchema = {
           type: "integer",
         };
-        const oneOf: RJSFSchemaDefinition[] = [
+        const oneOf: RJSFSchema["oneOf"] = [
           true,
           { properties: undefined },
           { properties: { foo: { type: "string" } } },

--- a/packages/validator-ajv6/src/validator.ts
+++ b/packages/validator-ajv6/src/validator.ts
@@ -229,7 +229,7 @@ export default class AJV6Validator<T = any> implements ValidatorType<T> {
    * @param [transformErrors] - An optional function that is used to transform errors after AJV validation
    */
   validateFormData(
-    formData: T,
+    formData: T | undefined,
     schema: RJSFSchema,
     customValidate?: CustomValidator<T>,
     transformErrors?: ErrorTransformer
@@ -324,7 +324,7 @@ export default class AJV6Validator<T = any> implements ValidatorType<T> {
   /** Takes a `node` object list and transforms any contained `$ref` node variables with a prefix, recursively calling
    * `withIdRefPrefix` for any other elements.
    *
-   * @param nodeThe - list of object nodes to which a ROOT_SCHEMA_PREFIX is added when a REF_KEY is part of it
+   * @param node - The list of object nodes to which a ROOT_SCHEMA_PREFIX is added when a REF_KEY is part of it
    * @private
    */
   private withIdRefPrefixArray(node: object[]): RJSFSchema {

--- a/packages/validator-ajv6/test/validator.test.ts
+++ b/packages/validator-ajv6/test/validator.test.ts
@@ -47,7 +47,7 @@ describe("AJV6Validator", () => {
         expect(validator.isValid(schema, { foo: 12345 }, schema)).toBe(false);
       });
       it("should return false if the schema is invalid", () => {
-        const schema: RJSFSchema = "foobarbaz" as RJSFSchema;
+        const schema: RJSFSchema = "foobarbaz" as unknown as RJSFSchema;
 
         expect(validator.isValid(schema, { foo: "bar" }, schema)).toBe(false);
       });

--- a/packages/validator-ajv8/src/customizeValidator.ts
+++ b/packages/validator-ajv8/src/customizeValidator.ts
@@ -1,4 +1,4 @@
-import { ValidatorType } from "@rjsf/utils";
+import { RJSFSchema, StrictRJSFSchema, ValidatorType } from "@rjsf/utils";
 
 import { CustomValidatorOptionsType, Localizer } from "./types";
 import AJV8Validator from "./validator";
@@ -9,9 +9,12 @@ import AJV8Validator from "./validator";
  * @param [options={}] - The `CustomValidatorOptionsType` options that are used to create the `ValidatorType` instance
  * @param [localizer] - If provided, is used to localize a list of Ajv `ErrorObject`s
  */
-export default function customizeValidator<T = any>(
+export default function customizeValidator<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema
+>(
   options: CustomValidatorOptionsType = {},
   localizer?: Localizer
-): ValidatorType<T> {
-  return new AJV8Validator<T>(options, localizer);
+): ValidatorType<T, S> {
+  return new AJV8Validator<T, S>(options, localizer);
 }

--- a/packages/validator-ajv8/src/validator.ts
+++ b/packages/validator-ajv8/src/validator.ts
@@ -346,7 +346,7 @@ export default class AJV8Validator<
   /** Takes a `node` object list and transforms any contained `$ref` node variables with a prefix, recursively calling
    * `withIdRefPrefix` for any other elements.
    *
-   * @param node- The list of object nodes to which a ROOT_SCHEMA_PREFIX is added when a REF_KEY is part of it
+   * @param node - The list of object nodes to which a ROOT_SCHEMA_PREFIX is added when a REF_KEY is part of it
    * @private
    */
   private withIdRefPrefixArray(node: S[]): S[] {

--- a/packages/validator-ajv8/test/validator.test.ts
+++ b/packages/validator-ajv8/test/validator.test.ts
@@ -47,7 +47,7 @@ describe("AJV8Validator", () => {
         expect(validator.isValid(schema, { foo: 12345 }, schema)).toBe(false);
       });
       it("should return false if the schema is invalid", () => {
-        const schema: RJSFSchema = "foobarbaz" as RJSFSchema;
+        const schema: RJSFSchema = "foobarbaz" as unknown as RJSFSchema;
 
         expect(validator.isValid(schema, { foo: "bar" }, schema)).toBe(false);
       });


### PR DESCRIPTION
### Reasons for making this change

Partially fix #3189 by allowing for changing the type of the `schema` via a new generic `S`

- Updated `@rjsf/utils` to make the `schema` and `rootSchema` props use a new generic type `S`
  - Added the new `StrictRJSFSchema` type as the alias to `JSON7Schema` changing `RJSFSchema` to be `StrictRJSFSchema & GenericObjectType`
  - Deleted the `RJSFSchemaDefinition` type in favor of accessing it indirectly via the `S["<prop-with-definition>"]` syntax
  - Added the new generic `S extends StrictRJSFSchema = RJSFSchema` to all types that directly or indirectly used `RJSFSchema` after the `T = any` type
  - Updated `SchemaUtilsType` to add the `F = any` generic to the whole interface, removing it from the definition of the two functions that need it
  - Updated all functions that used `RJSFSchema` to take the new generic, replacing `RJSFSchema` with `S`
  - Added missing generics where needed
- Updated `@rjsf/core` to insert the `S extends StrictRJSFSchema = RJSFSchema` to every component that needed it, after the `T = any` generic
  - Updated the `index.ts` for the `ButtonTemplates`, `field`, `templates` and `widgets` to make them functions that take the `T`, `S` and `F` generics
  - Updated `getDefaultRegistry()` and `templates()` to call the appropriate functions
  - Replaced all uses of `RJSFSchema` and `RJSFSchemaDefinition` with `S` and `S["<prop-with-definition>"]`
  - Added missing generics where needed
  - Fixed a few type casts due the to the change in the `RJSFSchema` type
- Updated `@rjsf/validator-ajv6` to fix a few type casts due to the change in the `RJSFSchema` type
- Updated `@rjsf/validator-ajv8` to add the `S extends StrictRJSFSchema = RJSFSchema` generic to the `customizeValidator()` function and the `AJV8Validator` class
  - Replaced all uses of `RJSFSchema` and `RJSFSchemaDefinition` with `S` and `S["<prop-with-definition>"]`
  - Changed `RJSFSchema` to `S` where applicable
  - Fixed a few type casts due the to the change in the `RJSFSchema` type

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
