### PR TITLE
isObject should return false for Date as well as File, null, and Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated `computedDefaults` (used by `getDefaultFormState`) to skip saving the computed default if it's an empty object unless `includeUndefinedValues` is truthy, fixing [#2150](https://github.com/rjsf-team/react-jsonschema-form/issues/2150) and [#2708](https://github.com/rjsf-team/react-jsonschema-form/issues/2708)
 - Expanded the `getDefaultFormState` util's `includeUndefinedValues` prop to accept a boolean or `"excludeObjectChildren"` if it does not want to include undefined values in nested objects
 - Updated `mergeObjects` to add new `preventDuplicates` mode when concatenating arrays so that only unique values from the source object array are copied to the destination object array
-- Fix isObject to correctly identify 'Date' as not mergable with Object default value.
+- Fix `isObject` to correctly identify 'Date' as not an object, similar to 'File', thus preventing them from being merged with Object default values.
 
 ## Dev / docs / playground
 - Removed extraneous leading space on the examples in the validation documentation, fixing [#3282](https://github.com/rjsf-team/react-jsonschema-form/issues/3282)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 - Added `ref` definition to `ThemeProps` fixing [#2135](https://github.com/rjsf-team/react-jsonschema-form/issues/2135)
 - Updated the `onChange` handler in `Form` to use the new `preventDuplicates` mode of `mergeObjects()` when merging `extraErrors` when live validation is off, fixing [#3169](https://github.com/rjsf-team/react-jsonschema-form/issues/3169)
-- Fix isObject to correctly identify 'Date' as not mergable with Object default value.
 
 ## @rjsf/material-ui
 - Fix RangeWidget missing htmlFor and schema.title [#3281](https://github.com/rjsf-team/react-jsonschema-form/pull/3281)
@@ -46,6 +45,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated `computedDefaults` (used by `getDefaultFormState`) to skip saving the computed default if it's an empty object unless `includeUndefinedValues` is truthy, fixing [#2150](https://github.com/rjsf-team/react-jsonschema-form/issues/2150) and [#2708](https://github.com/rjsf-team/react-jsonschema-form/issues/2708)
 - Expanded the `getDefaultFormState` util's `includeUndefinedValues` prop to accept a boolean or `"excludeObjectChildren"` if it does not want to include undefined values in nested objects
 - Updated `mergeObjects` to add new `preventDuplicates` mode when concatenating arrays so that only unique values from the source object array are copied to the destination object array
+- Fix isObject to correctly identify 'Date' as not mergable with Object default value.
 
 ## Dev / docs / playground
 - Removed extraneous leading space on the examples in the validation documentation, fixing [#3282](https://github.com/rjsf-team/react-jsonschema-form/issues/3282)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 - Added `ref` definition to `ThemeProps` fixing [#2135](https://github.com/rjsf-team/react-jsonschema-form/issues/2135)
 - Updated the `onChange` handler in `Form` to use the new `preventDuplicates` mode of `mergeObjects()` when merging `extraErrors` when live validation is off, fixing [#3169](https://github.com/rjsf-team/react-jsonschema-form/issues/3169)
+- Fix isObject to correctly identify 'Date' as not mergable with Object default value.
 
 ## @rjsf/material-ui
 - Fix RangeWidget missing htmlFor and schema.title [#3281](https://github.com/rjsf-team/react-jsonschema-form/pull/3281)

--- a/packages/utils/src/isObject.ts
+++ b/packages/utils/src/isObject.ts
@@ -8,5 +8,8 @@ export default function isObject(thing: any) {
   if (typeof File !== "undefined" && thing instanceof File) {
     return false;
   }
+  if (typeof Date !== "undefined" && thing instanceof Date) {
+    return false;
+  }
   return typeof thing === "object" && thing !== null && !Array.isArray(thing);
 }

--- a/packages/utils/test/isObject.test.ts
+++ b/packages/utils/test/isObject.test.ts
@@ -25,6 +25,10 @@ describe('isObject()', () => {
     const file = new File(["test"], "test.txt");
     expect(isObject(file)).toBe(false);
   });
+  it('returns false when a Date is provided', () => {
+    const date = new Date();
+    expect(isObject(date)).toBe(false);
+  });
   it('returns false when an array is provided', () => {
     expect(isObject(['foo'])).toBe(false);
   });

--- a/packages/utils/test/isObject.test.ts
+++ b/packages/utils/test/isObject.test.ts
@@ -1,38 +1,29 @@
-import { isObject } from '../src';
+import { isObject } from "../src";
 
-const NON_OBJECTS = [
-  'string',
-  10,
-  NaN,
-  true,
-  null,
-  undefined,
-];
+const NON_OBJECTS = ["string", 10, NaN, true, null, undefined];
 
-const OBJECTS = [
-  { plain: 'object' },
-  new Object(),
-  new Map(),
-];
+const OBJECTS = [{ plain: "object" }, new Object(), new Map()];
 
-describe('isObject()', () => {
-  it('returns false when a non-object is provided', () => {
-    NON_OBJECTS.forEach((nonObject: string | number | boolean | null | undefined) => {
-      expect(isObject(nonObject)).toBe(false);
-    });
+describe("isObject()", () => {
+  it("returns false when a non-object is provided", () => {
+    NON_OBJECTS.forEach(
+      (nonObject: string | number | boolean | null | undefined) => {
+        expect(isObject(nonObject)).toBe(false);
+      }
+    );
   });
-  it('returns false when a File is provided', () => {
+  it("returns false when a File is provided", () => {
     const file = new File(["test"], "test.txt");
     expect(isObject(file)).toBe(false);
   });
-  it('returns false when a Date is provided', () => {
+  it("returns false when a Date is provided", () => {
     const date = new Date();
     expect(isObject(date)).toBe(false);
   });
-  it('returns false when an array is provided', () => {
-    expect(isObject(['foo'])).toBe(false);
+  it("returns false when an array is provided", () => {
+    expect(isObject(["foo"])).toBe(false);
   });
-  it('returns true when an object is provided', () => {
+  it("returns true when an object is provided", () => {
     OBJECTS.forEach((object: any) => {
       expect(isObject(object)).toBe(true);
     });

--- a/packages/utils/test/isObject.test.ts
+++ b/packages/utils/test/isObject.test.ts
@@ -1,0 +1,36 @@
+import { isObject } from '../src';
+
+const NON_OBJECTS = [
+  'string',
+  10,
+  NaN,
+  true,
+  null,
+  undefined,
+];
+
+const OBJECTS = [
+  { plain: 'object' },
+  new Object(),
+  new Map(),
+];
+
+describe('isObject()', () => {
+  it('returns false when a non-object is provided', () => {
+    NON_OBJECTS.forEach((nonObject: string | number | boolean | null | undefined) => {
+      expect(isObject(nonObject)).toBe(false);
+    });
+  });
+  it('returns false when a File is provided', () => {
+    const file = new File(["test"], "test.txt");
+    expect(isObject(file)).toBe(false);
+  });
+  it('returns false when an array is provided', () => {
+    expect(isObject(['foo'])).toBe(false);
+  });
+  it('returns true when an object is provided', () => {
+    OBJECTS.forEach((object: any) => {
+      expect(isObject(object)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
### Reasons for making this change

Without this, assigning dates to the form's value instead merges them with a default value for objects of `{}` (in mergeDefaultsWithFormData), which stops them being dates.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
