### PR TITLE
Fix issues with validating schemas with "$id"s in @rjsf/validator-ajv8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,13 @@ should change the heading of the (upcoming) version to include a major version b
 - Fix Vite development server [#3228](https://github.com/rjsf-team/react-jsonschema-form/issues/3228)
 
 ## @rjsf/validator-ajv8
+- BREAKING CHANGE: Disable form data validation for invalid JSON Schemas. Use @rjsf/validator-ajv6 if you need to validate against invalid schemas.
 - Fix additionalProperties validation [#3213](https://github.com/rjsf-team/react-jsonschema-form/issues/3213)
 - Report all schema errors thrown by Ajv. Previously, we would only report errors thrown for a missing meta-schema. This behavior is unchanged for @rjsf/validator-ajv6.
 - Disable Ajv strict mode by default.
 - Add RJSF-specific additional properties keywords to Ajv to prevent errors from being reported in strict mode.
+- For JSON Schemas with `$id`s, use a pre-compiled Ajv validation function when available.
+- No longer fail to validate inner schemas with `$id`s, fixing [#2821](https://github.com/rjsf-team/react-jsonschema-form/issues/2181).
 
 # 5.0.0-beta.12
 


### PR DESCRIPTION
@rjsf/validator-ajv8
- BREAKING: No longer attempt to validate data against invalid schemas
- Use pre-compiled validator from Ajv if the schema has an $id
- isValid: Use rootSchema.$id over the default value if it exists (Ajv uses it anyway)
- isValid: Log warning on compilation error

### Reasons for making this change

Fixes #2821, fixes #3212

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
