### PR TITLE
fix(material-ui): fix RangeWidget onChange handler #2161

### DIFF
--- a/packages/material-ui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/material-ui/src/RangeWidget/RangeWidget.tsx
@@ -19,7 +19,7 @@ const RangeWidget = ({
   const sliderProps = { value, label, id, name: id, ...rangeSpec(schema) };
 
   const _onChange = (_: any, value?: number | number[]) => {
-    onChange(value ? options.emptyValue : value);
+    onChange(value ? value : options.emptyValue);
   };
   const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
     onBlur(id, value);

--- a/packages/mui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/mui/src/RangeWidget/RangeWidget.tsx
@@ -19,7 +19,7 @@ const RangeWidget = ({
   const sliderProps = { value, label, id, name: id, ...rangeSpec(schema) };
 
   const _onChange = (_: any, value?: number | number[]) => {
-    onChange(value ? options.emptyValue : value);
+    onChange(value ? value : options.emptyValue);
   };
   const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
     onBlur(id, value);


### PR DESCRIPTION
fix: #2161 

RangeWidget's onChange handler for material-ui package was broken due to conditional being the wrong way around. This caused new non empty values to be changed to options.emptyValue on change.