### PR TITLE
fix: Add support for custom styles in a manner similar to classNames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/antd
 - Enable searching in the `SelectWidget` by the label that the user sees rather than by the value
-- Added support for new `styles` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200) 
+- Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200) 
 
 ## @rjsf/bootstrap-4
 - Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
@@ -47,7 +47,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 
 ## @rjsf/utils
-- Updated the `FieldTemplateProps`, `WrapIfAdditionalTemplateProps` and `UIOptionsBaseType` types to add `styles?: StyleHTMLAttributes<any>`, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200) 
+- Updated the `FieldTemplateProps`, `WrapIfAdditionalTemplateProps` and `UIOptionsBaseType` types to add `style?: StyleHTMLAttributes<any>`, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200) 
 
 ## @rjsf/validator-ajv8
 - Remove alias for ajv -> ajv8 in package.json. This fixes [#3215](https://github.com/rjsf-team/react-jsonschema-form/issues/3215).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,19 +19,44 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/antd
 - Enable searching in the `SelectWidget` by the label that the user sees rather than by the value
+- Added support for new `styles` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200) 
+
+## @rjsf/bootstrap-4
+- Added support for new `styles` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
+
+## @rjsf/chakra-ui
+- Added support for new `styles` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
+
+## @rjsf/core
+- Updated `SchemaField` to handle the new `styles` prop in the `uiSchema` similarly to `classNames`, passing it to the `FieldTemplate` and removing it from being passed down to children.
+  - Also, added support for new `styles` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper
+  - This partially fixes [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
+
+## @rjsf/fluent-ui
+- Added support for new `styles` prop on `FieldTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 
 ## @rjsf/material-ui
 - Updated `SelectWidget` to support additional `TextFieldProps` in a manner similar to how `BaseInputTemplate` does
+- Added support for new `styles` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 
 ## @rjsf/mui
 - Updated `SelectWidget` to support additional `TextFieldProps` in a manner similar to how `BaseInputTemplate` does
+- Added support for new `styles` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 
-## @rjsf/playground
-- Change Vite `preserveSymlinks` to `true`, which provides an alternative fix for [#3228](https://github.com/rjsf-team/react-jsonschema-form/issues/3228) since the prior fix caused [#3215](https://github.com/rjsf-team/react-jsonschema-form/issues/3215).
+## @rjsf/semantic-ui
+- Added support for new `styles` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
+
+## @rjsf/utils
+- Updated the `FieldTemplateProps`, `WrapIfAdditionalTemplateProps` and `UIOptionsBaseType` types to add `styles?: StyleHTMLAttributes<any>`, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200) 
 
 ## @rjsf/validator-ajv8
 - Remove alias for ajv -> ajv8 in package.json. This fixes [#3215](https://github.com/rjsf-team/react-jsonschema-form/issues/3215).
 - Updated `AJV8Validator#transformRJSFValidationErrors` to return more human readable error messages.  The ajv8 `ErrorObject` message is enhanced by replacing the error message field with either the `uiSchema`'s `ui:title` field if one exists or the `parentSchema` title if one exists. Fixes [#3246](https://github.com/rjsf-team/react-jsonschema-form/issues/3246)
+
+## Dev / docs / playground
+- In the playground, change Vite `preserveSymlinks` to `true`, which provides an alternative fix for [#3228](https://github.com/rjsf-team/react-jsonschema-form/issues/3228) since the prior fix caused [#3215](https://github.com/rjsf-team/react-jsonschema-form/issues/3215).
+- Updated the `custom-templates.md` and `uiSchema.md` to document the new `styles` prop
+- Updated the `validation.md` documentation to describe the new `uiSchema` parameter passed to the `customValidate()` and `transformError()` functions
 
 # 5.0.0-beta-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,29 +22,29 @@ should change the heading of the (upcoming) version to include a major version b
 - Added support for new `styles` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200) 
 
 ## @rjsf/bootstrap-4
-- Added support for new `styles` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
+- Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 
 ## @rjsf/chakra-ui
-- Added support for new `styles` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
+- Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 
 ## @rjsf/core
-- Updated `SchemaField` to handle the new `styles` prop in the `uiSchema` similarly to `classNames`, passing it to the `FieldTemplate` and removing it from being passed down to children.
-  - Also, added support for new `styles` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper
+- Updated `SchemaField` to handle the new `style` prop in the `uiSchema` similarly to `classNames`, passing it to the `FieldTemplate` and removing it from being passed down to children.
+  - Also, added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper
   - This partially fixes [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 
 ## @rjsf/fluent-ui
-- Added support for new `styles` prop on `FieldTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
+- Added support for new `style` prop on `FieldTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 
 ## @rjsf/material-ui
 - Updated `SelectWidget` to support additional `TextFieldProps` in a manner similar to how `BaseInputTemplate` does
-- Added support for new `styles` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
+- Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 
 ## @rjsf/mui
 - Updated `SelectWidget` to support additional `TextFieldProps` in a manner similar to how `BaseInputTemplate` does
-- Added support for new `styles` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
+- Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 
 ## @rjsf/semantic-ui
-- Added support for new `styles` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
+- Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 
 ## @rjsf/utils
 - Updated the `FieldTemplateProps`, `WrapIfAdditionalTemplateProps` and `UIOptionsBaseType` types to add `styles?: StyleHTMLAttributes<any>`, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200) 
@@ -55,7 +55,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## Dev / docs / playground
 - In the playground, change Vite `preserveSymlinks` to `true`, which provides an alternative fix for [#3228](https://github.com/rjsf-team/react-jsonschema-form/issues/3228) since the prior fix caused [#3215](https://github.com/rjsf-team/react-jsonschema-form/issues/3215).
-- Updated the `custom-templates.md` and `uiSchema.md` to document the new `styles` prop
+- Updated the `custom-templates.md` and `uiSchema.md` to document the new `style` prop
 - Updated the `validation.md` documentation to describe the new `uiSchema` parameter passed to the `customValidate()` and `transformError()` functions
 
 # 5.0.0-beta-16

--- a/docs/advanced-customization/custom-templates.md
+++ b/docs/advanced-customization/custom-templates.md
@@ -561,9 +561,9 @@ const schema: RJSFSchema = {
 };
 
 function CustomFieldTemplate(props: FieldTemplateProps) {
-  const {id, classNames, label, help, required, description, errors, children} = props;
+  const {id, classNames, styles, label, help, required, description, errors, children} = props;
   return (
-    <div className={classNames}>
+    <div className={classNames} style={styles}>
       <label htmlFor={id}>{label}{required ? "*" : null}</label>
       {description}
       {children}
@@ -594,6 +594,7 @@ The following props are passed to a custom field template component:
 
 - `id`: The id of the field in the hierarchy. You can use it to render a label targeting the wrapped widget.
 - `classNames`: A string containing the base Bootstrap CSS classes, merged with any [custom ones](#custom-css-class-names) defined in your uiSchema.
+- `styles`: An object containing the `StyleHTMLAttributes` defined in the `uiSchema`.
 - `label`: The computed label for this field, as a string.
 - `description`: A component instance rendering the field description, if one is defined (this will use any [custom `DescriptionField`](#custom-descriptions) defined).
 - `rawDescription`: A string containing any `ui:description` uiSchema directive defined.
@@ -793,6 +794,8 @@ function WrapIfAdditionalTemplate(
     children,
     uiSchema,
     registry,
+    classNames,
+    styles,
   } = props;
   const { RemoveButton } = registry.templates.ButtonTemplates;
   const additional = ADDITIONAL_PROPERTY_FLAG in schema;
@@ -802,7 +805,7 @@ function WrapIfAdditionalTemplate(
   }
 
   return (
-    <div>
+    <div className={classNames} style={styles}>
       <label label={keyLabel} id={`${id}-key`}>Custom Field Key</label>
       <input 
           className="form-control"
@@ -830,6 +833,7 @@ The following props are passed to the `WrapIfAdditionalTemplate`:
 
 - `id`: The id of the field in the hierarchy. You can use it to render a label targeting the wrapped widget.
 - `classNames`: A string containing the base Bootstrap CSS classes, merged with any [custom ones](#custom-css-class-names) defined in your uiSchema.
+- `styles`: An object containing the `StyleHTMLAttributes` defined in the `uiSchema`.
 - `label`: The computed label for this field, as a string.
 - `required`: A boolean value stating if the field is required.
 - `readonly`: A boolean value stating if the field is read-only.

--- a/docs/advanced-customization/custom-templates.md
+++ b/docs/advanced-customization/custom-templates.md
@@ -561,9 +561,9 @@ const schema: RJSFSchema = {
 };
 
 function CustomFieldTemplate(props: FieldTemplateProps) {
-  const {id, classNames, styles, label, help, required, description, errors, children} = props;
+  const {id, classNames, style, label, help, required, description, errors, children} = props;
   return (
-    <div className={classNames} style={styles}>
+    <div className={classNames} style={style}>
       <label htmlFor={id}>{label}{required ? "*" : null}</label>
       {description}
       {children}
@@ -594,7 +594,7 @@ The following props are passed to a custom field template component:
 
 - `id`: The id of the field in the hierarchy. You can use it to render a label targeting the wrapped widget.
 - `classNames`: A string containing the base Bootstrap CSS classes, merged with any [custom ones](#custom-css-class-names) defined in your uiSchema.
-- `styles`: An object containing the `StyleHTMLAttributes` defined in the `uiSchema`.
+- `style`: An object containing the `StyleHTMLAttributes` defined in the `uiSchema`.
 - `label`: The computed label for this field, as a string.
 - `description`: A component instance rendering the field description, if one is defined (this will use any [custom `DescriptionField`](#custom-descriptions) defined).
 - `rawDescription`: A string containing any `ui:description` uiSchema directive defined.
@@ -795,7 +795,7 @@ function WrapIfAdditionalTemplate(
     uiSchema,
     registry,
     classNames,
-    styles,
+    style,
   } = props;
   const { RemoveButton } = registry.templates.ButtonTemplates;
   const additional = ADDITIONAL_PROPERTY_FLAG in schema;
@@ -805,7 +805,7 @@ function WrapIfAdditionalTemplate(
   }
 
   return (
-    <div className={classNames} style={styles}>
+    <div className={classNames} style={style}>
       <label label={keyLabel} id={`${id}-key`}>Custom Field Key</label>
       <input 
           className="form-control"
@@ -833,7 +833,7 @@ The following props are passed to the `WrapIfAdditionalTemplate`:
 
 - `id`: The id of the field in the hierarchy. You can use it to render a label targeting the wrapped widget.
 - `classNames`: A string containing the base Bootstrap CSS classes, merged with any [custom ones](#custom-css-class-names) defined in your uiSchema.
-- `styles`: An object containing the `StyleHTMLAttributes` defined in the `uiSchema`.
+- `style`: An object containing the `StyleHTMLAttributes` defined in the `uiSchema`.
 - `label`: The computed label for this field, as a string.
 - `required`: A boolean value stating if the field is required.
 - `readonly`: A boolean value stating if the field is read-only.

--- a/docs/api-reference/uiSchema.md
+++ b/docs/api-reference/uiSchema.md
@@ -112,16 +112,16 @@ Will result in:
   </label>
 </div>
 ```
-### styles
+### style
 
-The uiSchema object accepts a `ui:styles` property for each field of the schema:
+The uiSchema object accepts a `ui:style` property for each field of the schema:
 
 ```tsx
 import { UiSchema } from "@rjsf/utils";
 
 const uiSchema = {
   title: {
-    "ui:styles": { color: "red" }
+    "ui:style": { color: "red" }
   }
 };
 ```

--- a/docs/api-reference/uiSchema.md
+++ b/docs/api-reference/uiSchema.md
@@ -112,6 +112,30 @@ Will result in:
   </label>
 </div>
 ```
+### styles
+
+The uiSchema object accepts a `ui:styles` property for each field of the schema:
+
+```tsx
+import { UiSchema } from "@rjsf/utils";
+
+const uiSchema = {
+  title: {
+    "ui:styles": { color: "red" }
+  }
+};
+```
+
+Will result in:
+
+```html
+<div class="field field-string task-title" style={{ color: "red" }}>
+  <label>
+    <span>Title*</span>
+    <input value="My task" required="" type="text">
+  </label>
+</div>
+```
 
 ### autocomplete
 

--- a/docs/usage/validation.md
+++ b/docs/usage/validation.md
@@ -99,7 +99,7 @@ This is especially useful when the validation depends on several interdependent 
 import { RJSFSchema } from "@rjsf/utils";
 import validator from "@rjsf/validator-ajv8";
 
-function customValidate(formData, errors) {
+function customValidate(formData, errors, uiSchema) {
   if (formData.pass1 !== formData.pass2) {
     errors.pass2.addError("Passwords don't match");
   }
@@ -123,6 +123,7 @@ render((
 > - The `customValidate()` function must implement the `CustomValidator` interface found in `@rjsf/utils`.
 > - The `customValidate()` function must **always** return the `errors` object received as second argument.
 > - The `customValidate()` function is called **after** the JSON schema validation.
+> - The `customValidate()` function is passed the `uiSchema` as the third argument. This allows the `customValidate()` function to be able to derive additional information from it for generating errors.
 
 ## Custom error messages
 
@@ -133,7 +134,7 @@ If you need to change these messages or make any other modifications to the erro
 import { RJSFSchema } from "@rjsf/utils";
 import validator from "@rjsf/validator-ajv8";
 
-function transformErrors(errors) {
+function transformErrors(errors, uiSchema) {
   return errors.map(error => {
     if (error.name === "pattern") {
       error.message = "Only digits are allowed"
@@ -157,6 +158,7 @@ render((
 > Notes:
 > - The `transformErrors()` function must implement the `ErrorTransformer` interface found in `@rjsf/utils`.
 > - The `transformErrors()` function must return the list of errors. Modifying the list in place without returning it will result in an error.
+> - The `transformErrors()` function is passed the `uiSchema` as the second argument. This allows the `transformErrors()` function to be able to derive additional information from it for transforming errors.
 
 Each element in the `errors` list passed to `transformErrors` is a `RJSFValidationError` interface (in `@rjsf/utils`) and has the following properties:
 

--- a/packages/antd/src/templates/FieldTemplate/index.tsx
+++ b/packages/antd/src/templates/FieldTemplate/index.tsx
@@ -26,7 +26,7 @@ export default function FieldTemplate<
   const {
     children,
     classNames,
-    styles,
+    style,
     description,
     disabled,
     displayLabel,
@@ -69,7 +69,7 @@ export default function FieldTemplate<
   return (
     <WrapIfAdditionalTemplate
       classNames={classNames}
-      styles={styles}
+      style={style}
       disabled={disabled}
       id={id}
       label={label}

--- a/packages/antd/src/templates/FieldTemplate/index.tsx
+++ b/packages/antd/src/templates/FieldTemplate/index.tsx
@@ -26,6 +26,7 @@ export default function FieldTemplate<
   const {
     children,
     classNames,
+    styles,
     description,
     disabled,
     displayLabel,
@@ -68,6 +69,7 @@ export default function FieldTemplate<
   return (
     <WrapIfAdditionalTemplate
       classNames={classNames}
+      styles={styles}
       disabled={disabled}
       id={id}
       label={label}

--- a/packages/antd/src/templates/WrapIfAdditionalTemplate/index.tsx
+++ b/packages/antd/src/templates/WrapIfAdditionalTemplate/index.tsx
@@ -32,7 +32,7 @@ export default function WrapIfAdditionalTemplate<
   const {
     children,
     classNames,
-    styles,
+    style,
     disabled,
     id,
     label,
@@ -61,7 +61,7 @@ export default function WrapIfAdditionalTemplate<
 
   if (!additional) {
     return (
-      <div className={classNames} style={styles}>
+      <div className={classNames} style={style}>
         {children}
       </div>
     );
@@ -78,7 +78,7 @@ export default function WrapIfAdditionalTemplate<
   };
 
   return (
-    <div className={classNames} style={styles}>
+    <div className={classNames} style={style}>
       <Row align={toolbarAlign} gutter={rowGutter}>
         <Col className="form-additional" flex="1">
           <div className="form-group">

--- a/packages/antd/src/templates/WrapIfAdditionalTemplate/index.tsx
+++ b/packages/antd/src/templates/WrapIfAdditionalTemplate/index.tsx
@@ -32,6 +32,7 @@ export default function WrapIfAdditionalTemplate<
   const {
     children,
     classNames,
+    styles,
     disabled,
     id,
     label,
@@ -59,7 +60,11 @@ export default function WrapIfAdditionalTemplate<
   const additional = ADDITIONAL_PROPERTY_FLAG in schema;
 
   if (!additional) {
-    return <div className={classNames}>{children}</div>;
+    return (
+      <div className={classNames} style={styles}>
+        {children}
+      </div>
+    );
   }
 
   const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
@@ -73,7 +78,7 @@ export default function WrapIfAdditionalTemplate<
   };
 
   return (
-    <div className={classNames}>
+    <div className={classNames} style={styles}>
       <Row align={toolbarAlign} gutter={rowGutter}>
         <Col className="form-additional" flex="1">
           <div className="form-group">

--- a/packages/bootstrap-4/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/bootstrap-4/src/FieldTemplate/FieldTemplate.tsx
@@ -22,7 +22,7 @@ export default function FieldTemplate<
   help,
   rawDescription,
   classNames,
-  styles,
+  style,
   disabled,
   label,
   hidden,
@@ -47,7 +47,7 @@ export default function FieldTemplate<
   return (
     <WrapIfAdditionalTemplate
       classNames={classNames}
-      styles={styles}
+      style={style}
       disabled={disabled}
       id={id}
       label={label}

--- a/packages/bootstrap-4/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/bootstrap-4/src/FieldTemplate/FieldTemplate.tsx
@@ -22,6 +22,7 @@ export default function FieldTemplate<
   help,
   rawDescription,
   classNames,
+  styles,
   disabled,
   label,
   hidden,
@@ -46,6 +47,7 @@ export default function FieldTemplate<
   return (
     <WrapIfAdditionalTemplate
       classNames={classNames}
+      styles={styles}
       disabled={disabled}
       id={id}
       label={label}

--- a/packages/bootstrap-4/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/bootstrap-4/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -18,6 +18,7 @@ export default function WrapIfAdditionalTemplate<
   F extends FormContextType = any
 >({
   classNames,
+  styles,
   children,
   disabled,
   id,
@@ -36,7 +37,11 @@ export default function WrapIfAdditionalTemplate<
   const additional = ADDITIONAL_PROPERTY_FLAG in schema;
 
   if (!additional) {
-    return <div className={classNames}>{children}</div>;
+    return (
+      <div className={classNames} style={styles}>
+        {children}
+      </div>
+    );
   }
 
   const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
@@ -44,7 +49,7 @@ export default function WrapIfAdditionalTemplate<
   const keyId = `${id}-key`;
 
   return (
-    <Row className={classNames} key={keyId}>
+    <Row className={classNames} style={styles} key={keyId}>
       <Col xs={5}>
         <Form.Group>
           <Form.Label htmlFor={keyId}>{keyLabel}</Form.Label>

--- a/packages/bootstrap-4/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/bootstrap-4/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -18,7 +18,7 @@ export default function WrapIfAdditionalTemplate<
   F extends FormContextType = any
 >({
   classNames,
-  styles,
+  style,
   children,
   disabled,
   id,
@@ -38,7 +38,7 @@ export default function WrapIfAdditionalTemplate<
 
   if (!additional) {
     return (
-      <div className={classNames} style={styles}>
+      <div className={classNames} style={style}>
         {children}
       </div>
     );
@@ -49,7 +49,7 @@ export default function WrapIfAdditionalTemplate<
   const keyId = `${id}-key`;
 
   return (
-    <Row className={classNames} style={styles} key={keyId}>
+    <Row className={classNames} style={style} key={keyId}>
       <Col xs={5}>
         <Form.Group>
           <Form.Label htmlFor={keyId}>{keyLabel}</Form.Label>

--- a/packages/chakra-ui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/chakra-ui/src/FieldTemplate/FieldTemplate.tsx
@@ -18,7 +18,7 @@ export default function FieldTemplate<
     id,
     children,
     classNames,
-    styles,
+    style,
     disabled,
     displayLabel,
     hidden,
@@ -50,7 +50,7 @@ export default function FieldTemplate<
   return (
     <WrapIfAdditionalTemplate
       classNames={classNames}
-      styles={styles}
+      style={style}
       disabled={disabled}
       id={id}
       label={label}

--- a/packages/chakra-ui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/chakra-ui/src/FieldTemplate/FieldTemplate.tsx
@@ -18,6 +18,7 @@ export default function FieldTemplate<
     id,
     children,
     classNames,
+    styles,
     disabled,
     displayLabel,
     hidden,
@@ -49,6 +50,7 @@ export default function FieldTemplate<
   return (
     <WrapIfAdditionalTemplate
       classNames={classNames}
+      styles={styles}
       disabled={disabled}
       id={id}
       label={label}

--- a/packages/chakra-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/chakra-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -22,7 +22,7 @@ export default function WrapIfAdditionalTemplate<
   const {
     children,
     classNames,
-    styles,
+    style,
     disabled,
     id,
     label,
@@ -39,7 +39,7 @@ export default function WrapIfAdditionalTemplate<
   const additional = ADDITIONAL_PROPERTY_FLAG in schema;
   if (!additional) {
     return (
-      <div className={classNames} style={styles}>
+      <div className={classNames} style={style}>
         {children}
       </div>
     );
@@ -53,7 +53,7 @@ export default function WrapIfAdditionalTemplate<
     <Grid
       key={`${id}-key`}
       className={classNames}
-      style={styles}
+      style={style}
       alignItems="center"
       gap={2}
     >

--- a/packages/chakra-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/chakra-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -22,6 +22,7 @@ export default function WrapIfAdditionalTemplate<
   const {
     children,
     classNames,
+    styles,
     disabled,
     id,
     label,
@@ -37,7 +38,11 @@ export default function WrapIfAdditionalTemplate<
   const { RemoveButton } = registry.templates.ButtonTemplates;
   const additional = ADDITIONAL_PROPERTY_FLAG in schema;
   if (!additional) {
-    return <div className={classNames}>{children}</div>;
+    return (
+      <div className={classNames} style={styles}>
+        {children}
+      </div>
+    );
   }
   const keyLabel = `${label} Key`;
 
@@ -45,7 +50,13 @@ export default function WrapIfAdditionalTemplate<
     onKeyChange(target.value);
 
   return (
-    <Grid key={`${id}-key`} className={classNames} alignItems="center" gap={2}>
+    <Grid
+      key={`${id}-key`}
+      className={classNames}
+      style={styles}
+      alignItems="center"
+      gap={2}
+    >
       <GridItem>
         <FormControl isRequired={required}>
           <FormLabel htmlFor={`${id}-key`} id={`${id}-key-label`}>

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -16,6 +16,7 @@ import {
   UIOptionsType,
   ID_KEY,
   ADDITIONAL_PROPERTY_FLAG,
+  UI_OPTIONS_KEY,
 } from "@rjsf/utils";
 import isObject from "lodash/isObject";
 import omit from "lodash/omit";
@@ -188,11 +189,16 @@ function SchemaFieldRender<
   const displayLabel = schemaUtils.getDisplayLabel(schema, uiSchema);
 
   const { __errors, ...fieldErrorSchema } = errorSchema || {};
-  // See #439: uiSchema: Don't pass consumed class names to child components
-  const fieldUiSchema = omit(uiSchema, ["ui:classNames", "classNames"]);
-  if ("ui:options" in fieldUiSchema) {
-    fieldUiSchema["ui:options"] = omit(fieldUiSchema["ui:options"], [
+  // See #439: uiSchema: Don't pass consumed class names or styles to child components
+  const fieldUiSchema = omit(uiSchema, [
+    "ui:classNames",
+    "classNames",
+    "ui:styles",
+  ]);
+  if (UI_OPTIONS_KEY in fieldUiSchema) {
+    fieldUiSchema[UI_OPTIONS_KEY] = omit(fieldUiSchema[UI_OPTIONS_KEY], [
       "classNames",
+      "styles",
     ]);
   }
 
@@ -297,6 +303,7 @@ function SchemaFieldRender<
     hideError,
     displayLabel,
     classNames: classNames.join(" ").trim(),
+    styles: uiOptions.styles,
     formContext,
     formData,
     schema,

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -189,16 +189,16 @@ function SchemaFieldRender<
   const displayLabel = schemaUtils.getDisplayLabel(schema, uiSchema);
 
   const { __errors, ...fieldErrorSchema } = errorSchema || {};
-  // See #439: uiSchema: Don't pass consumed class names or styles to child components
+  // See #439: uiSchema: Don't pass consumed class names or style to child components
   const fieldUiSchema = omit(uiSchema, [
     "ui:classNames",
     "classNames",
-    "ui:styles",
+    "ui:style",
   ]);
   if (UI_OPTIONS_KEY in fieldUiSchema) {
     fieldUiSchema[UI_OPTIONS_KEY] = omit(fieldUiSchema[UI_OPTIONS_KEY], [
       "classNames",
-      "styles",
+      "style",
     ]);
   }
 
@@ -303,7 +303,7 @@ function SchemaFieldRender<
     hideError,
     displayLabel,
     classNames: classNames.join(" ").trim(),
-    styles: uiOptions.styles,
+    style: uiOptions.style,
     formContext,
     formData,
     schema,

--- a/packages/core/src/components/templates/WrapIfAdditionalTemplate.tsx
+++ b/packages/core/src/components/templates/WrapIfAdditionalTemplate.tsx
@@ -22,6 +22,7 @@ export default function WrapIfAdditionalTemplate<
   const {
     id,
     classNames,
+    styles,
     disabled,
     label,
     onKeyChange,
@@ -39,11 +40,15 @@ export default function WrapIfAdditionalTemplate<
   const additional = ADDITIONAL_PROPERTY_FLAG in schema;
 
   if (!additional) {
-    return <div className={classNames}>{children}</div>;
+    return (
+      <div className={classNames} style={styles}>
+        {children}
+      </div>
+    );
   }
 
   return (
-    <div className={classNames}>
+    <div className={classNames} style={styles}>
       <div className="row">
         <div className="col-xs-5 form-additional">
           <div className="form-group">

--- a/packages/core/src/components/templates/WrapIfAdditionalTemplate.tsx
+++ b/packages/core/src/components/templates/WrapIfAdditionalTemplate.tsx
@@ -22,7 +22,7 @@ export default function WrapIfAdditionalTemplate<
   const {
     id,
     classNames,
-    styles,
+    style,
     disabled,
     label,
     onKeyChange,
@@ -41,14 +41,14 @@ export default function WrapIfAdditionalTemplate<
 
   if (!additional) {
     return (
-      <div className={classNames} style={styles}>
+      <div className={classNames} style={style}>
         {children}
       </div>
     );
   }
 
   return (
-    <div className={classNames} style={styles}>
+    <div className={classNames} style={style}>
       <div className="row">
         <div className="col-xs-5 form-additional">
           <div className="form-group">

--- a/packages/core/test/SchemaField_test.js
+++ b/packages/core/test/SchemaField_test.js
@@ -203,7 +203,7 @@ describe("SchemaField", () => {
       expect(node.querySelectorAll("#custom")).to.have.length.of(1);
     });
 
-    it("should not pass ui:classNames to child component", () => {
+    it("should not pass ui:classNames or ui:styles to child component", () => {
       const CustomSchemaField = function (props) {
         return (
           <SchemaField
@@ -219,14 +219,16 @@ describe("SchemaField", () => {
       const uiSchema = {
         "ui:field": "customSchemaField",
         "ui:classNames": "foo",
+        "ui:styles": { color: "red" },
       };
       const fields = { customSchemaField: CustomSchemaField };
 
       const { node } = createFormComponent({ schema, uiSchema, fields });
 
       expect(node.querySelectorAll(".foo")).to.have.length.of(1);
+      expect(node.querySelectorAll("[style*='red']")).to.have.length.of(1);
     });
-    it("should not pass ui:options.classNames to child component", () => {
+    it("should not pass ui:options { classNames or styles } to child component", () => {
       const CustomSchemaField = function (props) {
         return (
           <SchemaField
@@ -243,6 +245,7 @@ describe("SchemaField", () => {
         "ui:field": "customSchemaField",
         "ui:options": {
           classNames: "foo",
+          styles: { color: "red" },
         },
       };
       const fields = { customSchemaField: CustomSchemaField };
@@ -250,6 +253,7 @@ describe("SchemaField", () => {
       const { node } = createFormComponent({ schema, uiSchema, fields });
 
       expect(node.querySelectorAll(".foo")).to.have.length.of(1);
+      expect(node.querySelectorAll("[style*='red']")).to.have.length.of(1);
     });
   });
 

--- a/packages/core/test/SchemaField_test.js
+++ b/packages/core/test/SchemaField_test.js
@@ -203,7 +203,7 @@ describe("SchemaField", () => {
       expect(node.querySelectorAll("#custom")).to.have.length.of(1);
     });
 
-    it("should not pass ui:classNames or ui:styles to child component", () => {
+    it("should not pass ui:classNames or ui:style to child component", () => {
       const CustomSchemaField = function (props) {
         return (
           <SchemaField
@@ -219,7 +219,7 @@ describe("SchemaField", () => {
       const uiSchema = {
         "ui:field": "customSchemaField",
         "ui:classNames": "foo",
-        "ui:styles": { color: "red" },
+        "ui:style": { color: "red" },
       };
       const fields = { customSchemaField: CustomSchemaField };
 
@@ -228,7 +228,7 @@ describe("SchemaField", () => {
       expect(node.querySelectorAll(".foo")).to.have.length.of(1);
       expect(node.querySelectorAll("[style*='red']")).to.have.length.of(1);
     });
-    it("should not pass ui:options { classNames or styles } to child component", () => {
+    it("should not pass ui:options { classNames or style } to child component", () => {
       const CustomSchemaField = function (props) {
         return (
           <SchemaField
@@ -245,7 +245,7 @@ describe("SchemaField", () => {
         "ui:field": "customSchemaField",
         "ui:options": {
           classNames: "foo",
-          styles: { color: "red" },
+          style: { color: "red" },
         },
       };
       const fields = { customSchemaField: CustomSchemaField };

--- a/packages/core/test/uiSchema_test.js
+++ b/packages/core/test/uiSchema_test.js
@@ -82,19 +82,19 @@ describe("uiSchema", () => {
 
     const uiSchema = {
       foo: {
-        "ui:styles": {
+        "ui:style": {
           paddingRight: "1em",
         },
       },
       bar: {
-        "ui:styles": {
+        "ui:style": {
           paddingLeft: "1.5em",
           color: "orange",
         },
       },
     };
 
-    it("should apply custom styles to target widgets", () => {
+    it("should apply custom style to target widgets", () => {
       const { node } = createFormComponent({ schema, uiSchema });
       const [foo, bar] = node.querySelectorAll(".field-string");
 

--- a/packages/core/test/uiSchema_test.js
+++ b/packages/core/test/uiSchema_test.js
@@ -67,6 +67,43 @@ describe("uiSchema", () => {
     });
   });
 
+  describe("custom style", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        foo: {
+          type: "string",
+        },
+        bar: {
+          type: "string",
+        },
+      },
+    };
+
+    const uiSchema = {
+      foo: {
+        "ui:styles": {
+          paddingRight: "1em",
+        },
+      },
+      bar: {
+        "ui:styles": {
+          paddingLeft: "1.5em",
+          color: "orange",
+        },
+      },
+    };
+
+    it("should apply custom styles to target widgets", () => {
+      const { node } = createFormComponent({ schema, uiSchema });
+      const [foo, bar] = node.querySelectorAll(".field-string");
+
+      expect(foo.style.paddingRight).eql("1em");
+      expect(bar.style.paddingLeft).eql("1.5em");
+      expect(bar.style.color).eql("orange");
+    });
+  });
+
   describe("custom widget", () => {
     describe("root widget", () => {
       const schema = {

--- a/packages/material-ui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/material-ui/src/FieldTemplate/FieldTemplate.tsx
@@ -24,6 +24,7 @@ export default function FieldTemplate<
     id,
     children,
     classNames,
+    styles,
     disabled,
     displayLabel,
     hidden,
@@ -54,6 +55,7 @@ export default function FieldTemplate<
   return (
     <WrapIfAdditionalTemplate
       classNames={classNames}
+      styles={styles}
       disabled={disabled}
       id={id}
       label={label}

--- a/packages/material-ui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/material-ui/src/FieldTemplate/FieldTemplate.tsx
@@ -24,7 +24,7 @@ export default function FieldTemplate<
     id,
     children,
     classNames,
-    styles,
+    style,
     disabled,
     displayLabel,
     hidden,
@@ -55,7 +55,7 @@ export default function FieldTemplate<
   return (
     <WrapIfAdditionalTemplate
       classNames={classNames}
-      styles={styles}
+      style={style}
       disabled={disabled}
       id={id}
       label={label}

--- a/packages/material-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/material-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -24,6 +24,7 @@ export default function WrapIfAdditionalTemplate<
   const {
     children,
     classNames,
+    styles,
     disabled,
     id,
     label,
@@ -47,7 +48,11 @@ export default function WrapIfAdditionalTemplate<
   };
 
   if (!additional) {
-    return <div className={classNames}>{children}</div>;
+    return (
+      <div className={classNames} style={styles}>
+        {children}
+      </div>
+    );
   }
 
   const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
@@ -60,6 +65,7 @@ export default function WrapIfAdditionalTemplate<
       alignItems="center"
       spacing={2}
       className={classNames}
+      style={styles}
     >
       <Grid item xs>
         <FormControl fullWidth={true} required={required}>

--- a/packages/material-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/material-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -24,7 +24,7 @@ export default function WrapIfAdditionalTemplate<
   const {
     children,
     classNames,
-    styles,
+    style,
     disabled,
     id,
     label,
@@ -49,7 +49,7 @@ export default function WrapIfAdditionalTemplate<
 
   if (!additional) {
     return (
-      <div className={classNames} style={styles}>
+      <div className={classNames} style={style}>
         {children}
       </div>
     );
@@ -65,7 +65,7 @@ export default function WrapIfAdditionalTemplate<
       alignItems="center"
       spacing={2}
       className={classNames}
-      style={styles}
+      style={style}
     >
       <Grid item xs>
         <FormControl fullWidth={true} required={required}>

--- a/packages/mui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/mui/src/FieldTemplate/FieldTemplate.tsx
@@ -24,6 +24,7 @@ export default function FieldTemplate<
     id,
     children,
     classNames,
+    styles,
     disabled,
     displayLabel,
     hidden,
@@ -54,6 +55,7 @@ export default function FieldTemplate<
   return (
     <WrapIfAdditionalTemplate
       classNames={classNames}
+      styles={styles}
       disabled={disabled}
       id={id}
       label={label}

--- a/packages/mui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/mui/src/FieldTemplate/FieldTemplate.tsx
@@ -24,7 +24,7 @@ export default function FieldTemplate<
     id,
     children,
     classNames,
-    styles,
+    style,
     disabled,
     displayLabel,
     hidden,
@@ -55,7 +55,7 @@ export default function FieldTemplate<
   return (
     <WrapIfAdditionalTemplate
       classNames={classNames}
-      styles={styles}
+      style={style}
       disabled={disabled}
       id={id}
       label={label}

--- a/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -24,6 +24,7 @@ export default function WrapIfAdditionalTemplate<
   const {
     children,
     classNames,
+    styles,
     disabled,
     id,
     label,
@@ -47,7 +48,11 @@ export default function WrapIfAdditionalTemplate<
   };
 
   if (!additional) {
-    return <div className={classNames}>{children}</div>;
+    return (
+      <div className={classNames} style={styles}>
+        {children}
+      </div>
+    );
   }
 
   const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
@@ -60,6 +65,7 @@ export default function WrapIfAdditionalTemplate<
       alignItems="center"
       spacing={2}
       className={classNames}
+      style={styles}
     >
       <Grid item xs>
         <FormControl fullWidth={true} required={required}>

--- a/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -24,7 +24,7 @@ export default function WrapIfAdditionalTemplate<
   const {
     children,
     classNames,
-    styles,
+    style,
     disabled,
     id,
     label,
@@ -49,7 +49,7 @@ export default function WrapIfAdditionalTemplate<
 
   if (!additional) {
     return (
-      <div className={classNames} style={styles}>
+      <div className={classNames} style={style}>
         {children}
       </div>
     );
@@ -65,7 +65,7 @@ export default function WrapIfAdditionalTemplate<
       alignItems="center"
       spacing={2}
       className={classNames}
-      style={styles}
+      style={style}
     >
       <Grid item xs>
         <FormControl fullWidth={true} required={required}>

--- a/packages/semantic-ui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/semantic-ui/src/FieldTemplate/FieldTemplate.tsx
@@ -24,7 +24,7 @@ export default function FieldTemplate<
     id,
     children,
     classNames,
-    styles,
+    style,
     displayLabel,
     label,
     errors,
@@ -59,7 +59,7 @@ export default function FieldTemplate<
   return (
     <WrapIfAdditionalTemplate
       classNames={classNames}
-      styles={styles}
+      style={style}
       id={id}
       label={label}
       registry={registry}

--- a/packages/semantic-ui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/semantic-ui/src/FieldTemplate/FieldTemplate.tsx
@@ -24,6 +24,7 @@ export default function FieldTemplate<
     id,
     children,
     classNames,
+    styles,
     displayLabel,
     label,
     errors,
@@ -58,6 +59,7 @@ export default function FieldTemplate<
   return (
     <WrapIfAdditionalTemplate
       classNames={classNames}
+      styles={styles}
       id={id}
       label={label}
       registry={registry}

--- a/packages/semantic-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/semantic-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -21,6 +21,7 @@ export default function WrapIfAdditionalTemplate<
   const {
     children,
     classNames,
+    styles,
     disabled,
     id,
     label,
@@ -40,14 +41,18 @@ export default function WrapIfAdditionalTemplate<
   const additional = ADDITIONAL_PROPERTY_FLAG in schema;
 
   if (!additional) {
-    return <div className={classNames}>{children}</div>;
+    return (
+      <div className={classNames} style={styles}>
+        {children}
+      </div>
+    );
   }
 
   const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
     onKeyChange(target.value);
 
   return (
-    <div className={classNames} key={`${id}-key`}>
+    <div className={classNames} style={styles} key={`${id}-key`}>
       <Grid columns="equal">
         <Grid.Row>
           <Grid.Column className="form-additional">

--- a/packages/semantic-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/semantic-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -21,7 +21,7 @@ export default function WrapIfAdditionalTemplate<
   const {
     children,
     classNames,
-    styles,
+    style,
     disabled,
     id,
     label,
@@ -42,7 +42,7 @@ export default function WrapIfAdditionalTemplate<
 
   if (!additional) {
     return (
-      <div className={classNames} style={styles}>
+      <div className={classNames} style={style}>
         {children}
       </div>
     );
@@ -52,7 +52,7 @@ export default function WrapIfAdditionalTemplate<
     onKeyChange(target.value);
 
   return (
-    <div className={classNames} style={styles} key={`${id}-key`}>
+    <div className={classNames} style={style} key={`${id}-key`}>
       <Grid columns="equal">
         <Grid.Row>
           <Grid.Column className="form-additional">

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -358,8 +358,8 @@ export type FieldTemplateProps<
   id: string;
   /** A string containing the base CSS classes, merged with any custom ones defined in your uiSchema */
   classNames?: string;
-  /** An object containing the styles as defined in the `uiSchema` */
-  styles?: StyleHTMLAttributes<any>;
+  /** An object containing the style as defined in the `uiSchema` */
+  style?: StyleHTMLAttributes<any>;
   /** The computed label for this field, as a string */
   label: string;
   /** A component instance rendering the field description, if one is defined (this will use any custom
@@ -636,7 +636,7 @@ export type WrapIfAdditionalTemplateProps<
   FieldTemplateProps<T, S, F>,
   | "id"
   | "classNames"
-  | "styles"
+  | "style"
   | "label"
   | "required"
   | "readonly"
@@ -778,8 +778,8 @@ type UIOptionsBaseType<
 > = Partial<Omit<TemplatesType<T, S, F>, "ButtonTemplates">> & {
   /** Any classnames that the user wants to be applied to a field in the ui */
   classNames?: string;
-  /** Any custom styles that the user wants to apply to a field in the ui, applied on the same element as classNames */
-  styles?: StyleHTMLAttributes<any>;
+  /** Any custom style that the user wants to apply to a field in the ui, applied on the same element as classNames */
+  style?: StyleHTMLAttributes<any>;
   /** We know that for title, it will be a string, if it is provided */
   title?: string;
   /** We know that for description, it will be a string, if it is provided */

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { StyleHTMLAttributes } from "react";
 import { JSONSchema7 } from "json-schema";
 
 /** The representation of any generic object type, usually used as an intersection on other types to make them more
@@ -358,6 +358,8 @@ export type FieldTemplateProps<
   id: string;
   /** A string containing the base CSS classes, merged with any custom ones defined in your uiSchema */
   classNames?: string;
+  /** An object containing the styles as defined in the `uiSchema` */
+  styles?: StyleHTMLAttributes<any>;
   /** The computed label for this field, as a string */
   label: string;
   /** A component instance rendering the field description, if one is defined (this will use any custom
@@ -634,6 +636,7 @@ export type WrapIfAdditionalTemplateProps<
   FieldTemplateProps<T, S, F>,
   | "id"
   | "classNames"
+  | "styles"
   | "label"
   | "required"
   | "readonly"
@@ -775,6 +778,8 @@ type UIOptionsBaseType<
 > = Partial<Omit<TemplatesType<T, S, F>, "ButtonTemplates">> & {
   /** Any classnames that the user wants to be applied to a field in the ui */
   classNames?: string;
+  /** Any custom styles that the user wants to apply to a field in the ui, applied on the same element as classNames */
+  styles?: StyleHTMLAttributes<any>;
   /** We know that for title, it will be a string, if it is provided */
   title?: string;
   /** We know that for description, it will be a string, if it is provided */


### PR DESCRIPTION
### Reasons for making this change

Fixes #1200 by reimplementing #1256
- In `@rjsf/utils`, added the new `style` prop onto `FieldTemplateProps`, `WrapIfAdditionalTemplateProps` and `UIOptionsBaseType`
- In `@rjsf/core`, added support for the new `style` prop in `uiSchema` as follows:
  - Updated `SchemaField` to handle the new `style` prop in the `uiSchema` similarly to `classNames`, passing it to the `FieldTemplate` and removing it from being passed down to children.
  - Also, added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper
  - Added or updated tests to verify the `style` prop functionality
- In all the themes, added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper
  - Fluent-ui is a special case since it doesn't currently implement `WrapIfAdditionalTemplate` fully
- Updated the documentation to describe this new `style` prop
  - Also updated the `validation` documentation to describe the `uiSchema` prop that can be passed to the `customValidate()` and `transformError()` functions
- Updated the `CHANGELOG.md` accordingly

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
