### PR TITLE
Fixes for #3228 (playground dev crash), #3213 (Ajv8 additionalProperties validation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.0.0-beta.13
+
+## @rjsf/playground
+- Fix Vite development server [#3228](https://github.com/rjsf-team/react-jsonschema-form/issues/3228)
+
 # 5.0.0-beta.12
 
 ## @rjsf/antd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/playground
 - Fix Vite development server [#3228](https://github.com/rjsf-team/react-jsonschema-form/issues/3228)
 
+## @rjsf/validator-ajv8
+- Fix additionalProperties validation [#3213](https://github.com/rjsf-team/react-jsonschema-form/issues/3213)
+- Report all schema errors thrown by Ajv. Previously, we would only report errors thrown for a missing meta-schema. This behavior is unchanged for @rjsf/validator-ajv6.
+- Disable Ajv strict mode by default.
+- Add RJSF-specific additional properties keywords to Ajv to prevent errors from being reported in strict mode.
+
 # 5.0.0-beta.12
 
 ## @rjsf/antd

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -9,6 +9,7 @@
       rel="stylesheet"
       href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"
     />
+    <script>window.global = globalThis</script>
   </head>
   <body>
     <div id="app"></div>

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -16,6 +16,17 @@
         "@fluentui/react": "^7.190.3",
         "@material-ui/core": "^4.12.4",
         "@mui/material": "^5.10.11",
+        "@rjsf/antd": "^5.0.0-beta.12",
+        "@rjsf/bootstrap-4": "^5.0.0-beta.12",
+        "@rjsf/chakra-ui": "^5.0.0-beta.12",
+        "@rjsf/core": "^5.0.0-beta.12",
+        "@rjsf/fluent-ui": "^5.0.0-beta.12",
+        "@rjsf/material-ui": "^5.0.0-beta.12",
+        "@rjsf/mui": "^5.0.0-beta.12",
+        "@rjsf/semantic-ui": "^5.0.0-beta.12",
+        "@rjsf/utils": "^5.0.0-beta.12",
+        "@rjsf/validator-ajv6": "^5.0.0-beta.12",
+        "@rjsf/validator-ajv8": "^5.0.0-beta.12",
         "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
         "ajv-i18n": "^4.2.0",
@@ -52,7 +63,7 @@
         "@material-ui/icons": "^4.11.3",
         "@monaco-editor/react": "^4.4.6",
         "@mui/icons-material": "^5.10.9",
-        "@vitejs/plugin-react": "^2.1.0",
+        "@vitejs/plugin-react": "^2.2.0",
         "atob": "^2.1.2",
         "cross-env": "^7.0.3",
         "eslint": "^8.26.0",
@@ -75,7 +86,7 @@
         "rimraf": "^3.0.2",
         "sass": "^1.55.0",
         "source-map-loader": "^4.0.1",
-        "vite": "^3.1.8"
+        "vite": "^3.2.2"
       },
       "engines": {
         "node": ">=14"
@@ -2065,12 +2076,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.18.6.tgz",
-      "integrity": "sha512-utZmlASneDfdaMh0m/WausbjUjEdGrQJz0vFK93d7wD3xf5wBtX219+q6IlCNZeguIcxS2f/CvLZrlLSvSHQXw==",
+      "version": "7.19.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.19.6.tgz",
+      "integrity": "sha512-RpAi004QyMNisst/pvSanoRdJ4q+jMCWyk9zdw/CyLB9j8RXEahodR6l2GyttDRyEVWZtbN+TpLiHJ3t34LbsQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6"
+        "@babel/helper-plugin-utils": "^7.19.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -4211,6 +4222,36 @@
         "react-dom": ">=16.8.0 <18.0.0"
       }
     },
+    "node_modules/@fluentui/react-component-event-listener": {
+      "version": "0.51.7",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-component-event-listener/-/react-component-event-listener-0.51.7.tgz",
+      "integrity": "sha512-NjVm+crN0T9A7vITL8alZeHnuV8zi2gos0nezU/2YOxaUAB9E4zKiPxt/6k5U50rJs/gj8Nu45iXxnjO41HbZg==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17",
+        "react-dom": "^16.8.0 || ^17"
+      }
+    },
+    "node_modules/@fluentui/react-component-ref": {
+      "version": "0.51.7",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-component-ref/-/react-component-ref-0.51.7.tgz",
+      "integrity": "sha512-CX27jVJYaFoBCWpuWAizQZ2se137ku1dmDyn8sw+ySNJa+kkQf7LnMydiPW5K7cRdUSqUJW3eS4EjKRvVAx8xA==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.4",
+        "react-is": "^16.6.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17",
+        "react-dom": "^16.8.0 || ^17"
+      }
+    },
+    "node_modules/@fluentui/react-component-ref/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "node_modules/@fluentui/react-focus": {
       "version": "7.18.16",
       "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.18.16.tgz",
