### PR TITLE
Update ErrorSchema type

### DIFF
--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -116,7 +116,7 @@ export type FieldErrors = {
 /** Type describing a recursive structure of `FieldErrors`s for an object with a non-empty set of keys */
 export type ErrorSchema<T = any> = FieldErrors & {
   /** The set of errors for fields in the recursive object structure */
-  [key in keyof T]?: ErrorSchema<T[key]>;
+  [key in keyof T]?: ErrorSchema<T[key]> | FieldErrors;
 };
 
 /** Type that describes the list of errors for a field being actively validated by a custom validator */


### PR DESCRIPTION
### Reasons for making this change

The current `ErrorSchema` type-definition does not allow one to create an `ErrorSchema` as recommended in the documentation.

This fixes #3239.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
