### PR TITLE
fix: 3253 By adding schema to ArrayFieldTemplateItemType type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.0.0-beta-15
+
+# @rjsf/core
+- Pass the `schema` along to the `ArrayFieldItemTemplate` as part of the fix for [#3253](https://github.com/rjsf-team/react-jsonschema-form/issues/3253)
+
+# @rjsf/utils
+- Update the `ArrayFieldItemTemplate` to add `schema` as part of the fix for [#3253](https://github.com/rjsf-team/react-jsonschema-form/issues/3253)
+
+## Dev / docs / playground
+- Fixed the documentation for `ArrayFieldItemTemplate` as part of the fix for [#3253](https://github.com/rjsf-team/react-jsonschema-form/issues/3253)
+
 # 5.0.0-beta.14
 
 ## @rjsf/antd

--- a/docs/advanced-customization/custom-templates.md
+++ b/docs/advanced-customization/custom-templates.md
@@ -222,6 +222,7 @@ The following props are passed to each `ArrayFieldItemTemplate`:
 - `onDropIndexClick: (index) => (event?) => void`: Returns a function that removes the item at `index`.
 - `onReorderClick: (index, newIndex) => (event?) => void`: Returns a function that swaps the items at `index` with `newIndex`.
 - `readonly`: A boolean value stating if the array item is read-only.
+- `schema`: The schema object for this array item.
 - `uiSchema`: The uiSchema object for this array item.
 - `registry`: The `registry` object.
 

--- a/packages/core/src/components/fields/ArrayField.tsx
+++ b/packages/core/src/components/fields/ArrayField.tsx
@@ -862,6 +862,7 @@ class ArrayField<
       onReorderClick: this.onReorderClick,
       readonly,
       registry,
+      schema: itemSchema,
       uiSchema: itemUiSchema,
     };
   }

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -520,7 +520,9 @@ export type ArrayFieldTemplateItemType<
   readonly: boolean;
   /** A stable, unique key for the array item */
   key: string;
-  /** The uiSchema object for this field */
+  /** The schema object for this array item */
+  schema: S;
+  /** The uiSchema object for this array item */
   uiSchema?: UiSchema<T, S, F>;
   /** The `registry` object */
   registry: Registry<T, S, F>;


### PR DESCRIPTION
### Reasons for making this change

fix: #3253 by adding `schema` prop `ArrayFieldTemplateItemType` type to make it consistent with all the rest of the template types
- In `@rjsf/utils`, updated `types.ts` to add `schema` to the `ArrayFieldTemplateItemType` type
- In `@rjsf/core`, updated the `ArrayField` template to pass the `schema` to the props that are provided to the instance of the `ArrayFieldItemTemplate`
- Updated `custom-templates.md` to add the `schema` to the documentation for `ArrayFieldItemTemplate`
- Updated the `CHANGELOG.md` accordingly

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