@@ -4317,6 +4358,19 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@hypnosphi/create-react-context": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
+      "integrity": "sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==",
+      "dependencies": {
+        "gud": "^1.0.0",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.0.0",
+        "react": ">=0.14.0"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -5014,6 +5068,14 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
+    "node_modules/@react-icons/all-files": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@react-icons/all-files/-/all-files-4.1.0.tgz",
+      "integrity": "sha512-hxBI2UOuVaI3O/BhQfhtb4kcGn9ft12RWAFVMUeNjqqhLsHvFtzIkFaptBJpFDANTKoDfdVoHTKZDlwKCACbMQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/@restart/context": {
       "version": "2.1.4",
       "license": "MIT",
@@ -5030,6 +5092,229 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@rjsf/antd": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/antd/-/antd-5.0.0-beta.12.tgz",
+      "integrity": "sha512-2U5x4DV3TeVQFjX6YJgLBw1ND/sJoZlUyePTyygOPqltto4wPUdXdJS7m5+zRinowlCZrcr9l2u7RCwA4Bnpwg==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@ant-design/icons": "^4.0.0",
+        "@rjsf/core": "^5.0.0-beta.1",
+        "@rjsf/utils": "^5.0.0-beta.1",
+        "antd": "^4.0.0",
+        "dayjs": "^1.8.0",
+        "react": "^16.14.0 || >=17"
+      }
+    },
+    "node_modules/@rjsf/bootstrap-4": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/bootstrap-4/-/bootstrap-4-5.0.0-beta.12.tgz",
+      "integrity": "sha512-D3AbxTBTUQLCiCB2mOmH/QAMS3lmyZUmgvSrl88KEoECU0ZFimD1GMIcCtlN5PPVrhjs/ghku193AigdZVRhlw==",
+      "dependencies": {
+        "@react-icons/all-files": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@rjsf/core": "^5.0.0-beta.1",
+        "@rjsf/utils": "^5.0.0-beta.1",
+        "react": "^16.14.0 || >=17",
+        "react-bootstrap": "^1.6.5"
+      }
+    },
+    "node_modules/@rjsf/chakra-ui": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/chakra-ui/-/chakra-ui-5.0.0-beta.12.tgz",
+      "integrity": "sha512-JsOjeST0yOd0Qz9wBnpPomBsaiab4lJeFeNojEcHQymjFHRSa+MOdBmI1o+9TCUgJNIDfvQG+u4GnAH/AWWpKA==",
+      "dependencies": {
+        "react-select": "^5.5.6"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@chakra-ui/icons": ">=1.1.1",
+        "@chakra-ui/react": ">=1.7.3",
+        "@rjsf/core": "^5.0.0-beta.1",
+        "@rjsf/utils": "^5.0.0-beta.1",
+        "chakra-react-select": ">=3.3.8",
+        "framer-motion": ">=5.6.0",
+        "react": "^16.14.0 || >=17"
+      }
+    },
+    "node_modules/@rjsf/core": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-5.0.0-beta.12.tgz",
+      "integrity": "sha512-UPGlJNAq2ub1td8XN+0KJ1VtQIKHER4i8zCmVhAViGEH98hWmsks9iRt2PqLkwCBdprR/ZwR09R7OOdsWJz7EA==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15",
+        "nanoid": "^3.3.4",
+        "prop-types": "^15.7.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@rjsf/utils": "^5.0.0-beta.1",
+        "react": "^16.14.0 || >=17"
+      }
+    },
+    "node_modules/@rjsf/fluent-ui": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/fluent-ui/-/fluent-ui-5.0.0-beta.12.tgz",
+      "integrity": "sha512-150niPPjwvlwAFW6K+AoQ9jkUhGYGZrrmjyHY0g5grBrA7Zi7X/Pa4KEuBQTDb4GHBamKwP1/ngwnJr2FRulsA==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@fluentui/react": "^7.190.3",
+        "@rjsf/core": "^5.0.0-beta.1",
+        "@rjsf/utils": "^5.0.0-beta.1",
+        "react": "^16.14.0 || >=17"
+      }
+    },
+    "node_modules/@rjsf/material-ui": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/material-ui/-/material-ui-5.0.0-beta.12.tgz",
+      "integrity": "sha512-gBV+NDMsordjoIcVQ6W/JrNUJBFaHTrWdcrGItyMynak9uvP7imhaid6J/vmJWlY6trwbr0DmQx55U06gIU4GA==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@material-ui/core": "^4.12.3",
+        "@material-ui/icons": "^4.11.2",
+        "@rjsf/core": "^5.0.0-beta.1",
+        "@rjsf/utils": "^5.0.0-beta.1",
+        "react": "^16.14.0 || >=17"
+      }
+    },
+    "node_modules/@rjsf/mui": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/mui/-/mui-5.0.0-beta.12.tgz",
+      "integrity": "sha512-oTY+0xWekVwY4RTYKXZ+BOyel7bOAqM5CyjjgicEfCrR6Jjo/yclh6A7Fxkc5K6xYEM3nExQNrJEw1jDOxOojg==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.7.0",
+        "@emotion/styled": "^11.6.0",
+        "@mui/icons-material": "^5.2.0",
+        "@mui/material": "^5.2.2",
+        "@rjsf/core": "^5.0.0-beta.1",
+        "@rjsf/utils": "^5.0.0-beta.1",
+        "react": ">=17"
+      }
+    },
+    "node_modules/@rjsf/semantic-ui": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/semantic-ui/-/semantic-ui-5.0.0-beta.12.tgz",
+      "integrity": "sha512-7B7Iwzk+Q5fz7Vov/kmjzowWwG2pVd95BJrmzj4I3HtjNDuTefMd1NaARRYS/Gw+Y2uAYQHKk4zxjZNipqoZwg==",
+      "dependencies": {
+        "semantic-ui-css": "^2.5.0",
+        "semantic-ui-react": "1.3.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@rjsf/core": "^5.0.0-beta.1",
+        "@rjsf/utils": "^5.0.0-beta.1",
+        "react": "^16.14.0 || >=17",
+        "semantic-ui-react": "1.3.1"
+      }
+    },
+    "node_modules/@rjsf/utils": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.0.0-beta.12.tgz",
+      "integrity": "sha512-RH965WMGp3Z25iQ2PTn+BFkQusJuvG0e2fl8V+wx1N21EkrZnW2+twouWUmqNqHwke2Z0OOimF5picZVgobl7g==",
+      "dependencies": {
+        "json-schema-merge-allof": "^0.8.1",
+        "jsonpointer": "^5.0.1",
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15",
+        "react-is": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || >=17"
+      }
+    },
+    "node_modules/@rjsf/validator-ajv6": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/validator-ajv6/-/validator-ajv6-5.0.0-beta.12.tgz",
+      "integrity": "sha512-dGMacqI/M/p9UdTa1EaIhxQjnGUEE8rbjO3qC/HFLbD8Qit2bjpWFFeC1vPt5aXdahSP7f27n9s1vZPv5IPNzA==",
+      "dependencies": {
+        "ajv": "^6.7.0",
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@rjsf/utils": "^5.0.0-beta.1"
+      }
+    },
+    "node_modules/@rjsf/validator-ajv6/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@rjsf/validator-ajv6/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/@rjsf/validator-ajv8": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/validator-ajv8/-/validator-ajv8-5.0.0-beta.12.tgz",
+      "integrity": "sha512-29iqu6ajec93mz0b+0NQq1DdoZE5NxatHYWEOeAvolcfOWa+8ai8e8A5u+fn2RtgsspQTtLjsXjF6CtblI1V0A==",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-formats": "^2.1.1",
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@rjsf/utils": "^5.0.0-beta.1"
+      }
+    },
+    "node_modules/@semantic-ui-react/event-stack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-3.1.3.tgz",
+      "integrity": "sha512-FdTmJyWvJaYinHrKRsMLDrz4tTMGdFfds299Qory53hBugiDvGC0tEJf+cHsi5igDwWb/CLOgOiChInHwq8URQ==",
+      "dependencies": {
+        "exenv": "^1.2.2",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@types/html-minifier-terser": {
@@ -5202,17 +5487,17 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-2.1.0.tgz",
-      "integrity": "sha512-am6rPyyU3LzUYne3Gd9oj9c4Rzbq5hQnuGXSMT6Gujq45Il/+bunwq3lrB7wghLkiF45ygMwft37vgJ/NE8IAA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-2.2.0.tgz",
+      "integrity": "sha512-FFpefhvExd1toVRlokZgxgy2JtnBOdp4ZDsq7ldCWaqGSGn9UhWMAVm/1lxPL14JfNS5yGz+s9yFrQY6shoStA==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.18.13",
-        "@babel/plugin-transform-react-jsx": "^7.18.10",
+        "@babel/core": "^7.19.6",
+        "@babel/plugin-transform-react-jsx": "^7.19.0",
         "@babel/plugin-transform-react-jsx-development": "^7.18.6",
         "@babel/plugin-transform-react-jsx-self": "^7.18.6",
-        "@babel/plugin-transform-react-jsx-source": "^7.18.6",
-        "magic-string": "^0.26.2",
+        "@babel/plugin-transform-react-jsx-source": "^7.19.6",
+        "magic-string": "^0.26.7",
         "react-refresh": "^0.14.0"
       },
       "engines": {
@@ -5716,7 +6001,6 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -5956,6 +6240,27 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/compute-gcd": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
+      "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
+      "dependencies": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
+    "node_modules/compute-lcm": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
+      "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
+      "dependencies": {
+        "compute-gcd": "^1.2.1",
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
     },
     "node_modules/compute-scroll-into-view": {
       "version": "1.0.14",
@@ -6204,6 +6509,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dependencies": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -6233,7 +6554,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
       "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-      "dev": true,
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
@@ -7208,6 +7528,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
+    },
     "node_modules/express": {
       "version": "4.18.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
@@ -7278,8 +7603,7 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -7654,6 +7978,14 @@
       "version": "1.1.1",
       "license": "MIT"
     },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "dev": true,
@@ -7672,7 +8004,6 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -7831,6 +8162,11 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
+    "node_modules/gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -7854,7 +8190,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
       "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.1"
       },
