### PR TITLE
Undo ajv8 alias and fix Vite dev server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ should change the heading of the (upcoming) version to include a major version b
 # 5.0.0-beta-17
 
 ## @rjsf/playground
-- Change Vite `mode` to `'production'`, which provides an alternative fix for [#3228](https://github.com/rjsf-team/react-jsonschema-form/issues/3228) since the prior fix caused [#3215](https://github.com/rjsf-team/react-jsonschema-form/issues/3215).
+- Change Vite `preserveSymlinks` to `true`, which provides an alternative fix for [#3228](https://github.com/rjsf-team/react-jsonschema-form/issues/3228) since the prior fix caused [#3215](https://github.com/rjsf-team/react-jsonschema-form/issues/3215).
 
 ## @rjsf/validator-ajv8
 - Remove alias for ajv -> ajv8 in package.json. This fixes [#3215](https://github.com/rjsf-team/react-jsonschema-form/issues/3215).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.0.0-beta-17
+
+## @rjsf/playground
+- Change Vite `mode` to `'production'`, which provides an alternative fix for [#3228](https://github.com/rjsf-team/react-jsonschema-form/issues/3228) since the prior fix caused [#3215](https://github.com/rjsf-team/react-jsonschema-form/issues/3215).
+
+## @rjsf/validator-ajv8
+- Remove alias for ajv -> ajv8 in package.json. This fixes [#3215](https://github.com/rjsf-team/react-jsonschema-form/issues/3215).
+
 # 5.0.0-beta-16
 
 ## @rjsf/antd

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     open: process.env.NODE_ENV !== "production",
   }, // maintain the old webpack behavior in dev
   plugins: [react()],
+  mode: "production", // Fixes https://github.com/rjsf-team/react-jsonschema-form/issues/3228
   resolve: {
     alias: {
       // The following is needed to allow the material ui v4 and v5 themes to properly load the css

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -11,8 +11,8 @@ export default defineConfig({
     open: process.env.NODE_ENV !== "production",
   }, // maintain the old webpack behavior in dev
   plugins: [react()],
-  mode: "production", // Fixes https://github.com/rjsf-team/react-jsonschema-form/issues/3228
   resolve: {
+    preserveSymlinks: true, // Fixes https://github.com/rjsf-team/react-jsonschema-form/issues/3228
     alias: {
       // The following is needed to allow the material ui v4 and v5 themes to properly load the css
       "@mui/styles": path.resolve("./node_modules", "@mui/styles"),

--- a/packages/validator-ajv8/package-lock.json
+++ b/packages/validator-ajv8/package-lock.json
@@ -9,8 +9,8 @@
       "version": "5.0.0-beta.16",
       "license": "Apache-2.0",
       "dependencies": {
+        "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
-        "ajv8": "npm:ajv@^8.11.0",
         "lodash": "^4.17.15",
         "lodash-es": "^4.17.15"
       },
@@ -2951,22 +2951,6 @@
         "ajv": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ajv8": {
-      "name": "ajv",
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-colors": {
@@ -12349,17 +12333,6 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "requires": {
         "ajv": "^8.0.0"
-      }
-    },
-    "ajv8": {
-      "version": "npm:ajv@8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
       }
     },
     "ansi-colors": {

--- a/packages/validator-ajv8/package.json
+++ b/packages/validator-ajv8/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "ajv-formats": "^2.1.1",
-    "ajv8": "npm:ajv@^8.11.0",
+    "ajv": "^8.11.0",
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.15"
   },

--- a/packages/validator-ajv8/src/createAjvInstance.ts
+++ b/packages/validator-ajv8/src/createAjvInstance.ts
@@ -1,4 +1,4 @@
-import Ajv, { Options } from "ajv8";
+import Ajv, { Options } from "ajv";
 import addFormats, { FormatsPluginOptions } from "ajv-formats";
 import isObject from "lodash/isObject";
 

--- a/packages/validator-ajv8/src/types.ts
+++ b/packages/validator-ajv8/src/types.ts
@@ -1,4 +1,4 @@
-import Ajv, { Options, ErrorObject } from "ajv8";
+import Ajv, { Options, ErrorObject } from "ajv";
 import { FormatsPluginOptions } from "ajv-formats";
 
 /** The type describing how to customize the AJV6 validator

--- a/packages/validator-ajv8/src/validator.ts
+++ b/packages/validator-ajv8/src/validator.ts
@@ -1,4 +1,4 @@
-import Ajv, { ErrorObject, ValidateFunction } from "ajv8";
+import Ajv, { ErrorObject, ValidateFunction } from "ajv";
 import toPath from "lodash/toPath";
 import isObject from "lodash/isObject";
 import clone from "lodash/clone";

--- a/packages/validator-ajv8/test/createAjvInstance.test.ts
+++ b/packages/validator-ajv8/test/createAjvInstance.test.ts
@@ -1,5 +1,5 @@
-import Ajv from "ajv8";
-import Ajv2019 from "ajv8/dist/2019";
+import Ajv from "ajv";
+import Ajv2019 from "ajv/dist/2019";
 import addFormats from "ajv-formats";
 
 import createAjvInstance, {
@@ -9,8 +9,8 @@ import createAjvInstance, {
 } from "../src/createAjvInstance";
 import { CustomValidatorOptionsType } from "../src";
 
-jest.mock("ajv8");
-jest.mock("ajv8/dist/2019");
+jest.mock("ajv");
+jest.mock("ajv/dist/2019");
 jest.mock("ajv-formats");
 
 export const CUSTOM_OPTIONS: CustomValidatorOptionsType = {


### PR DESCRIPTION
- Upgrade vite to 4.0.4
- Remove ajv8 alias for validator-ajv8 (will fix issues in skypack)
- Set preserveSymlinks to `true` in vite.config.js (fixes issue in Vite dev server where @rjsf/validator-ajv8 incorrectly uses ajv@6)

### Reasons for making this change

Fixes #3215

We have an issue where the Vite development server is accessing files from ajv v6 when it should be using ajv v8. It's unclear if this is a Vite/esbuild bug, or some configuration error.

We originally fixed this in #3229, but this solution has caused other downstream issues (e.g. Skypack, which is used in CodePen examples, cannot handle npm aliases).

Setting the Vite config `preserveSymlinks` parameter to `true` seems to fix this issue.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
