### PR TITLE
Fix umd builds

### DIFF
--- a/packages/core/dts.config.js
+++ b/packages/core/dts.config.js
@@ -1,0 +1,11 @@
+// Not transpiled with TypeScript or Babel, so use plain Es6/Node.js!
+/**
+ * @type {import('dts-cli').DtsConfig}
+ */
+module.exports = {
+    // This function will run for each entry/format/env combination
+    rollup(config, options) {
+      config.output.name = "JSONSchemaForm";
+      return config; // always return a config.
+    },
+  };


### PR DESCRIPTION
Fix umd builds by adding a default JSONSchemaForm export. This addresses part of the issue of https://github.com/rjsf-team/react-jsonschema-form/issues/3215.