### PR TITLE
fix: Update SelectWidget to take extra props, reimplementing #2232

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # 5.0.0-beta-17
 
+## @rjsf/material-ui
+- Updated `SelectWidget` to support additional `TextFieldProps` in a manner similar to how `BaseInputTemplate` does
+
+## @rjsf/mui
+- Updated `SelectWidget` to support additional `TextFieldProps` in a manner similar to how `BaseInputTemplate` does
+
 ## @rjsf/playground
 - Change Vite `preserveSymlinks` to `true`, which provides an alternative fix for [#3228](https://github.com/rjsf-team/react-jsonschema-form/issues/3228) since the prior fix caused [#3215](https://github.com/rjsf-team/react-jsonschema-form/issues/3215).
 

--- a/packages/material-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/material-ui/src/SelectWidget/SelectWidget.tsx
@@ -26,6 +26,7 @@ export default function SelectWidget<
   required,
   disabled,
   readonly,
+  placeholder,
   value,
   multiple,
   autofocus,
@@ -33,6 +34,10 @@ export default function SelectWidget<
   onBlur,
   onFocus,
   rawErrors = [],
+  registry,
+  uiSchema,
+  hideError,
+  formContext,
   ...textFieldProps
 }: WidgetProps<T, S, F>) {
   const { enumOptions, enumDisabled } = options;
@@ -59,6 +64,7 @@ export default function SelectWidget<
       required={required}
       disabled={disabled || readonly}
       autoFocus={autofocus}
+      placeholder={placeholder}
       error={rawErrors.length > 0}
       onChange={_onChange}
       onBlur={_onBlur}

--- a/packages/material-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/material-ui/src/SelectWidget/SelectWidget.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import MenuItem from "@material-ui/core/MenuItem";
-import TextField from "@material-ui/core/TextField";
+import TextField, { TextFieldProps } from "@material-ui/core/TextField";
 import {
   processSelectValue,
   FormContextType,
@@ -33,6 +33,7 @@ export default function SelectWidget<
   onBlur,
   onFocus,
   rawErrors = [],
+  ...textFieldProps
 }: WidgetProps<T, S, F>) {
   const { enumOptions, enumDisabled } = options;
 
@@ -54,7 +55,6 @@ export default function SelectWidget<
       id={id}
       name={id}
       label={label || schema.title}
-      select
       value={typeof value === "undefined" ? emptyValue : value}
       required={required}
       disabled={disabled || readonly}
@@ -63,10 +63,14 @@ export default function SelectWidget<
       onChange={_onChange}
       onBlur={_onBlur}
       onFocus={_onFocus}
+      {...(textFieldProps as TextFieldProps)}
+      select // Apply this and the following props after the potential overrides defined in textFieldProps
       InputLabelProps={{
+        ...textFieldProps.InputLabelProps,
         shrink: true,
       }}
       SelectProps={{
+        ...textFieldProps.SelectProps,
         multiple: typeof multiple === "undefined" ? false : multiple,
       }}
     >

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -1756,6 +1756,7 @@ exports[`single fields select field 1`] = `
             name="root"
             onAnimationStart={[Function]}
             onChange={[Function]}
+            placeholder=""
             required={false}
             tabIndex={-1}
             value=""

--- a/packages/mui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/mui/src/SelectWidget/SelectWidget.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import MenuItem from "@mui/material/MenuItem";
-import TextField from "@mui/material/TextField";
+import TextField, { TextFieldProps } from "@mui/material/TextField";
 import {
   processSelectValue,
   FormContextType,
@@ -33,6 +33,7 @@ export default function SelectWidget<
   onBlur,
   onFocus,
   rawErrors = [],
+  ...textFieldProps
 }: WidgetProps<T, S, F>) {
   const { enumOptions, enumDisabled } = options;
 
@@ -54,7 +55,6 @@ export default function SelectWidget<
       id={id}
       name={id}
       label={label || schema.title}
-      select
       value={typeof value === "undefined" ? emptyValue : value}
       required={required}
       disabled={disabled || readonly}
@@ -63,10 +63,14 @@ export default function SelectWidget<
       onChange={_onChange}
       onBlur={_onBlur}
       onFocus={_onFocus}
+      {...(textFieldProps as TextFieldProps)}
+      select // Apply this and the following props after the potential overrides defined in textFieldProps
       InputLabelProps={{
+        ...textFieldProps.InputLabelProps,
         shrink: true,
       }}
       SelectProps={{
+        ...textFieldProps.SelectProps,
         multiple: typeof multiple === "undefined" ? false : multiple,
       }}
     >

--- a/packages/mui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/mui/src/SelectWidget/SelectWidget.tsx
@@ -25,6 +25,7 @@ export default function SelectWidget<
   label,
   required,
   disabled,
+  placeholder,
   readonly,
   value,
   multiple,
@@ -33,6 +34,10 @@ export default function SelectWidget<
   onBlur,
   onFocus,
   rawErrors = [],
+  registry,
+  uiSchema,
+  hideError,
+  formContext,
   ...textFieldProps
 }: WidgetProps<T, S, F>) {
   const { enumOptions, enumDisabled } = options;
@@ -59,6 +64,7 @@ export default function SelectWidget<
       required={required}
       disabled={disabled || readonly}
       autoFocus={autofocus}
+      placeholder={placeholder}
       error={rawErrors.length > 0}
       onChange={_onChange}
       onBlur={_onBlur}

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -7718,6 +7718,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
             name="root"
             onAnimationStart={[Function]}
             onChange={[Function]}
+            placeholder=""
             required={false}
             tabIndex={-1}
             value=""


### PR DESCRIPTION
### Reasons for making this change

For the material-ui and mui themes, the `BaseInputTemplate` supports feeding in extra props, but the `SelectWidget` does not. They use the same underlying `TextField` component.

Reimplements #2232 in the newer typescript world

- In `@rjsf/material-ui` and `@rjsf/material-ui`, added `...textFieldProps` to the arguments, passing them into the underlying `TextField`
- Updated the `CHANGELOG.md` accordingly

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