@@ -7866,7 +8201,20 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -8133,6 +8481,21 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "license": "MIT"
@@ -8143,6 +8506,20 @@
       "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "dependencies": {
         "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8215,6 +8592,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-typedarray": {
@@ -8399,6 +8791,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
+      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw=="
+    },
     "node_modules/js-sdsl": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
@@ -8443,6 +8840,27 @@
       "version": "2.3.1",
       "license": "MIT"
     },
+    "node_modules/json-schema-compare": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+      "dependencies": {
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/json-schema-merge-allof": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.8.1.tgz",
+      "integrity": "sha512-CTUKmIlPJbsWfzRRnOXz+0MjIqvnleIXwFTzz+t9T86HnYX/Rozria6ZVGLktAU9e+NygNljveP+yxqtQp/Q4w==",
+      "dependencies": {
+        "compute-lcm": "^1.1.2",
+        "json-schema-compare": "^0.2.2",
+        "lodash": "^4.17.20"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -8467,6 +8885,14 @@
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/jss": {
@@ -8696,6 +9122,11 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
+    "node_modules/keyboard-key": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keyboard-key/-/keyboard-key-1.1.0.tgz",
+      "integrity": "sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ=="
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -8813,6 +9244,11 @@
       "version": "4.17.21",
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -8861,9 +9297,9 @@
       "dev": true
     },
     "node_modules/magic-string": {
-      "version": "0.26.3",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.3.tgz",
-      "integrity": "sha512-u1Po0NDyFcwdg2nzHT88wSK0+Rih0N1M+Ph1Sp08k8yvFFU3KR72wryS7e1qMPJypt99WB7fIFVCA92mQrMjrg==",
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
       "dev": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
@@ -9021,7 +9457,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -9331,11 +9766,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -9703,9 +10152,9 @@
       "license": "MIT"
     },
     "node_modules/postcss": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "version": "8.4.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
+      "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
       "dev": true,
       "funding": [
         {
@@ -10670,6 +11119,33 @@
         "react-dom": ">=16.3.0"
       }
     },
+    "node_modules/react-popper": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.11.tgz",
+      "integrity": "sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2",
+        "@hypnosphi/create-react-context": "^0.3.1",
+        "deep-equal": "^1.1.1",
+        "popper.js": "^1.14.4",
+        "prop-types": "^15.6.1",
+        "typed-styles": "^0.0.7",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": "0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/react-popper/node_modules/popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/react-portal": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.2.tgz",
@@ -10745,16 +11221,16 @@
       }
     },
     "node_modules/react-select": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.5.2.tgz",
-      "integrity": "sha512-zbcxtiqXvFW2Wh+dd8zAqMY6QaqX9Ez0WlcjSXycXn1ASpKdc17LcGJj7gAJiUcHI/UVlo6wfg44hgBsUPyEBQ==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.6.0.tgz",
+      "integrity": "sha512-uUvP/72rA8NGhOL16RVBaeC12Wa4NUE0iXIa6hz0YRno9ZgxTmpuMeKzjR7vHcwmigpVCoe0prP+3NVb6Obq8Q==",
       "dependencies": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
         "@emotion/react": "^11.8.1",
         "@floating-ui/dom": "^1.0.1",
         "@types/react-transition-group": "^4.4.0",
-        "memoize-one": "^5.0.0",
+        "memoize-one": "^6.0.0",
         "prop-types": "^15.6.0",
         "react-transition-group": "^4.3.0",
         "use-isomorphic-layout-effect": "^1.1.2"
@@ -10763,11 +11239,6 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
-    },
-    "node_modules/react-select/node_modules/memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "node_modules/react-style-singleton": {
       "version": "2.1.1",
@@ -10873,6 +11344,22 @@
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.8.4"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/regexpp": {
@@ -11040,9 +11527,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.78.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
-      "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -11144,6 +11631,42 @@
       "dependencies": {
         "compute-scroll-into-view": "^1.0.14"
       }
+    },
+    "node_modules/semantic-ui-css": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.5.0.tgz",
+      "integrity": "sha512-jIWn3WXXE2uSaWCcB+gVJVRG3masIKtTMNEP2X8Aw909H2rHpXGneYOxzO3hT8TpyvB5/dEEo9mBFCitGwoj1A==",
+      "dependencies": {
+        "jquery": "x.*"
+      }
+    },
+    "node_modules/semantic-ui-react": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-1.3.1.tgz",
+      "integrity": "sha512-3EE8Cl2Tq9re+J5An8QOZHgjRJjHqNDBq+Aoaa0TLFnd79UgYzovJPQGy3AWIxgCkxDPj4c3yxl72ImumJLyeA==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@fluentui/react-component-event-listener": "~0.51.1",
+        "@fluentui/react-component-ref": "~0.51.1",
+        "@semantic-ui-react/event-stack": "^3.1.0",
+        "clsx": "^1.1.1",
+        "keyboard-key": "^1.1.0",
+        "lodash": "^4.17.19",
+        "lodash-es": "^4.17.15",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6",
+        "react-popper": "^1.3.7",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0",
+        "react-dom": "^16.8.0"
+      }
+    },
+    "node_modules/semantic-ui-react/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -11633,6 +12156,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-styles": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
+      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
+    },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "dev": true,
@@ -11819,6 +12347,38 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg=="
+    },
+    "node_modules/validate.io-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+      "integrity": "sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ=="
+    },
+    "node_modules/validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==",
+      "dependencies": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "node_modules/validate.io-integer-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
+      "integrity": "sha512-mTrMk/1ytQHtCY0oNO3dztafHYyGU88KL+jRxWuzfOmQb+4qqnWmI+gykvGp8usKZOM0H7keJHEbRaFiYA0VrA==",
+      "dependencies": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-integer": "^1.0.4"
+      }
+    },
+    "node_modules/validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg=="
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "dev": true,
@@ -11828,15 +12388,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.8.tgz",
-      "integrity": "sha512-m7jJe3nufUbuOfotkntGFupinL/fmuTNuQmiVE7cH2IZMuf4UbfbGYMUT3jVWgGYuRVLY9j8NnrRqgw5rr5QTg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.2.tgz",
+      "integrity": "sha512-pLrhatFFOWO9kS19bQ658CnRYzv0WLbsPih6R+iFeEEhDOuYgYCX2rztUViMz/uy/V8cLCJvLFeiOK7RJEzHcw==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.15.9",
-        "postcss": "^8.4.16",
+        "postcss": "^8.4.18",
         "resolve": "^1.22.1",
