### PR TITLE
Fix docs link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <p align="center">
     A simple <a href="http://facebook.github.io/react/">React</a> component capable of using <a href="http://json-schema.org/">JSON Schema</a> to declaratively build and customize web forms.
     <br />
-    <a href="https://react-jsonschema-form.readthedocs.io/en/stable/"><strong>Explore the docs »</strong></a>
+    <a href="https://react-jsonschema-form.readthedocs.io"><strong>Explore the docs »</strong></a>
     <br />
     <br />
     <a href="https://rjsf-team.github.io/react-jsonschema-form/">View Playground</a>


### PR DESCRIPTION
### Reasons for making this change

Link to docs were broken; this fixes it!

### Checklist

* [x] **I'm updating documentation**
  - ~[ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added~
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
