### PR TITLE
feature: Support raw validation in the playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,20 +50,24 @@ should change the heading of the (upcoming) version to include a major version b
   - `StrictRJSFSchema` was added as the alias to `JSON7Schema` and `RJSFSchema` was modified to be `StrictRJSFSchema & GenericObjectType`
   - This new generic was added BEFORE the newly added `F = any` generic because it is assumed that more people will want to change the schema than the formContext types
   - This provides future support for the newer draft versions of the schema
+- Updated the `ValidatorType` interface to add a new `rawValidation()` method for use by the playground
 
 ## @rjsf/validator-ajv6
 - Fixed a few type casts given the new expanded definition of the `RJSFSchema` type change
 - Deprecated this library in favor of the `@rjsf/validator-ajv8`
+- Refactored out the `rawValidation()` function for use by the playground
 
 ## @rjsf/validator-ajv8
 - Updated the typing to add the new `S extends StrictRJSFSchema = RJSFSchema` generic and fixed up type casts
 - Added the `AjvClass` prop to the `CustomValidatorOptionsType` to support using the `Ajv2019` or `Ajv2020` class implementation instead of the default `Ajv` class; fixing [#3189](https://github.com/rjsf-team/react-jsonschema-form/issues/3189)
+- Refactored out the `rawValidation()` function for use by the playground
 
 ## Dev / docs / playground
 - Updated the `5.x upgrade guide` and `utility-functions.md` to document the new `StrictRJSFSchema` and `S` generic
 - Updated the `validation` guide to document the new `AjvClass` prop on `CustomValidatorOptionsType` and mentioning the deprecation of `@rjsf/validator-ajv6`
 - Updated the playground to add support for using the AJV 8 validator with the `draft-2019-09` and `draft-2020-12` schemas and to make the `AJV8` validator the default validator, marking `AJV6` as deprecated
 - Updated all the documentation to switch to Typescript notation where missing along with switching to using the `@rjsf/validator-ajv8` validator as the default
+- Added a way of doing a raw Ajv validation in the playground to determine whether an issue is with RJSF or Ajv
 
 # 5.0.0-beta.11
 

--- a/packages/playground/src/app.jsx
+++ b/packages/playground/src/app.jsx
@@ -285,17 +285,17 @@ class CopyLink extends Component {
   }
 }
 
-const EMPTY_RAW_VALIDATION = { errors: undefined, validationError: undefined };
-
 function RawValidatorTest({ validator, schema, formData }) {
   const [rawValidation, setRawValidation] = React.useState();
-  const { errors, validationError } = rawValidation || EMPTY_RAW_VALIDATION;
   const handleClearClick = () => setRawValidation(undefined);
   const handleRawClick = () => setRawValidation(validator.rawValidation(schema, formData));
 
   let displayErrors;
   if (rawValidation) {
-    displayErrors = errors ? JSON.stringify(errors, null, 2) : "No AJV errors encountered";
+    displayErrors =
+      rawValidation.errors || rawValidation.validationError ?
+        JSON.stringify(rawValidation, null, 2) :
+        "No AJV errors encountered";
   }
   return (
     <div>

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -902,10 +902,20 @@ export interface ValidatorType<
    * false.
    *
    * @param schema - The schema against which to validate the form data   * @param schema
-   * @param formData- - The form data to validate
+   * @param formData - The form data to validate
    * @param rootSchema - The root schema used to provide $ref resolutions
    */
   isValid(schema: S, formData: T, rootSchema: S): boolean;
+  /** Runs the pure validation of the `schema` and `formData` without any of the RJSF functionality. Provided for use
+   * by the playground. Returns the `errors` from the validation
+   *
+   * @param schema - The schema against which to validate the form data   * @param schema
+   * @param formData - The form data to validate
+   */
+  rawValidation<Result = any>(
+    schema: S,
+    formData?: T
+  ): { errors?: Result[]; validationError?: Error };
 }
 
 /** The `SchemaUtilsType` interface provides a wrapper around the publicly exported APIs in the `@rjsf/utils/schema`

--- a/packages/utils/test/testUtils/getTestValidator.ts
+++ b/packages/utils/test/testUtils/getTestValidator.ts
@@ -45,6 +45,7 @@ export default function getTestValidator<T = any>({
         }
         return [];
       }),
+      rawValidation: jest.fn().mockImplementation(() => {}),
       setReturnValues({ isValid, data, errorList }: TestValidatorParams) {
         if (isValid !== undefined) {
           testValidator._isValid = isValid;

--- a/packages/validator-ajv6/test/utilsTests/getTestValidator.ts
+++ b/packages/validator-ajv6/test/utilsTests/getTestValidator.ts
@@ -37,6 +37,12 @@ export default function getTestValidator<T = any>(
     isValid(schema: RJSFSchema, formData: T, rootSchema: RJSFSchema): boolean {
       return validator.isValid(schema, formData, rootSchema);
     },
+    rawValidation<Result = any>(
+      schema: RJSFSchema,
+      formData?: T
+    ): { errors?: Result[]; validationError?: Error } {
+      return validator.rawValidation(schema, formData);
+    },
     // This is intentionally a no-op as we are using the real validator here
     setReturnValues() {},
   };

--- a/packages/validator-ajv8/test/utilsTests/getTestValidator.ts
+++ b/packages/validator-ajv8/test/utilsTests/getTestValidator.ts
@@ -37,6 +37,12 @@ export default function getTestValidator<T = any>(
     isValid(schema: RJSFSchema, formData: T, rootSchema: RJSFSchema): boolean {
       return validator.isValid(schema, formData, rootSchema);
     },
+    rawValidation<Result = any>(
+      schema: RJSFSchema,
+      formData?: T
+    ): { errors?: Result[]; validationError?: Error } {
+      return validator.rawValidation(schema, formData);
+    },
     // This is intentionally a no-op as we are using the real validator here
     setReturnValues() {},
   };


### PR DESCRIPTION
### Reasons for making this change

To help users determine whether validation issues are specific to Ajv or RJSF, a new raw validation feature was added to the playground
- Updated the `ValidatorType` interface to add the new `rawValidation()` function
- Refactored the `validator-ajv6` and `validator-ajv8` `ValidatorType` implementations to create the `rawValidation()` function
- Updated the Test validation implementations to implement the `rawValidation()` function
- Updated the playground's `app.js` to update the accidentally committed code to better display any validation errors

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

<img width="882" alt="Screenshot 2022-10-30 at 11 10 05 PM" src="https://user-images.githubusercontent.com/51679588/198942898-26e6ea1c-926e-419e-b6b8-4e6f6368dc88.png">