-        "rollup": "~2.78.0"
+        "rollup": "^2.79.1"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -11851,6 +12411,7 @@
         "less": "*",
         "sass": "*",
         "stylus": "*",
+        "sugarss": "*",
         "terser": "^5.4.0"
       },
       "peerDependenciesMeta": {
@@ -11861,6 +12422,9 @@
           "optional": true
         },
         "stylus": {
+          "optional": true
+        },
+        "sugarss": {
           "optional": true
         },
         "terser": {
@@ -13017,12 +13581,12 @@
       }
     },
     "@babel/plugin-transform-react-jsx-source": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.18.6.tgz",
-      "integrity": "sha512-utZmlASneDfdaMh0m/WausbjUjEdGrQJz0vFK93d7wD3xf5wBtX219+q6IlCNZeguIcxS2f/CvLZrlLSvSHQXw==",
+      "version": "7.19.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.19.6.tgz",
+      "integrity": "sha512-RpAi004QyMNisst/pvSanoRdJ4q+jMCWyk9zdw/CyLB9j8RXEahodR6l2GyttDRyEVWZtbN+TpLiHJ3t34LbsQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.18.6"
+        "@babel/helper-plugin-utils": "^7.19.0"
       }
     },
     "@babel/plugin-transform-react-pure-annotations": {
@@ -14690,6 +15254,30 @@
         "tslib": "^1.10.0"
       }
     },
+    "@fluentui/react-component-event-listener": {
+      "version": "0.51.7",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-component-event-listener/-/react-component-event-listener-0.51.7.tgz",
+      "integrity": "sha512-NjVm+crN0T9A7vITL8alZeHnuV8zi2gos0nezU/2YOxaUAB9E4zKiPxt/6k5U50rJs/gj8Nu45iXxnjO41HbZg==",
+      "requires": {
+        "@babel/runtime": "^7.10.4"
+      }
+    },
+    "@fluentui/react-component-ref": {
+      "version": "0.51.7",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-component-ref/-/react-component-ref-0.51.7.tgz",
+      "integrity": "sha512-CX27jVJYaFoBCWpuWAizQZ2se137ku1dmDyn8sw+ySNJa+kkQf7LnMydiPW5K7cRdUSqUJW3eS4EjKRvVAx8xA==",
+      "requires": {
+        "@babel/runtime": "^7.10.4",
+        "react-is": "^16.6.3"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
     "@fluentui/react-focus": {
       "version": "7.18.16",
       "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.18.16.tgz",
@@ -14762,6 +15350,15 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "@hypnosphi/create-react-context": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
+      "integrity": "sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==",
+      "requires": {
+        "gud": "^1.0.0",
+        "warning": "^4.0.3"
+      }
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -15192,6 +15789,11 @@
         }
       }
     },
+    "@react-icons/all-files": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@react-icons/all-files/-/all-files-4.1.0.tgz",
+      "integrity": "sha512-hxBI2UOuVaI3O/BhQfhtb4kcGn9ft12RWAFVMUeNjqqhLsHvFtzIkFaptBJpFDANTKoDfdVoHTKZDlwKCACbMQ=="
+    },
     "@restart/context": {
       "version": "2.1.4"
     },
@@ -15201,6 +15803,126 @@
       "integrity": "sha512-ZbjlEHcG+FQtpDPHd7i4FzNNvJf2enAwZfJbpM8CW7BhmOAbsHpZe3tsHwfQUrBuyrxWqPYp2x5UMnilWcY22A==",
       "requires": {
         "dequal": "^2.0.2"
+      }
+    },
+    "@rjsf/antd": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/antd/-/antd-5.0.0-beta.12.tgz",
+      "integrity": "sha512-2U5x4DV3TeVQFjX6YJgLBw1ND/sJoZlUyePTyygOPqltto4wPUdXdJS7m5+zRinowlCZrcr9l2u7RCwA4Bnpwg=="
+    },
+    "@rjsf/bootstrap-4": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/bootstrap-4/-/bootstrap-4-5.0.0-beta.12.tgz",
+      "integrity": "sha512-D3AbxTBTUQLCiCB2mOmH/QAMS3lmyZUmgvSrl88KEoECU0ZFimD1GMIcCtlN5PPVrhjs/ghku193AigdZVRhlw==",
+      "requires": {
+        "@react-icons/all-files": "^4.1.0"
+      }
+    },
+    "@rjsf/chakra-ui": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/chakra-ui/-/chakra-ui-5.0.0-beta.12.tgz",
+      "integrity": "sha512-JsOjeST0yOd0Qz9wBnpPomBsaiab4lJeFeNojEcHQymjFHRSa+MOdBmI1o+9TCUgJNIDfvQG+u4GnAH/AWWpKA==",
+      "requires": {
+        "react-select": "^5.5.6"
+      }
+    },
+    "@rjsf/core": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-5.0.0-beta.12.tgz",
+      "integrity": "sha512-UPGlJNAq2ub1td8XN+0KJ1VtQIKHER4i8zCmVhAViGEH98hWmsks9iRt2PqLkwCBdprR/ZwR09R7OOdsWJz7EA==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15",
+        "nanoid": "^3.3.4",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "@rjsf/fluent-ui": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/fluent-ui/-/fluent-ui-5.0.0-beta.12.tgz",
+      "integrity": "sha512-150niPPjwvlwAFW6K+AoQ9jkUhGYGZrrmjyHY0g5grBrA7Zi7X/Pa4KEuBQTDb4GHBamKwP1/ngwnJr2FRulsA==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@rjsf/material-ui": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/material-ui/-/material-ui-5.0.0-beta.12.tgz",
+      "integrity": "sha512-gBV+NDMsordjoIcVQ6W/JrNUJBFaHTrWdcrGItyMynak9uvP7imhaid6J/vmJWlY6trwbr0DmQx55U06gIU4GA=="
+    },
+    "@rjsf/mui": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/mui/-/mui-5.0.0-beta.12.tgz",
+      "integrity": "sha512-oTY+0xWekVwY4RTYKXZ+BOyel7bOAqM5CyjjgicEfCrR6Jjo/yclh6A7Fxkc5K6xYEM3nExQNrJEw1jDOxOojg=="
+    },
+    "@rjsf/semantic-ui": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/semantic-ui/-/semantic-ui-5.0.0-beta.12.tgz",
+      "integrity": "sha512-7B7Iwzk+Q5fz7Vov/kmjzowWwG2pVd95BJrmzj4I3HtjNDuTefMd1NaARRYS/Gw+Y2uAYQHKk4zxjZNipqoZwg==",
+      "requires": {
+        "semantic-ui-css": "^2.5.0",
+        "semantic-ui-react": "1.3.1"
+      }
+    },
+    "@rjsf/utils": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.0.0-beta.12.tgz",
+      "integrity": "sha512-RH965WMGp3Z25iQ2PTn+BFkQusJuvG0e2fl8V+wx1N21EkrZnW2+twouWUmqNqHwke2Z0OOimF5picZVgobl7g==",
+      "requires": {
+        "json-schema-merge-allof": "^0.8.1",
+        "jsonpointer": "^5.0.1",
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15",
+        "react-is": "^18.2.0"
+      }
+    },
+    "@rjsf/validator-ajv6": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/validator-ajv6/-/validator-ajv6-5.0.0-beta.12.tgz",
+      "integrity": "sha512-dGMacqI/M/p9UdTa1EaIhxQjnGUEE8rbjO3qC/HFLbD8Qit2bjpWFFeC1vPt5aXdahSP7f27n9s1vZPv5IPNzA==",
+      "requires": {
+        "ajv": "^6.7.0",
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        }
+      }
+    },
+    "@rjsf/validator-ajv8": {
+      "version": "5.0.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@rjsf/validator-ajv8/-/validator-ajv8-5.0.0-beta.12.tgz",
+      "integrity": "sha512-29iqu6ajec93mz0b+0NQq1DdoZE5NxatHYWEOeAvolcfOWa+8ai8e8A5u+fn2RtgsspQTtLjsXjF6CtblI1V0A==",
+      "requires": {
+        "ajv": "^8.11.0",
+        "ajv-formats": "^2.1.1",
+        "lodash": "^4.17.15",
+        "lodash-es": "^4.17.15"
+      }
+    },
+    "@semantic-ui-react/event-stack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-3.1.3.tgz",
+      "integrity": "sha512-FdTmJyWvJaYinHrKRsMLDrz4tTMGdFfds299Qory53hBugiDvGC0tEJf+cHsi5igDwWb/CLOgOiChInHwq8URQ==",
+      "requires": {
+        "exenv": "^1.2.2",
+        "prop-types": "^15.6.2"
       }
     },
     "@types/html-minifier-terser": {
@@ -15351,17 +16073,17 @@
       }
     },
     "@vitejs/plugin-react": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-2.1.0.tgz",
