### PR TITLE
fix: Reimplement #2548 to fix #2262

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,15 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
-# 5.0.0-beta-18
+# 5.0.0-beta.19
+
+## @rjsf/core
+- Updated `MultiSchemaField` to cache options with refs in state and to output better labels for options without them when a title is available in either the `schema` or `uiSchema`
+
+## @rjsf/utils
+- Updated `toPathSchema()` to handle `oneOf`/`anyOf` by picking the closest option and generating the path for it, fixing [#2262](https://github.com/rjsf-team/react-jsonschema-form/issues/2262)
+
+# 5.0.0-beta.18
 
 ## @rjsf/core
 - Updated `MultiSchemaField` to utilize the new `getClosestMatchingOption()` and `sanitizeDataForNewSchema()` functions, fixing the following issues:
@@ -57,7 +65,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated the documentation for `utility-functions` and the `5.x upgrade guide` to add the new utility functions and to document the deprecation of `getMatchingOption()`
   - Also updated `utility-functions`, making all optional parameters without a default (as denoted by the syntax `[<parameter>]: <type>`) to add ` | undefined` onto the type to make it clear it supports passing in undefined as a value.
 
-# 5.0.0-beta-17
+# 5.0.0-beta.17
 
 ## @rjsf/antd
 - Enable searching in the `SelectWidget` by the label that the user sees rather than by the value
@@ -128,7 +136,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated the `utility-functions` documentation to add the new `enumOptionsDeselectValue()` and `enumOptionsSelectValue()` functions and to describe the new id generator functions
 - Updated the `5.x migration guide` documentation to describe potential breaking `id` changes
 
-# 5.0.0-beta-16
+# 5.0.0-beta.16
 
 ## @rjsf/antd
 - Updated the usage of the `ButtonTemplates` to pass the new required `registry` prop, filtering it out in the actual implementations before spreading props, fixing - [#3314](https://github.com/rjsf-team/react-jsonschema-form/issues/3314)
@@ -197,7 +205,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Added new `typescript.md` documentation to `Advanced Customization` describing how to use custom generics as part of the fix for [#3072](https://github.com/rjsf-team/react-jsonschema-form/issues/3072)
 - Updated the documentation in `utilty-functions.md` to add the new `F` generic to all the places which needed them 
 
-# 5.0.0-beta-15
+# 5.0.0-beta.15
 
 ## @rjsf/core
 - Pass the `schema` along to the `ArrayFieldItemTemplate` as part of the fix for [#3253](https://github.com/rjsf-team/react-jsonschema-form/issues/3253)

--- a/packages/core/test/Form_test.js
+++ b/packages/core/test/Form_test.js
@@ -3386,6 +3386,84 @@ describe("Form omitExtraData and liveOmit", () => {
     );
   });
 
+  it("should allow oneOf data entry with omitExtraData=true and liveOmit=true", () => {
+    const { node, onChange } = createFormComponent(
+      {
+        schema: {
+          type: "object",
+          oneOf: [
+            {
+              properties: {
+                lorem: {
+                  type: "string",
+                },
+              },
+              required: ["lorem"],
+            },
+            {
+              properties: {
+                ipsum: {
+                  type: "string",
+                },
+              },
+              required: ["ipsum"],
+            },
+          ],
+        },
+        formData: { lorum: "" },
+      },
+      { omitExtraData: true, liveOmit: true }
+    );
+
+    const textNode = node.querySelector("#root_lorem");
+    Simulate.change(textNode, {
+      target: { value: "12" },
+    });
+
+    sinon.assert.calledWithMatch(onChange.lastCall, {
+      formData: { lorem: "12" },
+    });
+  });
+
+  it("should allow anyOf data entry with omitExtraData=true and liveOmit=true", () => {
+    const { node, onChange } = createFormComponent(
+      {
+        schema: {
+          type: "object",
+          anyOf: [
+            {
+              properties: {
+                lorem: {
+                  type: "string",
+                },
+              },
+              required: ["lorem"],
+            },
+            {
+              properties: {
+                ipsum: {
+                  type: "string",
+                },
+              },
+              required: ["ipsum"],
+            },
+          ],
+        },
+        formData: { ipsum: "" },
+      },
+      { omitExtraData: true, liveOmit: true }
+    );
+
+    const textNode = node.querySelector("#root_ipsum");
+    Simulate.change(textNode, {
+      target: { value: "12" },
+    });
+
+    sinon.assert.calledWithMatch(onChange.lastCall, {
+      formData: { ipsum: "12" },
+    });
+  });
+
   describe("Async errors", () => {
     it("should render the async errors", () => {
       const schema = {

--- a/packages/core/test/anyOf_test.js
+++ b/packages/core/test/anyOf_test.js
@@ -1089,6 +1089,88 @@ describe("anyOf", () => {
       expect($select.options[2].text).eql("Baz");
     });
 
+    it("should correctly set the label of the options, with schema title prefix", () => {
+      const schema = {
+        type: "object",
+        title: "Root Title",
+        anyOf: [
+          {
+            title: "Foo",
+            properties: {
+              foo: { type: "string" },
+            },
+          },
+          {
+            properties: {
+              bar: { type: "string" },
+            },
+          },
+          {
+            $ref: "#/definitions/baz",
+          },
+        ],
+        definitions: {
+          baz: {
+            title: "Baz",
+            properties: {
+              baz: { type: "string" },
+            },
+          },
+        },
+      };
+
+      const { node } = createFormComponent({
+        schema,
+      });
+
+      const $select = node.querySelector("select");
+
+      expect($select.options[0].text).eql("Foo");
+      expect($select.options[1].text).eql("Root Title option 2");
+      expect($select.options[2].text).eql("Baz");
+    });
+
+    it("should correctly set the label of the options, with uiSchema title prefix", () => {
+      const schema = {
+        type: "object",
+        anyOf: [
+          {
+            title: "Foo",
+            properties: {
+              foo: { type: "string" },
+            },
+          },
+          {
+            properties: {
+              bar: { type: "string" },
+            },
+          },
+          {
+            $ref: "#/definitions/baz",
+          },
+        ],
+        definitions: {
+          baz: {
+            title: "Baz",
+            properties: {
+              baz: { type: "string" },
+            },
+          },
+        },
+      };
+
+      const { node } = createFormComponent({
+        schema,
+        uiSchema: { "ui:title": "My Title" },
+      });
+
+      const $select = node.querySelector("select");
+
+      expect($select.options[0].text).eql("Foo");
+      expect($select.options[1].text).eql("My Title option 2");
+      expect($select.options[2].text).eql("Baz");
+    });
+
     it("should correctly render mixed types for anyOf inside array items", () => {
       const schema = {
         type: "object",

--- a/packages/core/test/oneOf_test.js
+++ b/packages/core/test/oneOf_test.js
@@ -882,6 +882,88 @@ describe("oneOf", () => {
       expect($select.options[1].text).eql("Option 2");
       expect($select.options[2].text).eql("Baz");
     });
+
+    it("should correctly set the label of the options, with schema title prefix", () => {
+      const schema = {
+        type: "object",
+        title: "Root Title",
+        oneOf: [
+          {
+            title: "Foo",
+            properties: {
+              foo: { type: "string" },
+            },
+          },
+          {
+            properties: {
+              bar: { type: "string" },
+            },
+          },
+          {
+            $ref: "#/definitions/baz",
+          },
+        ],
+        definitions: {
+          baz: {
+            title: "Baz",
+            properties: {
+              baz: { type: "string" },
+            },
+          },
+        },
+      };
+
+      const { node } = createFormComponent({
+        schema,
+      });
+
+      const $select = node.querySelector("select");
+
+      expect($select.options[0].text).eql("Foo");
+      expect($select.options[1].text).eql("Root Title option 2");
+      expect($select.options[2].text).eql("Baz");
+    });
+
+    it("should correctly set the label of the options, with uiSchema title prefix", () => {
+      const schema = {
+        type: "object",
+        oneOf: [
+          {
+            title: "Foo",
+            properties: {
+              foo: { type: "string" },
+            },
+          },
+          {
+            properties: {
+              bar: { type: "string" },
+            },
+          },
+          {
+            $ref: "#/definitions/baz",
+          },
+        ],
+        definitions: {
+          baz: {
+            title: "Baz",
+            properties: {
+              baz: { type: "string" },
+            },
+          },
+        },
+      };
+
+      const { node } = createFormComponent({
+        schema,
+        uiSchema: { "ui:title": "My Title" },
+      });
+
+      const $select = node.querySelector("select");
+
+      expect($select.options[0].text).eql("Foo");
+      expect($select.options[1].text).eql("My Title option 2");
+      expect($select.options[2].text).eql("Baz");
+    });
   });
 
   it("should correctly infer the selected option based on value", () => {

--- a/packages/utils/src/schema/toPathSchema.ts
+++ b/packages/utils/src/schema/toPathSchema.ts
@@ -3,10 +3,12 @@ import set from "lodash/set";
 
 import {
   ALL_OF_KEY,
+  ANY_OF_KEY,
   ADDITIONAL_PROPERTIES_KEY,
   DEPENDENCIES_KEY,
   ITEMS_KEY,
   NAME_KEY,
+  ONE_OF_KEY,
   PROPERTIES_KEY,
   REF_KEY,
   RJSF_ADDITONAL_PROPERTIES_FLAG,
@@ -18,6 +20,7 @@ import {
   StrictRJSFSchema,
   ValidatorType,
 } from "../types";
+import { getClosestMatchingOption } from "./index";
 import retrieveSchema from "./retrieveSchema";
 
 /** Generates an `PathSchema` object for the `schema`, recursively
@@ -59,6 +62,42 @@ export default function toPathSchema<
   const pathSchema: PathSchema = {
     [NAME_KEY]: name.replace(/^\./, ""),
   } as PathSchema;
+
+  if (ONE_OF_KEY in schema) {
+    const index = getClosestMatchingOption<T, S, F>(
+      validator,
+      rootSchema!,
+      formData,
+      schema.oneOf as S[],
+      0
+    );
+    const _schema: S = schema.oneOf![index] as S;
+    return toPathSchema<T, S, F>(
+      validator,
+      _schema,
+      name,
+      rootSchema,
+      formData
+    );
+  }
+
+  if (ANY_OF_KEY in schema) {
+    const index = getClosestMatchingOption<T, S, F>(
+      validator,
+      rootSchema!,
+      formData,
+      schema.anyOf as S[],
+      0
+    );
+    const _schema: S = schema.anyOf![index] as S;
+    return toPathSchema<T, S, F>(
+      validator,
+      _schema,
+      name,
+      rootSchema,
+      formData
+    );
+  }
 
   if (
     ADDITIONAL_PROPERTIES_KEY in schema &&

--- a/packages/utils/test/schema/toPathSchemaTest.ts
+++ b/packages/utils/test/schema/toPathSchemaTest.ts
@@ -611,5 +611,79 @@ export default function toPathSchemaTest(testValidator: TestValidatorType) {
         },
       });
     });
+    it("should return a pathSchema for a schema with oneOf", () => {
+      const schema: RJSFSchema = {
+        type: "object",
+        oneOf: [
+          {
+            properties: {
+              lorem: {
+                type: "string",
+              },
+            },
+          },
+          {
+            properties: {
+              ipsum: {
+                type: "string",
+              },
+            },
+          },
+        ],
+      };
+
+      const formData = {
+        lorem: "loremValue",
+      };
+
+      // Two options per getClosestMatchingOption, the first one is false, the second one makes the lorem value true
+      testValidator.setReturnValues({ isValid: [false, true] });
+
+      expect(toPathSchema(testValidator, schema, "", schema, formData)).toEqual(
+        {
+          $name: "",
+          lorem: {
+            $name: "lorem",
+          },
+        }
+      );
+    });
+    it("should return a pathSchema for a schema with anyOf", () => {
+      const schema: RJSFSchema = {
+        type: "object",
+        anyOf: [
+          {
+            properties: {
+              lorem: {
+                type: "string",
+              },
+            },
+          },
+          {
+            properties: {
+              ipsum: {
+                type: "string",
+              },
+            },
+          },
+        ],
+      };
+
+      const formData = {
+        ipsum: "ipsumValue",
+      };
+      // Two per option using getClosestMatchingOption, the first ones are both false
+      // the second ones make the ipsum value true
+      testValidator.setReturnValues({ isValid: [false, false, false, true] });
+
+      expect(toPathSchema(testValidator, schema, "", schema, formData)).toEqual(
+        {
+          $name: "",
+          ipsum: {
+            $name: "ipsum",
+          },
+        }
+      );
+    });
   });
 }


### PR DESCRIPTION
### Reasons for making this change

Fixes: #2262 by reimplementing #2548

- Updated `@rjsf/utils` to update the `toPathSchema()` method to pick the closest matching option for `oneOf`/`anyOf` choices to render a path schema for it
  - Updated test to maintain 100% coverage
- Updated `@rjsf/core` to cache retrieved options in state for use in the rest of the component
  - Also improved enumOptions to output better labels for options without them when a title is available in either the `schema` or `uiSchema`
  - Added tests to validate both fixes
- Updated the `CHANGELOG.md` accordingly

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
