### PR TITLE
Fix MUI/material-ui RangeWidget missing htmlFor and schema.title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ should change the heading of the (upcoming) version to include a major version b
 - Added `ref` definition to `ThemeProps` fixing [#2135](https://github.com/rjsf-team/react-jsonschema-form/issues/2135)
 - Updated the `onChange` handler in `Form` to use the new `preventDuplicates` mode of `mergeObjects()` when merging `extraErrors` when live validation is off, fixing [#3169](https://github.com/rjsf-team/react-jsonschema-form/issues/3169)
 
+## @rjsf/material-ui
+- Fix RangeWidget missing htmlFor and schema.title [#3281](https://github.com/rjsf-team/react-jsonschema-form/pull/3281)
+
+## @rjsf/mui
+- Fix RangeWidget missing htmlFor and schema.title [#3281](https://github.com/rjsf-team/react-jsonschema-form/pull/3281)
+
 ## @rjsf/utils
 - Updated `computedDefaults` (used by `getDefaultFormState`) to skip saving the computed default if it's an empty object unless `includeUndefinedValues` is truthy, fixing [#2150](https://github.com/rjsf-team/react-jsonschema-form/issues/2150) and [#2708](https://github.com/rjsf-team/react-jsonschema-form/issues/2708)
 - Expanded the `getDefaultFormState` util's `includeUndefinedValues` prop to accept a boolean or `"excludeObjectChildren"` if it does not want to include undefined values in nested objects

--- a/packages/material-ui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/material-ui/src/RangeWidget/RangeWidget.tsx
@@ -29,8 +29,8 @@ const RangeWidget = ({
 
   return (
     <>
-      <FormLabel required={required} id={id}>
-        {label}
+      <FormLabel required={required} htmlFor={id}>
+        {label || schema.title}
       </FormLabel>
       <Slider
         disabled={disabled || readonly}

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -1821,10 +1821,8 @@ exports[`single fields slider field 1`] = `
     >
       <label
         className="MuiFormLabel-root"
-        id="root"
-      >
-        
-      </label>
+        htmlFor="root"
+      />
       <span
         className="MuiSlider-root MuiSlider-colorPrimary"
         id="root"

--- a/packages/mui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/mui/src/RangeWidget/RangeWidget.tsx
@@ -29,8 +29,8 @@ const RangeWidget = ({
 
   return (
     <>
-      <FormLabel required={required} id={id}>
-        {label}
+      <FormLabel required={required} htmlFor={id}>
+        {label || schema.title}
       </FormLabel>
       <Slider
         disabled={disabled || readonly}

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -8130,10 +8130,8 @@ exports[`single fields slider field 1`] = `
     >
       <label
         className="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-1"
-        id="root"
-      >
-        
-      </label>
+        htmlFor="root"
+      />
       <span
         className="MuiSlider-root MuiSlider-colorPrimary MuiSlider-sizeMedium emotion-2"
         id="root"


### PR DESCRIPTION
### Reasons for making this change
The `RangeWidget` for both the Material UI v4 and v5 themes did not have the `htmlFor` prop, which may cause accessibility issues.

Also I noticed that the other widgets included `schema.title` in the `FormLabel`, so I went ahead and included that also just to ensure consistency with the other widgets' `FormLabel`s. Also I don't think the `id` prop is necessary either (it's not in the other `FormLabel`s either).

I also searched both `@rjsf/mui` and `@rjsf/material-ui` to make sure there was no other `FormLabel` components missing the `htmlFor` prop. `RangeWidget` was the only one missing it. I also found no other components that were missing the `schema.title` either.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