-      "integrity": "sha512-am6rPyyU3LzUYne3Gd9oj9c4Rzbq5hQnuGXSMT6Gujq45Il/+bunwq3lrB7wghLkiF45ygMwft37vgJ/NE8IAA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-2.2.0.tgz",
+      "integrity": "sha512-FFpefhvExd1toVRlokZgxgy2JtnBOdp4ZDsq7ldCWaqGSGn9UhWMAVm/1lxPL14JfNS5yGz+s9yFrQY6shoStA==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.18.13",
-        "@babel/plugin-transform-react-jsx": "^7.18.10",
+        "@babel/core": "^7.19.6",
+        "@babel/plugin-transform-react-jsx": "^7.19.0",
         "@babel/plugin-transform-react-jsx-development": "^7.18.6",
         "@babel/plugin-transform-react-jsx-self": "^7.18.6",
-        "@babel/plugin-transform-react-jsx-source": "^7.18.6",
-        "magic-string": "^0.26.2",
+        "@babel/plugin-transform-react-jsx-source": "^7.19.6",
+        "magic-string": "^0.26.7",
         "react-refresh": "^0.14.0"
       }
     },
@@ -15727,7 +16449,6 @@
     },
     "call-bind": {
       "version": "1.0.2",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -15891,6 +16612,27 @@
     "commondir": {
       "version": "1.0.1",
       "dev": true
+    },
+    "compute-gcd": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
+      "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
+      "requires": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
+    },
+    "compute-lcm": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
+      "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
+      "requires": {
+        "compute-gcd": "^1.2.1",
+        "validate.io-array": "^1.0.3",
+        "validate.io-function": "^1.0.2",
+        "validate.io-integer-array": "^1.0.0"
+      }
     },
     "compute-scroll-into-view": {
       "version": "1.0.14"
@@ -16062,6 +16804,19 @@
       "version": "1.2.0",
       "dev": true
     },
+    "deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -16085,7 +16840,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
       "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-      "dev": true,
       "requires": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
@@ -16696,6 +17450,11 @@
       "version": "1.8.1",
       "dev": true
     },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
+    },
     "express": {
       "version": "4.18.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
@@ -16751,8 +17510,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -17019,6 +17777,11 @@
     "function-bind": {
       "version": "1.1.1"
     },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "dev": true
@@ -17029,7 +17792,6 @@
     },
     "get-intrinsic": {
       "version": "1.1.1",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -17138,6 +17900,11 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -17154,7 +17921,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
       "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.1"
       }
@@ -17162,8 +17928,15 @@
     "has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
     },
     "hasha": {
       "version": "5.2.2",
@@ -17344,6 +18117,15 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true
     },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1"
     },
@@ -17353,6 +18135,14 @@
       "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "requires": {
         "has": "^1.0.3"
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-extglob": {
@@ -17398,6 +18188,15 @@
           "version": "3.0.1",
           "dev": true
         }
+      }
+    },
+    "is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-typedarray": {
@@ -17522,6 +18321,11 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
+    "jquery": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
+      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw=="
+    },
     "js-sdsl": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
@@ -17557,6 +18361,24 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1"
     },
+    "json-schema-compare": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+      "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+      "requires": {
+        "lodash": "^4.17.4"
+      }
+    },
+    "json-schema-merge-allof": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.8.1.tgz",
+      "integrity": "sha512-CTUKmIlPJbsWfzRRnOXz+0MjIqvnleIXwFTzz+t9T86HnYX/Rozria6ZVGLktAU9e+NygNljveP+yxqtQp/Q4w==",
+      "requires": {
+        "compute-lcm": "^1.1.2",
+        "json-schema-compare": "^0.2.2",
+        "lodash": "^4.17.20"
+      }
+    },
     "json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -17580,6 +18402,11 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "jsonpointer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+      "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="
     },
     "jss": {
       "version": "10.9.2",
@@ -17792,6 +18619,11 @@
         }
       }
     },
+    "keyboard-key": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keyboard-key/-/keyboard-key-1.1.0.tgz",
+      "integrity": "sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ=="
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -17872,6 +18704,11 @@
     "lodash": {
       "version": "4.17.21"
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -17917,9 +18754,9 @@
       }
     },
     "magic-string": {
-      "version": "0.26.3",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.3.tgz",
-      "integrity": "sha512-u1Po0NDyFcwdg2nzHT88wSK0+Rih0N1M+Ph1Sp08k8yvFFU3KR72wryS7e1qMPJypt99WB7fIFVCA92mQrMjrg==",
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.7.tgz",
+      "integrity": "sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==",
       "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.8"
@@ -18026,8 +18863,7 @@
     "nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -18256,11 +19092,19 @@
       "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true
     },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
       "version": "4.1.2",
@@ -18529,9 +19373,9 @@
       "version": "1.16.1-lts"
     },
     "postcss": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "version": "8.4.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
+      "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
       "dev": true,
       "requires": {
         "nanoid": "^3.3.4",
@@ -19201,6 +20045,27 @@
         "warning": "^4.0.3"
       }
     },
+    "react-popper": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.11.tgz",
+      "integrity": "sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "@hypnosphi/create-react-context": "^0.3.1",
+        "deep-equal": "^1.1.1",
+        "popper.js": "^1.14.4",
+        "prop-types": "^15.6.1",
+        "typed-styles": "^0.0.7",
+        "warning": "^4.0.2"
+      },
+      "dependencies": {
+        "popper.js": {
+          "version": "1.16.1",
+          "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+          "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
+        }
+      }
+    },
     "react-portal": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.2.tgz",
@@ -19242,26 +20107,19 @@
       }
     },
     "react-select": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.5.2.tgz",
