### PR TITLE
fix: reimplement #2386 to add aria-describedby elements onto all inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,19 +21,19 @@ should change the heading of the (upcoming) version to include a major version b
 - Enable searching in the `SelectWidget` by the label that the user sees rather than by the value
 - Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200) 
 - Updated all the user "input" controls to have an `aria-describedby` value built using the `ariaDescribedByIds()` function, partially fixing [#959](https://github.com/rjsf-team/react-jsonschema-form/issues/959)
-  - Also updated the generation of ids for the title, description, error, examples and help blocks using the associated new id generation utilty functions
+  - Also updated the generation of ids for the title, description, error, examples, options and help blocks using the associated new id generation utilty functions
 
 ## @rjsf/bootstrap-4
 - Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 - Updated `CheckboxesWidget` to treat the value as an array when selecting/deselecting values and when determining the checked state - fixing [#2141](https://github.com/rjsf-team/react-jsonschema-form/issues/2141)
 - Updated all the user "input" controls to have an `aria-describedby` value built using the `ariaDescribedByIds()` function, partially fixing [#959](https://github.com/rjsf-team/react-jsonschema-form/issues/959)
-  - Also updated the generation of ids for the title, description, error, examples and help blocks using the associated new id generation utilty functions
+  - Also updated the generation of ids for the title, description, error, examples, options and help blocks using the associated new id generation utilty functions
 
 ## @rjsf/chakra-ui
 - Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 - Updated `CheckboxesWidget` to treat the value as an array when selecting/deselecting values and when determining the checked state - fixing [#2141](https://github.com/rjsf-team/react-jsonschema-form/issues/2141)
 - Updated all the user "input" controls to have an `aria-describedby` value built using the `ariaDescribedByIds()` function, partially fixing [#959](https://github.com/rjsf-team/react-jsonschema-form/issues/959)
-  - Also updated the generation of ids for the title, description, error, examples and help blocks using the associated new id generation utilty functions
+  - Also updated the generation of ids for the title, description, error, examples, options and help blocks using the associated new id generation utilty functions
 
 ## @rjsf/core
 - Updated `SchemaField` to handle the new `style` prop in the `uiSchema` similarly to `classNames`, passing it to the `FieldTemplate` and removing it from being passed down to children.
@@ -41,43 +41,43 @@ should change the heading of the (upcoming) version to include a major version b
   - This partially fixes [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 - Updated `CheckboxesWidget` to treat the value as an array when selecting/deselecting values and when determining the checked state - fixing [#2141](https://github.com/rjsf-team/react-jsonschema-form/issues/2141)
 - Updated all the user "input" controls to have an `aria-describedby` value built using the `ariaDescribedByIds()` function, partially fixing [#959](https://github.com/rjsf-team/react-jsonschema-form/issues/959)
-  - Also updated the generation of ids for the title, description, error, examples and help blocks using the associated new id generation utilty functions
+  - Also updated the generation of ids for the title, description, error, examples, options and help blocks using the associated new id generation utilty functions
 
 ## @rjsf/fluent-ui
 - Added support for new `style` prop on `FieldTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 - Updated `CheckboxesWidget` to treat the value as an array when selecting/deselecting values and when determining the checked state - fixing [#2141](https://github.com/rjsf-team/react-jsonschema-form/issues/2141)
 - Updated all the user "input" controls to have an `aria-describedby` value built using the `ariaDescribedByIds()` function, partially fixing [#959](https://github.com/rjsf-team/react-jsonschema-form/issues/959)
-  - Also updated the generation of ids for the title, description, error, examples and help blocks using the associated new id generation utilty functions
+  - Also updated the generation of ids for the title, description, error, examples, options and help blocks using the associated new id generation utilty functions
 
 ## @rjsf/material-ui
 - Updated `SelectWidget` to support additional `TextFieldProps` in a manner similar to how `BaseInputTemplate` does
 - Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 - Updated `CheckboxesWidget` to treat the value as an array when selecting/deselecting values and when determining the checked state - fixing [#2141](https://github.com/rjsf-team/react-jsonschema-form/issues/2141)
 - Updated all the user "input" controls to have an `aria-describedby` value built using the `ariaDescribedByIds()` function, partially fixing [#959](https://github.com/rjsf-team/react-jsonschema-form/issues/959)
-  - Also updated the generation of ids for the title, description, error, examples and help blocks using the associated new id generation utilty functions
+  - Also updated the generation of ids for the title, description, error, examples, options and help blocks using the associated new id generation utilty functions
 
 ## @rjsf/mui
 - Updated `SelectWidget` to support additional `TextFieldProps` in a manner similar to how `BaseInputTemplate` does
 - Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 - Updated `CheckboxesWidget` to treat the value as an array when selecting/deselecting values and when determining the checked state - fixing [#2141](https://github.com/rjsf-team/react-jsonschema-form/issues/2141)
 - Updated all the user "input" controls to have an `aria-describedby` value built using the `ariaDescribedByIds()` function, partially fixing [#959](https://github.com/rjsf-team/react-jsonschema-form/issues/959)
-  - Also updated the generation of ids for the title, description, error, examples and help blocks using the associated new id generation utilty functions
+  - Also updated the generation of ids for the title, description, error, examples, options and help blocks using the associated new id generation utilty functions
 
 ## @rjsf/semantic-ui
 - Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 - Updated `CheckboxesWidget` to treat the value as an array when selecting/deselecting values and when determining the checked state - fixing [#2141](https://github.com/rjsf-team/react-jsonschema-form/issues/2141)
 - Updated all the user "input" controls to have an `aria-describedby` value built using the `ariaDescribedByIds()` function, partially fixing [#959](https://github.com/rjsf-team/react-jsonschema-form/issues/959)
-  - Also updated the generation of ids for the title, description, error, examples and help blocks using the associated new id generation utilty functions
+  - Also updated the generation of ids for the title, description, error, examples, options and help blocks using the associated new id generation utilty functions
 
 ## @rjsf/utils
 - Updated the `FieldTemplateProps`, `WrapIfAdditionalTemplateProps` and `UIOptionsBaseType` types to add `style?: StyleHTMLAttributes<any>`, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 - Added `enumOptionsDeselectValue()` and `enumOptionsSelectValue()` as a loose refactor of the duplicated functions in the various `CheckboxesWidget` implementations
-- Updated the `FieldTemplateProps`, `WrapIfAdditionalTemplateProps` and `UIOptionsBaseType` types to add `style?: StyleHTMLAttributes<any>`, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200) 
-- Added new `ariaDescribedByIds()`, `descriptionId()`, `errorId()`, `helpId()` and `titleId()` id generator functions
+- Updated the `FieldTemplateProps`, `WrapIfAdditionalTemplateProps` and `UIOptionsBaseType` types to add `style?: StyleHTMLAttributes<any>`, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
+- Added new `ariaDescribedByIds()`, `descriptionId()`, `errorId()`, `examplesId()`, `helpId()` `optionId()` and `titleId()` id generator functions
 
 ## @rjsf/validator-ajv8
 - Remove alias for ajv -> ajv8 in package.json. This fixes [#3215](https://github.com/rjsf-team/react-jsonschema-form/issues/3215).
-- Updated `AJV8Validator#transformRJSFValidationErrors` to return more human readable error messages.  The ajv8 `ErrorObject` message is enhanced by replacing the error message field with either the `uiSchema`'s `ui:title` field if one exists or the `parentSchema` title if one exists. Fixes [#3246](https://github.com/rjsf-team/react-jsonschema-form/issues/3246)
+- Updated `AJV8Validator#transformRJSFValidationErrors` to return more human-readable error messages.  The ajv8 `ErrorObject` message is enhanced by replacing the error message field with either the `uiSchema`'s `ui:title` field if one exists or the `parentSchema` title if one exists. Fixes [#3246](https://github.com/rjsf-team/react-jsonschema-form/issues/3246)
 
 ## Dev / docs / playground
 - In the playground, change Vite `preserveSymlinks` to `true`, which provides an alternative fix for [#3228](https://github.com/rjsf-team/react-jsonschema-form/issues/3228) since the prior fix caused [#3215](https://github.com/rjsf-team/react-jsonschema-form/issues/3215).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,42 +20,60 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/antd
 - Enable searching in the `SelectWidget` by the label that the user sees rather than by the value
 - Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200) 
+- Updated all the user "input" controls to have an `aria-describedby` value built using the `ariaDescribedByIds()` function, partially fixing [#959](https://github.com/rjsf-team/react-jsonschema-form/issues/959)
+  - Also updated the generation of ids for the title, description, error, examples and help blocks using the associated new id generation utilty functions
 
 ## @rjsf/bootstrap-4
 - Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 - Updated `CheckboxesWidget` to treat the value as an array when selecting/deselecting values and when determining the checked state - fixing [#2141](https://github.com/rjsf-team/react-jsonschema-form/issues/2141)
+- Updated all the user "input" controls to have an `aria-describedby` value built using the `ariaDescribedByIds()` function, partially fixing [#959](https://github.com/rjsf-team/react-jsonschema-form/issues/959)
+  - Also updated the generation of ids for the title, description, error, examples and help blocks using the associated new id generation utilty functions
 
 ## @rjsf/chakra-ui
 - Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 - Updated `CheckboxesWidget` to treat the value as an array when selecting/deselecting values and when determining the checked state - fixing [#2141](https://github.com/rjsf-team/react-jsonschema-form/issues/2141)
+- Updated all the user "input" controls to have an `aria-describedby` value built using the `ariaDescribedByIds()` function, partially fixing [#959](https://github.com/rjsf-team/react-jsonschema-form/issues/959)
+  - Also updated the generation of ids for the title, description, error, examples and help blocks using the associated new id generation utilty functions
 
 ## @rjsf/core
 - Updated `SchemaField` to handle the new `style` prop in the `uiSchema` similarly to `classNames`, passing it to the `FieldTemplate` and removing it from being passed down to children.
   - Also, added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper
   - This partially fixes [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 - Updated `CheckboxesWidget` to treat the value as an array when selecting/deselecting values and when determining the checked state - fixing [#2141](https://github.com/rjsf-team/react-jsonschema-form/issues/2141)
+- Updated all the user "input" controls to have an `aria-describedby` value built using the `ariaDescribedByIds()` function, partially fixing [#959](https://github.com/rjsf-team/react-jsonschema-form/issues/959)
+  - Also updated the generation of ids for the title, description, error, examples and help blocks using the associated new id generation utilty functions
 
 ## @rjsf/fluent-ui
 - Added support for new `style` prop on `FieldTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 - Updated `CheckboxesWidget` to treat the value as an array when selecting/deselecting values and when determining the checked state - fixing [#2141](https://github.com/rjsf-team/react-jsonschema-form/issues/2141)
+- Updated all the user "input" controls to have an `aria-describedby` value built using the `ariaDescribedByIds()` function, partially fixing [#959](https://github.com/rjsf-team/react-jsonschema-form/issues/959)
+  - Also updated the generation of ids for the title, description, error, examples and help blocks using the associated new id generation utilty functions
 
 ## @rjsf/material-ui
 - Updated `SelectWidget` to support additional `TextFieldProps` in a manner similar to how `BaseInputTemplate` does
 - Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 - Updated `CheckboxesWidget` to treat the value as an array when selecting/deselecting values and when determining the checked state - fixing [#2141](https://github.com/rjsf-team/react-jsonschema-form/issues/2141)
+- Updated all the user "input" controls to have an `aria-describedby` value built using the `ariaDescribedByIds()` function, partially fixing [#959](https://github.com/rjsf-team/react-jsonschema-form/issues/959)
+  - Also updated the generation of ids for the title, description, error, examples and help blocks using the associated new id generation utilty functions
 
 ## @rjsf/mui
 - Updated `SelectWidget` to support additional `TextFieldProps` in a manner similar to how `BaseInputTemplate` does
 - Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 - Updated `CheckboxesWidget` to treat the value as an array when selecting/deselecting values and when determining the checked state - fixing [#2141](https://github.com/rjsf-team/react-jsonschema-form/issues/2141)
+- Updated all the user "input" controls to have an `aria-describedby` value built using the `ariaDescribedByIds()` function, partially fixing [#959](https://github.com/rjsf-team/react-jsonschema-form/issues/959)
+  - Also updated the generation of ids for the title, description, error, examples and help blocks using the associated new id generation utilty functions
 
 ## @rjsf/semantic-ui
 - Added support for new `style` prop on `FieldTemplate` and `WrapIfAdditionalTemplate` rendering them on the outermost wrapper, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 - Updated `CheckboxesWidget` to treat the value as an array when selecting/deselecting values and when determining the checked state - fixing [#2141](https://github.com/rjsf-team/react-jsonschema-form/issues/2141)
+- Updated all the user "input" controls to have an `aria-describedby` value built using the `ariaDescribedByIds()` function, partially fixing [#959](https://github.com/rjsf-team/react-jsonschema-form/issues/959)
+  - Also updated the generation of ids for the title, description, error, examples and help blocks using the associated new id generation utilty functions
 
 ## @rjsf/utils
 - Updated the `FieldTemplateProps`, `WrapIfAdditionalTemplateProps` and `UIOptionsBaseType` types to add `style?: StyleHTMLAttributes<any>`, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200)
 - Added `enumOptionsDeselectValue()` and `enumOptionsSelectValue()` as a loose refactor of the duplicated functions in the various `CheckboxesWidget` implementations
+- Updated the `FieldTemplateProps`, `WrapIfAdditionalTemplateProps` and `UIOptionsBaseType` types to add `style?: StyleHTMLAttributes<any>`, partially fixing [#1200](https://github.com/rjsf-team/react-jsonschema-form/issues/1200) 
+- Added new `ariaDescribedByIds()`, `descriptionId()`, `errorId()`, `helpId()` and `titleId()` id generator functions
 
 ## @rjsf/validator-ajv8
 - Remove alias for ajv -> ajv8 in package.json. This fixes [#3215](https://github.com/rjsf-team/react-jsonschema-form/issues/3215).
@@ -65,7 +83,8 @@ should change the heading of the (upcoming) version to include a major version b
 - In the playground, change Vite `preserveSymlinks` to `true`, which provides an alternative fix for [#3228](https://github.com/rjsf-team/react-jsonschema-form/issues/3228) since the prior fix caused [#3215](https://github.com/rjsf-team/react-jsonschema-form/issues/3215).
 - Updated the `custom-templates.md` and `uiSchema.md` to document the new `style` prop
 - Updated the `validation.md` documentation to describe the new `uiSchema` parameter passed to the `customValidate()` and `transformError()` functions
-- Updated the `utility-functions` documentation to add the new `enumOptionsDeselectValue()` and `enumOptionsSelectValue()` functions
+- Updated the `utility-functions` documentation to add the new `enumOptionsDeselectValue()` and `enumOptionsSelectValue()` functions and to describe the new id generator functions
+- Updated the `5.x migration guide` documentation to describe potential breaking `id` changes
 
 # 5.0.0-beta-16
 

--- a/docs/5.x upgrade guide.md
+++ b/docs/5.x upgrade guide.md
@@ -34,7 +34,7 @@ There are four new packages added in RJSF version 5:
 
 ### `id` BREAKING CHANGES
 
-In many of the themes the `id`s for the `Title` and `Description` blocks were update to all have a consistent value of `xxx__title` and `xxx_description`, respectively, where `xxx` is the id of the field.
+In many of the themes the `id`s for the `Title`, `Description` and `Examples` blocks were update to all have a consistent value of `xxx__title`, `xxx__description` and `xxx__examples`, respectively, where `xxx` is the id of the field.
 In addition, some of the `id`s for various input values were updated to be consistent across themes or to fix small bugs.
 For instance, the values for radio buttons in the `RadioWidget` and checkboxes in the `CheckboxesWidget` are of the form `id-${option.value}`.
 

--- a/docs/5.x upgrade guide.md
+++ b/docs/5.x upgrade guide.md
@@ -32,6 +32,12 @@ There are four new packages added in RJSF version 5:
 - `@rjsf/validator-ajv8`: The [ajv](https://github.com/ajv-validator/ajv)-v8-based validator that is an upgrade of the `@rjsf/validator-ajv6`, that implements the `ValidatorType` interface defined in `@rjsf/utils`. See the ajv 6 to 8 [migration guide](https://ajv.js.org/v6-to-v8-migration.html) for more information.
 - `@rjsf/mui`: Previously `@rjsf/material-ui/v5`, now provided as its own theme.
 
+### `id` BREAKING CHANGES
+
+In many of the themes the `id`s for the `Title` and `Description` blocks were update to all have a consistent value of `xxx__title` and `xxx_description`, respectively, where `xxx` is the id of the field.
+In addition, some of the `id`s for various input values were updated to be consistent across themes or to fix small bugs.
+For instance, the values for radio buttons in the `RadioWidget` and checkboxes in the `CheckboxesWidget` are of the form `id-${option.value}`.
+
 ### `@rjsf/core` BREAKING CHANGES
 
 #### Types
@@ -274,8 +280,8 @@ The result is that if you had an `ErrorSchema` that looks like:
 
 ```tsx
 const errorSchema: ErrorSchema = {
-  __error: [ "error message 1"],
-  password: { __error: "passwords do not match" }
+  __errors: [ "error message 1"],
+  password: { __errors: "passwords do not match" }
 }
 ```
 
@@ -306,8 +312,8 @@ In other words, if custom validation or `extraErrors` produced the following `Er
 
 ```tsx
 {
-  __error: [ "Please correct your password"],
-  password2: { __error: "passwords do not match" }
+  __errors: [ "Please correct your password"],
+  password2: { __errors: "passwords do not match" }
 }
 ```
 
@@ -315,7 +321,7 @@ And the AJV validation produced the following `ErrorSchema`:
 
 ```tsx
 {
-  __error: [{
+  __errors: [{
     message: "should NOT be shorter than 3 characters",
     name: "minLength",
     params: { limit: 3 },

--- a/docs/5.x upgrade guide.md
+++ b/docs/5.x upgrade guide.md
@@ -36,7 +36,7 @@ There are four new packages added in RJSF version 5:
 
 In many of the themes the `id`s for the `Title`, `Description` and `Examples` blocks were update to all have a consistent value of `xxx__title`, `xxx__description` and `xxx__examples`, respectively, where `xxx` is the id of the field.
 In addition, some of the `id`s for various input values were updated to be consistent across themes or to fix small bugs.
-For instance, the values for radio buttons in the `RadioWidget` and checkboxes in the `CheckboxesWidget` are of the form `id-${option.value}`.
+For instance, the values for radio buttons in the `RadioWidget` and checkboxes in the `CheckboxesWidget` are of the form `xxx-${option.value}`, where `xxx` is the id of the field.
 
 ### `@rjsf/core` BREAKING CHANGES
 

--- a/docs/advanced-customization/custom-templates.md
+++ b/docs/advanced-customization/custom-templates.md
@@ -133,7 +133,7 @@ If you want different behavior for the rendering of the description of an array 
 If you want a different behavior for the rendering of ALL descriptions in the `Form`, see [DescriptionFieldTemplate](#descriptionfieldtemplate)
 
 ```tsx
-import { ArrayFieldDescriptionProps, RJSFSchema } from "@rjsf/utils";
+import { ArrayFieldDescriptionProps, RJSFSchema, descriptionId } from "@rjsf/utils";
 import validator from '@rjsf/validator-ajv8';
 
 const schema: RJSFSchema = {
@@ -145,7 +145,7 @@ const schema: RJSFSchema = {
 
 function ArrayFieldDescriptionTemplate(props: ArrayFieldDescriptionProps) {
   const { description, idSchema } = props;
-  const id = `${idSchema.$id}__description`;
+  const id = descriptionId(idSchema);
   return (
     <details id={id}>
       <summary>Description</summary>
@@ -235,7 +235,7 @@ If you want a different behavior for the rendering of the title of an array fiel
 If you want a different behavior for the rendering of ALL titles in the `Form`, see [TitleFieldTemplate](#titlefieldtemplate) 
 
 ```tsx
-import { ArrayFieldTitleTemplateProps, RJSFSchema } from "@rjsf/utils";
+import { ArrayFieldTitleTemplateProps, RJSFSchema, titleId } from "@rjsf/utils";
 import validator from '@rjsf/validator-ajv8';
 
 const schema: RJSFSchema = {
@@ -247,7 +247,7 @@ const schema: RJSFSchema = {
 
 function ArrayFieldTitleTemplate(props: ArrayFieldTitleProps) {
   const { description, idSchema } = props;
-  const id = `${idSchema.$id}__title`;
+  const id = titleId(idSchema);
   return (
     <h1 id={id}>
       {title}
@@ -518,7 +518,7 @@ The `FieldHelpTemplate` is the template that renders the help associated a singl
 If you want to customize how the help is rendered you can.
 
 ```tsx
-import { FieldHelpProps, RJSFSchema } from "@rjsf/utils";
+import { FieldHelpProps, RJSFSchema, helpId } from "@rjsf/utils";
 import validator from '@rjsf/validator-ajv8';
 
 const schema: RJSFSchema = {
@@ -529,7 +529,7 @@ const schema: RJSFSchema = {
 
 function FieldHelpTemplate(props: FieldHelpProps) {
   const { help, idSchema } = props;
-  const id = `${idSchema.$id}__help`;
+  const id = helpId(idSchema);
   return <aside id={id}>{help}</aside>;
 }
 

--- a/docs/api-reference/utility-functions.md
+++ b/docs/api-reference/utility-functions.md
@@ -34,7 +34,8 @@ The user is warned in the console if `schema.additionalItems` has the value `tru
 Return a list of element ids that contain additional information about the field that can be used to as the aria description of the field.
 
 #### Parameters
-- id: string - Either simple string id or an IdSchema from which to extract it
+- id: IdSchema<T> | string - Either simple string id or an IdSchema from which to extract it
+- [includeExamples=false]: boolean - Optional flag, if true, will add the `examplesId` into the list
 
 #### Returns
 - string: The string containing the list of ids for use in an `aria-describedBy` attribute
@@ -89,7 +90,7 @@ Implements a deep equals using the `lodash.isEqualWith` function, that provides 
 Return a consistent `id` for the field description element.
 
 #### Parameters
-- id: string - Either simple string id or an IdSchema from which to extract it
+- id: IdSchema<T> | string - Either simple string id or an IdSchema from which to extract it
 
 #### Returns
 - string: The consistent id for the field description element from the given `id`
@@ -119,10 +120,19 @@ Add the `value` to the list of `selected` values in the proper order as defined 
 Return a consistent `id` for the field error element.
 
 #### Parameters
-- id: string - Either simple string id or an IdSchema from which to extract it
+- id: IdSchema<T> | string - Either simple string id or an IdSchema from which to extract it
 
 #### Returns
 - string: The consistent id for the field error element from the given `id`
+
+### examplesId<T = any>()
+Return a consistent `id` for the field examples element.
+
+#### Parameters
+- id: IdSchema<T> | string - Either simple string id or an IdSchema from which to extract it
+
+#### Returns
+- string: The consistent id for the field examples element from the given `id`
 
 ### findSchemaDefinition\<S extends StrictRJSFSchema = RJSFSchema>()
 Given the name of a `$ref` from within a schema, using the `rootSchema`, look up and return the sub-schema using the path provided by that reference.
@@ -237,7 +247,7 @@ Detects whether the `widget` exists for the `schema` with the associated `regist
 Return a consistent `id` for the field help element.
 
 #### Parameters
-- id: string - Either simple string id or an IdSchema from which to extract it
+- id: IdSchema<T> | string - Either simple string id or an IdSchema from which to extract it
 
 #### Returns
 - string: The consistent id for the field help element from the given `id`
@@ -328,6 +338,16 @@ The difference between mergeSchemas and mergeObjects is that mergeSchemas only c
 
 #### Returns
 - GenericObjectType: The merged schema object
+
+### optionId\<S extends StrictRJSFSchema = RJSFSchema>()
+Return a consistent `id` for the `option`s of a `Radio` or `Checkboxes` widget
+
+#### Parameters
+- id: string - The id of the parent component for the option
+- option: EnumOptionsType<S> - The option for which the id is desired
+
+#### Returns
+- string: An id for the option based on the parent `id`
 
 ### optionsList\<S extends StrictRJSFSchema = RJSFSchema>()
 Gets the list of options from the schema. If the schema has an enum list, then those enum values are returned.
@@ -432,7 +452,7 @@ If either of those two sets are not the same, then the component should be reren
 Return a consistent `id` for the field title element.
 
 #### Parameters
-- id: string - Either simple string id or an IdSchema from which to extract it
+- id: IdSchema<T> | string - Either simple string id or an IdSchema from which to extract it
 
 #### Returns
 - string: The consistent id for the field title element from the given `id`

--- a/docs/api-reference/utility-functions.md
+++ b/docs/api-reference/utility-functions.md
@@ -30,6 +30,15 @@ The user is warned in the console if `schema.additionalItems` has the value `tru
 #### Returns
 - boolean: True if additional items is allowed, otherwise false
 
+### ariaDescribedByIds<T = any>()
+Return a list of element ids that contain additional information about the field that can be used to as the aria description of the field.
+
+#### Parameters
+- id: string - Either simple string id or an IdSchema from which to extract it
+
+#### Returns
+- string: The string containing the list of ids for use in an `aria-describedBy` attribute
+
 ### asNumber()
 Attempts to convert the string into a number. If an empty string is provided, then `undefined` is returned.
 If a `null` is provided, it is returned.
@@ -76,6 +85,15 @@ Implements a deep equals using the `lodash.isEqualWith` function, that provides 
 #### Returns
 - boolean: True if the `a` and `b` are deeply equal, false otherwise
 
+### descriptionId<T = any>()
+Return a consistent `id` for the field description element.
+
+#### Parameters
+- id: string - Either simple string id or an IdSchema from which to extract it
+
+#### Returns
+- string: The consistent id for the field description element from the given `id`
+
 ### enumOptionsDeselectValue\<S extends StrictRJSFSchema = RJSFSchema>()
 Removes the `value` from the currently `selected` list of values.
 
@@ -97,10 +115,19 @@ Add the `value` to the list of `selected` values in the proper order as defined 
 #### Returns
 - EnumOptionsType<S>["value"][]: The updated list of selected enum values with `value` added to it in the proper location
 
+### errorId<T = any>()
+Return a consistent `id` for the field error element.
+
+#### Parameters
+- id: string - Either simple string id or an IdSchema from which to extract it
+
+#### Returns
+- string: The consistent id for the field error element from the given `id`
+
 ### findSchemaDefinition\<S extends StrictRJSFSchema = RJSFSchema>()
 Given the name of a `$ref` from within a schema, using the `rootSchema`, look up and return the sub-schema using the path provided by that reference.
 If `#` is not the first character of the reference, or the path does not exist in the schema, then throw an Error.
-Otherwise return the sub-schema. Also deals with nested `$ref`s in the sub-schema.
+Otherwise, return the sub-schema. Also deals with nested `$ref`s in the sub-schema.
 
 #### Parameters
 - $ref: string - The ref string for which the schema definition is desired
@@ -205,6 +232,15 @@ Detects whether the `widget` exists for the `schema` with the associated `regist
 
 #### Returns
 - boolean: True if the widget exists, false otherwise
+
+### helpId<T = any>()
+Return a consistent `id` for the field help element.
+
+#### Parameters
+- id: string - Either simple string id or an IdSchema from which to extract it
+
+#### Returns
+- string: The consistent id for the field help element from the given `id`
 
 ### isConstant\<S extends StrictRJSFSchema = RJSFSchema>()
 This function checks if the given `schema` matches a single constant value.
@@ -392,9 +428,18 @@ If either of those two sets are not the same, then the component should be reren
 #### Returns
 - True if boolean: the component should be re-rendered, false otherwise
 
+### titleId<T = any>()
+Return a consistent `id` for the field title element.
+
+#### Parameters
+- id: string - Either simple string id or an IdSchema from which to extract it
+
+#### Returns
+- string: The consistent id for the field title element from the given `id`
+
 ### toConstant\<S extends StrictRJSFSchema = RJSFSchema>()
 Returns the constant value from the schema when it is either a single value enum or has a const key.
-Otherwise throws an error.
+Otherwise, throws an error.
 
 #### Parameters
 - schema: S - The schema from which to obtain the constant value

--- a/packages/antd/src/templates/BaseInputTemplate/index.tsx
+++ b/packages/antd/src/templates/BaseInputTemplate/index.tsx
@@ -3,6 +3,7 @@ import Input from "antd/lib/input";
 import InputNumber from "antd/lib/input-number";
 import {
   ariaDescribedByIds,
+  examplesId,
   getInputProps,
   FormContextType,
   RJSFSchema,
@@ -65,10 +66,10 @@ export default function BaseInputTemplate<
         onFocus={!readonly ? handleFocus : undefined}
         placeholder={placeholder}
         style={INPUT_STYLE}
-        list={schema.examples ? `examples_${id}` : undefined}
+        list={schema.examples ? examplesId<T>(id) : undefined}
         {...inputProps}
         value={value}
-        aria-describedby={ariaDescribedByIds<T>(id)}
+        aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
       />
     ) : (
       <Input
@@ -80,10 +81,10 @@ export default function BaseInputTemplate<
         onFocus={!readonly ? handleFocus : undefined}
         placeholder={placeholder}
         style={INPUT_STYLE}
-        list={schema.examples ? `examples_${id}` : undefined}
+        list={schema.examples ? examplesId<T>(id) : undefined}
         {...inputProps}
         value={value}
-        aria-describedby={ariaDescribedByIds<T>(id)}
+        aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
       />
     );
 
@@ -91,7 +92,7 @@ export default function BaseInputTemplate<
     <>
       {input}
       {schema.examples && (
-        <datalist id={`examples_${id}`}>
+        <datalist id={examplesId<T>(id)}>
           {(schema.examples as string[])
             .concat(schema.default ? ([schema.default] as string[]) : [])
             .map((example) => {

--- a/packages/antd/src/templates/BaseInputTemplate/index.tsx
+++ b/packages/antd/src/templates/BaseInputTemplate/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Input from "antd/lib/input";
 import InputNumber from "antd/lib/input-number";
 import {
+  ariaDescribedByIds,
   getInputProps,
   FormContextType,
   RJSFSchema,
@@ -67,6 +68,7 @@ export default function BaseInputTemplate<
         list={schema.examples ? `examples_${id}` : undefined}
         {...inputProps}
         value={value}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
     ) : (
       <Input
@@ -81,6 +83,7 @@ export default function BaseInputTemplate<
         list={schema.examples ? `examples_${id}` : undefined}
         {...inputProps}
         value={value}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
     );
 

--- a/packages/antd/src/templates/FieldErrorTemplate/index.tsx
+++ b/packages/antd/src/templates/FieldErrorTemplate/index.tsx
@@ -4,6 +4,7 @@ import {
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
+  errorId,
 } from "@rjsf/utils";
 
 /** The `FieldErrorTemplate` component renders the errors local to the particular field
@@ -19,7 +20,7 @@ export default function FieldErrorTemplate<
   if (errors.length === 0) {
     return null;
   }
-  const id = `${idSchema.$id}__error`;
+  const id = errorId<T>(idSchema);
 
   return (
     <div id={id}>

--- a/packages/antd/src/templates/ObjectFieldTemplate/index.tsx
+++ b/packages/antd/src/templates/ObjectFieldTemplate/index.tsx
@@ -12,8 +12,10 @@ import {
   StrictRJSFSchema,
   UiSchema,
   canExpand,
+  descriptionId,
   getTemplate,
   getUiOptions,
+  titleId,
 } from "@rjsf/utils";
 import Col from "antd/lib/col";
 import Row from "antd/lib/row";
@@ -139,7 +141,7 @@ export default function ObjectFieldTemplate<
               {(uiOptions.title || title) && (
                 <Col className={labelColClassName} span={24}>
                   <TitleFieldTemplate
-                    id={`${idSchema.$id}-title`}
+                    id={titleId<T>(idSchema)}
                     required={required}
                     title={uiOptions.title || title}
                     schema={schema}
@@ -152,7 +154,7 @@ export default function ObjectFieldTemplate<
                 <Col span={24} style={DESCRIPTION_COL_STYLE}>
                   <DescriptionFieldTemplate
                     description={uiOptions.description || description!}
-                    id={`${idSchema.$id}-description`}
+                    id={descriptionId<T>(idSchema)}
                     schema={schema}
                     uiSchema={uiSchema}
                     registry={registry}

--- a/packages/antd/src/templates/ObjectFieldTemplate/index.tsx
+++ b/packages/antd/src/templates/ObjectFieldTemplate/index.tsx
@@ -142,8 +142,8 @@ export default function ObjectFieldTemplate<
                 <Col className={labelColClassName} span={24}>
                   <TitleFieldTemplate
                     id={titleId<T>(idSchema)}
-                    required={required}
                     title={uiOptions.title || title}
+                    required={required}
                     schema={schema}
                     uiSchema={uiSchema}
                     registry={registry}
@@ -153,8 +153,8 @@ export default function ObjectFieldTemplate<
               {(uiOptions.description || description) && (
                 <Col span={24} style={DESCRIPTION_COL_STYLE}>
                   <DescriptionFieldTemplate
-                    description={uiOptions.description || description!}
                     id={descriptionId<T>(idSchema)}
+                    description={uiOptions.description || description!}
                     schema={schema}
                     uiSchema={uiSchema}
                     registry={registry}

--- a/packages/antd/src/widgets/AltDateWidget/index.tsx
+++ b/packages/antd/src/widgets/AltDateWidget/index.tsx
@@ -3,6 +3,7 @@ import Button from "antd/lib/button";
 import Col from "antd/lib/col";
 import Row from "antd/lib/row";
 import {
+  ariaDescribedByIds,
   pad,
   parseDateString,
   toDateString,
@@ -151,6 +152,7 @@ export default function AltDateWidget<
       value={elemProps.value}
       registry={registry}
       label=""
+      aria-describedby={ariaDescribedByIds<T>(id)}
     />
   );
 

--- a/packages/antd/src/widgets/CheckboxWidget/index.tsx
+++ b/packages/antd/src/widgets/CheckboxWidget/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Checkbox, { CheckboxChangeEvent } from "antd/lib/checkbox";
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -57,6 +58,7 @@ export default function CheckboxWidget<
       name={id}
       onChange={!readonly ? handleChange : undefined}
       {...extraProps}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     >
       {label}
     </Checkbox>

--- a/packages/antd/src/widgets/CheckboxesWidget/index.tsx
+++ b/packages/antd/src/widgets/CheckboxesWidget/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Checkbox from "antd/lib/checkbox";
 import {
   ariaDescribedByIds,
+  optionId,
   FormContextType,
   WidgetProps,
   RJSFSchema,
@@ -60,19 +61,19 @@ export default function CheckboxesWidget<
       aria-describedby={ariaDescribedByIds<T>(id)}
     >
       {Array.isArray(enumOptions) &&
-        enumOptions.map(({ value: optionValue, label: optionLabel }, i) => (
-          <span key={optionValue}>
+        enumOptions.map((option, i) => (
+          <span key={option.value}>
             <Checkbox
-              id={`${id}-${optionValue}`}
+              id={optionId<S>(id, option)}
               name={id}
               autoFocus={i === 0 ? autofocus : false}
               disabled={
                 Array.isArray(enumDisabled) &&
                 enumDisabled.indexOf(value) !== -1
               }
-              value={optionValue}
+              value={option.value}
             >
-              {optionLabel}
+              {option.label}
             </Checkbox>
             {!inline && <br />}
           </span>

--- a/packages/antd/src/widgets/CheckboxesWidget/index.tsx
+++ b/packages/antd/src/widgets/CheckboxesWidget/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Checkbox from "antd/lib/checkbox";
 import {
+  ariaDescribedByIds,
   FormContextType,
   WidgetProps,
   RJSFSchema,
@@ -56,6 +57,7 @@ export default function CheckboxesWidget<
       onChange={!readonly ? handleChange : undefined}
       value={value}
       {...extraProps}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     >
       {Array.isArray(enumOptions) &&
         enumOptions.map(({ value: optionValue, label: optionLabel }, i) => (

--- a/packages/antd/src/widgets/DateTimeWidget/index.tsx
+++ b/packages/antd/src/widgets/DateTimeWidget/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import dayjs from "dayjs";
 import {
+  ariaDescribedByIds,
   FormContextType,
   GenericObjectType,
   RJSFSchema,
@@ -59,6 +60,7 @@ export default function DateTimeWidget<
       showTime
       style={DATE_PICKER_STYLE}
       value={value && dayjs(value)}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     />
   );
 }

--- a/packages/antd/src/widgets/DateWidget/index.tsx
+++ b/packages/antd/src/widgets/DateWidget/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import dayjs from "dayjs";
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -59,6 +60,7 @@ export default function DateWidget<
       showTime={false}
       style={DATE_PICKER_STYLE}
       value={value && dayjs(value)}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     />
   );
 }

--- a/packages/antd/src/widgets/PasswordWidget/index.tsx
+++ b/packages/antd/src/widgets/PasswordWidget/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Input from "antd/lib/input";
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -52,6 +53,7 @@ export default function PasswordWidget<
       onFocus={!readonly ? handleFocus : undefined}
       placeholder={placeholder}
       value={value || ""}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     />
   );
 }

--- a/packages/antd/src/widgets/RadioWidget/index.tsx
+++ b/packages/antd/src/widgets/RadioWidget/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Radio, { RadioChangeEvent } from "antd/lib/radio";
 import {
+  ariaDescribedByIds,
   FormContextType,
   GenericObjectType,
   RJSFSchema,
@@ -52,6 +53,7 @@ export default function RadioWidget<
       onBlur={!readonly ? handleBlur : undefined}
       onFocus={!readonly ? handleFocus : undefined}
       value={`${value}`}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     >
       {Array.isArray(enumOptions) &&
         enumOptions.map(({ value: optionValue, label: optionLabel }, i) => (

--- a/packages/antd/src/widgets/RadioWidget/index.tsx
+++ b/packages/antd/src/widgets/RadioWidget/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Radio, { RadioChangeEvent } from "antd/lib/radio";
 import {
   ariaDescribedByIds,
+  optionId,
   FormContextType,
   GenericObjectType,
   RJSFSchema,
@@ -56,18 +57,18 @@ export default function RadioWidget<
       aria-describedby={ariaDescribedByIds<T>(id)}
     >
       {Array.isArray(enumOptions) &&
-        enumOptions.map(({ value: optionValue, label: optionLabel }, i) => (
+        enumOptions.map((option, i) => (
           <Radio
-            id={`${id}-${optionValue}`}
+            id={optionId<S>(id, option)}
             name={id}
             autoFocus={i === 0 ? autofocus : false}
             disabled={
               Array.isArray(enumDisabled) && enumDisabled.indexOf(value) !== -1
             }
-            key={optionValue}
-            value={`${optionValue}`}
+            key={option.value}
+            value={`${option.value}`}
           >
-            {optionLabel}
+            {option.label}
           </Radio>
         ))}
     </Radio.Group>

--- a/packages/antd/src/widgets/RangeWidget/index.tsx
+++ b/packages/antd/src/widgets/RangeWidget/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Slider from "antd/lib/slider";
 import {
+  ariaDescribedByIds,
   rangeSpec,
   FormContextType,
   RJSFSchema,
@@ -66,6 +67,7 @@ export default function RangeWidget<
       step={step}
       value={value}
       {...extraProps}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     />
   );
 }

--- a/packages/antd/src/widgets/SelectWidget/index.tsx
+++ b/packages/antd/src/widgets/SelectWidget/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Select, { DefaultOptionType } from "antd/lib/select";
 import {
+  ariaDescribedByIds,
   processSelectValue,
   FormContextType,
   GenericObjectType,
@@ -84,6 +85,7 @@ export default function SelectWidget<
       value={typeof value !== "undefined" ? stringify(value) : undefined}
       {...extraProps}
       filterOption={filterOption}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     >
       {Array.isArray(enumOptions) &&
         enumOptions.map(({ value: optionValue, label: optionLabel }) => (

--- a/packages/antd/src/widgets/TextareaWidget/index.tsx
+++ b/packages/antd/src/widgets/TextareaWidget/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Input from "antd/lib/input";
 import {
+  ariaDescribedByIds,
   FormContextType,
   GenericObjectType,
   RJSFSchema,
@@ -62,6 +63,7 @@ export default function TextareaWidget<
       style={INPUT_STYLE}
       value={value}
       {...extraProps}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     />
   );
 }

--- a/packages/antd/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Array.test.tsx.snap
@@ -190,6 +190,7 @@ exports[`array fields array icons 1`] = `
                             }
                           >
                             <input
+                              aria-describedby="root_0__error root_0__description root_0__help"
                               className="ant-input"
                               hidden={null}
                               id="root_0"
@@ -380,6 +381,7 @@ exports[`array fields array icons 1`] = `
                             }
                           >
                             <input
+                              aria-describedby="root_1__error root_1__description root_1__help"
                               className="ant-input"
                               hidden={null}
                               id="root_1"
@@ -609,6 +611,7 @@ exports[`array fields checkboxes 1`] = `
     className="form-group field field-array"
   >
     <div
+      aria-describedby="root__error root__description root__help"
       className="ant-select ant-select-multiple ant-select-show-search"
       name="root"
       onBlur={[Function]}
@@ -657,6 +660,7 @@ exports[`array fields checkboxes 1`] = `
                 aria-activedescendant="root_list_0"
                 aria-autocomplete="list"
                 aria-controls="root_list"
+                aria-describedby="root__error root__description root__help"
                 aria-haspopup="listbox"
                 aria-owns="root_list"
                 autoComplete="off"
@@ -783,6 +787,7 @@ exports[`array fields empty errors array 1`] = `
                         }
                       >
                         <input
+                          aria-describedby="root_name__error root_name__description root_name__help"
                           className="ant-input"
                           hidden={null}
                           id="root_name"
@@ -904,6 +909,7 @@ exports[`array fields fixed array 1`] = `
                             }
                           >
                             <input
+                              aria-describedby="root_0__error root_0__description root_0__help"
                               className="ant-input"
                               hidden={null}
                               id="root_0"
@@ -1055,6 +1061,7 @@ exports[`array fields fixed array 1`] = `
                                 className="ant-input-number-input-wrap"
                               >
                                 <input
+                                  aria-describedby="root_1__error root_1__description root_1__help"
                                   aria-valuenow={null}
                                   autoComplete="off"
                                   className="ant-input-number-input"
@@ -1252,6 +1259,7 @@ exports[`array fields has errors 1`] = `
                         }
                       >
                         <input
+                          aria-describedby="root_name__error root_name__description root_name__help"
                           className="ant-input"
                           hidden={null}
                           id="root_name"
@@ -1389,6 +1397,7 @@ exports[`array fields no errors 1`] = `
                         }
                       >
                         <input
+                          aria-describedby="root_name__error root_name__description root_name__help"
                           className="ant-input"
                           hidden={null}
                           id="root_name"

--- a/packages/antd/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Form.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`single fields checkbox field 1`] = `
         style={Object {}}
       >
         <input
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           checked={false}
           className="ant-checkbox-input"
@@ -70,6 +71,7 @@ exports[`single fields checkbox field with label 1`] = `
         style={Object {}}
       >
         <input
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           checked={false}
           className="ant-checkbox-input"
@@ -116,6 +118,7 @@ exports[`single fields checkboxes field 1`] = `
     className="form-group field field-array"
   >
     <div
+      aria-describedby="root__error root__description root__help"
       className="ant-checkbox-group"
       id="root"
       name="root"
@@ -346,6 +349,7 @@ exports[`single fields field with description 1`] = `
                         }
                       >
                         <input
+                          aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
                           className="ant-input"
                           hidden={null}
                           id="root_my-field"
@@ -468,6 +472,7 @@ exports[`single fields field with description in uiSchema 1`] = `
                         }
                       >
                         <input
+                          aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
                           className="ant-input"
                           hidden={null}
                           id="root_my-field"
@@ -527,6 +532,7 @@ exports[`single fields format color 1`] = `
     className="form-group field field-string"
   >
     <input
+      aria-describedby="root__error root__description root__help"
       className="ant-input"
       id="root"
       name="root"
@@ -579,6 +585,7 @@ exports[`single fields format date 1`] = `
         className="ant-picker-input"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           autoComplete="off"
           disabled={false}
           id="root"
@@ -655,6 +662,7 @@ exports[`single fields format datetime 1`] = `
         className="ant-picker-input"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           autoComplete="off"
           disabled={false}
           id="root"
@@ -797,6 +805,7 @@ exports[`single fields help and error display 1`] = `
     className="form-group field field-string field-error has-error has-danger"
   >
     <input
+      aria-describedby="root__error root__description root__help"
       className="ant-input"
       id="root"
       name="root"
@@ -875,6 +884,7 @@ exports[`single fields hidden label 1`] = `
     className="form-group field field-string"
   >
     <input
+      aria-describedby="root__error root__description root__help"
       className="ant-input"
       id="root"
       name="root"
@@ -1018,6 +1028,7 @@ exports[`single fields number field 0 1`] = `
         className="ant-input-number-input-wrap"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           aria-valuenow="0"
           autoComplete="off"
           className="ant-input-number-input"
@@ -1140,6 +1151,7 @@ exports[`single fields number field 1`] = `
         className="ant-input-number-input-wrap"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           aria-valuenow={null}
           autoComplete="off"
           className="ant-input-number-input"
@@ -1185,6 +1197,7 @@ exports[`single fields password field 1`] = `
       onClick={[Function]}
     >
       <input
+        aria-describedby="root__error root__description root__help"
         className="ant-input"
         hidden={null}
         id="root"
@@ -1253,6 +1266,7 @@ exports[`single fields radio field 1`] = `
     className="form-group field field-boolean"
   >
     <div
+      aria-describedby="root__error root__description root__help"
       className="ant-radio-group ant-radio-group-outline"
       id="root"
       onBlur={[Function]}
@@ -1345,6 +1359,7 @@ exports[`single fields schema examples 1`] = `
     className="form-group field field-string"
   >
     <input
+      aria-describedby="root__error root__description root__help"
       className="ant-input"
       id="root"
       list="examples_root"
@@ -1405,6 +1420,7 @@ exports[`single fields select field 1`] = `
     className="form-group field field-string"
   >
     <div
+      aria-describedby="root__error root__description root__help"
       className="ant-select ant-select-single ant-select-show-arrow"
       name="root"
       onBlur={[Function]}
@@ -1430,6 +1446,7 @@ exports[`single fields select field 1`] = `
             aria-activedescendant="root_list_0"
             aria-autocomplete="list"
             aria-controls="root_list"
+            aria-describedby="root__error root__description root__help"
             aria-haspopup="listbox"
             aria-owns="root_list"
             autoComplete="off"
@@ -1587,6 +1604,7 @@ exports[`single fields string field format data-url 1`] = `
     <div>
       <p>
         <input
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           defaultValue=""
           disabled={false}
@@ -1621,6 +1639,7 @@ exports[`single fields string field format email 1`] = `
     className="form-group field field-string"
   >
     <input
+      aria-describedby="root__error root__description root__help"
       className="ant-input"
       id="root"
       name="root"
@@ -1661,6 +1680,7 @@ exports[`single fields string field format uri 1`] = `
     className="form-group field field-string"
   >
     <input
+      aria-describedby="root__error root__description root__help"
       className="ant-input"
       id="root"
       name="root"
@@ -1701,6 +1721,7 @@ exports[`single fields string field regular 1`] = `
     className="form-group field field-string"
   >
     <input
+      aria-describedby="root__error root__description root__help"
       className="ant-input"
       id="root"
       name="root"
@@ -1741,6 +1762,7 @@ exports[`single fields string field with placeholder 1`] = `
     className="form-group field field-string"
   >
     <input
+      aria-describedby="root__error root__description root__help"
       className="ant-input"
       id="root"
       name="root"
@@ -1781,6 +1803,7 @@ exports[`single fields textarea field 1`] = `
     className="form-group field field-string"
   >
     <textarea
+      aria-describedby="root__error root__description root__help"
       className="ant-input"
       disabled={false}
       id="root"
@@ -1847,7 +1870,7 @@ exports[`single fields title field 1`] = `
         >
           <label
             className=""
-            htmlFor="root-title"
+            htmlFor="root__title"
             onClick={[Function]}
             title="Titre 1"
           >
@@ -1905,6 +1928,7 @@ exports[`single fields title field 1`] = `
                         }
                       >
                         <input
+                          aria-describedby="root_title__error root_title__description root_title__help"
                           className="ant-input"
                           hidden={null}
                           id="root_title"
@@ -2081,6 +2105,7 @@ exports[`single fields up/down field 1`] = `
         className="ant-input-number-input-wrap"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           aria-valuenow={null}
           autoComplete="off"
           className="ant-input-number-input"
@@ -2122,6 +2147,7 @@ exports[`single fields using custom tagName 1`] = `
     className="form-group field field-string"
   >
     <input
+      aria-describedby="root__error root__description root__help"
       className="ant-input"
       id="root"
       name="root"

--- a/packages/antd/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Form.test.tsx.snap
@@ -1359,10 +1359,10 @@ exports[`single fields schema examples 1`] = `
     className="form-group field field-string"
   >
     <input
-      aria-describedby="root__error root__description root__help"
+      aria-describedby="root__error root__description root__help root__examples"
       className="ant-input"
       id="root"
-      list="examples_root"
+      list="root__examples"
       name="root"
       onBlur={[Function]}
       onChange={[Function]}
@@ -1378,7 +1378,7 @@ exports[`single fields schema examples 1`] = `
       value=""
     />
     <datalist
-      id="examples_root"
+      id="root__examples"
     >
       <option
         value="Firefox"

--- a/packages/antd/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Object.test.tsx.snap
@@ -167,6 +167,7 @@ exports[`object fields additionalProperties 1`] = `
                             }
                           >
                             <input
+                              aria-describedby="root_foo__error root_foo__description root_foo__help"
                               className="ant-input"
                               hidden={null}
                               id="root_foo"
@@ -376,6 +377,7 @@ exports[`object fields object 1`] = `
                         }
                       >
                         <input
+                          aria-describedby="root_a__error root_a__description root_a__help"
                           className="ant-input"
                           hidden={null}
                           id="root_a"
@@ -528,6 +530,7 @@ exports[`object fields object 1`] = `
                             className="ant-input-number-input-wrap"
                           >
                             <input
+                              aria-describedby="root_b__error root_b__description root_b__help"
                               aria-valuenow={null}
                               autoComplete="off"
                               className="ant-input-number-input"

--- a/packages/bootstrap-4/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/bootstrap-4/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Form from "react-bootstrap/Form";
 import {
+  ariaDescribedByIds,
   FormContextType,
   getInputProps,
   RJSFSchema,
@@ -62,6 +63,7 @@ export default function BaseInputTemplate<
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
       {children}
       {schema.examples ? (

--- a/packages/bootstrap-4/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/bootstrap-4/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Form from "react-bootstrap/Form";
 import {
   ariaDescribedByIds,
+  examplesId,
   FormContextType,
   getInputProps,
   RJSFSchema,
@@ -57,17 +58,17 @@ export default function BaseInputTemplate<
         disabled={disabled}
         readOnly={readonly}
         className={rawErrors.length > 0 ? "is-invalid" : ""}
-        list={schema.examples ? `examples_${id}` : undefined}
+        list={schema.examples ? examplesId<T>(id) : undefined}
         {...inputProps}
         value={value || value === 0 ? value : ""}
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
-        aria-describedby={ariaDescribedByIds<T>(id)}
+        aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
       />
       {children}
       {schema.examples ? (
-        <datalist id={`examples_${id}`}>
+        <datalist id={examplesId<T>(id)}>
           {(schema.examples as string[])
             .concat(schema.default ? ([schema.default] as string[]) : [])
             .map((example: any) => {

--- a/packages/bootstrap-4/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/bootstrap-4/src/CheckboxWidget/CheckboxWidget.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  ariaDescribedByIds,
   WidgetProps,
   schemaRequiresTrueValue,
   StrictRJSFSchema,
@@ -44,6 +45,7 @@ export default function CheckboxWidget<
   return (
     <Form.Group
       className={`checkbox ${disabled || readonly ? "disabled" : ""}`}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     >
       <Form.Check
         id={id}

--- a/packages/bootstrap-4/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/bootstrap-4/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -4,6 +4,7 @@ import {
   ariaDescribedByIds,
   enumOptionsDeselectValue,
   enumOptionsSelectValue,
+  optionId,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -65,7 +66,7 @@ export default function CheckboxesWidget<
               checked={checked}
               className="bg-transparent border-0"
               type={"checkbox"}
-              id={`${id}-${option.value}`}
+              id={optionId<S>(id, option)}
               name={id}
               label={option.label}
               autoFocus={autofocus && index === 0}

--- a/packages/bootstrap-4/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/bootstrap-4/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Form from "react-bootstrap/Form";
 import {
+  ariaDescribedByIds,
   enumOptionsDeselectValue,
   enumOptionsSelectValue,
   FormContextType,
@@ -72,6 +73,7 @@ export default function CheckboxesWidget<
               onBlur={_onBlur}
               onFocus={_onFocus}
               disabled={disabled || itemDisabled || readonly}
+              aria-describedby={ariaDescribedByIds<T>(id)}
             />
           );
         })}

--- a/packages/bootstrap-4/src/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/bootstrap-4/src/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -4,6 +4,7 @@ import {
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
+  errorId,
 } from "@rjsf/utils";
 import ListGroup from "react-bootstrap/ListGroup";
 
@@ -20,7 +21,7 @@ export default function FieldErrorTemplate<
   if (errors.length === 0) {
     return null;
   }
-  const id = `${idSchema.$id}__error`;
+  const id = errorId<T>(idSchema);
 
   return (
     <ListGroup as="ul" id={id}>

--- a/packages/bootstrap-4/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/bootstrap-4/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -4,6 +4,7 @@ import {
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
+  helpId,
 } from "@rjsf/utils";
 import Form from "react-bootstrap/Form";
 
@@ -20,7 +21,7 @@ export default function FieldHelpTemplate<
   if (!help) {
     return null;
   }
-  const id = `${idSchema.$id}__help`;
+  const id = helpId<T>(idSchema);
   return (
     <Form.Text className={hasErrors ? "text-danger" : "text-muted"} id={id}>
       {help}

--- a/packages/bootstrap-4/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/bootstrap-4/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -6,12 +6,14 @@ import Container from "react-bootstrap/Container";
 
 import {
   canExpand,
+  descriptionId,
   FormContextType,
   getTemplate,
   getUiOptions,
   ObjectFieldTemplateProps,
   RJSFSchema,
   StrictRJSFSchema,
+  titleId,
 } from "@rjsf/utils";
 
 export default function ObjectFieldTemplate<
@@ -52,7 +54,7 @@ export default function ObjectFieldTemplate<
     <>
       {(uiOptions.title || title) && (
         <TitleFieldTemplate
-          id={`${idSchema.$id}-title`}
+          id={titleId<T>(idSchema)}
           title={uiOptions.title || title}
           required={required}
           schema={schema}
@@ -62,7 +64,7 @@ export default function ObjectFieldTemplate<
       )}
       {(uiOptions.description || description) && (
         <DescriptionFieldTemplate
-          id={`${idSchema.$id}-description`}
+          id={descriptionId<T>(idSchema)}
           description={uiOptions.description || description!}
           schema={schema}
           uiSchema={uiSchema}

--- a/packages/bootstrap-4/src/RadioWidget/RadioWidget.tsx
+++ b/packages/bootstrap-4/src/RadioWidget/RadioWidget.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import Form from "react-bootstrap/Form";
 
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -63,6 +64,7 @@ export default function RadioWidget<
               onChange={_onChange}
               onBlur={_onBlur}
               onFocus={_onFocus}
+              aria-describedby={ariaDescribedByIds<T>(id)}
             />
           );
           return radio;

--- a/packages/bootstrap-4/src/RadioWidget/RadioWidget.tsx
+++ b/packages/bootstrap-4/src/RadioWidget/RadioWidget.tsx
@@ -1,9 +1,8 @@
 import React from "react";
-
 import Form from "react-bootstrap/Form";
-
 import {
   ariaDescribedByIds,
+  optionId,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -53,7 +52,7 @@ export default function RadioWidget<
             <Form.Check
               inline={inline}
               label={option.label}
-              id={`${id}-${option.value}`}
+              id={optionId<S>(id, option)}
               key={option.value}
               name={id}
               type="radio"

--- a/packages/bootstrap-4/src/SelectWidget/SelectWidget.tsx
+++ b/packages/bootstrap-4/src/SelectWidget/SelectWidget.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-
 import Form from "react-bootstrap/Form";
-
 import {
+  ariaDescribedByIds,
   FormContextType,
   processSelectValue,
   RJSFSchema,
@@ -78,6 +77,7 @@ export default function SelectWidget<
         const newValue = getValue(event, multiple);
         onChange(processSelectValue<T, S, F>(schema, newValue, options));
       }}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     >
       {!multiple && schema.default === undefined && (
         <option value="">{placeholder}</option>

--- a/packages/bootstrap-4/src/TextareaWidget/TextareaWidget.tsx
+++ b/packages/bootstrap-4/src/TextareaWidget/TextareaWidget.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -61,6 +61,7 @@ export default function TextareaWidget<
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
     </InputGroup>
   );

--- a/packages/bootstrap-4/test/__snapshots__/AdditionalProperties.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/AdditionalProperties.test.tsx.snap
@@ -68,6 +68,7 @@ exports[`AdditionalProperties tests show add button and fields if additionalProp
                     additionalProperty
                   </label>
                   <input
+                    aria-describedby="root__error root__description root__help"
                     autoFocus={false}
                     className="form-control"
                     disabled={false}

--- a/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
@@ -136,6 +136,7 @@ exports[`array fields array icons 1`] = `
                           *
                         </label>
                         <input
+                          aria-describedby="root_0__error root_0__description root_0__help"
                           autoFocus={false}
                           className="form-control"
                           disabled={false}
@@ -299,6 +300,7 @@ exports[`array fields array icons 1`] = `
                           *
                         </label>
                         <input
+                          aria-describedby="root_1__error root_1__description root_1__help"
                           autoFocus={false}
                           className="form-control"
                           disabled={false}
@@ -531,6 +533,7 @@ exports[`array fields checkboxes 1`] = `
         
       </label>
       <select
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="custom-select"
         disabled={false}
@@ -621,6 +624,7 @@ exports[`array fields empty errors array 1`] = `
                   name
                 </label>
                 <input
+                  aria-describedby="root_name__error root_name__description root_name__help"
                   autoFocus={false}
                   className="form-control"
                   disabled={false}
@@ -698,6 +702,7 @@ exports[`array fields fixed array 1`] = `
                           *
                         </label>
                         <input
+                          aria-describedby="root_0__error root_0__description root_0__help"
                           autoFocus={false}
                           className="form-control"
                           disabled={false}
@@ -742,6 +747,7 @@ exports[`array fields fixed array 1`] = `
                           *
                         </label>
                         <input
+                          aria-describedby="root_1__error root_1__description root_1__help"
                           autoFocus={false}
                           className="form-control"
                           disabled={false}
@@ -825,6 +831,7 @@ exports[`array fields no errors 1`] = `
                   name
                 </label>
                 <input
+                  aria-describedby="root_name__error root_name__description root_name__help"
                   autoFocus={false}
                   className="form-control"
                   disabled={false}

--- a/packages/bootstrap-4/test/__snapshots__/CheckboxesWidget.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/CheckboxesWidget.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`CheckboxesWidget inline 1`] = `
     className="bg-transparent border-0 custom-control custom-checkbox custom-control-inline"
   >
     <input
+      aria-describedby="_id__error _id__description _id__help"
       autoFocus={true}
       checked={false}
       className="custom-control-input"
@@ -39,6 +40,7 @@ exports[`CheckboxesWidget simple 1`] = `
     className="bg-transparent border-0 custom-control custom-checkbox"
   >
     <input
+      aria-describedby="_id__error _id__description _id__help"
       autoFocus={true}
       checked={false}
       className="custom-control-input"

--- a/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`single fields checkbox field 1`] = `
       className="form-group"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="checkbox  form-group"
       >
         <div
@@ -60,6 +61,7 @@ exports[`single fields checkbox field with label 1`] = `
       className="form-group"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="checkbox  form-group"
       >
         <div
@@ -126,6 +128,7 @@ exports[`single fields checkboxes field 1`] = `
           className="bg-transparent border-0 custom-control custom-checkbox"
         >
           <input
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             checked={false}
             className="custom-control-input"
@@ -150,6 +153,7 @@ exports[`single fields checkboxes field 1`] = `
           className="bg-transparent border-0 custom-control custom-checkbox"
         >
           <input
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             checked={false}
             className="custom-control-input"
@@ -174,6 +178,7 @@ exports[`single fields checkboxes field 1`] = `
           className="bg-transparent border-0 custom-control custom-checkbox"
         >
           <input
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             checked={false}
             className="custom-control-input"
@@ -198,6 +203,7 @@ exports[`single fields checkboxes field 1`] = `
           className="bg-transparent border-0 custom-control custom-checkbox"
         >
           <input
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             checked={false}
             className="custom-control-input"
@@ -275,6 +281,7 @@ exports[`single fields field with description 1`] = `
                   my-field
                 </label>
                 <input
+                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
                   autoFocus={false}
                   className="form-control"
                   disabled={false}
@@ -354,6 +361,7 @@ exports[`single fields field with description in uiSchema 1`] = `
                   my-field
                 </label>
                 <input
+                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
                   autoFocus={false}
                   className="form-control"
                   disabled={false}
@@ -411,6 +419,7 @@ exports[`single fields format color 1`] = `
         
       </label>
       <input
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="form-control"
         disabled={false}
@@ -458,6 +467,7 @@ exports[`single fields format date 1`] = `
         
       </label>
       <input
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="form-control"
         disabled={false}
@@ -505,6 +515,7 @@ exports[`single fields format datetime 1`] = `
         
       </label>
       <input
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="form-control"
         disabled={false}
@@ -580,6 +591,7 @@ exports[`single fields help and error display 1`] = `
         
       </label>
       <input
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="is-invalid form-control"
         disabled={false}
@@ -700,6 +712,7 @@ exports[`single fields hidden label 1`] = `
       className="form-group"
     >
       <input
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="form-control"
         disabled={false}
@@ -779,6 +792,7 @@ exports[`single fields number field 0 1`] = `
         
       </label>
       <input
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="form-control"
         disabled={false}
@@ -827,6 +841,7 @@ exports[`single fields number field 1`] = `
         
       </label>
       <input
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="form-control"
         disabled={false}
@@ -875,6 +890,7 @@ exports[`single fields password field 1`] = `
         
       </label>
       <input
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="form-control"
         disabled={false}
@@ -928,6 +944,7 @@ exports[`single fields radio field 1`] = `
           className="form-check"
         >
           <input
+            aria-describedby="root__error root__description root__help"
             checked={false}
             className="form-check-input"
             disabled={false}
@@ -951,6 +968,7 @@ exports[`single fields radio field 1`] = `
           className="form-check"
         >
           <input
+            aria-describedby="root__error root__description root__help"
             checked={false}
             className="form-check-input"
             disabled={false}
@@ -1005,6 +1023,7 @@ exports[`single fields schema examples 1`] = `
         
       </label>
       <input
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="form-control"
         disabled={false}
@@ -1072,6 +1091,7 @@ exports[`single fields select field 1`] = `
         
       </label>
       <select
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="custom-select"
         disabled={false}
@@ -1136,6 +1156,7 @@ exports[`single fields slider field 1`] = `
         
       </label>
       <input
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="form-control"
         disabled={false}
@@ -1191,6 +1212,7 @@ exports[`single fields string field format data-url 1`] = `
         
       </label>
       <input
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="form-control-file"
         disabled={false}
@@ -1238,6 +1260,7 @@ exports[`single fields string field format email 1`] = `
         
       </label>
       <input
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="form-control"
         disabled={false}
@@ -1285,6 +1308,7 @@ exports[`single fields string field format uri 1`] = `
         
       </label>
       <input
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="form-control"
         disabled={false}
@@ -1332,6 +1356,7 @@ exports[`single fields string field regular 1`] = `
         
       </label>
       <input
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="form-control"
         disabled={false}
@@ -1379,6 +1404,7 @@ exports[`single fields string field with placeholder 1`] = `
         
       </label>
       <input
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="form-control"
         disabled={false}
@@ -1429,6 +1455,7 @@ exports[`single fields textarea field 1`] = `
         className="input-group"
       >
         <textarea
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           className="form-control"
           disabled={false}
@@ -1471,7 +1498,7 @@ exports[`single fields title field 1`] = `
     >
       <div
         className="my-1"
-        id="root-title"
+        id="root__title"
       >
         <h5>
           Titre 1
@@ -1513,6 +1540,7 @@ exports[`single fields title field 1`] = `
                   Titre 2
                 </label>
                 <input
+                  aria-describedby="root_title__error root_title__description root_title__help"
                   autoFocus={false}
                   className="form-control"
                   disabled={false}
@@ -1621,6 +1649,7 @@ exports[`single fields up/down field 1`] = `
         
       </label>
       <input
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="form-control"
         disabled={false}
@@ -1668,6 +1697,7 @@ exports[`single fields using custom tagName 1`] = `
         
       </label>
       <input
+        aria-describedby="root__error root__description root__help"
         autoFocus={false}
         className="form-control"
         disabled={false}

--- a/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
@@ -1023,12 +1023,12 @@ exports[`single fields schema examples 1`] = `
         
       </label>
       <input
-        aria-describedby="root__error root__description root__help"
+        aria-describedby="root__error root__description root__help root__examples"
         autoFocus={false}
         className="form-control"
         disabled={false}
         id="root"
-        list="examples_root"
+        list="root__examples"
         name="root"
         onBlur={[Function]}
         onChange={[Function]}
@@ -1039,7 +1039,7 @@ exports[`single fields schema examples 1`] = `
         value=""
       />
       <datalist
-        id="examples_root"
+        id="root__examples"
       >
         <option
           value="Firefox"

--- a/packages/bootstrap-4/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Object.test.tsx.snap
@@ -68,6 +68,7 @@ exports[`object fields additionalProperties 1`] = `
                     foo
                   </label>
                   <input
+                    aria-describedby="root_foo__error root_foo__description root_foo__help"
                     autoFocus={false}
                     className="form-control"
                     disabled={false}
@@ -220,6 +221,7 @@ exports[`object fields object 1`] = `
                   A
                 </label>
                 <input
+                  aria-describedby="root_a__error root_a__description root_a__help"
                   autoFocus={false}
                   className="form-control"
                   disabled={false}
@@ -264,6 +266,7 @@ exports[`object fields object 1`] = `
                   B
                 </label>
                 <input
+                  aria-describedby="root_b__error root_b__description root_b__help"
                   autoFocus={false}
                   className="form-control"
                   disabled={false}

--- a/packages/bootstrap-4/test/__snapshots__/TextAreaWidget.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/TextAreaWidget.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`TextareaWidget simple with errors 1`] = `
   className="input-group"
 >
   <textarea
+    aria-describedby="_id__error _id__description _id__help"
     autoFocus={true}
     className="form-control"
     disabled={false}
@@ -27,6 +28,7 @@ exports[`TextareaWidget simple without errors 1`] = `
   className="input-group"
 >
   <textarea
+    aria-describedby="_id__error _id__description _id__help"
     autoFocus={true}
     className="form-control"
     disabled={false}
@@ -49,6 +51,7 @@ exports[`TextareaWidget simple without required 1`] = `
   className="input-group"
 >
   <textarea
+    aria-describedby="_id__error _id__description _id__help"
     autoFocus={true}
     className="form-control"
     disabled={false}

--- a/packages/chakra-ui/src/AltDateWidget/AltDateWidget.tsx
+++ b/packages/chakra-ui/src/AltDateWidget/AltDateWidget.tsx
@@ -1,5 +1,6 @@
 import React, { MouseEvent, useEffect, useState } from "react";
 import {
+  ariaDescribedByIds,
   DateObject,
   FormContextType,
   pad,
@@ -40,6 +41,7 @@ function DateElement<
       placeholder={props.type}
       schema={{ type: "integer" } as S}
       value={value}
+      aria-describedby={ariaDescribedByIds<T>(props.name)}
     />
   );
 }

--- a/packages/chakra-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/chakra-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { FormControl, FormLabel, Input } from "@chakra-ui/react";
 import {
   ariaDescribedByIds,
+  examplesId,
   FormContextType,
   getInputProps,
   RJSFSchema,
@@ -76,11 +77,11 @@ export default function BaseInputTemplate<
         autoFocus={autofocus}
         placeholder={placeholder}
         {...inputProps}
-        list={schema.examples ? `examples_${id}` : undefined}
-        aria-describedby={ariaDescribedByIds<T>(id)}
+        list={schema.examples ? examplesId<T>(id) : undefined}
+        aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
       />
       {schema.examples ? (
-        <datalist id={`examples_${id}`}>
+        <datalist id={examplesId<T>(id)}>
           {(schema.examples as string[])
             .concat(schema.default ? ([schema.default] as string[]) : [])
             .map((example: any) => {

--- a/packages/chakra-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/chakra-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { FormControl, FormLabel, Input } from "@chakra-ui/react";
 import {
+  ariaDescribedByIds,
   FormContextType,
   getInputProps,
   RJSFSchema,
@@ -76,6 +77,7 @@ export default function BaseInputTemplate<
         placeholder={placeholder}
         {...inputProps}
         list={schema.examples ? `examples_${id}` : undefined}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
       {schema.examples ? (
         <datalist id={`examples_${id}`}>

--- a/packages/chakra-ui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/chakra-ui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Checkbox, FormControl, Text } from "@chakra-ui/react";
 import {
+  ariaDescribedByIds,
   WidgetProps,
   schemaRequiresTrueValue,
   StrictRJSFSchema,
@@ -52,6 +53,7 @@ export default function CheckboxWidget<
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       >
         {label && <Text>{label}</Text>}
       </Checkbox>

--- a/packages/chakra-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/chakra-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -9,6 +9,7 @@ import {
 } from "@chakra-ui/react";
 import {
   ariaDescribedByIds,
+  optionId,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -76,7 +77,7 @@ export default function CheckboxesWidget<
               return (
                 <Checkbox
                   key={option.value}
-                  id={`${id}-${option.value}`}
+                  id={optionId<S>(id, option)}
                   name={id}
                   value={option.value}
                   isChecked={checked}

--- a/packages/chakra-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/chakra-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -8,6 +8,7 @@ import {
   Stack,
 } from "@chakra-ui/react";
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -63,6 +64,7 @@ export default function CheckboxesWidget<
       <CheckboxGroup
         onChange={(option) => onChange(option)}
         defaultValue={value}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       >
         <Stack direction={row ? "row" : "column"}>
           {Array.isArray(enumOptions) &&

--- a/packages/chakra-ui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/chakra-ui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  errorId,
   FieldErrorProps,
   FormContextType,
   RJSFSchema,
@@ -20,7 +21,7 @@ export default function FieldErrorTemplate<
   if (errors.length === 0) {
     return null;
   }
-  const id = `${idSchema.$id}__error`;
+  const id = errorId<T>(idSchema);
 
   return (
     <List>

--- a/packages/chakra-ui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/chakra-ui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  helpId,
   FieldHelpProps,
   FormContextType,
   RJSFSchema,
@@ -20,6 +21,6 @@ export default function FieldHelpTemplate<
   if (!help) {
     return null;
   }
-  const id = `${idSchema.$id}__help`;
+  const id = helpId<T>(idSchema);
   return <FormHelperText id={id}>{help}</FormHelperText>;
 }

--- a/packages/chakra-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/chakra-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -2,12 +2,14 @@ import React from "react";
 import { Grid, GridItem } from "@chakra-ui/react";
 import {
   canExpand,
+  descriptionId,
   FormContextType,
   getTemplate,
   getUiOptions,
   ObjectFieldTemplateProps,
   RJSFSchema,
   StrictRJSFSchema,
+  titleId,
 } from "@rjsf/utils";
 
 export default function ObjectFieldTemplate<
@@ -50,7 +52,7 @@ export default function ObjectFieldTemplate<
     <React.Fragment>
       {(uiOptions.title || title) && (
         <TitleFieldTemplate
-          id={`${idSchema.$id}-title`}
+          id={titleId<T>(idSchema)}
           title={uiOptions.title || title}
           required={required}
           schema={schema}
@@ -60,7 +62,7 @@ export default function ObjectFieldTemplate<
       )}
       {(uiOptions.description || description) && (
         <DescriptionFieldTemplate
-          id={`${idSchema.$id}-description`}
+          id={descriptionId<T>(idSchema)}
           description={uiOptions.description || description!}
           schema={schema}
           uiSchema={uiSchema}

--- a/packages/chakra-ui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/chakra-ui/src/RadioWidget/RadioWidget.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-
 import {
   FormControl,
   FormLabel,
@@ -7,8 +6,8 @@ import {
   RadioGroup,
   Stack,
 } from "@chakra-ui/react";
-
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -62,6 +61,7 @@ export default function RadioWidget<
         onFocus={_onFocus}
         value={`${value}`}
         name={id}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       >
         <Stack direction={row ? "row" : "column"}>
           {Array.isArray(enumOptions) &&

--- a/packages/chakra-ui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/chakra-ui/src/RadioWidget/RadioWidget.tsx
@@ -8,6 +8,7 @@ import {
 } from "@chakra-ui/react";
 import {
   ariaDescribedByIds,
+  optionId,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -74,7 +75,7 @@ export default function RadioWidget<
                 <Radio
                   value={`${option.value}`}
                   key={option.value}
-                  id={`${id}-${option.value}`}
+                  id={optionId<S>(id, option)}
                   disabled={disabled || itemDisabled || readonly}
                 >
                   {`${option.label}`}

--- a/packages/chakra-ui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/chakra-ui/src/RangeWidget/RangeWidget.tsx
@@ -8,6 +8,7 @@ import {
   SliderTrack,
 } from "@chakra-ui/react";
 import {
+  ariaDescribedByIds,
   FormContextType,
   rangeSpec,
   RJSFSchema,
@@ -64,6 +65,7 @@ export default function RangeWidget<
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       >
         <SliderTrack>
           <SliderFilledTrack />

--- a/packages/chakra-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/chakra-ui/src/SelectWidget/SelectWidget.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FormControl, FormLabel } from "@chakra-ui/react";
 import {
+  ariaDescribedByIds,
   FormContextType,
   processSelectValue,
   RJSFSchema,
@@ -106,6 +107,7 @@ export default function SelectWidget<
         onFocus={_onFocus}
         autoFocus={autofocus}
         value={formValue}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
     </FormControl>
   );

--- a/packages/chakra-ui/src/TextareaWidget/TextareaWidget.tsx
+++ b/packages/chakra-ui/src/TextareaWidget/TextareaWidget.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FormControl, FormLabel, Textarea } from "@chakra-ui/react";
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -68,6 +69,7 @@ export default function TextareaWidget<
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
     </FormControl>
   );

--- a/packages/chakra-ui/src/UpDownWidget/UpDownWidget.tsx
+++ b/packages/chakra-ui/src/UpDownWidget/UpDownWidget.tsx
@@ -9,6 +9,7 @@ import {
   FormLabel,
 } from "@chakra-ui/react";
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -69,6 +70,7 @@ export default function UpDownWidget<
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       >
         <NumberInputField id={id} name={id} />
         <NumberInputStepper>

--- a/packages/chakra-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Array.test.tsx.snap
@@ -345,6 +345,7 @@ exports[`array fields array icons 1`] = `
                       role="group"
                     >
                       <input
+                        aria-describedby="root_0__error root_0__description root_0__help"
                         aria-required={true}
                         autoFocus={false}
                         className="chakra-input emotion-0"
@@ -455,6 +456,7 @@ exports[`array fields array icons 1`] = `
                       role="group"
                     >
                       <input
+                        aria-describedby="root_1__error root_1__description root_1__help"
                         aria-required={true}
                         autoFocus={false}
                         className="chakra-input emotion-0"
@@ -1008,6 +1010,7 @@ exports[`array fields empty errors array 1`] = `
                   name
                 </label>
                 <input
+                  aria-describedby="root_name__error root_name__description root_name__help"
                   autoFocus={false}
                   className="chakra-input emotion-0"
                   disabled={false}
@@ -1153,6 +1156,7 @@ exports[`array fields fixed array 1`] = `
                       role="group"
                     >
                       <input
+                        aria-describedby="root_0__error root_0__description root_0__help"
                         aria-required={true}
                         autoFocus={false}
                         className="chakra-input emotion-0"
@@ -1191,6 +1195,7 @@ exports[`array fields fixed array 1`] = `
                       role="group"
                     >
                       <input
+                        aria-describedby="root_1__error root_1__description root_1__help"
                         aria-required={true}
                         autoFocus={false}
                         className="chakra-input emotion-0"
@@ -1318,6 +1323,7 @@ exports[`array fields no errors 1`] = `
                   name
                 </label>
                 <input
+                  aria-describedby="root_name__error root_name__description root_name__help"
                   autoFocus={false}
                   className="chakra-input emotion-0"
                   disabled={false}

--- a/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
@@ -2209,12 +2209,12 @@ exports[`single fields schema examples 1`] = `
         role="group"
       >
         <input
-          aria-describedby="root__error root__description root__help"
+          aria-describedby="root__error root__description root__help root__examples"
           autoFocus={false}
           className="chakra-input emotion-0"
           disabled={false}
           id="root"
-          list="examples_root"
+          list="root__examples"
           name="root"
           onBlur={[Function]}
           onChange={[Function]}
@@ -2226,7 +2226,7 @@ exports[`single fields schema examples 1`] = `
           value=""
         />
         <datalist
-          id="examples_root"
+          id="root__examples"
         >
           <option
             value="Firefox"

--- a/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
@@ -102,6 +102,7 @@ exports[`single fields checkbox field 1`] = `
           onClick={[Function]}
         >
           <input
+            aria-describedby="root__error root__description root__help"
             aria-disabled={false}
             checked={false}
             className="chakra-checkbox__input"
@@ -262,6 +263,7 @@ exports[`single fields checkbox field with label 1`] = `
           onClick={[Function]}
         >
           <input
+            aria-describedby="root__error root__description root__help"
             aria-disabled={false}
             checked={false}
             className="chakra-checkbox__input"
@@ -776,6 +778,7 @@ exports[`single fields field with description 1`] = `
                   my-field
                 </label>
                 <input
+                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
                   autoFocus={false}
                   className="chakra-input emotion-0"
                   disabled={false}
@@ -907,6 +910,7 @@ exports[`single fields field with description in uiSchema 1`] = `
                   my-field
                 </label>
                 <input
+                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
                   autoFocus={false}
                   className="chakra-input emotion-0"
                   disabled={false}
@@ -1002,6 +1006,7 @@ exports[`single fields format color 1`] = `
         role="group"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           className="chakra-input emotion-0"
           disabled={false}
@@ -1088,6 +1093,7 @@ exports[`single fields format date 1`] = `
         role="group"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           className="chakra-input emotion-0"
           disabled={false}
@@ -1174,6 +1180,7 @@ exports[`single fields format datetime 1`] = `
         role="group"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           className="chakra-input emotion-0"
           disabled={false}
@@ -1344,6 +1351,7 @@ exports[`single fields help and error display 1`] = `
         role="group"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           aria-invalid={true}
           autoFocus={false}
           className="chakra-input emotion-1"
@@ -1540,6 +1548,7 @@ exports[`single fields hidden label 1`] = `
         role="group"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           className="chakra-input emotion-0"
           disabled={false}
@@ -1687,6 +1696,7 @@ exports[`single fields number field 0 1`] = `
         role="group"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           className="chakra-input emotion-0"
           disabled={false}
@@ -1774,6 +1784,7 @@ exports[`single fields number field 1`] = `
         role="group"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           className="chakra-input emotion-0"
           disabled={false}
@@ -1861,6 +1872,7 @@ exports[`single fields password field 1`] = `
         role="group"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           className="chakra-input emotion-0"
           disabled={false}
@@ -2016,6 +2028,7 @@ exports[`single fields radio field 1`] = `
           id="root-label"
         />
         <div
+          aria-describedby="root__error root__description root__help"
           className="chakra-radio-group emotion-0"
           onBlur={[Function]}
           onFocus={[Function]}
@@ -2196,6 +2209,7 @@ exports[`single fields schema examples 1`] = `
         role="group"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           className="chakra-input emotion-0"
           disabled={false}
@@ -4675,6 +4689,7 @@ exports[`single fields slider field 1`] = `
         role="group"
       >
         <div
+          aria-describedby="root__error root__description root__help"
           className="chakra-slider emotion-0"
           label=""
           onBlur={[Function]}
@@ -4813,6 +4828,7 @@ exports[`single fields string field format data-url 1`] = `
       <div>
         <p>
           <input
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             defaultValue=""
             disabled={false}
@@ -4894,6 +4910,7 @@ exports[`single fields string field format email 1`] = `
         role="group"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           className="chakra-input emotion-0"
           disabled={false}
@@ -4980,6 +4997,7 @@ exports[`single fields string field format uri 1`] = `
         role="group"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           className="chakra-input emotion-0"
           disabled={false}
@@ -5066,6 +5084,7 @@ exports[`single fields string field regular 1`] = `
         role="group"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           className="chakra-input emotion-0"
           disabled={false}
@@ -5152,6 +5171,7 @@ exports[`single fields string field with placeholder 1`] = `
         role="group"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           className="chakra-input emotion-0"
           disabled={false}
@@ -5238,6 +5258,7 @@ exports[`single fields textarea field 1`] = `
         role="group"
       >
         <textarea
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           className="chakra-textarea emotion-0"
           disabled={false}
@@ -5342,7 +5363,7 @@ exports[`single fields title field 1`] = `
     >
       <div
         className="emotion-1"
-        id="root-title"
+        id="root__title"
       >
         <h5
           className="chakra-heading emotion-0"
@@ -5379,6 +5400,7 @@ exports[`single fields title field 1`] = `
                   title
                 </label>
                 <input
+                  aria-describedby="root_title__error root_title__description root_title__help"
                   autoFocus={false}
                   className="chakra-input emotion-0"
                   disabled={false}
@@ -5620,6 +5642,7 @@ exports[`single fields up/down field 1`] = `
           value=""
         >
           <input
+            aria-describedby="root__error root__description root__help"
             aria-readonly={false}
             aria-required={false}
             aria-valuemax={9007199254740991}
@@ -5762,6 +5785,7 @@ exports[`single fields using custom tagName 1`] = `
         role="group"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           className="chakra-input emotion-0"
           disabled={false}

--- a/packages/chakra-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Object.test.tsx.snap
@@ -188,6 +188,7 @@ exports[`object fields additionalProperties 1`] = `
                     foo
                   </label>
                   <input
+                    aria-describedby="root_foo__error root_foo__description root_foo__help"
                     autoFocus={false}
                     className="chakra-input emotion-0"
                     disabled={false}
@@ -365,6 +366,7 @@ exports[`object fields object 1`] = `
                   A
                 </label>
                 <input
+                  aria-describedby="root_a__error root_a__description root_a__help"
                   autoFocus={false}
                   className="chakra-input emotion-0"
                   disabled={false}
@@ -405,6 +407,7 @@ exports[`object fields object 1`] = `
                   B
                 </label>
                 <input
+                  aria-describedby="root_b__error root_b__description root_b__help"
                   autoFocus={false}
                   className="chakra-input emotion-0"
                   disabled={false}

--- a/packages/core/src/components/fields/ArrayField.tsx
+++ b/packages/core/src/components/fields/ArrayField.tsx
@@ -531,7 +531,7 @@ class ArrayField<
     const Widget = getWidget<T[], S, F>(schema, widget, widgets);
     return (
       <Widget
-        id={idSchema && idSchema.$id}
+        id={idSchema.$id}
         multiple
         onChange={this.onSelectChange}
         onBlur={onBlur}
@@ -581,7 +581,7 @@ class ArrayField<
     const Widget = getWidget<T[], S, F>(schema, widget, widgets);
     return (
       <Widget
-        id={idSchema && idSchema.$id}
+        id={idSchema.$id}
         multiple
         onChange={this.onSelectChange}
         onBlur={onBlur}
@@ -628,7 +628,7 @@ class ArrayField<
     return (
       <Widget
         options={options}
-        id={idSchema && idSchema.$id}
+        id={idSchema.$id}
         multiple
         onChange={this.onSelectChange}
         onBlur={onBlur}

--- a/packages/core/src/components/fields/BooleanField.tsx
+++ b/packages/core/src/components/fields/BooleanField.tsx
@@ -91,7 +91,7 @@ function BooleanField<
       options={{ ...options, enumOptions }}
       schema={schema}
       uiSchema={uiSchema}
-      id={idSchema && idSchema.$id}
+      id={idSchema.$id}
       onChange={onChange}
       onFocus={onFocus}
       onBlur={onBlur}

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   mergeObjects,
   deepEquals,
+  descriptionId,
   getUiOptions,
   getSchemaType,
   getTemplate,
@@ -279,7 +280,7 @@ function SchemaFieldRender<
   const fieldProps: Omit<FieldTemplateProps<T, S, F>, "children"> = {
     description: (
       <DescriptionFieldTemplate
-        id={`${id}__description`}
+        id={descriptionId<T>(id)}
         description={description}
         schema={schema}
         uiSchema={uiSchema}

--- a/packages/core/src/components/fields/StringField.tsx
+++ b/packages/core/src/components/fields/StringField.tsx
@@ -55,7 +55,7 @@ function StringField<
       options={{ ...options, enumOptions }}
       schema={schema}
       uiSchema={uiSchema}
-      id={idSchema && idSchema.$id}
+      id={idSchema.$id}
       label={title === undefined ? name : title}
       value={formData}
       onChange={onChange}

--- a/packages/core/src/components/templates/ArrayFieldDescriptionTemplate.tsx
+++ b/packages/core/src/components/templates/ArrayFieldDescriptionTemplate.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  descriptionId,
   getTemplate,
   getUiOptions,
   ArrayFieldDescriptionProps,
@@ -30,10 +31,9 @@ export default function ArrayFieldDescriptionTemplate<
     S,
     F
   >("DescriptionFieldTemplate", registry, options);
-  const id = `${idSchema.$id}__description`;
   return (
     <DescriptionFieldTemplate
-      id={id}
+      id={descriptionId<T>(idSchema)}
       description={description}
       schema={schema}
       uiSchema={uiSchema}

--- a/packages/core/src/components/templates/ArrayFieldTitleTemplate.tsx
+++ b/packages/core/src/components/templates/ArrayFieldTitleTemplate.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   getTemplate,
   getUiOptions,
+  titleId,
   ArrayFieldTitleProps,
   FormContextType,
   RJSFSchema,
@@ -31,10 +32,9 @@ export default function ArrayFieldTitleTemplate<
       registry,
       options
     );
-  const id = `${idSchema.$id}__title`;
   return (
     <TitleFieldTemplate
-      id={id}
+      id={titleId<T>(idSchema)}
       title={title}
       required={required}
       schema={schema}

--- a/packages/core/src/components/templates/BaseInputTemplate.tsx
+++ b/packages/core/src/components/templates/BaseInputTemplate.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from "react";
 import {
+  ariaDescribedByIds,
   getInputProps,
   FormContextType,
   RJSFSchema,
@@ -86,6 +87,7 @@ export default function BaseInputTemplate<
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
       {Array.isArray(schema.examples) && (
         <datalist key={`datalist_${id}`} id={`examples_${id}`}>

--- a/packages/core/src/components/templates/BaseInputTemplate.tsx
+++ b/packages/core/src/components/templates/BaseInputTemplate.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from "react";
 import {
   ariaDescribedByIds,
+  examplesId,
   getInputProps,
   FormContextType,
   RJSFSchema,
@@ -83,14 +84,14 @@ export default function BaseInputTemplate<
         autoFocus={autofocus}
         value={inputValue}
         {...inputProps}
-        list={schema.examples ? `examples_${id}` : undefined}
+        list={schema.examples ? examplesId<T>(id) : undefined}
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
-        aria-describedby={ariaDescribedByIds<T>(id)}
+        aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
       />
       {Array.isArray(schema.examples) && (
-        <datalist key={`datalist_${id}`} id={`examples_${id}`}>
+        <datalist key={`datalist_${id}`} id={examplesId<T>(id)}>
           {[
             ...new Set(
               schema.examples.concat(schema.default ? [schema.default] : [])

--- a/packages/core/src/components/templates/FieldErrorTemplate.tsx
+++ b/packages/core/src/components/templates/FieldErrorTemplate.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  errorId,
   FieldErrorProps,
   FormContextType,
   RJSFSchema,
@@ -19,7 +20,7 @@ export default function FieldErrorTemplate<
   if (errors.length === 0) {
     return null;
   }
-  const id = `${idSchema.$id}__error`;
+  const id = errorId<T>(idSchema);
 
   return (
     <div>

--- a/packages/core/src/components/templates/FieldHelpTemplate.tsx
+++ b/packages/core/src/components/templates/FieldHelpTemplate.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  helpId,
   FieldHelpProps,
   FormContextType,
   RJSFSchema,
@@ -19,7 +20,7 @@ export default function FieldHelpTemplate<
   if (!help) {
     return null;
   }
-  const id = `${idSchema.$id}__help`;
+  const id = helpId<T>(idSchema);
   if (typeof help === "string") {
     return (
       <p id={id} className="help-block">

--- a/packages/core/src/components/templates/ObjectFieldTemplate.tsx
+++ b/packages/core/src/components/templates/ObjectFieldTemplate.tsx
@@ -6,8 +6,10 @@ import {
   RJSFSchema,
   StrictRJSFSchema,
   canExpand,
+  descriptionId,
   getTemplate,
   getUiOptions,
+  titleId,
 } from "@rjsf/utils";
 
 /** The `ObjectFieldTemplate` is the template to use to render all the inner properties of an object along with the
@@ -55,7 +57,7 @@ export default function ObjectFieldTemplate<
     <fieldset id={idSchema.$id}>
       {(options.title || title) && (
         <TitleFieldTemplate
-          id={`${idSchema.$id}__title`}
+          id={titleId<T>(idSchema)}
           title={options.title || title}
           required={required}
           schema={schema}
@@ -65,7 +67,7 @@ export default function ObjectFieldTemplate<
       )}
       {(options.description || description) && (
         <DescriptionFieldTemplate
-          id={`${idSchema.$id}__description`}
+          id={descriptionId<T>(idSchema)}
           description={options.description || description!}
           schema={schema}
           uiSchema={uiSchema}

--- a/packages/core/src/components/widgets/AltDateWidget.tsx
+++ b/packages/core/src/components/widgets/AltDateWidget.tsx
@@ -1,6 +1,6 @@
 import React, { MouseEvent, useCallback, useEffect, useReducer } from "react";
-
 import {
+  ariaDescribedByIds,
   parseDateString,
   toDateString,
   pad,
@@ -103,6 +103,7 @@ function DateElement<
       onFocus={onFocus}
       registry={registry}
       label=""
+      aria-describedby={ariaDescribedByIds<T>(rootId)}
     />
   );
 }

--- a/packages/core/src/components/widgets/CheckboxWidget.tsx
+++ b/packages/core/src/components/widgets/CheckboxWidget.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback } from "react";
 import {
+  ariaDescribedByIds,
+  descriptionId,
   getTemplate,
   schemaRequiresTrueValue,
   FormContextType,
@@ -65,7 +67,7 @@ function CheckboxWidget<
     <div className={`checkbox ${disabled || readonly ? "disabled" : ""}`}>
       {schema.description && (
         <DescriptionFieldTemplate
-          id={id + "__description"}
+          id={descriptionId<T>(id)}
           description={schema.description}
           schema={schema}
           uiSchema={uiSchema}
@@ -84,6 +86,7 @@ function CheckboxWidget<
           onChange={handleChange}
           onBlur={handleBlur}
           onFocus={handleFocus}
+          aria-describedby={ariaDescribedByIds<T>(id)}
         />
         <span>{label}</span>
       </label>

--- a/packages/core/src/components/widgets/CheckboxesWidget.tsx
+++ b/packages/core/src/components/widgets/CheckboxesWidget.tsx
@@ -1,5 +1,6 @@
 import React, { ChangeEvent } from "react";
 import {
+  ariaDescribedByIds,
   enumOptionsDeselectValue,
   enumOptionsSelectValue,
   FormContextType,
@@ -64,6 +65,7 @@ function CheckboxesWidget<
                 disabled={disabled || itemDisabled || readonly}
                 autoFocus={autofocus && index === 0}
                 onChange={handleChange}
+                aria-describedby={ariaDescribedByIds<T>(id)}
               />
               <span>{option.label}</span>
             </span>

--- a/packages/core/src/components/widgets/CheckboxesWidget.tsx
+++ b/packages/core/src/components/widgets/CheckboxesWidget.tsx
@@ -3,6 +3,7 @@ import {
   ariaDescribedByIds,
   enumOptionsDeselectValue,
   enumOptionsSelectValue,
+  optionId,
   FormContextType,
   WidgetProps,
   RJSFSchema,
@@ -59,7 +60,7 @@ function CheckboxesWidget<
             <span>
               <input
                 type="checkbox"
-                id={`${id}-${option.value}`}
+                id={optionId<S>(id, option)}
                 name={id}
                 checked={checked}
                 disabled={disabled || itemDisabled || readonly}

--- a/packages/core/src/components/widgets/FileWidget.tsx
+++ b/packages/core/src/components/widgets/FileWidget.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent, useCallback, useMemo, useState } from "react";
-
 import {
+  ariaDescribedByIds,
   dataURItoBlob,
   FormContextType,
   RJSFSchema,
@@ -144,6 +144,7 @@ function FileWidget<
           autoFocus={autofocus}
           multiple={multiple}
           accept={options.accept ? String(options.accept) : undefined}
+          aria-describedby={ariaDescribedByIds<T>(id)}
         />
       </p>
       <FilesInfo filesInfo={filesInfo} />

--- a/packages/core/src/components/widgets/RadioWidget.tsx
+++ b/packages/core/src/components/widgets/RadioWidget.tsx
@@ -1,6 +1,7 @@
 import React, { FocusEvent, useCallback } from "react";
 import {
   ariaDescribedByIds,
+  optionId,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -61,7 +62,7 @@ function RadioWidget<
             <span>
               <input
                 type="radio"
-                id={`${id}-${option.value}`}
+                id={optionId<S>(id, option)}
                 checked={checked}
                 name={name}
                 required={required}

--- a/packages/core/src/components/widgets/RadioWidget.tsx
+++ b/packages/core/src/components/widgets/RadioWidget.tsx
@@ -1,5 +1,6 @@
 import React, { FocusEvent, useCallback } from "react";
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -70,6 +71,7 @@ function RadioWidget<
                 onChange={handleChange}
                 onBlur={handleBlur}
                 onFocus={handleFocus}
+                aria-describedby={ariaDescribedByIds<T>(id)}
               />
               <span>{option.label}</span>
             </span>

--- a/packages/core/src/components/widgets/SelectWidget.tsx
+++ b/packages/core/src/components/widgets/SelectWidget.tsx
@@ -1,5 +1,6 @@
 import React, { ChangeEvent, FocusEvent, useCallback } from "react";
 import {
+  ariaDescribedByIds,
   processSelectValue,
   FormContextType,
   RJSFSchema,
@@ -87,6 +88,7 @@ function SelectWidget<
       onBlur={handleBlur}
       onFocus={handleFocus}
       onChange={handleChange}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     >
       {!multiple && schema.default === undefined && (
         <option value="">{placeholder}</option>

--- a/packages/core/src/components/widgets/TextareaWidget.tsx
+++ b/packages/core/src/components/widgets/TextareaWidget.tsx
@@ -1,5 +1,6 @@
 import React, { FocusEvent, useCallback } from "react";
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -60,6 +61,7 @@ function TextareaWidget<
       onBlur={handleBlur}
       onFocus={handleFocus}
       onChange={handleChange}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     />
   );
 }

--- a/packages/fluent-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/fluent-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { TextField } from "@fluentui/react";
 import {
   ariaDescribedByIds,
+  examplesId,
   FormContextType,
   getInputProps,
   RJSFSchema,
@@ -106,12 +107,12 @@ export default function BaseInputTemplate<
         onBlur={_onBlur}
         onFocus={_onFocus}
         errorMessage={(rawErrors || []).join("\n")}
-        list={schema.examples ? `examples_${id}` : undefined}
+        list={schema.examples ? examplesId<T>(id) : undefined}
         {...uiProps}
-        aria-describedby={ariaDescribedByIds<T>(id)}
+        aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
       />
       {schema.examples && (
-        <datalist id={`examples_${id}`}>
+        <datalist id={examplesId<T>(id)}>
           {(schema.examples as string[])
             .concat(schema.default ? ([schema.default] as string[]) : [])
             .map((example: any) => {

--- a/packages/fluent-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/fluent-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { TextField } from "@fluentui/react";
 import {
+  ariaDescribedByIds,
   FormContextType,
   getInputProps,
   RJSFSchema,
@@ -107,6 +108,7 @@ export default function BaseInputTemplate<
         errorMessage={(rawErrors || []).join("\n")}
         list={schema.examples ? `examples_${id}` : undefined}
         {...uiProps}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
       {schema.examples && (
         <datalist id={`examples_${id}`}>

--- a/packages/fluent-ui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/fluent-ui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Checkbox } from "@fluentui/react";
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -81,6 +82,7 @@ export default function CheckboxWidget<
         checked={typeof value === "undefined" ? false : value}
         onChange={_onChange}
         {...uiProps}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
     </>
   );

--- a/packages/fluent-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/fluent-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -4,13 +4,14 @@ import {
   ariaDescribedByIds,
   enumOptionsDeselectValue,
   enumOptionsSelectValue,
+  optionId,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
   WidgetProps,
 } from "@rjsf/utils";
-import { allowedProps } from "../CheckboxWidget";
 import _pick from "lodash/pick";
+import { allowedProps } from "../CheckboxWidget";
 
 const styles_red = {
   // TODO: get this color from theme.
@@ -78,7 +79,7 @@ export default function CheckboxesWidget<
             enumDisabled.indexOf(option.value) !== -1;
           return (
             <Checkbox
-              id={`${id}-${option.value}`}
+              id={optionId<S>(id, option)}
               name={id}
               checked={checked}
               label={option.label}

--- a/packages/fluent-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/fluent-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Checkbox, Label } from "@fluentui/react";
 import {
+  ariaDescribedByIds,
   enumOptionsDeselectValue,
   enumOptionsSelectValue,
   FormContextType,
@@ -88,6 +89,7 @@ export default function CheckboxesWidget<
               onFocus={_onFocus}
               key={option.value}
               {...uiProps}
+              aria-describedby={ariaDescribedByIds<T>(id)}
             />
           );
         })}

--- a/packages/fluent-ui/src/ColorWidget/ColorWidget.tsx
+++ b/packages/fluent-ui/src/ColorWidget/ColorWidget.tsx
@@ -7,6 +7,7 @@ import {
   Label,
 } from "@fluentui/react";
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -44,7 +45,15 @@ export default function ColorWidget<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any
->({ schema, options, value, required, label, onChange }: WidgetProps<T, S, F>) {
+>({
+  id,
+  schema,
+  options,
+  value,
+  required,
+  label,
+  onChange,
+}: WidgetProps<T, S, F>) {
   const updateColor = (_ev: any, colorObj: IColor) => {
     onChange(colorObj.hex);
   };
@@ -63,6 +72,7 @@ export default function ColorWidget<
         alphaType={"alpha"}
         showPreview={true}
         {...uiProps}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
     </>
   );

--- a/packages/fluent-ui/src/DateWidget/DateWidget.tsx
+++ b/packages/fluent-ui/src/DateWidget/DateWidget.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  ariaDescribedByIds,
   WidgetProps,
   pad,
   StrictRJSFSchema,
@@ -123,6 +124,7 @@ export default function DateWidget<
       onFocus={_onFocus}
       value={parseDate(value)}
       {...uiProps}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     />
   );
 }

--- a/packages/fluent-ui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/fluent-ui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  errorId,
   FieldErrorProps,
   FormContextType,
   RJSFSchema,
@@ -20,7 +21,7 @@ export default function FieldErrorTemplate<
   if (errors.length === 0) {
     return null;
   }
-  const id = `${idSchema.$id}__error`;
+  const id = errorId<T>(idSchema);
 
   return <List id={id} items={errors} />;
 }

--- a/packages/fluent-ui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/fluent-ui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  helpId,
   FieldHelpProps,
   FormContextType,
   RJSFSchema,
@@ -20,6 +21,6 @@ export default function FieldHelpTemplate<
   if (!help) {
     return null;
   }
-  const id = `${idSchema.$id}__help`;
+  const id = helpId<T>(idSchema);
   return <Text id={id}>{help}</Text>;
 }

--- a/packages/fluent-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/fluent-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import {
+  descriptionId,
   FormContextType,
   getTemplate,
   getUiOptions,
   ObjectFieldTemplateProps,
   RJSFSchema,
   StrictRJSFSchema,
+  titleId,
 } from "@rjsf/utils";
 
 export default function ObjectFieldTemplate<
@@ -38,7 +40,7 @@ export default function ObjectFieldTemplate<
     <>
       {(uiOptions.title || title) && (
         <TitleFieldTemplate
-          id={`${idSchema.$id}-title`}
+          id={titleId<T>(idSchema)}
           title={title}
           required={required}
           schema={schema}
@@ -48,7 +50,7 @@ export default function ObjectFieldTemplate<
       )}
       {(uiOptions.description || description) && (
         <DescriptionFieldTemplate
-          id={`${idSchema.$id}-description`}
+          id={descriptionId<T>(idSchema)}
           schema={schema}
           uiSchema={uiSchema}
           description={uiOptions.description || description!}

--- a/packages/fluent-ui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/fluent-ui/src/RadioWidget/RadioWidget.tsx
@@ -6,6 +6,7 @@ import {
 } from "@fluentui/react";
 import {
   ariaDescribedByIds,
+  optionId,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -64,7 +65,7 @@ export default function RadioWidget<
     ? enumOptions.map((option) => ({
         key: option.value,
         name: id,
-        id: `${id}-${option.value}`,
+        id: optionId<S>(id, option),
         text: option.label,
         disabled:
           Array.isArray(enumDisabled) &&

--- a/packages/fluent-ui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/fluent-ui/src/RadioWidget/RadioWidget.tsx
@@ -5,6 +5,7 @@ import {
   IChoiceGroupProps,
 } from "@fluentui/react";
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -68,6 +69,7 @@ export default function RadioWidget<
         disabled:
           Array.isArray(enumDisabled) &&
           enumDisabled.indexOf(option.value) !== -1,
+        "aria-describedby": ariaDescribedByIds<T>(id),
       }))
     : [];
 

--- a/packages/fluent-ui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/fluent-ui/src/RangeWidget/RangeWidget.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Slider, Label } from "@fluentui/react";
-
 import {
+  ariaDescribedByIds,
   FormContextType,
   rangeSpec,
   RJSFSchema,
@@ -76,6 +76,7 @@ export default function RangeWidget<
         onChange={_onChange}
         snapToStep
         {...uiProps}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
     </>
   );

--- a/packages/fluent-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/fluent-ui/src/SelectWidget/SelectWidget.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Label, Dropdown, IDropdownOption } from "@fluentui/react";
 import {
+  ariaDescribedByIds,
   WidgetProps,
   processSelectValue,
   StrictRJSFSchema,
@@ -123,6 +124,7 @@ export default function SelectWidget<
         onBlur={_onBlur}
         onFocus={_onFocus}
         {...uiProps}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
     </>
   );

--- a/packages/fluent-ui/src/UpDownWidget/UpDownWidget.tsx
+++ b/packages/fluent-ui/src/UpDownWidget/UpDownWidget.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Label, SpinButton } from "@fluentui/react";
 import {
+  ariaDescribedByIds,
   FormContextType,
   rangeSpec,
   RJSFSchema,
@@ -123,6 +124,7 @@ WidgetProps<T, S, F>) {
         onIncrement={_onIncrement}
         onDecrement={_onDecrement}
         {...uiProps}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
     </>
   );

--- a/packages/fluent-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Array.test.tsx.snap
@@ -156,6 +156,7 @@ exports[`array fields array icons 1`] = `
                     className="ms-TextField-fieldGroup fieldGroup-56"
                   >
                     <input
+                      aria-describedby="root_0__error root_0__description root_0__help"
                       aria-invalid={false}
                       autoFocus={false}
                       className="ms-TextField-field field-57"
@@ -312,6 +313,7 @@ exports[`array fields array icons 1`] = `
                     className="ms-TextField-fieldGroup fieldGroup-56"
                   >
                     <input
+                      aria-describedby="root_1__error root_1__description root_1__help"
                       aria-invalid={false}
                       autoFocus={false}
                       className="ms-TextField-field field-57"
@@ -549,6 +551,7 @@ exports[`array fields checkboxes 1`] = `
       className="ms-Dropdown-container"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         aria-disabled={false}
         aria-expanded="false"
         aria-haspopup="listbox"
@@ -673,6 +676,7 @@ exports[`array fields empty errors array 1`] = `
                 className="ms-TextField-fieldGroup fieldGroup-90"
               >
                 <input
+                  aria-describedby="root_name__error root_name__description root_name__help"
                   aria-invalid={false}
                   aria-labelledby="TextFieldLabel56"
                   autoFocus={false}
@@ -785,6 +789,7 @@ exports[`array fields fixed array 1`] = `
                     className="ms-TextField-fieldGroup fieldGroup-56"
                   >
                     <input
+                      aria-describedby="root_0__error root_0__description root_0__help"
                       aria-invalid={false}
                       autoFocus={false}
                       className="ms-TextField-field field-57"
@@ -843,6 +848,7 @@ exports[`array fields fixed array 1`] = `
                     className="ms-TextField-fieldGroup fieldGroup-56"
                   >
                     <input
+                      aria-describedby="root_1__error root_1__description root_1__help"
                       aria-invalid={false}
                       autoFocus={false}
                       className="ms-TextField-field field-57"
@@ -959,6 +965,7 @@ exports[`array fields no errors 1`] = `
                 className="ms-TextField-fieldGroup fieldGroup-90"
               >
                 <input
+                  aria-describedby="root_name__error root_name__description root_name__help"
                   aria-invalid={false}
                   aria-labelledby="TextFieldLabel50"
                   autoFocus={false}

--- a/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
@@ -464,6 +464,7 @@ exports[`single fields field with description 1`] = `
                 className="ms-TextField-fieldGroup fieldGroup-43"
               >
                 <input
+                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
                   aria-invalid={false}
                   aria-labelledby="TextFieldLabel126"
                   autoFocus={false}
@@ -582,6 +583,7 @@ exports[`single fields field with description in uiSchema 1`] = `
                 className="ms-TextField-fieldGroup fieldGroup-43"
               >
                 <input
+                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
                   aria-invalid={false}
                   aria-labelledby="TextFieldLabel132"
                   autoFocus={false}
@@ -1028,6 +1030,7 @@ exports[`single fields format date 1`] = `
     }
   >
     <div
+      aria-describedby="root__error root__description root__help"
       className="ms-DatePicker control-82"
       id="root"
       onBlur={[Function]}
@@ -1144,6 +1147,7 @@ exports[`single fields format datetime 1`] = `
           className="ms-TextField-fieldGroup fieldGroup-43"
         >
           <input
+            aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
             className="ms-TextField-field field-44"
@@ -1462,6 +1466,7 @@ exports[`single fields hidden label 1`] = `
           className="ms-TextField-fieldGroup fieldGroup-43"
         >
           <input
+            aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
             className="ms-TextField-field field-44"
@@ -1600,6 +1605,7 @@ exports[`single fields number field 0 1`] = `
           className="ms-TextField-fieldGroup fieldGroup-43"
         >
           <input
+            aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
             className="ms-TextField-field field-44"
@@ -1684,6 +1690,7 @@ exports[`single fields number field 1`] = `
           className="ms-TextField-fieldGroup fieldGroup-43"
         >
           <input
+            aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
             className="ms-TextField-field field-44"
@@ -1768,6 +1775,7 @@ exports[`single fields password field 1`] = `
           className="ms-TextField-fieldGroup fieldGroup-43"
         >
           <input
+            aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
             className="ms-TextField-field field-44"
@@ -1842,6 +1850,7 @@ exports[`single fields radio field 1`] = `
     }
   >
     <div
+      aria-describedby="root__error root__description root__help"
       className=""
       id="root"
       name="root"
@@ -1983,6 +1992,7 @@ exports[`single fields schema examples 1`] = `
           className="ms-TextField-fieldGroup fieldGroup-43"
         >
           <input
+            aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
             className="ms-TextField-field field-44"
@@ -2083,6 +2093,7 @@ exports[`single fields select field 1`] = `
       className="ms-Dropdown-container"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         aria-disabled={false}
         aria-expanded="false"
         aria-haspopup="listbox"
@@ -2289,6 +2300,7 @@ exports[`single fields string field format data-url 1`] = `
     <div>
       <p>
         <input
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           defaultValue=""
           disabled={false}
@@ -2364,6 +2376,7 @@ exports[`single fields string field format email 1`] = `
           className="ms-TextField-fieldGroup fieldGroup-43"
         >
           <input
+            aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
             className="ms-TextField-field field-44"
@@ -2447,6 +2460,7 @@ exports[`single fields string field format uri 1`] = `
           className="ms-TextField-fieldGroup fieldGroup-43"
         >
           <input
+            aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
             className="ms-TextField-field field-44"
@@ -2530,6 +2544,7 @@ exports[`single fields string field regular 1`] = `
           className="ms-TextField-fieldGroup fieldGroup-43"
         >
           <input
+            aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
             className="ms-TextField-field field-44"
@@ -2613,6 +2628,7 @@ exports[`single fields string field with placeholder 1`] = `
           className="ms-TextField-fieldGroup fieldGroup-43"
         >
           <input
+            aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
             className="ms-TextField-field field-44"
@@ -2696,6 +2712,7 @@ exports[`single fields textarea field 1`] = `
           className="ms-TextField-fieldGroup fieldGroup-106"
         >
           <textarea
+            aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
             className="ms-TextField-field field-107"
@@ -2771,7 +2788,7 @@ exports[`single fields title field 1`] = `
   >
     <label
       className="ms-Label root-154"
-      id="root-title"
+      id="root__title"
     >
       Titre 1
     </label>
@@ -2809,6 +2826,7 @@ exports[`single fields title field 1`] = `
                 className="ms-TextField-fieldGroup fieldGroup-43"
               >
                 <input
+                  aria-describedby="root_title__error root_title__description root_title__help"
                   aria-invalid={false}
                   aria-labelledby="TextFieldLabel138"
                   autoFocus={false}
@@ -2976,6 +2994,7 @@ exports[`single fields up/down field 1`] = `
     >
       
       <div
+        aria-describedby="root__error root__description root__help"
         className="css-98"
         id="root"
         onChange={[Function]}
@@ -3136,6 +3155,7 @@ exports[`single fields using custom tagName 1`] = `
           className="ms-TextField-fieldGroup fieldGroup-43"
         >
           <input
+            aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
             className="ms-TextField-field field-44"

--- a/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
@@ -1850,7 +1850,6 @@ exports[`single fields radio field 1`] = `
     }
   >
     <div
-      aria-describedby="root__error root__description root__help"
       className=""
       id="root"
       name="root"
@@ -1871,6 +1870,7 @@ exports[`single fields radio field 1`] = `
               className="ms-ChoiceField-wrapper"
             >
               <input
+                aria-describedby="root__error root__description root__help"
                 checked={false}
                 className="ms-ChoiceField-input input-135"
                 disabled={false}
@@ -1901,6 +1901,7 @@ exports[`single fields radio field 1`] = `
               className="ms-ChoiceField-wrapper"
             >
               <input
+                aria-describedby="root__error root__description root__help"
                 checked={false}
                 className="ms-ChoiceField-input input-135"
                 disabled={false}

--- a/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
@@ -1993,13 +1993,13 @@ exports[`single fields schema examples 1`] = `
           className="ms-TextField-fieldGroup fieldGroup-43"
         >
           <input
-            aria-describedby="root__error root__description root__help"
+            aria-describedby="root__error root__description root__help root__examples"
             aria-invalid={false}
             autoFocus={false}
             className="ms-TextField-field field-44"
             disabled={false}
             id="root"
-            list="examples_root"
+            list="root__examples"
             name="root"
             onBlur={[Function]}
             onChange={[Function]}
@@ -2014,7 +2014,7 @@ exports[`single fields schema examples 1`] = `
       </div>
     </div>
     <datalist
-      id="examples_root"
+      id="root__examples"
     >
       <option
         value="Firefox"

--- a/packages/fluent-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Object.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`object fields additionalProperties 1`] = `
                 className="ms-TextField-fieldGroup fieldGroup-43"
               >
                 <input
+                  aria-describedby="root_foo__error root_foo__description root_foo__help"
                   aria-invalid={false}
                   aria-labelledby="TextFieldLabel11"
                   autoFocus={false}
@@ -165,6 +166,7 @@ exports[`object fields object 1`] = `
                 className="ms-TextField-fieldGroup fieldGroup-43"
               >
                 <input
+                  aria-describedby="root_a__error root_a__description root_a__help"
                   aria-invalid={false}
                   aria-labelledby="TextFieldLabel2"
                   autoFocus={false}
@@ -214,6 +216,7 @@ exports[`object fields object 1`] = `
                 className="ms-TextField-fieldGroup fieldGroup-43"
               >
                 <input
+                  aria-describedby="root_b__error root_b__description root_b__help"
                   aria-invalid={false}
                   aria-labelledby="TextFieldLabel5"
                   autoFocus={false}

--- a/packages/material-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/material-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import TextField, { TextFieldProps } from "@material-ui/core/TextField";
 import {
+  ariaDescribedByIds,
   getInputProps,
   FormContextType,
   RJSFSchema,
@@ -82,6 +83,7 @@ export default function BaseInputTemplate<
         onBlur={_onBlur}
         onFocus={_onFocus}
         {...(textFieldProps as TextFieldProps)}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
       {schema.examples && (
         <datalist id={`examples_${id}`}>

--- a/packages/material-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/material-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import TextField, { TextFieldProps } from "@material-ui/core/TextField";
 import {
   ariaDescribedByIds,
+  examplesId,
   getInputProps,
   FormContextType,
   RJSFSchema,
@@ -49,7 +50,7 @@ export default function BaseInputTemplate<
       step,
       min,
       max,
-      ...(schema.examples ? { list: `examples_${id}` } : undefined),
+      ...(schema.examples ? { list: examplesId<T>(id) } : undefined),
     },
     ...rest,
   };
@@ -83,10 +84,10 @@ export default function BaseInputTemplate<
         onBlur={_onBlur}
         onFocus={_onFocus}
         {...(textFieldProps as TextFieldProps)}
-        aria-describedby={ariaDescribedByIds<T>(id)}
+        aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
       />
       {schema.examples && (
-        <datalist id={`examples_${id}`}>
+        <datalist id={examplesId<T>(id)}>
           {(schema.examples as string[])
             .concat(schema.default ? ([schema.default] as string[]) : [])
             .map((example: any) => {

--- a/packages/material-ui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/material-ui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Checkbox from "@material-ui/core/Checkbox";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import {
+  ariaDescribedByIds,
   schemaRequiresTrueValue,
   FormContextType,
   RJSFSchema,
@@ -57,6 +58,7 @@ export default function CheckboxWidget<
           onChange={_onChange}
           onBlur={_onBlur}
           onFocus={_onFocus}
+          aria-describedby={ariaDescribedByIds<T>(id)}
         />
       }
       label={label || ""}

--- a/packages/material-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/material-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -4,6 +4,7 @@ import FormControlLabel from "@material-ui/core/FormControlLabel";
 import FormGroup from "@material-ui/core/FormGroup";
 import FormLabel from "@material-ui/core/FormLabel";
 import {
+  ariaDescribedByIds,
   enumOptionsDeselectValue,
   enumOptionsSelectValue,
   FormContextType,
@@ -79,6 +80,7 @@ export default function CheckboxesWidget<
                 onChange={_onChange(option)}
                 onBlur={_onBlur}
                 onFocus={_onFocus}
+                aria-describedby={ariaDescribedByIds<T>(id)}
               />
             );
             return (

--- a/packages/material-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/material-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -7,6 +7,7 @@ import {
   ariaDescribedByIds,
   enumOptionsDeselectValue,
   enumOptionsSelectValue,
+  optionId,
   FormContextType,
   WidgetProps,
   RJSFSchema,
@@ -72,7 +73,7 @@ export default function CheckboxesWidget<
               enumDisabled.indexOf(option.value) !== -1;
             const checkbox = (
               <Checkbox
-                id={`${id}-${option.value}`}
+                id={optionId<S>(id, option)}
                 name={id}
                 checked={checked}
                 disabled={disabled || itemDisabled || readonly}

--- a/packages/material-ui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/material-ui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -3,6 +3,7 @@ import ListItem from "@material-ui/core/ListItem";
 import FormHelperText from "@material-ui/core/FormHelperText";
 import List from "@material-ui/core/List";
 import {
+  errorId,
   FieldErrorProps,
   FormContextType,
   RJSFSchema,
@@ -22,7 +23,7 @@ export default function FieldErrorTemplate<
   if (errors.length === 0) {
     return null;
   }
-  const id = `${idSchema.$id}__error`;
+  const id = errorId<T>(idSchema);
 
   return (
     <List dense={true} disablePadding={true}>

--- a/packages/material-ui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/material-ui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import FormHelperText from "@material-ui/core/FormHelperText";
 import {
+  helpId,
   FieldHelpProps,
   FormContextType,
   RJSFSchema,
@@ -20,6 +21,6 @@ export default function FieldHelpTemplate<
   if (!help) {
     return null;
   }
-  const id = `${idSchema.$id}__help`;
+  const id = helpId<T>(idSchema);
   return <FormHelperText id={id}>{help}</FormHelperText>;
 }

--- a/packages/material-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/material-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -6,8 +6,10 @@ import {
   RJSFSchema,
   StrictRJSFSchema,
   canExpand,
+  descriptionId,
   getTemplate,
   getUiOptions,
+  titleId,
 } from "@rjsf/utils";
 
 /** The `ObjectFieldTemplate` is the template to use to render all the inner properties of an object along with the
@@ -55,7 +57,7 @@ export default function ObjectFieldTemplate<
     <>
       {(uiOptions.title || title) && (
         <TitleFieldTemplate
-          id={`${idSchema.$id}-title`}
+          id={titleId<T>(idSchema)}
           title={title}
           required={required}
           schema={schema}
@@ -65,7 +67,7 @@ export default function ObjectFieldTemplate<
       )}
       {(uiOptions.description || description) && (
         <DescriptionFieldTemplate
-          id={`${idSchema.$id}-description`}
+          id={descriptionId<T>(idSchema)}
           description={uiOptions.description || description!}
           schema={schema}
           uiSchema={uiSchema}

--- a/packages/material-ui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/material-ui/src/RadioWidget/RadioWidget.tsx
@@ -5,6 +5,7 @@ import Radio from "@material-ui/core/Radio";
 import RadioGroup from "@material-ui/core/RadioGroup";
 import {
   ariaDescribedByIds,
+  optionId,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -70,7 +71,7 @@ export default function RadioWidget<
                 control={
                   <Radio
                     name={id}
-                    id={`${id}-${option.value}`}
+                    id={optionId<S>(id, option)}
                     color="primary"
                   />
                 }

--- a/packages/material-ui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/material-ui/src/RadioWidget/RadioWidget.tsx
@@ -4,6 +4,7 @@ import FormLabel from "@material-ui/core/FormLabel";
 import Radio from "@material-ui/core/Radio";
 import RadioGroup from "@material-ui/core/RadioGroup";
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -57,6 +58,7 @@ export default function RadioWidget<
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       >
         {Array.isArray(enumOptions) &&
           enumOptions.map((option) => {

--- a/packages/material-ui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/material-ui/src/RangeWidget/RangeWidget.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import FormLabel from "@material-ui/core/FormLabel";
 import Slider from "@material-ui/core/Slider";
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -55,6 +56,7 @@ export default function RangeWidget<
         onFocus={_onFocus}
         valueLabelDisplay="auto"
         {...sliderProps}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
     </>
   );

--- a/packages/material-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/material-ui/src/SelectWidget/SelectWidget.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import MenuItem from "@material-ui/core/MenuItem";
 import TextField, { TextFieldProps } from "@material-ui/core/TextField";
 import {
+  ariaDescribedByIds,
   processSelectValue,
   FormContextType,
   RJSFSchema,
@@ -79,6 +80,7 @@ export default function SelectWidget<
         ...textFieldProps.SelectProps,
         multiple: typeof multiple === "undefined" ? false : multiple,
       }}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     >
       {(enumOptions as any).map(({ value, label }: any, i: number) => {
         const disabled: any =

--- a/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
@@ -150,6 +150,7 @@ exports[`array fields array icons 1`] = `
                           className="MuiFormControl-root MuiFormControl-fullWidth"
                         >
                           <div
+                            aria-describedby="root_0__error root_0__description root_0__help"
                             className="MuiFormControl-root MuiTextField-root"
                           >
                             <div
@@ -347,6 +348,7 @@ exports[`array fields array icons 1`] = `
                           className="MuiFormControl-root MuiFormControl-fullWidth"
                         >
                           <div
+                            aria-describedby="root_1__error root_1__description root_1__help"
                             className="MuiFormControl-root MuiTextField-root"
                           >
                             <div
@@ -617,6 +619,7 @@ exports[`array fields checkboxes 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div
@@ -734,6 +737,7 @@ exports[`array fields empty errors array 1`] = `
               className="MuiFormControl-root MuiFormControl-fullWidth"
             >
               <div
+                aria-describedby="root_name__error root_name__description root_name__help"
                 className="MuiFormControl-root MuiTextField-root"
               >
                 <label
@@ -853,6 +857,7 @@ exports[`array fields fixed array 1`] = `
                           className="MuiFormControl-root MuiFormControl-fullWidth"
                         >
                           <div
+                            aria-describedby="root_0__error root_0__description root_0__help"
                             className="MuiFormControl-root MuiTextField-root"
                           >
                             <div
@@ -911,6 +916,7 @@ exports[`array fields fixed array 1`] = `
                           className="MuiFormControl-root MuiFormControl-fullWidth"
                         >
                           <div
+                            aria-describedby="root_1__error root_1__description root_1__help"
                             className="MuiFormControl-root MuiTextField-root"
                           >
                             <div
@@ -1017,6 +1023,7 @@ exports[`array fields no errors 1`] = `
               className="MuiFormControl-root MuiFormControl-fullWidth"
             >
               <div
+                aria-describedby="root_name__error root_name__description root_name__help"
                 className="MuiFormControl-root MuiTextField-root"
               >
                 <label

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -1648,7 +1648,7 @@ exports[`single fields schema examples 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        aria-describedby="root__error root__description root__help"
+        aria-describedby="root__error root__description root__help root__examples"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div
@@ -1661,7 +1661,7 @@ exports[`single fields schema examples 1`] = `
             className="MuiInputBase-input MuiInput-input"
             disabled={false}
             id="root"
-            list="examples_root"
+            list="root__examples"
             name="root"
             onAnimationStart={[Function]}
             onBlur={[Function]}
@@ -1675,7 +1675,7 @@ exports[`single fields schema examples 1`] = `
         </div>
       </div>
       <datalist
-        id="examples_root"
+        id="root__examples"
       >
         <option
           value="Firefox"

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`single fields checkbox field 1`] = `
         className="MuiFormControlLabel-root"
       >
         <span
+          aria-describedby="root__error root__description root__help"
           aria-disabled={false}
           className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
           onBlur={[Function]}
@@ -112,6 +113,7 @@ exports[`single fields checkbox field with label 1`] = `
         className="MuiFormControlLabel-root"
       >
         <span
+          aria-describedby="root__error root__description root__help"
           aria-disabled={false}
           className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
           onBlur={[Function]}
@@ -222,6 +224,7 @@ exports[`single fields checkboxes field 1`] = `
           className="MuiFormControlLabel-root"
         >
           <span
+            aria-describedby="root__error root__description root__help"
             aria-disabled={false}
             className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
             onBlur={[Function]}
@@ -273,6 +276,7 @@ exports[`single fields checkboxes field 1`] = `
           className="MuiFormControlLabel-root"
         >
           <span
+            aria-describedby="root__error root__description root__help"
             aria-disabled={false}
             className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
             onBlur={[Function]}
@@ -324,6 +328,7 @@ exports[`single fields checkboxes field 1`] = `
           className="MuiFormControlLabel-root"
         >
           <span
+            aria-describedby="root__error root__description root__help"
             aria-disabled={false}
             className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
             onBlur={[Function]}
@@ -375,6 +380,7 @@ exports[`single fields checkboxes field 1`] = `
           className="MuiFormControlLabel-root"
         >
           <span
+            aria-describedby="root__error root__description root__help"
             aria-disabled={false}
             className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
             onBlur={[Function]}
@@ -491,6 +497,7 @@ exports[`single fields field with description 1`] = `
               className="MuiFormControl-root MuiFormControl-fullWidth"
             >
               <div
+                aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
                 className="MuiFormControl-root MuiTextField-root"
               >
                 <label
@@ -600,6 +607,7 @@ exports[`single fields field with description in uiSchema 1`] = `
               className="MuiFormControl-root MuiFormControl-fullWidth"
             >
               <div
+                aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
                 className="MuiFormControl-root MuiTextField-root"
               >
                 <label
@@ -689,6 +697,7 @@ exports[`single fields format color 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div
@@ -761,6 +770,7 @@ exports[`single fields format date 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div
@@ -830,6 +840,7 @@ exports[`single fields format datetime 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div
@@ -947,6 +958,7 @@ exports[`single fields help and error display 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div
@@ -1108,6 +1120,7 @@ exports[`single fields hidden label 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div
@@ -1226,6 +1239,7 @@ exports[`single fields number field 0 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div
@@ -1296,6 +1310,7 @@ exports[`single fields number field 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div
@@ -1369,6 +1384,7 @@ exports[`single fields password field 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div
@@ -1442,6 +1458,7 @@ exports[`single fields radio field 1`] = `
         htmlFor="root"
       />
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormGroup-root"
         id="root"
         onBlur={[Function]}
@@ -1631,6 +1648,7 @@ exports[`single fields schema examples 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div
@@ -1723,6 +1741,7 @@ exports[`single fields select field 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div
@@ -1825,6 +1844,7 @@ exports[`single fields slider field 1`] = `
         htmlFor="root"
       />
       <span
+        aria-describedby="root__error root__description root__help"
         className="MuiSlider-root MuiSlider-colorPrimary"
         id="root"
         label=""
@@ -1931,6 +1951,7 @@ exports[`single fields string field format data-url 1`] = `
       <div>
         <p>
           <input
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             defaultValue=""
             disabled={false}
@@ -1989,6 +2010,7 @@ exports[`single fields string field format email 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div
@@ -2061,6 +2083,7 @@ exports[`single fields string field format uri 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div
@@ -2130,6 +2153,7 @@ exports[`single fields string field regular 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div
@@ -2199,6 +2223,7 @@ exports[`single fields string field with placeholder 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div
@@ -2268,6 +2293,7 @@ exports[`single fields textarea field 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div
@@ -2338,7 +2364,7 @@ exports[`single fields title field 1`] = `
     >
       <div
         className="MuiBox-root MuiBox-root-37"
-        id="root-title"
+        id="root__title"
       >
         <h5
           className="MuiTypography-root MuiTypography-h5"
@@ -2372,6 +2398,7 @@ exports[`single fields title field 1`] = `
               className="MuiFormControl-root MuiFormControl-fullWidth"
             >
               <div
+                aria-describedby="root_title__error root_title__description root_title__help"
                 className="MuiFormControl-root MuiTextField-root"
               >
                 <label
@@ -2519,6 +2546,7 @@ exports[`single fields up/down field 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div
@@ -2591,6 +2619,7 @@ exports[`single fields using custom tagName 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root"
       >
         <div

--- a/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
@@ -72,6 +72,7 @@ exports[`object fields additionalProperties 1`] = `
                 className="MuiFormControl-root MuiFormControl-fullWidth"
               >
                 <div
+                  aria-describedby="root_foo__error root_foo__description root_foo__help"
                   className="MuiFormControl-root MuiTextField-root"
                 >
                   <label
@@ -274,6 +275,7 @@ exports[`object fields object 1`] = `
               className="MuiFormControl-root MuiFormControl-fullWidth"
             >
               <div
+                aria-describedby="root_a__error root_a__description root_a__help"
                 className="MuiFormControl-root MuiTextField-root"
               >
                 <label
@@ -324,6 +326,7 @@ exports[`object fields object 1`] = `
               className="MuiFormControl-root MuiFormControl-fullWidth"
             >
               <div
+                aria-describedby="root_b__error root_b__description root_b__help"
                 className="MuiFormControl-root MuiTextField-root"
               >
                 <label

--- a/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import TextField, { TextFieldProps } from "@mui/material/TextField";
 import {
   ariaDescribedByIds,
+  examplesId,
   getInputProps,
   FormContextType,
   RJSFSchema,
@@ -49,7 +50,7 @@ export default function BaseInputTemplate<
       step,
       min,
       max,
-      ...(schema.examples ? { list: `examples_${id}` } : undefined),
+      ...(schema.examples ? { list: examplesId<T>(id) } : undefined),
     },
     ...rest,
   };
@@ -83,10 +84,10 @@ export default function BaseInputTemplate<
         onBlur={_onBlur}
         onFocus={_onFocus}
         {...(textFieldProps as TextFieldProps)}
-        aria-describedby={ariaDescribedByIds<T>(id)}
+        aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
       />
       {schema.examples && (
-        <datalist id={`examples_${id}`}>
+        <datalist id={examplesId<T>(id)}>
           {(schema.examples as string[])
             .concat(schema.default ? ([schema.default] as string[]) : [])
             .map((example: any) => {

--- a/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import TextField, { TextFieldProps } from "@mui/material/TextField";
 import {
+  ariaDescribedByIds,
   getInputProps,
   FormContextType,
   RJSFSchema,
@@ -82,6 +83,7 @@ export default function BaseInputTemplate<
         onBlur={_onBlur}
         onFocus={_onFocus}
         {...(textFieldProps as TextFieldProps)}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
       {schema.examples && (
         <datalist id={`examples_${id}`}>

--- a/packages/mui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/mui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Checkbox from "@mui/material/Checkbox";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import {
+  ariaDescribedByIds,
   schemaRequiresTrueValue,
   FormContextType,
   RJSFSchema,
@@ -57,6 +58,7 @@ export default function CheckboxWidget<
           onChange={_onChange}
           onBlur={_onBlur}
           onFocus={_onFocus}
+          aria-describedby={ariaDescribedByIds<T>(id)}
         />
       }
       label={label || ""}

--- a/packages/mui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/mui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -4,6 +4,7 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import FormGroup from "@mui/material/FormGroup";
 import FormLabel from "@mui/material/FormLabel";
 import {
+  ariaDescribedByIds,
   enumOptionsDeselectValue,
   enumOptionsSelectValue,
   FormContextType,
@@ -79,6 +80,7 @@ export default function CheckboxesWidget<
                 onChange={_onChange(option)}
                 onBlur={_onBlur}
                 onFocus={_onFocus}
+                aria-describedby={ariaDescribedByIds<T>(id)}
               />
             );
             return (

--- a/packages/mui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/mui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -7,6 +7,7 @@ import {
   ariaDescribedByIds,
   enumOptionsDeselectValue,
   enumOptionsSelectValue,
+  optionId,
   FormContextType,
   WidgetProps,
   RJSFSchema,
@@ -72,7 +73,7 @@ export default function CheckboxesWidget<
               enumDisabled.indexOf(option.value) !== -1;
             const checkbox = (
               <Checkbox
-                id={`${id}-${option.value}`}
+                id={optionId<S>(id, option)}
                 name={id}
                 checked={checked}
                 disabled={disabled || itemDisabled || readonly}

--- a/packages/mui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/mui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -3,6 +3,7 @@ import ListItem from "@mui/material/ListItem";
 import FormHelperText from "@mui/material/FormHelperText";
 import List from "@mui/material/List";
 import {
+  errorId,
   FieldErrorProps,
   FormContextType,
   RJSFSchema,
@@ -22,7 +23,7 @@ export default function FieldErrorTemplate<
   if (errors.length === 0) {
     return null;
   }
-  const id = `${idSchema.$id}__error`;
+  const id = errorId<T>(idSchema);
 
   return (
     <List dense={true} disablePadding={true}>

--- a/packages/mui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/mui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import FormHelperText from "@mui/material/FormHelperText";
 import {
+  helpId,
   FieldHelpProps,
   FormContextType,
   RJSFSchema,
@@ -20,6 +21,6 @@ export default function FieldHelpTemplate<
   if (!help) {
     return null;
   }
-  const id = `${idSchema.$id}__help`;
+  const id = helpId<T>(idSchema);
   return <FormHelperText id={id}>{help}</FormHelperText>;
 }

--- a/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -6,8 +6,10 @@ import {
   RJSFSchema,
   StrictRJSFSchema,
   canExpand,
+  descriptionId,
   getTemplate,
   getUiOptions,
+  titleId,
 } from "@rjsf/utils";
 
 /** The `ObjectFieldTemplate` is the template to use to render all the inner properties of an object along with the
@@ -55,7 +57,7 @@ export default function ObjectFieldTemplate<
     <>
       {(uiOptions.title || title) && (
         <TitleFieldTemplate
-          id={`${idSchema.$id}-title`}
+          id={titleId<T>(idSchema)}
           title={title}
           required={required}
           schema={schema}
@@ -65,7 +67,7 @@ export default function ObjectFieldTemplate<
       )}
       {(uiOptions.description || description) && (
         <DescriptionFieldTemplate
-          id={`${idSchema.$id}-description`}
+          id={descriptionId<T>(idSchema)}
           description={uiOptions.description || description!}
           schema={schema}
           uiSchema={uiSchema}

--- a/packages/mui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/mui/src/RadioWidget/RadioWidget.tsx
@@ -4,6 +4,7 @@ import FormLabel from "@mui/material/FormLabel";
 import Radio from "@mui/material/Radio";
 import RadioGroup from "@mui/material/RadioGroup";
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -57,6 +58,7 @@ export default function RadioWidget<
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       >
         {Array.isArray(enumOptions) &&
           enumOptions.map((option) => {

--- a/packages/mui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/mui/src/RadioWidget/RadioWidget.tsx
@@ -5,6 +5,7 @@ import Radio from "@mui/material/Radio";
 import RadioGroup from "@mui/material/RadioGroup";
 import {
   ariaDescribedByIds,
+  optionId,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -70,7 +71,7 @@ export default function RadioWidget<
                 control={
                   <Radio
                     name={id}
-                    id={`${id}-${option.value}`}
+                    id={optionId<S>(id, option)}
                     color="primary"
                   />
                 }

--- a/packages/mui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/mui/src/RangeWidget/RangeWidget.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import FormLabel from "@mui/material/FormLabel";
 import Slider from "@mui/material/Slider";
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -55,6 +56,7 @@ export default function RangeWidget<
         onFocus={_onFocus}
         valueLabelDisplay="auto"
         {...sliderProps}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
     </>
   );

--- a/packages/mui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/mui/src/SelectWidget/SelectWidget.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import MenuItem from "@mui/material/MenuItem";
 import TextField, { TextFieldProps } from "@mui/material/TextField";
 import {
+  ariaDescribedByIds,
   processSelectValue,
   FormContextType,
   RJSFSchema,
@@ -79,6 +80,7 @@ export default function SelectWidget<
         ...textFieldProps.SelectProps,
         multiple: typeof multiple === "undefined" ? false : multiple,
       }}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     >
       {(enumOptions as any).map(({ value, label }: any, i: number) => {
         const disabled: any =

--- a/packages/mui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Array.test.tsx.snap
@@ -1196,6 +1196,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                         >
                           <div
+                            aria-describedby="root_0__error root_0__description root_0__help"
                             className="MuiFormControl-root MuiTextField-root emotion-10"
                           >
                             <div
@@ -1401,6 +1402,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                         >
                           <div
+                            aria-describedby="root_1__error root_1__description root_1__help"
                             className="MuiFormControl-root MuiTextField-root emotion-10"
                           >
                             <div
@@ -2067,6 +2069,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div
@@ -2672,6 +2675,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
             >
               <div
+                aria-describedby="root_name__error root_name__description root_name__help"
                 className="MuiFormControl-root MuiTextField-root emotion-4"
               >
                 <label
@@ -3249,6 +3253,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                         >
                           <div
+                            aria-describedby="root_0__error root_0__description root_0__help"
                             className="MuiFormControl-root MuiTextField-root emotion-10"
                           >
                             <div
@@ -3321,6 +3326,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                         >
                           <div
+                            aria-describedby="root_1__error root_1__description root_1__help"
                             className="MuiFormControl-root MuiTextField-root emotion-10"
                           >
                             <div
@@ -3902,6 +3908,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
             >
               <div
+                aria-describedby="root_name__error root_name__description root_name__help"
                 className="MuiFormControl-root MuiTextField-root emotion-4"
               >
                 <label

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -277,6 +277,7 @@ exports[`single fields checkbox field 1`] = `
         className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-1"
       >
         <span
+          aria-describedby="root__error root__description root__help"
           className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-2"
           onBlur={[Function]}
           onContextMenu={[Function]}
@@ -622,6 +623,7 @@ exports[`single fields checkbox field with label 1`] = `
         className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-1"
       >
         <span
+          aria-describedby="root__error root__description root__help"
           className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-2"
           onBlur={[Function]}
           onContextMenu={[Function]}
@@ -1018,6 +1020,7 @@ exports[`single fields checkboxes field 1`] = `
           className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
         >
           <span
+            aria-describedby="root__error root__description root__help"
             className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-4"
             onBlur={[Function]}
             onContextMenu={[Function]}
@@ -1069,6 +1072,7 @@ exports[`single fields checkboxes field 1`] = `
           className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
         >
           <span
+            aria-describedby="root__error root__description root__help"
             className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-4"
             onBlur={[Function]}
             onContextMenu={[Function]}
@@ -1120,6 +1124,7 @@ exports[`single fields checkboxes field 1`] = `
           className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
         >
           <span
+            aria-describedby="root__error root__description root__help"
             className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-4"
             onBlur={[Function]}
             onContextMenu={[Function]}
@@ -1171,6 +1176,7 @@ exports[`single fields checkboxes field 1`] = `
           className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
         >
           <span
+            aria-describedby="root__error root__description root__help"
             className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-root MuiCheckbox-colorPrimary emotion-4"
             onBlur={[Function]}
             onContextMenu={[Function]}
@@ -1773,6 +1779,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
             >
               <div
+                aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
                 className="MuiFormControl-root MuiTextField-root emotion-4"
               >
                 <label
@@ -2368,6 +2375,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
             >
               <div
+                aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
                 className="MuiFormControl-root MuiTextField-root emotion-4"
               >
                 <label
@@ -2791,6 +2799,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div
@@ -3190,6 +3199,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div
@@ -3598,6 +3608,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div
@@ -4245,6 +4256,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-9"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root emotion-10"
       >
         <div
@@ -4923,6 +4935,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-4:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <label
@@ -5488,6 +5501,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div
@@ -5897,6 +5911,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div
@@ -6297,6 +6312,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div
@@ -6703,6 +6719,7 @@ exports[`single fields radio field 1`] = `
         htmlFor="root"
       />
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormGroup-root emotion-2"
         id="root"
         onBlur={[Function]}
@@ -7192,6 +7209,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div
@@ -7685,6 +7703,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div
@@ -8142,6 +8161,7 @@ exports[`single fields slider field 1`] = `
         htmlFor="root"
       />
       <span
+        aria-describedby="root__error root__description root__help"
         className="MuiSlider-root MuiSlider-colorPrimary MuiSlider-sizeMedium emotion-2"
         id="root"
         label=""
@@ -8393,6 +8413,7 @@ exports[`single fields string field format data-url 1`] = `
       <div>
         <p>
           <input
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             defaultValue=""
             disabled={false}
@@ -8776,6 +8797,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div
@@ -9175,6 +9197,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div
@@ -9571,6 +9594,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div
@@ -9967,6 +9991,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div
@@ -10379,6 +10404,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div
@@ -10988,7 +11014,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-10:focus::-ms-input-
     >
       <div
         className="MuiBox-root emotion-1"
-        id="root-title"
+        id="root__title"
       >
         <h5
           className="MuiTypography-root MuiTypography-h5 emotion-2"
@@ -11022,6 +11048,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-10:focus::-ms-input-
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
             >
               <div
+                aria-describedby="root_title__error root_title__description root_title__help"
                 className="MuiFormControl-root MuiTextField-root emotion-7"
               >
                 <label
@@ -11619,6 +11646,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div
@@ -12030,6 +12058,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
+        aria-describedby="root__error root__description root__help"
         className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -7209,7 +7209,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        aria-describedby="root__error root__description root__help"
+        aria-describedby="root__error root__description root__help root__examples"
         className="MuiFormControl-root MuiTextField-root emotion-1"
       >
         <div
@@ -7222,7 +7222,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
             className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
             disabled={false}
             id="root"
-            list="examples_root"
+            list="root__examples"
             name="root"
             onAnimationStart={[Function]}
             onBlur={[Function]}
@@ -7250,7 +7250,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
         </div>
       </div>
       <datalist
-        id="examples_root"
+        id="root__examples"
       >
         <option
           value="Firefox"

--- a/packages/mui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Object.test.tsx.snap
@@ -938,6 +938,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
               >
                 <div
+                  aria-describedby="root_foo__error root_foo__description root_foo__help"
                   className="MuiFormControl-root MuiTextField-root emotion-13"
                 >
                   <label
@@ -1609,6 +1610,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
             >
               <div
+                aria-describedby="root_a__error root_a__description root_a__help"
                 className="MuiFormControl-root MuiTextField-root emotion-4"
               >
                 <label
@@ -1671,6 +1673,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
             >
               <div
+                aria-describedby="root_b__error root_b__description root_b__help"
                 className="MuiFormControl-root MuiTextField-root emotion-4"
               >
                 <label

--- a/packages/semantic-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/semantic-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -3,6 +3,7 @@ import { Form } from "semantic-ui-react";
 import { getSemanticProps } from "../util";
 import {
   ariaDescribedByIds,
+  examplesId,
   getInputProps,
   FormContextType,
   RJSFSchema,
@@ -68,17 +69,17 @@ export default function BaseInputTemplate<
         required={required}
         autoFocus={autofocus}
         disabled={disabled || readonly}
-        list={schema.examples ? `examples_${id}` : undefined}
+        list={schema.examples ? examplesId<T>(id) : undefined}
         {...semanticProps}
         value={value || value === 0 ? value : ""}
         error={rawErrors.length > 0}
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
-        aria-describedby={ariaDescribedByIds<T>(id)}
+        aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
       />
       {schema.examples && (
-        <datalist id={`examples_${id}`}>
+        <datalist id={examplesId<T>(id)}>
           {(schema.examples as string[])
             .concat(schema.default ? ([schema.default] as string[]) : [])
             .map((example) => {

--- a/packages/semantic-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/semantic-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Form } from "semantic-ui-react";
 import { getSemanticProps } from "../util";
 import {
+  ariaDescribedByIds,
   getInputProps,
   FormContextType,
   RJSFSchema,
@@ -74,6 +75,7 @@ export default function BaseInputTemplate<
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
       {schema.examples && (
         <datalist id={`examples_${id}`}>

--- a/packages/semantic-ui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/semantic-ui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  ariaDescribedByIds,
   schemaRequiresTrueValue,
   FormContextType,
   RJSFSchema,
@@ -68,6 +69,7 @@ export default function CheckboxWidget<
       onFocus={_onFocus}
       required={required}
       label={label || ""}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     />
   );
 }

--- a/packages/semantic-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/semantic-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { Form } from "semantic-ui-react";
 import {
-  EnumOptionsType,
-  FormContextType,
-  getTemplate,
-  RJSFSchema,
+  ariaDescribedByIds,
   enumOptionsDeselectValue,
   enumOptionsSelectValue,
+  getTemplate,
+  EnumOptionsType,
+  FormContextType,
+  RJSFSchema,
   StrictRJSFSchema,
   WidgetProps,
 } from "@rjsf/utils";
@@ -102,6 +103,7 @@ export default function CheckboxesWidget<
                 onChange={_onChange(option)}
                 onBlur={_onBlur}
                 onFocus={_onFocus}
+                aria-describedby={ariaDescribedByIds<T>(id)}
               />
             );
           })}

--- a/packages/semantic-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/semantic-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -5,6 +5,8 @@ import {
   enumOptionsDeselectValue,
   enumOptionsSelectValue,
   getTemplate,
+  optionId,
+  titleId,
   EnumOptionsType,
   FormContextType,
   RJSFSchema,
@@ -75,7 +77,7 @@ export default function CheckboxesWidget<
     <>
       {title && (
         <TitleFieldTemplate
-          id={`${id}-title`}
+          id={titleId<T>(id)}
           title={title}
           schema={schema}
           uiSchema={uiSchema}
@@ -91,7 +93,7 @@ export default function CheckboxesWidget<
               enumDisabled.indexOf(option.value) !== -1;
             return (
               <Form.Checkbox
-                id={`${id}-${option.value}`}
+                id={optionId<S>(id, option)}
                 name={id}
                 key={option.value}
                 label={option.label}

--- a/packages/semantic-ui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/semantic-ui/src/FieldTemplate/FieldTemplate.tsx
@@ -4,6 +4,7 @@ import {
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
+  descriptionId,
   getTemplate,
   getUiOptions,
 } from "@rjsf/utils";
@@ -74,7 +75,7 @@ export default function FieldTemplate<
             <MaybeWrap wrap={wrapLabel} className="sui-field-label">
               {rawDescription && (
                 <DescriptionFieldTemplate
-                  id={`${id}-description`}
+                  id={descriptionId<T>(id)}
                   description={rawDescription}
                   schema={schema}
                   uiSchema={uiSchema}

--- a/packages/semantic-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/semantic-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -6,8 +6,10 @@ import {
   RJSFSchema,
   StrictRJSFSchema,
   canExpand,
+  descriptionId,
   getTemplate,
   getUiOptions,
+  titleId,
 } from "@rjsf/utils";
 
 /** The `ObjectFieldTemplate` is the template to use to render all the inner properties of an object along with the
@@ -57,7 +59,7 @@ export default function ObjectFieldTemplate<
     <>
       {fieldTitle && (
         <TitleFieldTemplate
-          id={`${idSchema.$id}-title`}
+          id={titleId<T>(idSchema)}
           title={fieldTitle}
           required={required}
           schema={schema}
@@ -67,7 +69,7 @@ export default function ObjectFieldTemplate<
       )}
       {fieldDescription && (
         <DescriptionFieldTemplate
-          id={`${idSchema.$id}-description`}
+          id={descriptionId<T>(idSchema)}
           description={fieldDescription}
           schema={schema}
           uiSchema={uiSchema}

--- a/packages/semantic-ui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/semantic-ui/src/RadioWidget/RadioWidget.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -75,6 +76,7 @@ export default function RadioWidget<
               checked={value == option.value}
               onChange={_onChange}
               disabled={disabled || itemDisabled || readonly}
+              aria-describedby={ariaDescribedByIds<T>(id)}
             />
           );
         })}

--- a/packages/semantic-ui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/semantic-ui/src/RadioWidget/RadioWidget.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   ariaDescribedByIds,
+  optionId,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -64,7 +65,7 @@ export default function RadioWidget<
             <Form.Field
               required={required}
               control={Radio}
-              id={`${id}-${option.value}`}
+              id={optionId<S>(id, option)}
               name={id}
               {...semanticProps}
               onFocus={_onFocus}

--- a/packages/semantic-ui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/semantic-ui/src/RangeWidget/RangeWidget.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Input } from "semantic-ui-react";
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -67,6 +68,7 @@ export default function RangeWidget<
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
+        aria-describedby={ariaDescribedByIds<T>(id)}
       />
       <span>{value}</span>
     </>

--- a/packages/semantic-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/semantic-ui/src/SelectWidget/SelectWidget.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  ariaDescribedByIds,
   EnumOptionsType,
   processSelectValue,
   FormContextType,
@@ -117,6 +118,7 @@ export default function SelectWidget<
       onChange={_onChange}
       onBlur={_onBlur}
       onFocus={_onFocus}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     />
   );
 }

--- a/packages/semantic-ui/src/TextareaWidget/TextareaWidget.tsx
+++ b/packages/semantic-ui/src/TextareaWidget/TextareaWidget.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  ariaDescribedByIds,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
@@ -67,6 +68,7 @@ export default function TextareaWidget<
       onChange={_onChange}
       onBlur={_onBlur}
       onFocus={_onFocus}
+      aria-describedby={ariaDescribedByIds<T>(id)}
     />
   );
 }

--- a/packages/semantic-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Array.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`array fields array icons 1`] = `
                           className="ui fluid input"
                         >
                           <input
-                            aria-describedby={null}
+                            aria-describedby="root_0__error root_0__description root_0__help"
                             autoFocus={false}
                             disabled={false}
                             id="root_0"
@@ -194,7 +194,7 @@ exports[`array fields array icons 1`] = `
                           className="ui fluid input"
                         >
                           <input
-                            aria-describedby={null}
+                            aria-describedby="root_1__error root_1__description root_1__help"
                             autoFocus={false}
                             disabled={false}
                             id="root_1"
@@ -310,7 +310,7 @@ exports[`array fields checkboxes 1`] = `
         className="field"
       >
         <div
-          aria-describedby={null}
+          aria-describedby="root__error root__description root__help"
           aria-disabled={false}
           aria-expanded={false}
           aria-multiselectable={true}
@@ -442,7 +442,7 @@ exports[`array fields empty errors array 1`] = `
               className="ui fluid input"
             >
               <input
-                aria-describedby={null}
+                aria-describedby="root_name__error root_name__description root_name__help"
                 autoFocus={false}
                 disabled={false}
                 id="root_name"
@@ -519,7 +519,7 @@ exports[`array fields fixed array 1`] = `
                           className="ui fluid input"
                         >
                           <input
-                            aria-describedby={null}
+                            aria-describedby="root_0__error root_0__description root_0__help"
                             autoFocus={false}
                             disabled={false}
                             id="root_0"
@@ -569,7 +569,7 @@ exports[`array fields fixed array 1`] = `
                           className="ui fluid input"
                         >
                           <input
-                            aria-describedby={null}
+                            aria-describedby="root_1__error root_1__description root_1__help"
                             autoFocus={false}
                             disabled={false}
                             id="root_1"
@@ -637,7 +637,7 @@ exports[`array fields no errors 1`] = `
               className="ui fluid input"
             >
               <input
-                aria-describedby={null}
+                aria-describedby="root_name__error root_name__description root_name__help"
                 autoFocus={false}
                 disabled={false}
                 id="root_name"

--- a/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`single fields checkbox field 1`] = `
           onMouseUp={[Function]}
         >
           <input
-            aria-describedby={null}
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             checked={false}
             className="hidden"
@@ -83,7 +83,7 @@ exports[`single fields checkbox field with label 1`] = `
           onMouseUp={[Function]}
         >
           <input
-            aria-describedby={null}
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             checked={false}
             className="hidden"
@@ -145,7 +145,7 @@ exports[`single fields checkboxes field 1`] = `
             onMouseUp={[Function]}
           >
             <input
-              aria-describedby={null}
+              aria-describedby="root__error root__description root__help"
               autoFocus={false}
               checked={false}
               className="hidden"
@@ -177,7 +177,7 @@ exports[`single fields checkboxes field 1`] = `
             onMouseUp={[Function]}
           >
             <input
-              aria-describedby={null}
+              aria-describedby="root__error root__description root__help"
               autoFocus={false}
               checked={false}
               className="hidden"
@@ -209,7 +209,7 @@ exports[`single fields checkboxes field 1`] = `
             onMouseUp={[Function]}
           >
             <input
-              aria-describedby={null}
+              aria-describedby="root__error root__description root__help"
               autoFocus={false}
               checked={false}
               className="hidden"
@@ -241,7 +241,7 @@ exports[`single fields checkboxes field 1`] = `
             onMouseUp={[Function]}
           >
             <input
-              aria-describedby={null}
+              aria-describedby="root__error root__description root__help"
               autoFocus={false}
               checked={false}
               className="hidden"
@@ -304,7 +304,7 @@ exports[`single fields field with description 1`] = `
               className="ui fluid input"
             >
               <input
-                aria-describedby={null}
+                aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
                 autoFocus={false}
                 disabled={false}
                 id="root_my-field"
@@ -370,7 +370,7 @@ exports[`single fields field with description in uiSchema 1`] = `
               className="ui fluid input"
             >
               <input
-                aria-describedby={null}
+                aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
                 autoFocus={false}
                 disabled={false}
                 id="root_my-field"
@@ -419,13 +419,13 @@ exports[`single fields field with special semantic options 1`] = `
     >
       <h5
         className="ui dividing header"
-        id="root-title"
+        id="root__title"
       >
         A registration form
       </h5>
       <p
         className="sui-description"
-        id="root-description"
+        id="root__description"
       >
         A simple test theme form example.
       </p>
@@ -444,7 +444,7 @@ exports[`single fields field with special semantic options 1`] = `
               test
             </label>
             <div
-              aria-describedby={null}
+              aria-describedby="root_test__error root_test__description root_test__help"
               aria-disabled={false}
               aria-expanded={false}
               aria-multiselectable={false}
@@ -574,7 +574,7 @@ exports[`single fields format color 1`] = `
           className="ui fluid input"
         >
           <input
-            aria-describedby={null}
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             disabled={false}
             id="root"
@@ -620,7 +620,7 @@ exports[`single fields format date 1`] = `
           className="ui fluid input"
         >
           <input
-            aria-describedby={null}
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             disabled={false}
             id="root"
@@ -666,7 +666,7 @@ exports[`single fields format datetime 1`] = `
           className="ui fluid input"
         >
           <input
-            aria-describedby={null}
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             disabled={false}
             id="root"
@@ -730,7 +730,7 @@ exports[`single fields help and error display 1`] = `
           className="ui fluid input"
         >
           <input
-            aria-describedby="root-error-message"
+            aria-describedby="root__error root__description root__help"
             aria-invalid={true}
             autoFocus={false}
             disabled={false}
@@ -846,7 +846,7 @@ exports[`single fields hidden label 1`] = `
           className="ui fluid input"
         >
           <input
-            aria-describedby={null}
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             disabled={false}
             id="root"
@@ -916,7 +916,7 @@ exports[`single fields number field 0 1`] = `
           className="ui fluid input"
         >
           <input
-            aria-describedby={null}
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             disabled={false}
             id="root"
@@ -963,7 +963,7 @@ exports[`single fields number field 1`] = `
           className="ui fluid input"
         >
           <input
-            aria-describedby={null}
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             disabled={false}
             id="root"
@@ -1010,7 +1010,7 @@ exports[`single fields password field 1`] = `
           className="ui fluid input"
         >
           <input
-            aria-describedby={null}
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             disabled={false}
             id="root"
@@ -1067,7 +1067,7 @@ exports[`single fields radio field 1`] = `
             onMouseUp={[Function]}
           >
             <input
-              aria-describedby={null}
+              aria-describedby="root__error root__description root__help"
               checked={false}
               className="hidden"
               disabled={false}
@@ -1100,7 +1100,7 @@ exports[`single fields radio field 1`] = `
             onMouseUp={[Function]}
           >
             <input
-              aria-describedby={null}
+              aria-describedby="root__error root__description root__help"
               checked={false}
               className="hidden"
               disabled={false}
@@ -1151,7 +1151,7 @@ exports[`single fields schema examples 1`] = `
           className="ui fluid input"
         >
           <input
-            aria-describedby={null}
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             disabled={false}
             id="root"
@@ -1214,7 +1214,7 @@ exports[`single fields select field 1`] = `
         className="field"
       >
         <div
-          aria-describedby={null}
+          aria-describedby="root__error root__description root__help"
           aria-disabled={false}
           aria-expanded={false}
           aria-multiselectable={false}
@@ -1319,6 +1319,7 @@ exports[`single fields slider field 1`] = `
         className="ui fluid input"
       >
         <input
+          aria-describedby="root__error root__description root__help"
           disabled={false}
           id="root"
           max={100}
@@ -1362,6 +1363,7 @@ exports[`single fields string field format data-url 1`] = `
       <div>
         <p>
           <input
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             defaultValue=""
             disabled={false}
@@ -1404,7 +1406,7 @@ exports[`single fields string field format email 1`] = `
           className="ui fluid input"
         >
           <input
-            aria-describedby={null}
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             disabled={false}
             id="root"
@@ -1450,7 +1452,7 @@ exports[`single fields string field format uri 1`] = `
           className="ui fluid input"
         >
           <input
-            aria-describedby={null}
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             disabled={false}
             id="root"
@@ -1496,7 +1498,7 @@ exports[`single fields string field regular 1`] = `
           className="ui fluid input"
         >
           <input
-            aria-describedby={null}
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             disabled={false}
             id="root"
@@ -1542,7 +1544,7 @@ exports[`single fields string field with placeholder 1`] = `
           className="ui fluid input"
         >
           <input
-            aria-describedby={null}
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             disabled={false}
             id="root"
@@ -1585,7 +1587,7 @@ exports[`single fields textarea field 1`] = `
         className="field"
       >
         <textarea
-          aria-describedby={null}
+          aria-describedby="root__error root__description root__help"
           autoFocus={false}
           disabled={false}
           id="root"
@@ -1627,7 +1629,7 @@ exports[`single fields title field 1`] = `
     >
       <h5
         className="ui dividing header"
-        id="root-title"
+        id="root__title"
       >
         Titre 1
       </h5>
@@ -1649,7 +1651,7 @@ exports[`single fields title field 1`] = `
               className="ui fluid input"
             >
               <input
-                aria-describedby={null}
+                aria-describedby="root_title__error root_title__description root_title__help"
                 autoFocus={false}
                 disabled={false}
                 id="root_title"
@@ -1745,7 +1747,7 @@ exports[`single fields up/down field 1`] = `
           className="ui fluid input"
         >
           <input
-            aria-describedby={null}
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             disabled={false}
             id="root"
@@ -1791,7 +1793,7 @@ exports[`single fields using custom tagName 1`] = `
           className="ui fluid input"
         >
           <input
-            aria-describedby={null}
+            aria-describedby="root__error root__description root__help"
             autoFocus={false}
             disabled={false}
             id="root"

--- a/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
@@ -321,7 +321,7 @@ exports[`single fields field with description 1`] = `
           </div>
           <p
             className="sui-description"
-            id="root_my-field-description"
+            id="root_my-field__description"
           >
             some description
           </p>
@@ -387,7 +387,7 @@ exports[`single fields field with description in uiSchema 1`] = `
           </div>
           <p
             className="sui-description"
-            id="root_my-field-description"
+            id="root_my-field__description"
           >
             some other description
           </p>
@@ -1151,11 +1151,11 @@ exports[`single fields schema examples 1`] = `
           className="ui fluid input"
         >
           <input
-            aria-describedby="root__error root__description root__help"
+            aria-describedby="root__error root__description root__help root__examples"
             autoFocus={false}
             disabled={false}
             id="root"
-            list="examples_root"
+            list="root__examples"
             name="root"
             onBlur={[Function]}
             onChange={[Function]}
@@ -1167,7 +1167,7 @@ exports[`single fields schema examples 1`] = `
         </div>
       </div>
       <datalist
-        id="examples_root"
+        id="root__examples"
       >
         <option
           value="Firefox"

--- a/packages/semantic-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Object.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`object fields additionalProperties 1`] = `
                     className="ui fluid input"
                   >
                     <input
-                      aria-describedby={null}
+                      aria-describedby="root_foo__error root_foo__description root_foo__help"
                       autoFocus={false}
                       disabled={false}
                       id="root_foo"
@@ -182,7 +182,7 @@ exports[`object fields object 1`] = `
               className="ui fluid input"
             >
               <input
-                aria-describedby={null}
+                aria-describedby="root_a__error root_a__description root_a__help"
                 autoFocus={false}
                 disabled={false}
                 id="root_a"
@@ -218,7 +218,7 @@ exports[`object fields object 1`] = `
               className="ui fluid input"
             >
               <input
-                aria-describedby={null}
+                aria-describedby="root_b__error root_b__description root_b__help"
                 autoFocus={false}
                 disabled={false}
                 id="root_b"

--- a/packages/utils/src/idGenerators.ts
+++ b/packages/utils/src/idGenerators.ts
@@ -1,6 +1,11 @@
 import isString from "lodash/isString";
 
-import { IdSchema } from "./types";
+import {
+  EnumOptionsType,
+  IdSchema,
+  RJSFSchema,
+  StrictRJSFSchema,
+} from "./types";
 import { ID_KEY } from "./constants";
 
 /** Generates a consistent `id` pattern for a given `id` and a `suffix`
@@ -30,6 +35,15 @@ export function errorId<T = any>(id: IdSchema<T> | string) {
   return idGenerator<T>(id, "error");
 }
 
+/** Return a consistent `id` for the field examples element
+ *
+ * @param id - Either simple string id or an IdSchema from which to extract it
+ * @returns - The consistent id for the field examples element from the given `id`
+ */
+export function examplesId<T = any>(id: IdSchema<T> | string) {
+  return idGenerator<T>(id, "examples");
+}
+
 /** Return a consistent `id` for the field help element
  *
  * @param id - Either simple string id or an IdSchema from which to extract it
@@ -49,11 +63,32 @@ export function titleId<T = any>(id: IdSchema<T> | string) {
 }
 
 /** Return a list of element ids that contain additional information about the field that can be used to as the aria
- * description of the field
+ * description of the field. This is correctly omitting `titleId` which would be "labeling" rather than "describing" the
+ * element.
  *
  * @param id - Either simple string id or an IdSchema from which to extract it
+ * @param [includeExamples=false] - Optional flag, if true, will add the `examplesId` into the list
  * @returns - The string containing the list of ids for use in an `aria-describedBy` attribute
  */
-export function ariaDescribedByIds<T = any>(id: IdSchema<T> | string) {
-  return `${errorId(id)} ${descriptionId(id)} ${helpId(id)}`;
+export function ariaDescribedByIds<T = any>(
+  id: IdSchema<T> | string,
+  includeExamples = false
+) {
+  const examples = includeExamples ? ` ${examplesId<T>(id)}` : "";
+  return `${errorId<T>(id)} ${descriptionId<T>(id)} ${helpId<T>(
+    id
+  )}${examples}`;
+}
+
+/** Return a consistent `id` for the `option`s of a `Radio` or `Checkboxes` widget
+ *
+ * @param id - The id of the parent component for the option
+ * @param option - The option for which the id is desired
+ * @returns - An id for the option based on the parent `id`
+ */
+export function optionId<S extends StrictRJSFSchema = RJSFSchema>(
+  id: string,
+  option: EnumOptionsType<S>
+) {
+  return `${id}-${option.value}`;
 }

--- a/packages/utils/src/idGenerators.ts
+++ b/packages/utils/src/idGenerators.ts
@@ -1,0 +1,59 @@
+import isString from "lodash/isString";
+
+import { IdSchema } from "./types";
+import { ID_KEY } from "./constants";
+
+/** Generates a consistent `id` pattern for a given `id` and a `suffix`
+ *
+ * @param id - Either simple string id or an IdSchema from which to extract it
+ * @param suffix - The suffix to append to the id
+ */
+function idGenerator<T = any>(id: IdSchema<T> | string, suffix: string) {
+  const theId = isString(id) ? id : id[ID_KEY];
+  return `${theId}__${suffix}`;
+}
+/** Return a consistent `id` for the field description element
+ *
+ * @param id - Either simple string id or an IdSchema from which to extract it
+ * @returns - The consistent id for the field description element from the given `id`
+ */
+export function descriptionId<T = any>(id: IdSchema<T> | string) {
+  return idGenerator<T>(id, "description");
+}
+
+/** Return a consistent `id` for the field error element
+ *
+ * @param id - Either simple string id or an IdSchema from which to extract it
+ * @returns - The consistent id for the field error element from the given `id`
+ */
+export function errorId<T = any>(id: IdSchema<T> | string) {
+  return idGenerator<T>(id, "error");
+}
+
+/** Return a consistent `id` for the field help element
+ *
+ * @param id - Either simple string id or an IdSchema from which to extract it
+ * @returns - The consistent id for the field help element from the given `id`
+ */
+export function helpId<T = any>(id: IdSchema<T> | string) {
+  return idGenerator<T>(id, "help");
+}
+
+/** Return a consistent `id` for the field title element
+ *
+ * @param id - Either simple string id or an IdSchema from which to extract it
+ * @returns - The consistent id for the field title element from the given `id`
+ */
+export function titleId<T = any>(id: IdSchema<T> | string) {
+  return idGenerator<T>(id, "title");
+}
+
+/** Return a list of element ids that contain additional information about the field that can be used to as the aria
+ * description of the field
+ *
+ * @param id - Either simple string id or an IdSchema from which to extract it
+ * @returns - The string containing the list of ids for use in an `aria-describedBy` attribute
+ */
+export function ariaDescribedByIds<T = any>(id: IdSchema<T> | string) {
+  return `${errorId(id)} ${descriptionId(id)} ${helpId(id)}`;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -20,7 +20,9 @@ import {
   ariaDescribedByIds,
   descriptionId,
   errorId,
+  examplesId,
   helpId,
+  optionId,
   titleId,
 } from "./idGenerators";
 import isConstant from "./isConstant";
@@ -60,6 +62,7 @@ export {
   enumOptionsDeselectValue,
   enumOptionsSelectValue,
   errorId,
+  examplesId,
   ErrorSchemaBuilder,
   findSchemaDefinition,
   getInputProps,
@@ -79,6 +82,7 @@ export {
   mergeDefaultsWithFormData,
   mergeObjects,
   mergeSchemas,
+  optionId,
   optionsList,
   orderProperties,
   pad,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -16,6 +16,13 @@ import getUiOptions from "./getUiOptions";
 import getWidget from "./getWidget";
 import guessType from "./guessType";
 import hasWidget from "./hasWidget";
+import {
+  ariaDescribedByIds,
+  descriptionId,
+  errorId,
+  helpId,
+  titleId,
+} from "./idGenerators";
 import isConstant from "./isConstant";
 import isCustomWidget from "./isCustomWidget";
 import isFixedItems from "./isFixedItems";
@@ -43,13 +50,16 @@ export * from "./schema";
 
 export {
   allowAdditionalItems,
+  ariaDescribedByIds,
   asNumber,
   canExpand,
   createSchemaUtils,
   dataURItoBlob,
   deepEquals,
+  descriptionId,
   enumOptionsDeselectValue,
   enumOptionsSelectValue,
+  errorId,
   ErrorSchemaBuilder,
   findSchemaDefinition,
   getInputProps,
@@ -60,6 +70,7 @@ export {
   getWidget,
   guessType,
   hasWidget,
+  helpId,
   isConstant,
   isCustomWidget,
   isFixedItems,
@@ -76,6 +87,7 @@ export {
   rangeSpec,
   schemaRequiresTrueValue,
   shouldRender,
+  titleId,
   toConstant,
   toDateString,
   utcToLocal,

--- a/packages/utils/test/idGenerators.test.ts
+++ b/packages/utils/test/idGenerators.test.ts
@@ -1,0 +1,50 @@
+import {
+  IdSchema,
+  ID_KEY,
+  ariaDescribedByIds,
+  descriptionId,
+  errorId,
+  helpId,
+  titleId,
+} from "../src";
+
+const SIMPLE_ID = "simpleID";
+const SCHEMA_ID = "test";
+const ID_SCHEMA: IdSchema = { [ID_KEY]: SCHEMA_ID } as IdSchema;
+
+describe("idGenerators", () => {
+  it("description id is generated for simple id", () => {
+    expect(descriptionId(SIMPLE_ID)).toEqual(`${SIMPLE_ID}__description`);
+  });
+  it("description id is generated for IdSchema", () => {
+    expect(descriptionId(ID_SCHEMA)).toEqual(`${SCHEMA_ID}__description`);
+  });
+  it("error id is generated for simple id", () => {
+    expect(errorId(SIMPLE_ID)).toEqual(`${SIMPLE_ID}__error`);
+  });
+  it("error id is generated for IdSchema", () => {
+    expect(errorId(ID_SCHEMA)).toEqual(`${SCHEMA_ID}__error`);
+  });
+  it("help id is generated for simple id", () => {
+    expect(helpId(SIMPLE_ID)).toEqual(`${SIMPLE_ID}__help`);
+  });
+  it("help id is generated for IdSchema", () => {
+    expect(helpId(ID_SCHEMA)).toEqual(`${SCHEMA_ID}__help`);
+  });
+  it("title id is generated for simple id", () => {
+    expect(titleId(SIMPLE_ID)).toEqual(`${SIMPLE_ID}__title`);
+  });
+  it("title id is generated for IdSchema", () => {
+    expect(titleId(ID_SCHEMA)).toEqual(`${SCHEMA_ID}__title`);
+  });
+  it("ariaDescribedBy ids are generated for simple id", () => {
+    expect(ariaDescribedByIds(SIMPLE_ID)).toEqual(
+      `${SIMPLE_ID}__error ${SIMPLE_ID}__description ${SIMPLE_ID}__help`
+    );
+  });
+  it("ariaDescribedBy ids are generated for IdSchema", () => {
+    expect(ariaDescribedByIds(ID_SCHEMA)).toEqual(
+      `${SCHEMA_ID}__error ${SCHEMA_ID}__description ${SCHEMA_ID}__help`
+    );
+  });
+});

--- a/packages/utils/test/idGenerators.test.ts
+++ b/packages/utils/test/idGenerators.test.ts
@@ -1,16 +1,23 @@
 import {
   IdSchema,
+  EnumOptionsType,
   ID_KEY,
   ariaDescribedByIds,
   descriptionId,
   errorId,
+  examplesId,
   helpId,
+  optionId,
   titleId,
 } from "../src";
 
 const SIMPLE_ID = "simpleID";
 const SCHEMA_ID = "test";
 const ID_SCHEMA: IdSchema = { [ID_KEY]: SCHEMA_ID } as IdSchema;
+const OPTION: EnumOptionsType = {
+  label: "Foo",
+  value: "foo",
+};
 
 describe("idGenerators", () => {
   it("description id is generated for simple id", () => {
@@ -24,6 +31,12 @@ describe("idGenerators", () => {
   });
   it("error id is generated for IdSchema", () => {
     expect(errorId(ID_SCHEMA)).toEqual(`${SCHEMA_ID}__error`);
+  });
+  it("examples id is generated for simple id", () => {
+    expect(examplesId(SIMPLE_ID)).toEqual(`${SIMPLE_ID}__examples`);
+  });
+  it("examples id is generated for IdSchema", () => {
+    expect(examplesId(ID_SCHEMA)).toEqual(`${SCHEMA_ID}__examples`);
   });
   it("help id is generated for simple id", () => {
     expect(helpId(SIMPLE_ID)).toEqual(`${SIMPLE_ID}__help`);
@@ -46,5 +59,18 @@ describe("idGenerators", () => {
     expect(ariaDescribedByIds(ID_SCHEMA)).toEqual(
       `${SCHEMA_ID}__error ${SCHEMA_ID}__description ${SCHEMA_ID}__help`
     );
+  });
+  it("ariaDescribedBy ids are generated for simple id with examples", () => {
+    expect(ariaDescribedByIds(SIMPLE_ID, true)).toEqual(
+      `${SIMPLE_ID}__error ${SIMPLE_ID}__description ${SIMPLE_ID}__help ${SIMPLE_ID}__examples`
+    );
+  });
+  it("ariaDescribedBy ids are generated for IdSchema with examples", () => {
+    expect(ariaDescribedByIds(ID_SCHEMA, true)).toEqual(
+      `${SCHEMA_ID}__error ${SCHEMA_ID}__description ${SCHEMA_ID}__help ${SCHEMA_ID}__examples`
+    );
+  });
+  it("optionId generates the proper id for an option", () => {
+    expect(optionId(SIMPLE_ID, OPTION)).toEqual(`${SIMPLE_ID}-${OPTION.value}`);
   });
 });


### PR DESCRIPTION
### Reasons for making this change

Fixes #959 by reimplementing #2386 making it consistent across all themes

- In `@rjsf/utils`, added new `descriptionId()`, `errorId()`, `examplesId()`, `helpId()`, `optionId()`, `titleId()` and `ariaDescribedByIds()` functions with unit tests
- In all themes:
  - Updated the `FieldErrorTemplate` to use the `errorId()` function to generate its id
  - Updated the `FieldHelpTemplate` to use the `helpId()` function to generate its id
  - Updated the `ObjectFieldTemplate` to use the `titleId()` and `descriptionId()` functions to generate the ids for the `TitleFieldTemplate` and `DescriptionFieldTemplate` respectively
  - Updated the `CheckboxesWidget` and `RadioWidget` to use the `optionId()` function
  - Updated the `BaseInputTemplate` to pass the `ariaDescribedByIds()` value to `aria-describedby` on the "input" component
    - Also used the `examplesId()` passing in true to `ariaDescribedByIds()` when the schema has examples
  - For all the widgets that generated a user-accessible "input", passed in the `ariaDescribedByIds()` call into the `aria-describedby` on the "input" component
- Updated all the test snapshots to update the `title`, `examples` and `description` ids to the new values and to add the new `aria-describeby` properties
- Updated the documentation to indicate the existance of these new functions
- Updated the `5.x migration guide` to document the potential change of ids for Title, Description and `RadioWidget` and `CheckboxWidget`
  - Also fixed the incorrectly named `__error` to be `__errors` in the `ErrorSchema` examples
- Updated the `CHANGELOG.md` accordingly

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
