### PR TITLE
Update babel.config.js so build artifacts are compiled to ES5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 # @rjsf/core
 - Pass the `schema` along to the `ArrayFieldItemTemplate` as part of the fix for [#3253](https://github.com/rjsf-team/react-jsonschema-form/issues/3253)
+- Tweak Babel configuration to emit ES5-compatible output files, fixing [#3240](https://github.com/rjsf-team/react-jsonschema-form/issues/3240)
 
 # @rjsf/utils
 - Update the `ArrayFieldItemTemplate` to add `schema` as part of the fix for [#3253](https://github.com/rjsf-team/react-jsonschema-form/issues/3253)

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,7 @@
 const BABEL_ENV = process.env.BABEL_ENV;
 const IS_TEST = BABEL_ENV === "test"
 const ignore = IS_TEST ? [] : ['test/**/*.js']
-const targets = IS_TEST ? { node: "current" } : { browsers: "defaults" }
+const targets = IS_TEST ? { node: "current" } : {}
 
 module.exports = {
   presets: [


### PR DESCRIPTION
### Reasons for making this change

dts-cli will utilize the babel.config.js file on build. The `targets` option for the @babel/preset-env plugin will determine what features the compiled output will target. Per babel docs:

 > When no targets are specified: Babel will assume you are targeting the oldest browsers possible. For example, @babel/preset-env will transform all ES2015-ES2020 code to be ES5 compatible.

This approach will allow us to continue to write ESNext code while we can be confident RJSF users will still consume ES5 code.

Fixes #3240 

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