-      "integrity": "sha512-zbcxtiqXvFW2Wh+dd8zAqMY6QaqX9Ez0WlcjSXycXn1ASpKdc17LcGJj7gAJiUcHI/UVlo6wfg44hgBsUPyEBQ==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.6.0.tgz",
+      "integrity": "sha512-uUvP/72rA8NGhOL16RVBaeC12Wa4NUE0iXIa6hz0YRno9ZgxTmpuMeKzjR7vHcwmigpVCoe0prP+3NVb6Obq8Q==",
       "requires": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
         "@emotion/react": "^11.8.1",
         "@floating-ui/dom": "^1.0.1",
         "@types/react-transition-group": "^4.4.0",
-        "memoize-one": "^5.0.0",
+        "memoize-one": "^6.0.0",
         "prop-types": "^15.6.0",
         "react-transition-group": "^4.3.0",
         "use-isomorphic-layout-effect": "^1.1.2"
-      },
-      "dependencies": {
-        "memoize-one": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-          "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
-        }
       }
     },
     "react-style-singleton": {
@@ -19339,6 +20197,16 @@
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.8.4"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
       }
     },
     "regexpp": {
@@ -19459,9 +20327,9 @@
       }
     },
     "rollup": {
-      "version": "2.78.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
-      "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -19525,6 +20393,40 @@
       "version": "2.2.25",
       "requires": {
         "compute-scroll-into-view": "^1.0.14"
+      }
+    },
+    "semantic-ui-css": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.5.0.tgz",
+      "integrity": "sha512-jIWn3WXXE2uSaWCcB+gVJVRG3masIKtTMNEP2X8Aw909H2rHpXGneYOxzO3hT8TpyvB5/dEEo9mBFCitGwoj1A==",
+      "requires": {
+        "jquery": "x.*"
+      }
+    },
+    "semantic-ui-react": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-1.3.1.tgz",
+      "integrity": "sha512-3EE8Cl2Tq9re+J5An8QOZHgjRJjHqNDBq+Aoaa0TLFnd79UgYzovJPQGy3AWIxgCkxDPj4c3yxl72ImumJLyeA==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@fluentui/react-component-event-listener": "~0.51.1",
+        "@fluentui/react-component-ref": "~0.51.1",
+        "@semantic-ui-react/event-stack": "^3.1.0",
+        "clsx": "^1.1.1",
+        "keyboard-key": "^1.1.0",
+        "lodash": "^4.17.19",
+        "lodash-es": "^4.17.15",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6",
+        "react-popper": "^1.3.7",
+        "shallowequal": "^1.1.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
       }
     },
     "semver": {
@@ -19890,6 +20792,11 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typed-styles": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
+      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
+    },
     "typedarray": {
       "version": "0.0.6",
       "dev": true
@@ -20000,21 +20907,53 @@
       "version": "1.0.1",
       "dev": true
     },
+    "validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg=="
+    },
+    "validate.io-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+      "integrity": "sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ=="
+    },
+    "validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==",
+      "requires": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "validate.io-integer-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
+      "integrity": "sha512-mTrMk/1ytQHtCY0oNO3dztafHYyGU88KL+jRxWuzfOmQb+4qqnWmI+gykvGp8usKZOM0H7keJHEbRaFiYA0VrA==",
+      "requires": {
+        "validate.io-array": "^1.0.3",
+        "validate.io-integer": "^1.0.4"
+      }
+    },
+    "validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg=="
+    },
     "vary": {
       "version": "1.1.2",
       "dev": true
     },
     "vite": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.8.tgz",
-      "integrity": "sha512-m7jJe3nufUbuOfotkntGFupinL/fmuTNuQmiVE7cH2IZMuf4UbfbGYMUT3jVWgGYuRVLY9j8NnrRqgw5rr5QTg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.2.tgz",
+      "integrity": "sha512-pLrhatFFOWO9kS19bQ658CnRYzv0WLbsPih6R+iFeEEhDOuYgYCX2rztUViMz/uy/V8cLCJvLFeiOK7RJEzHcw==",
       "dev": true,
       "requires": {
         "esbuild": "^0.15.9",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.16",
+        "postcss": "^8.4.18",
         "resolve": "^1.22.1",
-        "rollup": "~2.78.0"
+        "rollup": "^2.79.1"
       }
     },
     "warning": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -91,7 +91,7 @@
     "@material-ui/icons": "^4.11.3",
     "@monaco-editor/react": "^4.4.6",
     "@mui/icons-material": "^5.10.9",
-    "@vitejs/plugin-react": "^2.1.0",
+    "@vitejs/plugin-react": "^2.2.0",
     "atob": "^2.1.2",
     "cross-env": "^7.0.3",
     "eslint": "^8.26.0",
@@ -114,7 +114,7 @@
     "rimraf": "^3.0.2",
     "sass": "^1.55.0",
     "source-map-loader": "^4.0.1",
-    "vite": "^3.1.8"
+    "vite": "^3.2.2"
   },
   "directories": {
     "test": "test"

--- a/packages/playground/src/app.jsx
+++ b/packages/playground/src/app.jsx
@@ -4,7 +4,7 @@ import { samples } from "./samples";
 import "react-app-polyfill/ie11";
 import Form, { withTheme } from "@rjsf/core";
 import { shouldRender } from "@rjsf/utils";
-import localValidator from "@rjsf/validator-ajv6";
+import localValidator from "@rjsf/validator-ajv8";
 
 import DemoFrame from "./DemoFrame";
 import ErrorBoundary from "./ErrorBoundary";
@@ -326,7 +326,7 @@ function RawValidatorTest({ validator, schema, formData }) {
           </>
         )}
       </div>
-      <textarea rows={4} readOnly disabled={!rawValidation} defaultValue="Validation not run" value={displayErrors} />
+      <textarea rows={4} readOnly disabled={!rawValidation} value={displayErrors} />
     </div>
   );
 }

--- a/packages/validator-ajv6/test/validator.test.ts
+++ b/packages/validator-ajv6/test/validator.test.ts
@@ -223,6 +223,31 @@ describe("AJV6Validator", () => {
           ]);
         });
       });
