### PR TITLE
feat(chakra-ui): add tooltip to RangeWidget

### DIFF
--- a/packages/chakra-ui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/chakra-ui/src/RangeWidget/RangeWidget.tsx
@@ -6,6 +6,7 @@ import {
   SliderFilledTrack,
   SliderThumb,
   SliderTrack,
+  Tooltip,
 } from "@chakra-ui/react";
 import { rangeSpec, WidgetProps } from "@rjsf/utils";
 import { getChakra } from "../utils";
@@ -58,7 +59,9 @@ const RangeWidget = ({
         <SliderTrack>
           <SliderFilledTrack />
         </SliderTrack>
-        <SliderThumb />
+        <Tooltip hasArrow placement="top" label={`${value}`}>
+          <SliderThumb />
+        </Tooltip>
       </Slider>
     </FormControl>
   );

--- a/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
@@ -4545,8 +4545,11 @@ exports[`single fields slider field 1`] = `
             className="chakra-slider__thumb emotion-0"
             id="slider-thumb-root"
             onBlur={[Function]}
+            onClick={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
             role="slider"
             style={
               Object {


### PR DESCRIPTION
### Reasons for making this change

there is no current value to show when chakra-ui renders the number field with RangeWidget. so I add a tooltip to the slider just like `material-ui`

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
