### PR TITLE
Fix: 2691 with an opt-out for custom fields for anyOf/oneOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,15 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 - Updated `MultiSchemaField` to cache options with refs in state and to output better labels for options without them when a title is available in either the `schema` or `uiSchema`
+- Improved fix for [#2691](https://github.com/rjsf-team/react-jsonschema-form/issues/2691) to remove the breaking change caused by the original fix [#2980](https://github.com/rjsf-team/react-jsonschema-form/issues/2980) as follows:
+  - Added a new `ui:fieldReplacesAnyOrOneOf` flag to the `uiSchema` that when true will allow users to opt-out of the `anyOf`/`oneOf` wrapping of a custom field
 
 ## @rjsf/utils
 - Updated `toPathSchema()` to handle `oneOf`/`anyOf` by picking the closest option and generating the path for it, fixing [#2262](https://github.com/rjsf-team/react-jsonschema-form/issues/2262)
+- Added new `uiSchema` only flag `ui:fieldReplacesAnyOrOneOf` that, if true allows the user to opt-out of the `anyOf`/`oneOf` wrapping of a custom field
+
+## Dev / docs / playground
+- Updated the `uiSchema` documentation for `ui:fieldReplacesAnyOrOneOf`
 
 # 5.0.0-beta.18
 

--- a/docs/api-reference/uiSchema.md
+++ b/docs/api-reference/uiSchema.md
@@ -71,6 +71,13 @@ Specify either the name of a field that is used to look up an implementation fro
 
 See [Custom Widgets and Fields](https://react-jsonschema-form.readthedocs.io/en/stable/api-reference/custom-widgets-fields#custom-field-components) for more information about how to use this property.
 
+### ui:fieldReplacesAnyOrOneOf
+
+By default, any field that is rendered for an `anyOf`/`oneOf` schema will be wrapped inside the `AnyOfField` or `OneOfField` component.
+By providing a `true` value for this flag in association with a custom `ui:field` the default behavior is skipped.
+Instead, it will be up to the custom field implementation to deal with rendering the `anyOf`/`oneOf` behavior.
+Providing a `false` value, will maintain the wrapping behavior rather than the replacing behavior.
+
 ### ui:options
 
 The `ui:options` property cannot be nested inside itself and thus is the last exception.

--- a/docs/api-reference/uiSchema.md
+++ b/docs/api-reference/uiSchema.md
@@ -74,9 +74,9 @@ See [Custom Widgets and Fields](https://react-jsonschema-form.readthedocs.io/en/
 ### ui:fieldReplacesAnyOrOneOf
 
 By default, any field that is rendered for an `anyOf`/`oneOf` schema will be wrapped inside the `AnyOfField` or `OneOfField` component.
-By providing a `true` value for this flag in association with a custom `ui:field` the default behavior is skipped.
-Instead, it will be up to the custom field implementation to deal with rendering the `anyOf`/`oneOf` behavior.
-Providing a `false` value, will maintain the wrapping behavior rather than the replacing behavior.
+This default behavior may be undesirable if your custom field already handles behavior related to choosing one or more subschemas contained in the `anyOf`/`oneOf` schema.
+By providing a `true` value for this flag in association with a custom `ui:field`, the wrapped components will be omitted, so just one instance of the custom field will be rendered.
+If the flag is omitted or set to `false`, your custom field will be wrapped by `AnyOfField`/`OneOfField`.
 
 ### ui:options
 

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -314,6 +314,8 @@ function SchemaFieldRender<
 
   const _AnyOfField = registry.fields.AnyOfField;
   const _OneOfField = registry.fields.OneOfField;
+  const isReplacingAnyOrOneOf =
+    uiSchema?.["ui:field"] && uiSchema?.["ui:fieldReplacesAnyOrOneOf"] === true;
 
   return (
     <FieldTemplate {...fieldProps}>
@@ -325,7 +327,7 @@ function SchemaFieldRender<
         rendering
       */}
         {schema.anyOf &&
-          !uiSchema?.["ui:field"] &&
+          !isReplacingAnyOrOneOf &&
           !schemaUtils.isSelect(schema) && (
             <_AnyOfField
               name={name}
@@ -354,7 +356,7 @@ function SchemaFieldRender<
             />
           )}
         {schema.oneOf &&
-          !uiSchema?.["ui:field"] &&
+          !isReplacingAnyOrOneOf &&
           !schemaUtils.isSelect(schema) && (
             <_OneOfField
               name={name}

--- a/packages/core/test/anyOf_test.js
+++ b/packages/core/test/anyOf_test.js
@@ -1401,7 +1401,7 @@ describe("anyOf", () => {
     });
   });
 
-  describe("Custom Field", function () {
+  describe("Custom Field without ui:fieldReplacesAnyOrOneOf", function () {
     const schema = {
       anyOf: [
         {
@@ -1414,6 +1414,33 @@ describe("anyOf", () => {
     };
     const uiSchema = {
       "ui:field": () => <div className="custom-field">Custom field</div>,
+    };
+    it("should be rendered twice", function () {
+      const { node } = createFormComponent({ schema, uiSchema });
+      const fields = node.querySelectorAll(".custom-field");
+      expect(fields).to.have.length.of(2);
+    });
+    it("should render <select>", function () {
+      const { node } = createFormComponent({ schema, uiSchema });
+      const selects = node.querySelectorAll("select");
+      expect(selects).to.have.length.of(1);
+    });
+  });
+
+  describe("Custom Field with ui:fieldReplacesAnyOrOneOf", function () {
+    const schema = {
+      anyOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "string",
+        },
+      ],
+    };
+    const uiSchema = {
+      "ui:field": () => <div className="custom-field">Custom field</div>,
+      "ui:fieldReplacesAnyOrOneOf": true,
     };
     it("should be rendered once", function () {
       const { node } = createFormComponent({ schema, uiSchema });

--- a/packages/core/test/oneOf_test.js
+++ b/packages/core/test/oneOf_test.js
@@ -1189,9 +1189,9 @@ describe("oneOf", () => {
     });
   });
 
-  describe("Custom Field", function () {
+  describe("Custom Field without ui:fieldReplacesAnyOrOneOf", function () {
     const schema = {
-      anyOf: [
+      oneOf: [
         {
           type: "number",
         },
@@ -1202,6 +1202,33 @@ describe("oneOf", () => {
     };
     const uiSchema = {
       "ui:field": () => <div className="custom-field">Custom field</div>,
+    };
+    it("should be rendered twice", function () {
+      const { node } = createFormComponent({ schema, uiSchema });
+      const fields = node.querySelectorAll(".custom-field");
+      expect(fields).to.have.length.of(2);
+    });
+    it("should render <select>", function () {
+      const { node } = createFormComponent({ schema, uiSchema });
+      const selects = node.querySelectorAll("select");
+      expect(selects).to.have.length.of(1);
+    });
+  });
+
+  describe("Custom Field with ui:fieldReplacesAnyOrOneOf", function () {
+    const schema = {
+      oneOf: [
+        {
+          type: "number",
+        },
+        {
+          type: "string",
+        },
+      ],
+    };
+    const uiSchema = {
+      "ui:field": () => <div className="custom-field">Custom field</div>,
+      "ui:fieldReplacesAnyOrOneOf": true,
     };
     it("should be rendered once", function () {
       const { node } = createFormComponent({ schema, uiSchema });

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -862,10 +862,11 @@ export type UiSchema<
      */
     "ui:field"?: Field<T, S, F> | string;
     /** By default, any field that is rendered for an `anyOf`/`oneOf` schema will be wrapped inside the `AnyOfField` or
-     * `OneOfField` component. By providing a `true` value for this flag in association with a custom `ui:field`, the
-     * default behavior is skipped. Instead, it will be up to the custom field implementation to deal with rendering the
-     * `anyOf`/`oneOf` behavior. Providing a `false` value, will maintain the wrapping behavior rather than the
-     * replacing behavior.
+     * `OneOfField` component. This default behavior may be undesirable if your custom field already handles behavior
+     * related to choosing one or more subschemas contained in the `anyOf`/`oneOf` schema.
+     * By providing a `true` value for this flag in association with a custom `ui:field`, the wrapped components will be
+     * omitted, so just one instance of the custom field will be rendered. If the flag is omitted or set to `false`,
+     * your custom field will be wrapped by `AnyOfField`/`OneOfField`.
      */
     "ui:fieldReplacesAnyOrOneOf"?: boolean;
     /** An object that contains all the potential UI options in a single object */

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -861,6 +861,13 @@ export type UiSchema<
      * to look up an implementation from the `fields` list or an actual one-off `Field` component implementation itself
      */
     "ui:field"?: Field<T, S, F> | string;
+    /** By default, any field that is rendered for an `anyOf`/`oneOf` schema will be wrapped inside the `AnyOfField` or
+     * `OneOfField` component. By providing a `true` value for this flag in association with a custom `ui:field`, the
+     * default behavior is skipped. Instead, it will be up to the custom field implementation to deal with rendering the
+     * `anyOf`/`oneOf` behavior. Providing a `false` value, will maintain the wrapping behavior rather than the
+     * replacing behavior.
+     */
+    "ui:fieldReplacesAnyOrOneOf"?: boolean;
     /** An object that contains all the potential UI options in a single object */
     "ui:options"?: UIOptionsType<T, S, F>;
   };


### PR DESCRIPTION
### Reasons for making this change

Fixes: #2691 better by providing an opt-out behavior for the automatic wrapping of fields by anyOf/oneOf components

The original fix (#2890) to never wrap components is a breaking change from 4.x and will cause existing users problems if they were counting on the old behavior (which my implementation did). This new fix provides an opt-out instead thereby reversing the breaking change

- In `@rjsf/utils`, updated just the `UiSchema` type to add the new `ui:fieldReplacesAnyOrOneOf` flag
- In `@rjsf/core`, updated `SchemaField` to only skip wrapping a custom field in the `anyOf`/`oneOf` if the `ui:fieldReplacesAnyOrOneOf` is true along with there being a custom field
  - Updated/added tests to verify the fix
- Updated the `uiSchema` documentation to include `ui:fieldReplacesAnyOrOneOf`
- Updated the `CHANGELOG.md` accordingly

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
