### PR TITLE
docs: remove reference to the deprecated uiSchema `classNames` property

### DIFF
--- a/docs/api-reference/uiSchema.md
+++ b/docs/api-reference/uiSchema.md
@@ -90,7 +90,7 @@ See [Custom Widgets and Fields](https://react-jsonschema-form.readthedocs.io/en/
 
 ### classNames
 
-The uiSchema object accepts a `classNames` property for each field of the schema:
+The uiSchema object accepts a `ui:classNames` property for each field of the schema:
 
 ```tsx
 import { UiSchema } from "@rjsf/utils";

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -63,7 +63,7 @@ const schema: RJSFSchema = {
 };
 
 const uiSchema: UiSchema = {
-  classNames: "custom-css-class"
+  "ui:classNames": "custom-css-class"
 };
 
 render((
@@ -94,10 +94,10 @@ const schema: RJSFSchema = {
 
 const uiSchema: UiSchema = {
   name: {
-    classNames: "custom-class-name"
+    "ui:classNames": "custom-class-name"
   },
   age: {
-    classNames: "custom-class-age"
+    "ui:classNames": "custom-class-age"
   }
 }
 


### PR DESCRIPTION
### Reasons for making this change

In the v5 migration guide, it is explained that `classNames` property within uiSchema is now deprecated in favor of `ui:classNames` property. When developer uses the legacy classNames, a deprecation warning is displayed within the console . But currently, in the uiSchema section within the quickstart guide, documentation still refers to this deprecated property that is weird for newcomers which will bootstrap a project with deprecation warnings.

### Checklist

* [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added