### PR TITLE
fix: reimplement PR 2356 to enable searching SelectWidget by label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # 5.0.0-beta-17
 
+## @rjsf/antd
+- Enable searching in the `SelectWidget` by the label that the user sees rather than by the value
+
 ## @rjsf/material-ui
 - Updated `SelectWidget` to support additional `TextFieldProps` in a manner similar to how `BaseInputTemplate` does
 

--- a/packages/antd/src/widgets/SelectWidget/index.tsx
+++ b/packages/antd/src/widgets/SelectWidget/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Select from "antd/lib/select";
+import Select, { DefaultOptionType } from "antd/lib/select";
 import {
   processSelectValue,
   FormContextType,
@@ -8,6 +8,7 @@ import {
   StrictRJSFSchema,
   WidgetProps,
 } from "@rjsf/utils";
+import isString from "lodash/isString";
 
 const SELECT_STYLE = {
   width: "100%",
@@ -50,6 +51,14 @@ export default function SelectWidget<
   const handleFocus = () =>
     onFocus(id, processSelectValue<T, S, F>(schema, value, options));
 
+  const filterOption = (input: string, option?: DefaultOptionType) => {
+    if (option && isString(option.label)) {
+      // labels are strings in this context
+      return option.label.toLowerCase().indexOf(input.toLowerCase()) >= 0;
+    }
+    return false;
+  };
+
   const getPopupContainer = (node: any) => node.parentNode;
 
   const stringify = (currentValue: any) =>
@@ -74,6 +83,7 @@ export default function SelectWidget<
       style={SELECT_STYLE}
       value={typeof value !== "undefined" ? stringify(value) : undefined}
       {...extraProps}
+      filterOption={filterOption}
     >
       {Array.isArray(enumOptions) &&
         enumOptions.map(({ value: optionValue, label: optionLabel }) => (


### PR DESCRIPTION
### Reasons for making this change

Antd Select widget allows to search in the option array. The current code makes the Select search by the key, not the value - the label that is presented to the user.

Reimplements #2356

- Updated the `SelectWidget` to implement a `filterOption` function that compares the string against the select option label

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