+      describe("No custom validate function, single additionalProperties value", () => {
+        let errors: RJSFValidationError[];
+        let errorSchema: ErrorSchema;
+
+        beforeAll(() => {
+          const schema: RJSFSchema = {
+            type: "object",
+            additionalProperties: {
+              type: "string",
+            },
+          };
+          const result = validator.validateFormData({ foo: 42 }, schema);
+          errors = result.errors;
+          errorSchema = result.errorSchema;
+        });
+
+        it("should return an error list", () => {
+          expect(errors).toHaveLength(1);
+          expect(errors[0].message).toEqual("should be string");
+        });
+        it("should return an errorSchema", () => {
+          expect(errorSchema.foo!.__errors).toHaveLength(1);
+          expect(errorSchema.foo!.__errors![0]).toEqual("should be string");
+        });
+      });
       describe("TransformErrors", () => {
         let errors: RJSFValidationError[];
         let newErrorMessage: string;

--- a/packages/validator-ajv8/package-lock.json
+++ b/packages/validator-ajv8/package-lock.json
@@ -9,8 +9,8 @@
       "version": "5.0.0-beta.12",
       "license": "Apache-2.0",
       "dependencies": {
-        "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
+        "ajv8": "npm:ajv@^8.11.0",
         "lodash": "^4.17.15",
         "lodash-es": "^4.17.15"
       },
@@ -38,7 +38,7 @@
     },
     "../utils": {
       "name": "@rjsf/utils",
-      "version": "5.0.0-beta.11",
+      "version": "5.0.0-beta.12",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -13774,6 +13774,22 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ajv8": {
+      "name": "ajv",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-colors": {
@@ -29995,6 +30011,17 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "requires": {
         "ajv": "^8.0.0"
+      }
+    },
+    "ajv8": {
+      "version": "npm:ajv@8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-colors": {

--- a/packages/validator-ajv8/package.json
+++ b/packages/validator-ajv8/package.json
@@ -27,13 +27,13 @@
     ]
   },
   "dependencies": {
-    "ajv": "^8.11.0",
+    "ajv8": "npm:ajv@^8.11.0",
     "ajv-formats": "^2.1.1",
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.15"
   },
   "peerDependencies": {
-    "@rjsf/utils": "^5.0.0-beta.1"
+    "@rjsf/utils": "^5.0.0-beta.12"
   },
   "devDependencies": {
     "@babel/core": "^7.19.6",

--- a/packages/validator-ajv8/src/createAjvInstance.ts
+++ b/packages/validator-ajv8/src/createAjvInstance.ts
@@ -35,7 +35,8 @@ export default function createAjvInstance(
   AjvClass: typeof Ajv = Ajv
 ) {
   const ajv = new AjvClass({ ...AJV_CONFIG, ...ajvOptionsOverrides });
-  if (typeof ajvFormatOptions !== "boolean") {
+  if (ajvFormatOptions && typeof ajvFormatOptions !== "boolean") {
+    console.log(ajvFormatOptions);
     addFormats(ajv, ajvFormatOptions);
   }
 

--- a/packages/validator-ajv8/src/createAjvInstance.ts
+++ b/packages/validator-ajv8/src/createAjvInstance.ts
@@ -1,12 +1,17 @@
-import Ajv, { Options } from "ajv";
+import Ajv, { Options } from "ajv8";
 import addFormats, { FormatsPluginOptions } from "ajv-formats";
 import isObject from "lodash/isObject";
 
 import { CustomValidatorOptionsType } from "./types";
+import {
+  ADDITIONAL_PROPERTY_FLAG,
+  RJSF_ADDITONAL_PROPERTIES_FLAG,
+} from "@rjsf/utils";
 
 export const AJV_CONFIG: Options = {
   allErrors: true,
   multipleOfPrecision: 8,
+  strict: false,
 } as const;
 export const COLOR_FORMAT_REGEX =
   /^(#?([0-9A-Fa-f]{3}){1,2}\b|aqua|black|blue|fuchsia|gray|green|lime|maroon|navy|olive|orange|purple|red|silver|teal|white|yellow|(rgb\(\s*\b([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\b\s*,\s*\b([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\b\s*,\s*\b([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\b\s*\))|(rgb\(\s*(\d?\d%|100%)+\s*,\s*(\d?\d%|100%)+\s*,\s*(\d?\d%|100%)+\s*\)))$/;
@@ -26,6 +31,7 @@ export const DATA_URL_FORMAT_REGEX =
  * @param [customFormats] - The set of additional custom formats that the validator will support
  * @param [ajvOptionsOverrides={}] - The set of validator config override options
  * @param [ajvFormatOptions] - The `ajv-format` options to use when adding formats to `ajv`; pass `false` to disable it
+ * @param [AjvClass] - The `Ajv` class to use when creating the validator instance
  */
 export default function createAjvInstance(
   additionalMetaSchemas?: CustomValidatorOptionsType["additionalMetaSchemas"],
@@ -35,14 +41,19 @@ export default function createAjvInstance(
   AjvClass: typeof Ajv = Ajv
 ) {
   const ajv = new AjvClass({ ...AJV_CONFIG, ...ajvOptionsOverrides });
-  if (ajvFormatOptions && typeof ajvFormatOptions !== "boolean") {
-    console.log(ajvFormatOptions);
+  if (ajvFormatOptions) {
     addFormats(ajv, ajvFormatOptions);
+  } else if (ajvFormatOptions !== false) {
+    addFormats(ajv);
   }
 
   // add custom formats
   ajv.addFormat("data-url", DATA_URL_FORMAT_REGEX);
   ajv.addFormat("color", COLOR_FORMAT_REGEX);
+
+  // Add RJSF-specific additional properties keywords so Ajv doesn't report errors if strict is enabled.
+  ajv.addKeyword(ADDITIONAL_PROPERTY_FLAG);
+  ajv.addKeyword(RJSF_ADDITONAL_PROPERTIES_FLAG);
 
   // add more schemas to validate against
   if (Array.isArray(additionalMetaSchemas)) {

--- a/packages/validator-ajv8/src/types.ts
+++ b/packages/validator-ajv8/src/types.ts
@@ -1,4 +1,4 @@
-import Ajv, { Options, ErrorObject } from "ajv";
+import Ajv, { Options, ErrorObject } from "ajv8";
 import { FormatsPluginOptions } from "ajv-formats";
 
 /** The type describing how to customize the AJV6 validator

--- a/packages/validator-ajv8/test/createAjvInstance.test.ts
+++ b/packages/validator-ajv8/test/createAjvInstance.test.ts
@@ -1,5 +1,5 @@
-import Ajv from "ajv";
-import Ajv2019 from "ajv/dist/2019";
+import Ajv from "ajv8";
+import Ajv2019 from "ajv8/dist/2019";
 import addFormats from "ajv-formats";
 
 import createAjvInstance, {
@@ -9,8 +9,8 @@ import createAjvInstance, {
 } from "../src/createAjvInstance";
 import { CustomValidatorOptionsType } from "../src";
 
-jest.mock("ajv");
-jest.mock("ajv/dist/2019");
+jest.mock("ajv8");
+jest.mock("ajv8/dist/2019");
 jest.mock("ajv-formats");
 
 export const CUSTOM_OPTIONS: CustomValidatorOptionsType = {
@@ -42,7 +42,7 @@ describe("createAjvInstance()", () => {
       expect(Ajv).toHaveBeenCalledWith(AJV_CONFIG);
     });
     it("expect addFormats to be called with the new ajv instance and undefined", () => {
-      expect(addFormats).toHaveBeenCalledWith(ajv, undefined);
+      expect(addFormats).toHaveBeenCalledWith(ajv);
     });
     it("addFormat() was called twice", () => {
       expect(ajv.addFormat).toHaveBeenCalledTimes(2);
@@ -87,7 +87,7 @@ describe("createAjvInstance()", () => {
       expect(Ajv).not.toHaveBeenCalled();
     });
     it("expect addFormats to be called with the new ajv instance and undefined", () => {
-      expect(addFormats).toHaveBeenCalledWith(ajv, undefined);
+      expect(addFormats).toHaveBeenCalledWith(ajv);
     });
     it("addFormat() was called twice", () => {
       expect(ajv.addFormat).toHaveBeenCalledTimes(2);

--- a/packages/validator-ajv8/test/validator.test.ts
+++ b/packages/validator-ajv8/test/validator.test.ts
@@ -225,6 +225,31 @@ describe("AJV8Validator", () => {
           ]);
         });
       });
+      describe("No custom validate function, single additionalProperties value", () => {
+        let errors: RJSFValidationError[];
+        let errorSchema: ErrorSchema;
+
+        beforeAll(() => {
+          const schema: RJSFSchema = {
+            type: "object",
+            additionalProperties: {
+              type: "string",
+            },
+          };
+          const result = validator.validateFormData({ foo: 42 }, schema);
+          errors = result.errors;
+          errorSchema = result.errorSchema;
+        });
+
+        it("should return an error list", () => {
+          expect(errors).toHaveLength(1);
+          expect(errors[0].message).toEqual("must be string");
+        });
+        it("should return an errorSchema", () => {
+          expect(errorSchema.foo!.__errors).toHaveLength(1);
+          expect(errorSchema.foo!.__errors![0]).toEqual("must be string");
+        });
+      });
       describe("TransformErrors", () => {
         let errors: RJSFValidationError[];
         let newErrorMessage: string;
@@ -376,7 +401,7 @@ describe("AJV8Validator", () => {
           errorSchema = result.errorSchema;
         });
         it("should return an error list", () => {
-          expect(errors).toHaveLength(1);
+          expect(errors).toHaveLength(2);
           expect(errors[0].name).toEqual("type");
           expect(errors[0].property).toEqual(".properties.foo.required");
           // TODO: This schema path is wrong due to a bug in ajv; change this test when https://github.com/ajv-validator/ajv/issues/512 is fixed.
@@ -384,6 +409,10 @@ describe("AJV8Validator", () => {
             "#/definitions/stringArray/type"
           );
           expect(errors[0].message).toEqual("must be array");
+
+          expect(errors[1].stack).toEqual(
+            "schema is invalid: data/properties/foo/required must be array"
+          );
         });
         it("should return an errorSchema", () => {
           expect(errorSchema.properties!.foo!.required!.__errors).toHaveLength(
@@ -600,6 +629,31 @@ describe("AJV8Validator", () => {
           ]);
         });
       });
+      describe("No custom validate function, single additionalProperties value", () => {
+        let errors: RJSFValidationError[];
+        let errorSchema: ErrorSchema;
+
+        beforeAll(() => {
+          const schema: RJSFSchema = {
+            type: "object",
+            additionalProperties: {
+              type: "string",
+            },
+          };
+          const result = validator.validateFormData({ foo: 42 }, schema);
+          errors = result.errors;
+          errorSchema = result.errorSchema;
+        });
+
+        it("should return an error list", () => {
+          expect(errors).toHaveLength(1);
+          expect(errors[0].message).toEqual("must be string");
+        });
+        it("should return an errorSchema", () => {
+          expect(errorSchema.foo!.__errors).toHaveLength(1);
+          expect(errorSchema.foo!.__errors![0]).toEqual("must be string");
+        });
+      });
       describe("TransformErrors", () => {
         let errors: RJSFValidationError[];
         let newErrorMessage: string;
@@ -751,12 +805,16 @@ describe("AJV8Validator", () => {
           errorSchema = result.errorSchema;
         });
         it("should return an error list", () => {
-          expect(errors).toHaveLength(1);
+          expect(errors).toHaveLength(2);
           expect(errors[0].name).toEqual("type");
           expect(errors[0].property).toEqual(".properties.foo.required");
           // Ajv2019 uses $defs rather than definitions
           expect(errors[0].schemaPath).toEqual("#/$defs/stringArray/type");
           expect(errors[0].message).toEqual("must be array");
+
+          expect(errors[1].stack).toEqual(
+            "schema is invalid: data/properties/foo/required must be array"
+          );
         });
         it("should return an errorSchema", () => {
           expect(errorSchema.properties!.foo!.required!.__errors).toHaveLength(
@@ -973,6 +1031,31 @@ describe("AJV8Validator", () => {
           ]);
         });
       });
+      describe("No custom validate function, single additionalProperties value", () => {
+        let errors: RJSFValidationError[];
+        let errorSchema: ErrorSchema;
+
+        beforeAll(() => {
+          const schema: RJSFSchema = {
+            type: "object",
+            additionalProperties: {
+              type: "string",
+            },
+          };
+          const result = validator.validateFormData({ foo: 42 }, schema);
+          errors = result.errors;
+          errorSchema = result.errorSchema;
+        });
+
+        it("should return an error list", () => {
+          expect(errors).toHaveLength(1);
+          expect(errors[0].message).toEqual("must be string");
+        });
+        it("should return an errorSchema", () => {
+          expect(errorSchema.foo!.__errors).toHaveLength(1);
+          expect(errorSchema.foo!.__errors![0]).toEqual("must be string");
+        });
+      });
       describe("TransformErrors", () => {
         let errors: RJSFValidationError[];
         let newErrorMessage: string;
@@ -1124,12 +1207,16 @@ describe("AJV8Validator", () => {
           errorSchema = result.errorSchema;
         });
         it("should return an error list", () => {
-          expect(errors).toHaveLength(1);
+          expect(errors).toHaveLength(2);
           expect(errors[0].name).toEqual("type");
           expect(errors[0].property).toEqual(".properties.foo.required");
           // Ajv2019 uses $defs rather than definitions
           expect(errors[0].schemaPath).toEqual("#/$defs/stringArray/type");
           expect(errors[0].message).toEqual("must be array");
+
+          expect(errors[1].stack).toEqual(
+            "schema is invalid: data/properties/foo/required must be array"
+          );
         });
         it("should return an errorSchema", () => {
           expect(errorSchema.properties!.foo!.required!.__errors).toHaveLength(
@@ -1253,7 +1340,7 @@ describe("AJV8Validator", () => {
           { phone: "800.555.2368" },
           schema
         );
-        expect(result.errors.length).toEqual(0);
+        expect(result.errors).toHaveLength(0);
       });
       describe("validating using a custom formats", () => {
         let errors: RJSFValidationError[];
@@ -1421,7 +1508,7 @@ describe("AJV8Validator", () => {
           { phone: "800.555.2368" },
           schema
         );
-        expect(result.errors.length).toEqual(0);
+        expect(result.errors).toHaveLength(0);
       });
       describe("validating using a custom formats", () => {
         let errors: RJSFValidationError[];
@@ -1589,7 +1676,7 @@ describe("AJV8Validator", () => {
           { phone: "800.555.2368" },
           schema
         );
-        expect(result.errors.length).toEqual(0);
+        expect(result.errors).toHaveLength(0);
       });
       describe("validating using a custom formats", () => {
         let errors: RJSFValidationError[];


### PR DESCRIPTION
Fixes #3228, #3213

Playground
- Playground `localValidator` should use @rjsf/validator-ajv8
- Upgrade Vite and @vitejs/plugin-react to latest

@rjsf/validator-ajv8
- Alias `ajv` to `ajv8` because in the playground, Vite erroneously imports Ajv 6
- Report any schema error thrown by Ajv
- Disable Ajv's strict mode by default
- Add RJSF-specific additional properties keywords to Ajv to prevent errors from being reported in strict mode.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
