### PR TITLE
fix: Fixed #3170 by passing `uiSchema` into the `validateFormData()` call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated `ArrayField` to pass the new `totalItems` and `canAdd` props to the `ArrayFieldItemTemplate` instances, fixing [#3315](https://github.com/rjsf-team/react-jsonschema-form/issues/3315)
   - Also refactored the near duplicate logic for `onAddClick` and `onAddIndexClick` into a new `_handleAddClick()` function, fixing [#3316](https://github.com/rjsf-team/react-jsonschema-form/issues/3316)
 - Fix passing of generic types to a few helper methods, partially fixing [#3072](https://github.com/rjsf-team/react-jsonschema-form/issues/3072)
+- Updated the types for `ValidatorType`, `CustomValidator` and `ErrorTransformer` to add the new generics, as well as passing `uiSchema` to the `validateFormData()` call, partially fixing [#3170](https://github.com/rjsf-team/react-jsonschema-form/issues/3170)
 
 ## @rjsf/fluent-ui
 - Updated the usage of the `ButtonTemplates` to pass the new required `registry` prop, filtering it out in the actual implementations before spreading props, fixing - [#3314](https://github.com/rjsf-team/react-jsonschema-form/issues/3314)
@@ -66,11 +67,21 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/utils
 - Updated the `SubmitButtonProps` and `IconButtonProps` to add required `registry` prop, fixing - [#3314](https://github.com/rjsf-team/react-jsonschema-form/issues/3314)
 - Updated the `ArrayFieldTemplateItemType` to add the new `totalItems` and `canAdd` props, fixing [#3315](https://github.com/rjsf-team/react-jsonschema-form/issues/3315)
+- Updated the `CustomValidator` and `ErrorTransformer` types to take the full set of `T`, `S`, `F` generics in order to accept a new optional `uiSchema` property, partially fixing [#3170](https://github.com/rjsf-team/react-jsonschema-form/issues/3170)
+- Updated the `ValidatorType` to add the `F` generic to allow the `validateFormData()` function to take a new optional `uiSchema` parameter, partially fixing [#3170](https://github.com/rjsf-team/react-jsonschema-form/issues/3170)
+  - Updated many of the schema-based utility functions to take the additional generics as well to fulfill the `ValidatorType` interface change 
+
+## @rjsf/validator-ajv6
+- Updated the `customizeValidator` and `AJV6Validator` implementations to add the `S` and `F` generics, so that `validateFormData()` can accept a new optional `uiSchema` parameter that is passed to `transformErrors()` and `customValidate()`, partially fixing [#3170](https://github.com/rjsf-team/react-jsonschema-form/issues/3170)
+
+## @rjsf/validator-ajv8
+- Updated the `customizeValidator` and `AJV8Validator` implementations to add the `F` generic, so that `validateFormData()` can accept a new optional `uiSchema` parameter that is passed to `transformErrors()` and `customValidate()`, partially fixing [#3170](https://github.com/rjsf-team/react-jsonschema-form/issues/3170)
 
 ## Dev / docs / playground
 - Fixed the documentation for `ArrayFieldItemTemplate`, `SubmitButtonProps` and `IconButtonProps` as part of the fix for [#3314](https://github.com/rjsf-team/react-jsonschema-form/issues/3314) and [#3315](https://github.com/rjsf-team/react-jsonschema-form/issues/3315)
 - Updated the documentation in `form-props.md` for `children`, fixing [#3322](https://github.com/rjsf-team/react-jsonschema-form/issues/3322)
 - Added new `typescript.md` documentation to `Advanced Customization` describing how to use custom generics as part of the fix for [#3072](https://github.com/rjsf-team/react-jsonschema-form/issues/3072)
+- Updated the documentation in `utilty-functions.md` to add the new `F` generic to all the places which needed them 
 
 # 5.0.0-beta-15
 

--- a/docs/advanced-customization/typescript.md
+++ b/docs/advanced-customization/typescript.md
@@ -47,7 +47,7 @@ If you are working with a simple, unchanging JSON Schema and you have defined a 
 
 ```tsx
 import { RJSFSchema } from "@rjsf/utils";
-import { validator } from "@rjsf/validator-ajv8";
+import { customizeValidator } from "@rjsf/validator-ajv8";
 import { Form } from "@rjsf/core";
 
 interface FormData {
@@ -65,6 +65,8 @@ const schema: RJSFSchema = {
 
 const formData: FormData = {};
 
+const validator = customizeValidator<FormData>();
+
 render((
   <Form<FormData> schema={schema} validator={validator} formData={formData} />
 ), document.getElementById("app"));
@@ -78,7 +80,7 @@ If you are using something like the [Ajv utility types for schemas](https://ajv.
 ```tsx
 import { JSONSchemaType } from "ajv";
 import { RJSFSchema } from "@rjsf/utils";
-import { validator } from "@rjsf/validator-ajv8";
+import { customizeValidator } from "@rjsf/validator-ajv8";
 import { Form } from "@rjsf/core";
 
 interface FormData {
@@ -96,11 +98,14 @@ const schema: MySchema = {
   }
 };
 
+const validator = customizeValidator<any, MySchema>();
+
 render((
   <Form<any, MySchema> schema={schema} validator={validator} />
 ), document.getElementById("app"));
 
 // Alternatively since you have the type, you could also use this
+// const validator = customizeValidator<FormData, MySchema>();
 // render((
 //  <Form<FormData, MySchema> schema={schema} validator={validator} />
 //), document.getElementById("app"));
@@ -115,7 +120,7 @@ If you have a type for this data, you can override this generic as follows:
 
 ```tsx
 import { RJSFSchema } from "@rjsf/utils";
-import { validator } from "@rjsf/validator-ajv8";
+import { customizeValidator } from "@rjsf/validator-ajv8";
 import { Form } from "@rjsf/core";
 
 interface FormContext {
@@ -136,6 +141,8 @@ const formContext: FormContext = {
   }
 };
 
+const validator = customizeValidator<any, RJSFSchema, FormContext>();
+
 render((
   <Form<any, RJSFSchema, FormContext> schema={schema} validator={validator} formContext={formContext} />
 ), document.getElementById("app"));
@@ -147,7 +154,7 @@ Using the `withTheme()` function is just as easy:
 
 ```tsx
 import { RJSFSchema } from "@rjsf/utils";
-import { validator } from "@rjsf/validator-ajv8";
+import { customizeValidator } from "@rjsf/validator-ajv8";
 import { withTheme, ThemeProps } from '@rjsf/core';
 
 interface FormData {
@@ -173,6 +180,8 @@ const theme: ThemeProps<FormData, MySchema, FormContext> = { widgets: {test: () 
 
 const ThemedForm = withTheme<FormData, MySchema, FormContext>(theme);
 
+const validator = customizeValidator<FormData, MySchema, FormContext>();
+
 const Demo = () => (
   <ThemedForm schema={schema} uiSchema={uiSchema} validator={validator} />
 );
@@ -190,7 +199,7 @@ If you are doing something like the following to create a new theme based on `@r
 import React from "react";
 import { WidgetProps } from "@rjsf/utils";
 import { ThemeProps, withTheme } from "@rjsf/core";
-import { validator } from "@rjsf/validator-ajv8";
+import validator from "@rjsf/validator-ajv8";
 import { Theme } from "@rjsf/mui";
 
 const OldBaseInputTemplate = Theme.templates.BaseInputTemplate;
@@ -221,7 +230,7 @@ Then you would use the new `generateTheme()` and `generateForm()` functions as f
 import React from "react";
 import { WidgetProps } from "@rjsf/utils";
 import { ThemeProps, withTheme } from "@rjsf/core";
-import { validator } from "@rjsf/validator-ajv8";
+import { customizeValidator } from "@rjsf/validator-ajv8";
 import { generateTheme } from "@rjsf/mui";
 
 interface FormData {
@@ -261,6 +270,8 @@ const myTheme: ThemeProps<FormData, MySchema, FormContext> = {
 };
 
 const ThemedForm = withTheme<FormData, MySchema, FormContext>(myTheme);
+
+const validator = customizeValidator<FormData, MySchema, FormContext>();
 
 // You could also do since they are effectively the same:
 // const ThemedForm = generateForm<FormData, MySchema, FormContext>(myTheme);

--- a/docs/api-reference/utility-functions.md
+++ b/docs/api-reference/utility-functions.md
@@ -347,7 +347,7 @@ Extracts the range spec information `{ step?: number, min?: number, max?: number
 #### Returns
 - RangeSpecType: A range specification from the schema
 
-### schemaRequiresTrueValue()
+### schemaRequiresTrueValue\<S extends StrictRJSFSchema = RJSFSchema>()
 Check to see if a `schema` specifies that a value must be true. This happens when:
 - `schema.const` is truthy
 - `schema.enum` == `[true]`
@@ -407,11 +407,11 @@ Converts a UTC date string into a local Date format
 
 ## Validator-based utility functions
 
-### getDefaultFormState<T = any, S extends StrictRJSFSchema = RJSFSchema,>()
+### getDefaultFormState<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>()
 Returns the superset of `formData` that includes the given set updated to include any missing fields that have computed to have defaults provided in the `schema`.
 
 #### Parameters
-- validator: ValidatorType<T, S> - An implementation of the `ValidatorType` interface that will be used when necessary
+- validator: ValidatorType<T, S, F> - An implementation of the `ValidatorType` interface that will be used when necessary
 - theSchema: S - The schema for which the default state is desired
 - [formData]: T - The current formData, if any, onto which to provide any missing defaults
 - [rootSchema]: S - The root schema, used to primarily to look up `$ref`s
@@ -424,7 +424,7 @@ Returns the superset of `formData` that includes the given set updated to includ
 Determines whether the combination of `schema` and `uiSchema` properties indicates that the label for the `schema` should be displayed in a UI.
 
 #### Parameters
-- validator: ValidatorType<T, S> - An implementation of the `ValidatorType` interface that will be used when necessary
+- validator: ValidatorType<T, S, F> - An implementation of the `ValidatorType` interface that will be used when necessary
 - schema: S - The schema for which the display label flag is desired
 - [uiSchema={}]: UiSchema<T, S, F> - The UI schema from which to derive potentially displayable information
 - [rootSchema]: S - The root schema, used to primarily to look up `$ref`s
@@ -432,11 +432,11 @@ Determines whether the combination of `schema` and `uiSchema` properties indicat
 #### Returns
 - boolean: True if the label should be displayed or false if it should not
 
-### getMatchingOption<T = any, S extends StrictRJSFSchema = RJSFSchema,>()
+### getMatchingOption<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>()
 Given the `formData` and list of `options`, attempts to find the index of the option that best matches the data.
 
 #### Parameters
-- validator: ValidatorType<T, S> - An implementation of the `ValidatorType` interface that will be used when necessary
+- validator: ValidatorType<T, S, F> - An implementation of the `ValidatorType` interface that will be used when necessary
 - formData: T | undefined - The current formData, if any, used to figure out a match
 - options: S[] - The list of options to find a matching options from
 - rootSchema: S - The root schema, used to primarily to look up `$ref`s
@@ -448,7 +448,7 @@ Given the `formData` and list of `options`, attempts to find the index of the op
 Checks to see if the `schema` and `uiSchema` combination represents an array of files
 
 #### Parameters
-- validator: ValidatorType<T, S> - An implementation of the `ValidatorType` interface that will be used when necessary
+- validator: ValidatorType<T, S, F> - An implementation of the `ValidatorType` interface that will be used when necessary
 - schema: S - The schema for which check for array of files flag is desired
 - [uiSchema={}]: UiSchema<T, S, F> - The UI schema from which to check the widget
 - [rootSchema]: S - The root schema, used to primarily to look up `$ref`s
@@ -456,47 +456,47 @@ Checks to see if the `schema` and `uiSchema` combination represents an array of 
 #### Returns
 - boolean: True if schema/uiSchema contains an array of files, otherwise false
 
-### isMultiSelect<T = any, S extends StrictRJSFSchema = RJSFSchema,>()
+### isMultiSelect<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>()
 Checks to see if the `schema` combination represents a multi-select
 
 #### Parameters
-- validator: ValidatorType<T, S> - An implementation of the `ValidatorType` interface that will be used when necessary
+- validator: ValidatorType<T, S, F> - An implementation of the `ValidatorType` interface that will be used when necessary
 - schema: S - The schema for which check for a multi-select flag is desired
 - [rootSchema]: S - The root schema, used to primarily to look up `$ref`s
 
 #### Returns
 - boolean: True if schema contains a multi-select, otherwise false
 
-### isSelect<T = any, S extends StrictRJSFSchema = RJSFSchema,>()
+### isSelect<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>()
 Checks to see if the `schema` combination represents a select
 
 #### Parameters
-- validator: ValidatorType<T, S> - An implementation of the `ValidatorType` interface that will be used when necessary
+- validator: ValidatorType<T, S, F> - An implementation of the `ValidatorType` interface that will be used when necessary
 - theSchema: S - The schema for which check for a select flag is desired
 - [rootSchema]: S - The root schema, used to primarily to look up `$ref`s
 
 #### Returns
 - boolean: True if schema contains a select, otherwise false
 
-### mergeValidationData<T = any, S extends StrictRJSFSchema = RJSFSchema>()
+### mergeValidationData<T = any, S extends StrictRJSFSchema = RJSFSchema,  F extends FormContextType = any>()
 Merges the errors in `additionalErrorSchema` into the existing `validationData` by combining the hierarchies in the two `ErrorSchema`s and then appending the error list from the `additionalErrorSchema` obtained by calling `validator.toErrorList()` onto the `errors` in the `validationData`.
 If no `additionalErrorSchema` is passed, then `validationData` is returned.
 
 #### Parameters
-- validator: ValidatorType<T, S> - An implementation of the `ValidatorType` interface that will be used to convert an ErrorSchema to a list of errors
+- validator: ValidatorType<T, S, F> - An implementation of the `ValidatorType` interface that will be used to convert an ErrorSchema to a list of errors
 - validationData: ValidationData<T> - The current `ValidationData` into which to merge the additional errors
 - [additionalErrorSchema]: ErrorSchema<T> - The additional set of errors in an `ErrorSchema`
 
 #### Returns
 - ValidationData<T>: The `validationData` with the additional errors from `additionalErrorSchema` merged into it, if provided.
 
-### retrieveSchema<T = any, S extends StrictRJSFSchema = RJSFSchema,>()
+### retrieveSchema<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>()
 Retrieves an expanded schema that has had all of its conditions, additional properties, references and dependencies
 resolved and merged into the `schema` given a `validator`, `rootSchema` and `rawFormData` that is used to do the
 potentially recursive resolution.
 
 #### Parameters
-- validator: ValidatorType<T, S> - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
+- validator: ValidatorType<T, S, F> - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
 - schema: S - The schema for which retrieving a schema is desired
 - [rootSchema={}]: S - The root schema that will be forwarded to all the APIs
 - [rawFormData]: T - The current formData, if any, to assist retrieving a schema
@@ -504,11 +504,11 @@ potentially recursive resolution.
 #### Returns
 - RJSFSchema: The schema having its conditions, additional properties, references and dependencies resolved
 
-### toIdSchema<T = any, S extends StrictRJSFSchema = RJSFSchema,>()
+### toIdSchema<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>()
 Generates an `IdSchema` object for the `schema`, recursively
 
 #### Parameters
-- validator: ValidatorType<T, S> - An implementation of the `ValidatorType` interface that will be used when necessary
+- validator: ValidatorType<T, S, F> - An implementation of the `ValidatorType` interface that will be used when necessary
 - schema: S - The schema for which the `IdSchema` is desired
 - [id]: string | null - The base id for the schema
 - [rootSchema]: S - The root schema, used to primarily to look up `$ref`s
@@ -519,11 +519,11 @@ Generates an `IdSchema` object for the `schema`, recursively
 #### Returns
 - IDSchema<T>: The `IdSchema` object for the `schema`
 
-### toPathSchema<T = any, S extends StrictRJSFSchema = RJSFSchema,>()
+### toPathSchema<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>()
 Generates an `PathSchema` object for the `schema`, recursively
 
 #### Parameters
-- validator: ValidatorType<T, S> - An implementation of the `ValidatorType` interface that will be used when necessary
+- validator: ValidatorType<T, S, F> - An implementation of the `ValidatorType` interface that will be used when necessary
 - schema: S - The schema for which the `PathSchema` is desired
 - [name='']: string - The base name for the schema
 - [rootSchema]: S - The root schema, used to primarily to look up `$ref`s
@@ -539,7 +539,7 @@ Creates a `SchemaUtilsType` interface that is based around the given `validator`
 The resulting interface implementation will forward the `validator` and `rootSchema` to all the wrapped APIs.
 
 #### Parameters
-- validator: ValidatorType<T, S> - an implementation of the `ValidatorType` interface that will be forwarded to all the APIs
+- validator: ValidatorType<T, S, F> - an implementation of the `ValidatorType` interface that will be forwarded to all the APIs
 - rootSchema: S - The root schema that will be forwarded to all the APIs
 
 #### Returns

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -43,7 +43,7 @@ export interface FormProps<
   /** The JSON schema object for the form */
   schema: S;
   /** An implementation of the `ValidatorType` interface that is needed for form validation to work */
-  validator: ValidatorType<T, S>;
+  validator: ValidatorType<T, S, F>;
   /** The optional children for the form, if provided, it will replace the default `SubmitButton` */
   children?: React.ReactNode;
   /** The uiSchema for the form */
@@ -138,7 +138,7 @@ export interface FormProps<
   target?: string;
   // Errors and validation
   /** Formerly the `validate` prop; Takes a function that specifies custom validation rules for the form */
-  customValidate?: CustomValidator<T>;
+  customValidate?: CustomValidator<T, S, F>;
   /** This prop allows passing in custom errors that are augmented with the existing JSON Schema errors on the form; it
    * can be used to implement asynchronous validation
    */
@@ -169,7 +169,7 @@ export interface FormProps<
   /** A function can be passed to this prop in order to make modifications to the default errors resulting from JSON
    * Schema validation
    */
-  transformErrors?: ErrorTransformer;
+  transformErrors?: ErrorTransformer<T, S, F>;
   // Private
   /**
    * _internalFormWrapper is currently used by the semantic-ui theme to provide a custom wrapper around `<Form />`
@@ -309,7 +309,7 @@ export default class Form<
       "liveValidate" in props ? props.liveValidate : this.props.liveValidate;
     const mustValidate = edit && !props.noValidate && liveValidate;
     const rootSchema = schema;
-    let schemaUtils: SchemaUtilsType<T, S> = state.schemaUtils;
+    let schemaUtils: SchemaUtilsType<T, S, F> = state.schemaUtils;
     if (
       !schemaUtils ||
       schemaUtils.doesSchemaUtilsDiffer(props.validator, rootSchema)
@@ -407,12 +407,12 @@ export default class Form<
   validate(
     formData: T,
     schema = this.props.schema,
-    altSchemaUtils?: SchemaUtilsType<T, S>
+    altSchemaUtils?: SchemaUtilsType<T, S, F>
   ): ValidationData<T> {
     const schemaUtils = altSchemaUtils
       ? altSchemaUtils
       : this.state.schemaUtils;
-    const { customValidate, transformErrors } = this.props;
+    const { customValidate, transformErrors, uiSchema } = this.props;
     const resolvedSchema = schemaUtils.retrieveSchema(schema, formData);
     return schemaUtils
       .getValidator()
@@ -420,7 +420,8 @@ export default class Form<
         formData,
         resolvedSchema,
         customValidate,
-        transformErrors
+        transformErrors,
+        uiSchema
       );
   }
 

--- a/packages/utils/src/createSchemaUtils.ts
+++ b/packages/utils/src/createSchemaUtils.ts
@@ -33,17 +33,17 @@ class SchemaUtils<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any
-> implements SchemaUtilsType<T, S>
+> implements SchemaUtilsType<T, S, F>
 {
   rootSchema: S;
-  validator: ValidatorType<T, S>;
+  validator: ValidatorType<T, S, F>;
 
   /** Constructs the `SchemaUtils` instance with the given `validator` and `rootSchema` stored as instance variables
    *
    * @param validator - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
    * @param rootSchema - The root schema that will be forwarded to all the APIs
    */
-  constructor(validator: ValidatorType<T, S>, rootSchema: S) {
+  constructor(validator: ValidatorType<T, S, F>, rootSchema: S) {
     this.rootSchema = rootSchema;
     this.validator = validator;
   }
@@ -65,7 +65,7 @@ class SchemaUtils<
    * @returns - True if the `SchemaUtilsType` differs from the given `validator` or `rootSchema`
    */
   doesSchemaUtilsDiffer(
-    validator: ValidatorType<T, S>,
+    validator: ValidatorType<T, S, F>,
     rootSchema: S
   ): boolean {
     if (!validator || !rootSchema) {
@@ -91,7 +91,7 @@ class SchemaUtils<
     formData?: T,
     includeUndefinedValues: boolean | "excludeObjectChildren" = false
   ): T | T[] | undefined {
-    return getDefaultFormState<T, S>(
+    return getDefaultFormState<T, S, F>(
       this.validator,
       schema,
       formData,
@@ -123,7 +123,7 @@ class SchemaUtils<
    * @returns - The index of the matched option or 0 if none is available
    */
   getMatchingOption(formData: T, options: S[]) {
-    return getMatchingOption<T, S>(
+    return getMatchingOption<T, S, F>(
       this.validator,
       formData,
       options,
@@ -152,7 +152,7 @@ class SchemaUtils<
    * @returns - True if schema contains a multi-select, otherwise false
    */
   isMultiSelect(schema: S) {
-    return isMultiSelect<T, S>(this.validator, schema, this.rootSchema);
+    return isMultiSelect<T, S, F>(this.validator, schema, this.rootSchema);
   }
 
   /** Checks to see if the `schema` combination represents a select
@@ -161,7 +161,7 @@ class SchemaUtils<
    * @returns - True if schema contains a select, otherwise false
    */
   isSelect(schema: S) {
-    return isSelect<T, S>(this.validator, schema, this.rootSchema);
+    return isSelect<T, S, F>(this.validator, schema, this.rootSchema);
   }
 
   /** Merges the errors in `additionalErrorSchema` into the existing `validationData` by combining the hierarchies in
@@ -177,7 +177,7 @@ class SchemaUtils<
     validationData: ValidationData<T>,
     additionalErrorSchema?: ErrorSchema<T>
   ): ValidationData<T> {
-    return mergeValidationData<T, S>(
+    return mergeValidationData<T, S, F>(
       this.validator,
       validationData,
       additionalErrorSchema
@@ -193,7 +193,7 @@ class SchemaUtils<
    * @returns - The schema having its conditions, additional properties, references and dependencies resolved
    */
   retrieveSchema(schema: S, rawFormData: T) {
-    return retrieveSchema<T, S>(
+    return retrieveSchema<T, S, F>(
       this.validator,
       schema,
       this.rootSchema,
@@ -217,7 +217,7 @@ class SchemaUtils<
     idPrefix = "root",
     idSeparator = "_"
   ): IdSchema<T> {
-    return toIdSchema<T, S>(
+    return toIdSchema<T, S, F>(
       this.validator,
       schema,
       id,
@@ -236,7 +236,7 @@ class SchemaUtils<
    * @returns - The `PathSchema` object for the `schema`
    */
   toPathSchema(schema: S, name?: string, formData?: T): PathSchema<T> {
-    return toPathSchema<T, S>(
+    return toPathSchema<T, S, F>(
       this.validator,
       schema,
       name,
@@ -257,6 +257,6 @@ export default function createSchemaUtils<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any
->(validator: ValidatorType<T, S>, rootSchema: S): SchemaUtilsType<T, S, F> {
+>(validator: ValidatorType<T, S, F>, rootSchema: S): SchemaUtilsType<T, S, F> {
   return new SchemaUtils<T, S, F>(validator, rootSchema);
 }

--- a/packages/utils/src/schema/getDisplayLabel.ts
+++ b/packages/utils/src/schema/getDisplayLabel.ts
@@ -26,7 +26,7 @@ export default function getDisplayLabel<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any
 >(
-  validator: ValidatorType<T, S>,
+  validator: ValidatorType<T, S, F>,
   schema: S,
   uiSchema: UiSchema<T, S, F> = {},
   rootSchema?: S
@@ -34,11 +34,11 @@ export default function getDisplayLabel<
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
   const { label = true } = uiOptions;
   let displayLabel = !!label;
-  const schemaType = getSchemaType(schema);
+  const schemaType = getSchemaType<S>(schema);
 
   if (schemaType === "array") {
     displayLabel =
-      isMultiSelect<T, S>(validator, schema, rootSchema) ||
+      isMultiSelect<T, S, F>(validator, schema, rootSchema) ||
       isFilesArray<T, S, F>(validator, schema, uiSchema, rootSchema) ||
       isCustomWidget(uiSchema);
   }

--- a/packages/utils/src/schema/getMatchingOption.ts
+++ b/packages/utils/src/schema/getMatchingOption.ts
@@ -1,4 +1,9 @@
-import { RJSFSchema, StrictRJSFSchema, ValidatorType } from "../types";
+import {
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  ValidatorType,
+} from "../types";
 
 /** Given the `formData` and list of `options`, attempts to find the index of the option that best matches the data.
  *
@@ -10,9 +15,10 @@ import { RJSFSchema, StrictRJSFSchema, ValidatorType } from "../types";
  */
 export default function getMatchingOption<
   T = any,
-  S extends StrictRJSFSchema = RJSFSchema
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
 >(
-  validator: ValidatorType<T, S>,
+  validator: ValidatorType<T, S, F>,
   formData: T | undefined,
   options: S[],
   rootSchema: S

--- a/packages/utils/src/schema/isFilesArray.ts
+++ b/packages/utils/src/schema/isFilesArray.ts
@@ -21,7 +21,7 @@ export default function isFilesArray<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any
 >(
-  validator: ValidatorType<T, S>,
+  validator: ValidatorType<T, S, F>,
   schema: S,
   uiSchema: UiSchema<T, S, F> = {},
   rootSchema?: S
@@ -30,7 +30,7 @@ export default function isFilesArray<
     return true;
   }
   if (schema.items) {
-    const itemsSchema = retrieveSchema<T, S>(
+    const itemsSchema = retrieveSchema<T, S, F>(
       validator,
       schema.items as S,
       rootSchema

--- a/packages/utils/src/schema/isMultiSelect.ts
+++ b/packages/utils/src/schema/isMultiSelect.ts
@@ -1,4 +1,9 @@
-import { RJSFSchema, StrictRJSFSchema, ValidatorType } from "../types";
+import {
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  ValidatorType,
+} from "../types";
 
 import isSelect from "./isSelect";
 
@@ -11,8 +16,9 @@ import isSelect from "./isSelect";
  */
 export default function isMultiSelect<
   T = any,
-  S extends StrictRJSFSchema = RJSFSchema
->(validator: ValidatorType<T, S>, schema: S, rootSchema?: S) {
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
+>(validator: ValidatorType<T, S, F>, schema: S, rootSchema?: S) {
   if (
     !schema.uniqueItems ||
     !schema.items ||
@@ -20,5 +26,5 @@ export default function isMultiSelect<
   ) {
     return false;
   }
-  return isSelect<T, S>(validator, schema.items as S, rootSchema);
+  return isSelect<T, S, F>(validator, schema.items as S, rootSchema);
 }

--- a/packages/utils/src/schema/isSelect.ts
+++ b/packages/utils/src/schema/isSelect.ts
@@ -1,5 +1,10 @@
 import isConstant from "../isConstant";
-import { RJSFSchema, StrictRJSFSchema, ValidatorType } from "../types";
+import {
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  ValidatorType,
+} from "../types";
 import retrieveSchema from "./retrieveSchema";
 
 /** Checks to see if the `schema` combination represents a select
@@ -11,9 +16,10 @@ import retrieveSchema from "./retrieveSchema";
  */
 export default function isSelect<
   T = any,
-  S extends StrictRJSFSchema = RJSFSchema
->(validator: ValidatorType<T, S>, theSchema: S, rootSchema: S = {} as S) {
-  const schema = retrieveSchema<T, S>(
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
+>(validator: ValidatorType<T, S, F>, theSchema: S, rootSchema: S = {} as S) {
+  const schema = retrieveSchema<T, S, F>(
     validator,
     theSchema,
     rootSchema,

--- a/packages/utils/src/schema/mergeValidationData.ts
+++ b/packages/utils/src/schema/mergeValidationData.ts
@@ -3,6 +3,7 @@ import isEmpty from "lodash/isEmpty";
 import mergeObjects from "../mergeObjects";
 import {
   ErrorSchema,
+  FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
   ValidationData,
@@ -21,9 +22,10 @@ import {
  */
 export default function mergeValidationData<
   T = any,
-  S extends StrictRJSFSchema = RJSFSchema
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
 >(
-  validator: ValidatorType<T, S>,
+  validator: ValidatorType<T, S, F>,
   validationData: ValidationData<T>,
   additionalErrorSchema?: ErrorSchema<T>
 ): ValidationData<T> {

--- a/packages/utils/src/schema/toIdSchema.ts
+++ b/packages/utils/src/schema/toIdSchema.ts
@@ -10,6 +10,7 @@ import {
 } from "../constants";
 import isObject from "../isObject";
 import {
+  FormContextType,
   IdSchema,
   RJSFSchema,
   StrictRJSFSchema,
@@ -30,9 +31,10 @@ import retrieveSchema from "./retrieveSchema";
  */
 export default function toIdSchema<
   T = any,
-  S extends StrictRJSFSchema = RJSFSchema
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
 >(
-  validator: ValidatorType<T, S>,
+  validator: ValidatorType<T, S, F>,
   schema: S,
   id?: string | null,
   rootSchema?: S,
@@ -41,13 +43,13 @@ export default function toIdSchema<
   idSeparator = "_"
 ): IdSchema<T> {
   if (REF_KEY in schema || DEPENDENCIES_KEY in schema || ALL_OF_KEY in schema) {
-    const _schema = retrieveSchema<T, S>(
+    const _schema = retrieveSchema<T, S, F>(
       validator,
       schema,
       rootSchema,
       formData
     );
-    return toIdSchema<T>(
+    return toIdSchema<T, S, F>(
       validator,
       _schema,
       id,
@@ -58,7 +60,7 @@ export default function toIdSchema<
     );
   }
   if (ITEMS_KEY in schema && !get(schema, [ITEMS_KEY, REF_KEY])) {
-    return toIdSchema<T, S>(
+    return toIdSchema<T, S, F>(
       validator,
       get(schema, ITEMS_KEY) as S,
       id,
@@ -74,7 +76,7 @@ export default function toIdSchema<
     for (const name in schema.properties) {
       const field = get(schema, [PROPERTIES_KEY, name]);
       const fieldId = idSchema[ID_KEY] + idSeparator + name;
-      idSchema[name] = toIdSchema<T, S>(
+      idSchema[name] = toIdSchema<T, S, F>(
         validator,
         isObject(field) ? field : {},
         fieldId,

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -856,19 +856,29 @@ export type UiSchema<
     "ui:options"?: UIOptionsType<T, S, F>;
   };
 
-/** A `CustomValidator` function takes in a `formData` and `errors` object and returns the given `errors` object back,
- * while potentially adding additional messages to the `errors`
+/** A `CustomValidator` function takes in a `formData`, `errors` and `uiSchema` objects and returns the given `errors`
+ * object back, while potentially adding additional messages to the `errors`
  */
-export type CustomValidator<T = any> = (
+export type CustomValidator<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
+> = (
   formData: T,
-  errors: FormValidation<T>
+  errors: FormValidation<T>,
+  uiSchema?: UiSchema<T, S, F>
 ) => FormValidation<T>;
 
-/** An `ErrorTransformer` function will take in a list of `errors` and potentially return a transformation of those
- * errors in what ever way it deems necessary
+/** An `ErrorTransformer` function will take in a list of `errors` & a `uiSchema` and potentially return a
+ * transformation of those errors in what ever way it deems necessary
  */
-export type ErrorTransformer = (
-  errors: RJSFValidationError[]
+export type ErrorTransformer<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
+> = (
+  errors: RJSFValidationError[],
+  uiSchema?: UiSchema<T, S, F>
 ) => RJSFValidationError[];
 
 /** The type that describes the data that is returned from the `ValidatorType.validateFormData()` function */
@@ -884,7 +894,8 @@ export type ValidationData<T> = {
  */
 export interface ValidatorType<
   T = any,
-  S extends StrictRJSFSchema = RJSFSchema
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
 > {
   /** This function processes the `formData` with an optional user contributed `customValidate` function, which receives
    * the form data and a `errorHandler` function that will be used to add custom validation errors for each field. Also
@@ -895,12 +906,14 @@ export interface ValidatorType<
    * @param schema - The schema against which to validate the form data
    * @param [customValidate] - An optional function that is used to perform custom validation
    * @param [transformErrors] - An optional function that is used to transform errors after AJV validation
+   * @param [uiSchema] - An optional uiSchema that is passed to `transformErrors` and `customValidate`
    */
   validateFormData(
     formData: T | undefined,
     schema: S,
-    customValidate?: CustomValidator<T>,
-    transformErrors?: ErrorTransformer
+    customValidate?: CustomValidator<T, S, F>,
+    transformErrors?: ErrorTransformer<T, S, F>,
+    uiSchema?: UiSchema<T, S, F>
   ): ValidationData<T>;
   /** Converts an `errorSchema` into a list of `RJSFValidationErrors`
    *
@@ -946,7 +959,7 @@ export interface SchemaUtilsType<
    *
    * @returns - The `ValidatorType`
    */
-  getValidator(): ValidatorType<T, S>;
+  getValidator(): ValidatorType<T, S, F>;
   /** Determines whether either the `validator` and `rootSchema` differ from the ones associated with this instance of
    * the `SchemaUtilsType`. If either `validator` or `rootSchema` are falsy, then return false to prevent the creation
    * of a new `SchemaUtilsType` with incomplete properties.
@@ -955,7 +968,10 @@ export interface SchemaUtilsType<
    * @param rootSchema - The root schema that will be compared against the current one
    * @returns - True if the `SchemaUtilsType` differs from the given `validator` or `rootSchema`
    */
-  doesSchemaUtilsDiffer(validator: ValidatorType<T, S>, rootSchema: S): boolean;
+  doesSchemaUtilsDiffer(
+    validator: ValidatorType<T, S, F>,
+    rootSchema: S
+  ): boolean;
   /** Returns the superset of `formData` that includes the given set updated to include any missing fields that have
    * computed to have defaults provided in the `schema`.
    *

--- a/packages/validator-ajv6/src/customizeValidator.ts
+++ b/packages/validator-ajv6/src/customizeValidator.ts
@@ -1,4 +1,9 @@
-import { ValidatorType } from "@rjsf/utils";
+import {
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  ValidatorType,
+} from "@rjsf/utils";
 
 import { CustomValidatorOptionsType } from "./types";
 import AJV6Validator from "./validator";
@@ -9,8 +14,10 @@ import AJV6Validator from "./validator";
  * @param [options={}] - The `CustomValidatorOptionsType` options that are used to create the `ValidatorType` instance
  * @deprecated in favor of the `@rjsf/validator-ajv8
  */
-export default function customizeValidator<T = any>(
-  options: CustomValidatorOptionsType = {}
-): ValidatorType<T> {
-  return new AJV6Validator<T>(options);
+export default function customizeValidator<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
+>(options: CustomValidatorOptionsType = {}): ValidatorType<T, S, F> {
+  return new AJV6Validator<T, S, F>(options);
 }

--- a/packages/validator-ajv8/src/customizeValidator.ts
+++ b/packages/validator-ajv8/src/customizeValidator.ts
@@ -1,4 +1,9 @@
-import { RJSFSchema, StrictRJSFSchema, ValidatorType } from "@rjsf/utils";
+import {
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  ValidatorType,
+} from "@rjsf/utils";
 
 import { CustomValidatorOptionsType, Localizer } from "./types";
 import AJV8Validator from "./validator";
@@ -11,10 +16,11 @@ import AJV8Validator from "./validator";
  */
 export default function customizeValidator<
   T = any,
-  S extends StrictRJSFSchema = RJSFSchema
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
 >(
   options: CustomValidatorOptionsType = {},
   localizer?: Localizer
-): ValidatorType<T, S> {
-  return new AJV8Validator<T, S>(options, localizer);
+): ValidatorType<T, S, F> {
+  return new AJV8Validator<T, S, F>(options, localizer);
 }

--- a/packages/validator-ajv8/test/validator.test.ts
+++ b/packages/validator-ajv8/test/validator.test.ts
@@ -6,6 +6,7 @@ import {
   FormValidation,
   RJSFSchema,
   RJSFValidationError,
+  UiSchema,
   ValidatorType,
 } from "@rjsf/utils";
 
@@ -372,6 +373,8 @@ describe("AJV8Validator", () => {
       describe("TransformErrors", () => {
         let errors: RJSFValidationError[];
         let newErrorMessage: string;
+        let transformErrors: jest.Mock;
+        let uiSchema: UiSchema;
         beforeAll(() => {
           const schema: RJSFSchema = {
             type: "object",
@@ -380,15 +383,19 @@ describe("AJV8Validator", () => {
               [illFormedKey]: { type: "string" },
             },
           };
-          newErrorMessage = "Better error message";
-          const transformErrors = (errors: RJSFValidationError[]) => {
-            return [Object.assign({}, errors[0], { message: newErrorMessage })];
+          uiSchema = {
+            foo: { "ui:label": false },
           };
+          newErrorMessage = "Better error message";
+          transformErrors = jest.fn((errors: RJSFValidationError[]) => {
+            return [Object.assign({}, errors[0], { message: newErrorMessage })];
+          });
           const result = validator.validateFormData(
             { foo: 42, [illFormedKey]: 41 },
             schema,
             undefined,
-            transformErrors
+            transformErrors,
+            uiSchema
           );
           errors = result.errors;
         });
@@ -397,10 +404,30 @@ describe("AJV8Validator", () => {
           expect(errors).not.toHaveLength(0);
           expect(errors[0].message).toEqual(newErrorMessage);
         });
+        it("transformErrors function was called with uiSchema", () => {
+          expect(transformErrors).toHaveBeenCalledWith(
+            expect.any(Array),
+            uiSchema
+          );
+        });
       });
       describe("Custom validate function", () => {
         let errors: RJSFValidationError[];
         let errorSchema: ErrorSchema;
+        let validate: jest.Mock;
+        let uiSchema: UiSchema;
+        beforeAll(() => {
+          uiSchema = {
+            foo: { "ui:label": false },
+          };
+
+          validate = jest.fn((formData: any, errors: FormValidation<any>) => {
+            if (formData.pass1 !== formData.pass2) {
+              errors.pass2!.addError("passwords don`t match.");
+            }
+            return errors;
+          });
+        });
         describe("formData is provided", () => {
           beforeAll(() => {
             const schema: RJSFSchema = {
@@ -412,18 +439,13 @@ describe("AJV8Validator", () => {
                 foo: { type: "array", items: { type: "string" } }, // Adding an array for test coverage
               },
             };
-
-            const validate = (formData: any, errors: FormValidation<any>) => {
-              if (formData.pass1 !== formData.pass2) {
-                errors.pass2!.addError("passwords don`t match.");
-              }
-              return errors;
-            };
             const formData = { pass1: "a", pass2: "b", foo: ["a"] };
             const result = validator.validateFormData(
               formData,
               schema,
-              validate
+              validate,
+              undefined,
+              uiSchema
             );
             errors = result.errors;
             errorSchema = result.errorSchema;
@@ -438,6 +460,13 @@ describe("AJV8Validator", () => {
               "passwords don`t match."
             );
           });
+          it("validate function was called with uiSchema", () => {
+            expect(validate).toHaveBeenCalledWith(
+              expect.any(Object),
+              expect.any(Object),
+              uiSchema
+            );
+          });
         });
         describe("formData is missing data", () => {
           beforeAll(() => {
@@ -447,12 +476,6 @@ describe("AJV8Validator", () => {
                 pass1: { type: "string" },
                 pass2: { type: "string" },
               },
-            };
-            const validate = (formData: any, errors: FormValidation<any>) => {
-              if (formData.pass1 !== formData.pass2) {
-                errors.pass2!.addError("passwords don`t match.");
-              }
-              return errors;
             };
             const formData = { pass1: "a" };
             const result = validator.validateFormData(
@@ -881,6 +904,8 @@ describe("AJV8Validator", () => {
       describe("TransformErrors", () => {
         let errors: RJSFValidationError[];
         let newErrorMessage: string;
+        let transformErrors: jest.Mock;
+        let uiSchema: UiSchema;
         beforeAll(() => {
           const schema: RJSFSchema = {
             type: "object",
@@ -889,15 +914,19 @@ describe("AJV8Validator", () => {
               [illFormedKey]: { type: "string" },
             },
           };
-          newErrorMessage = "Better error message";
-          const transformErrors = (errors: RJSFValidationError[]) => {
-            return [Object.assign({}, errors[0], { message: newErrorMessage })];
+          uiSchema = {
+            foo: { "ui:label": false },
           };
+          newErrorMessage = "Better error message";
+          transformErrors = jest.fn((errors: RJSFValidationError[]) => {
+            return [Object.assign({}, errors[0], { message: newErrorMessage })];
+          });
           const result = validator.validateFormData(
             { foo: 42, [illFormedKey]: 41 },
             schema,
             undefined,
-            transformErrors
+            transformErrors,
+            uiSchema
           );
           errors = result.errors;
         });
@@ -906,10 +935,30 @@ describe("AJV8Validator", () => {
           expect(errors).not.toHaveLength(0);
           expect(errors[0].message).toEqual(newErrorMessage);
         });
+        it("transformErrors function was called with uiSchema", () => {
+          expect(transformErrors).toHaveBeenCalledWith(
+            expect.any(Array),
+            uiSchema
+          );
+        });
       });
       describe("Custom validate function", () => {
         let errors: RJSFValidationError[];
         let errorSchema: ErrorSchema;
+        let validate: jest.Mock;
+        let uiSchema: UiSchema;
+        beforeAll(() => {
+          uiSchema = {
+            foo: { "ui:label": false },
+          };
+
+          validate = jest.fn((formData: any, errors: FormValidation<any>) => {
+            if (formData.pass1 !== formData.pass2) {
+              errors.pass2!.addError("passwords don`t match.");
+            }
+            return errors;
+          });
+        });
         describe("formData is provided", () => {
           beforeAll(() => {
             const schema: RJSFSchema = {
@@ -921,18 +970,13 @@ describe("AJV8Validator", () => {
                 foo: { type: "array", items: { type: "string" } }, // Adding an array for test coverage
               },
             };
-
-            const validate = (formData: any, errors: FormValidation<any>) => {
-              if (formData.pass1 !== formData.pass2) {
-                errors.pass2!.addError("passwords don`t match.");
-              }
-              return errors;
-            };
             const formData = { pass1: "a", pass2: "b", foo: ["a"] };
             const result = validator.validateFormData(
               formData,
               schema,
-              validate
+              validate,
+              undefined,
+              uiSchema
             );
             errors = result.errors;
             errorSchema = result.errorSchema;
@@ -947,6 +991,13 @@ describe("AJV8Validator", () => {
               "passwords don`t match."
             );
           });
+          it("validate function was called with uiSchema", () => {
+            expect(validate).toHaveBeenCalledWith(
+              expect.any(Object),
+              expect.any(Object),
+              uiSchema
+            );
+          });
         });
         describe("formData is missing data", () => {
           beforeAll(() => {
@@ -956,12 +1007,6 @@ describe("AJV8Validator", () => {
                 pass1: { type: "string" },
                 pass2: { type: "string" },
               },
-            };
-            const validate = (formData: any, errors: FormValidation<any>) => {
-              if (formData.pass1 !== formData.pass2) {
-                errors.pass2!.addError("passwords don`t match.");
-              }
-              return errors;
             };
             const formData = { pass1: "a" };
             const result = validator.validateFormData(
@@ -1390,6 +1435,8 @@ describe("AJV8Validator", () => {
       describe("TransformErrors", () => {
         let errors: RJSFValidationError[];
         let newErrorMessage: string;
+        let transformErrors: jest.Mock;
+        let uiSchema: UiSchema;
         beforeAll(() => {
           const schema: RJSFSchema = {
             type: "object",
@@ -1398,15 +1445,19 @@ describe("AJV8Validator", () => {
               [illFormedKey]: { type: "string" },
             },
           };
-          newErrorMessage = "Better error message";
-          const transformErrors = (errors: RJSFValidationError[]) => {
-            return [Object.assign({}, errors[0], { message: newErrorMessage })];
+          uiSchema = {
+            foo: { "ui:label": false },
           };
+          newErrorMessage = "Better error message";
+          transformErrors = jest.fn((errors: RJSFValidationError[]) => {
+            return [Object.assign({}, errors[0], { message: newErrorMessage })];
+          });
           const result = validator.validateFormData(
             { foo: 42, [illFormedKey]: 41 },
             schema,
             undefined,
-            transformErrors
+            transformErrors,
+            uiSchema
           );
           errors = result.errors;
         });
@@ -1415,10 +1466,30 @@ describe("AJV8Validator", () => {
           expect(errors).not.toHaveLength(0);
           expect(errors[0].message).toEqual(newErrorMessage);
         });
+        it("transformErrors function was called with uiSchema", () => {
+          expect(transformErrors).toHaveBeenCalledWith(
+            expect.any(Array),
+            uiSchema
+          );
+        });
       });
       describe("Custom validate function", () => {
         let errors: RJSFValidationError[];
         let errorSchema: ErrorSchema;
+        let validate: jest.Mock;
+        let uiSchema: UiSchema;
+        beforeAll(() => {
+          uiSchema = {
+            foo: { "ui:label": false },
+          };
+
+          validate = jest.fn((formData: any, errors: FormValidation<any>) => {
+            if (formData.pass1 !== formData.pass2) {
+              errors.pass2!.addError("passwords don`t match.");
+            }
+            return errors;
+          });
+        });
         describe("formData is provided", () => {
           beforeAll(() => {
             const schema: RJSFSchema = {
@@ -1430,18 +1501,13 @@ describe("AJV8Validator", () => {
                 foo: { type: "array", items: { type: "string" } }, // Adding an array for test coverage
               },
             };
-
-            const validate = (formData: any, errors: FormValidation<any>) => {
-              if (formData.pass1 !== formData.pass2) {
-                errors.pass2!.addError("passwords don`t match.");
-              }
-              return errors;
-            };
             const formData = { pass1: "a", pass2: "b", foo: ["a"] };
             const result = validator.validateFormData(
               formData,
               schema,
-              validate
+              validate,
+              undefined,
+              uiSchema
             );
             errors = result.errors;
             errorSchema = result.errorSchema;
@@ -1456,6 +1522,13 @@ describe("AJV8Validator", () => {
               "passwords don`t match."
             );
           });
+          it("validate function was called with uiSchema", () => {
+            expect(validate).toHaveBeenCalledWith(
+              expect.any(Object),
+              expect.any(Object),
+              uiSchema
+            );
+          });
         });
         describe("formData is missing data", () => {
           beforeAll(() => {
@@ -1465,12 +1538,6 @@ describe("AJV8Validator", () => {
                 pass1: { type: "string" },
                 pass2: { type: "string" },
               },
-            };
-            const validate = (formData: any, errors: FormValidation<any>) => {
-              if (formData.pass1 !== formData.pass2) {
-                errors.pass2!.addError("passwords don`t match.");
-              }
-              return errors;
             };
             const formData = { pass1: "a" };
             const result = validator.validateFormData(


### PR DESCRIPTION
### Reasons for making this change

Fixes #3170 by updating types and implementations to support passing `uiSchema` to the `validateFormData()` call so that it can be forwarded to `customValidate()` and `transformErrors()`
- In `@rjsf/utils`, updated the `ValidatorType` to take the `F` generic so that `validateFormData()` can be passed `uiSchema?: UiSchema<T, S, F>`
  - This required updating all of the schema-based functions to also take the `F` generic and properly adding generics to all the function calls
  - Also, the `CustomValidator` and `ErrorTransformer` types were updated to take all the generics needed to add the `uiSchema?: UiSchema<T, S, F>` parameter to the functions
- In `@rjsf/validator-ajv6`, updated the `customizeValidator` and `AJV6Validator` implementations to add the `S` and `F` generics
  - Updated `validateFormData()` to accept a new optional `uiSchema` parameter that is passed to `transformErrors()` and `customValidate()`
- In `@rjsf/validator-ajv8`, updated the `customizeValidator` and `AJV8Validator` implementations to add the `F` generic
  - Updated `validateFormData()` to accept a new optional `uiSchema` parameter that is passed to `transformErrors()` and `customValidate()`
- In `@rjsf/core`, updated the `ValidatorType`, `CustomValidator` and `ErrorTransformer` types to add the appropriate missing generics
  - Also passed `uiSchema` to the `validateFormData()` call
- Updated the `utility-functions.md` file to add the new generics
- Updated the `typescript.md` file to switch to using `customizeValidator()` with the generics to get the `validator`
- Updated the `CHANGELOG.md` file accordingly

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
