### PR TITLE
Remove ajv8 alias

### DIFF
--- a/packages/validator-ajv8/package-lock.json
+++ b/packages/validator-ajv8/package-lock.json
@@ -9,8 +9,8 @@
       "version": "5.0.0-beta.15",
       "license": "Apache-2.0",
       "dependencies": {
+        "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
-        "ajv8": "npm:ajv@^8.11.0",
         "lodash": "^4.17.15",
         "lodash-es": "^4.17.15"
       },
@@ -2897,22 +2897,6 @@
         "ajv": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ajv8": {
-      "name": "ajv",
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-colors": {
@@ -11937,17 +11921,6 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "requires": {
         "ajv": "^8.0.0"
-      }
-    },
-    "ajv8": {
-      "version": "npm:ajv@8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
       }
     },
     "ansi-colors": {

--- a/packages/validator-ajv8/package.json
+++ b/packages/validator-ajv8/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "ajv-formats": "^2.1.1",
-    "ajv8": "npm:ajv@^8.11.0",
+    "ajv": "^8.11.0",
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.15"
   },

--- a/packages/validator-ajv8/src/createAjvInstance.ts
+++ b/packages/validator-ajv8/src/createAjvInstance.ts
@@ -1,4 +1,4 @@
-import Ajv, { Options } from "ajv8";
+import Ajv, { Options } from "ajv";
 import addFormats, { FormatsPluginOptions } from "ajv-formats";
 import isObject from "lodash/isObject";
 

--- a/packages/validator-ajv8/src/types.ts
+++ b/packages/validator-ajv8/src/types.ts
@@ -1,4 +1,4 @@
-import Ajv, { Options, ErrorObject } from "ajv8";
+import Ajv, { Options, ErrorObject } from "ajv";
 import { FormatsPluginOptions } from "ajv-formats";
 
 /** The type describing how to customize the AJV6 validator

--- a/packages/validator-ajv8/src/validator.ts
+++ b/packages/validator-ajv8/src/validator.ts
@@ -1,4 +1,4 @@
-import Ajv, { ErrorObject, ValidateFunction } from "ajv8";
+import Ajv, { ErrorObject, ValidateFunction } from "ajv";
 import toPath from "lodash/toPath";
 import isObject from "lodash/isObject";
 import clone from "lodash/clone";

--- a/packages/validator-ajv8/test/createAjvInstance.test.ts
+++ b/packages/validator-ajv8/test/createAjvInstance.test.ts
@@ -1,5 +1,5 @@
-import Ajv from "ajv8";
-import Ajv2019 from "ajv8/dist/2019";
+import Ajv from "ajv";
+import Ajv2019 from "ajv/dist/2019";
 import addFormats from "ajv-formats";
 
 import createAjvInstance, {


### PR DESCRIPTION
### Reasons for making this change

Remove ajv8 alias as it just complicates things, I don't see a benefit to keep it in. This will also address https://github.com/skypackjs/skypack-cdn/issues/337 (which needs to resolved to fix https://github.com/rjsf-team/react-jsonschema-form/issues/3215).