### PR TITLE
fix: Pass undefined value when MultiSchemaField has nothing selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.0.0
+
+## @rjsf/core
+- Updated `MultiSchemaField` to pass `undefined` as the value to the widget when the `selectedOption` is -1, supporting `SelectWidget` implementations that allow the user to clear the selected value of the `anyOf`/`oneOf` field.
+
 # 5.0.0-beta.19
 
 ## @rjsf/core

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -187,6 +187,9 @@ export interface FormProps<
    * Use at your own risk as this prop is private and may change at any time without notice.
    */
   _internalFormWrapper?: React.ElementType;
+  /** Support receiving a React ref to the Form
+   */
+  ref?: React.Ref<Form<T, S, F>>;
 }
 
 /** The data that is contained within the state for the `Form` */

--- a/packages/core/src/components/fields/MultiSchemaField.tsx
+++ b/packages/core/src/components/fields/MultiSchemaField.tsx
@@ -201,7 +201,8 @@ class AnyOfField<
     const rawErrors = get(errorSchema, ERRORS_KEY, []);
     const fieldErrorSchema = omit(errorSchema, [ERRORS_KEY]);
 
-    const option = retrievedOptions[selectedOption] || null;
+    const option =
+      selectedOption >= 0 ? retrievedOptions[selectedOption] || null : null;
     let optionSchema: S;
 
     if (option) {
@@ -235,7 +236,7 @@ class AnyOfField<
             multiple={false}
             rawErrors={rawErrors}
             errorSchema={fieldErrorSchema}
-            value={selectedOption}
+            value={selectedOption >= 0 ? selectedOption : undefined}
             options={{ enumOptions, ...uiOptions }}
             registry={registry}
             formContext={formContext}

--- a/packages/core/src/withTheme.tsx
+++ b/packages/core/src/withTheme.tsx
@@ -13,16 +13,14 @@ export type ThemeProps<
 > = Pick<
   FormProps<T, S, F>,
   "fields" | "templates" | "widgets" | "_internalFormWrapper"
-> & {
-  ref?: React.Ref<Form<T, S, F>>;
-};
+>;
 
 /** A Higher-Order component that creates a wrapper around a `Form` with the overrides from the `WithThemeProps` */
 export default function withTheme<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any
->(themeProps: ThemeProps<T, S, F>) {
+>(themeProps: ThemeProps<T, S, F>): React.ComponentType<FormProps<T, S, F>> {
   return forwardRef(
     (
       { fields, widgets, templates, ...directProps }: FormProps<T, S, F>,


### PR DESCRIPTION
### Reasons for making this change

Some implementations of `SelectWidget` may allow clearing the value selected. In those circumstances, the `value` being passed back to the widget should be `undefined` not `-1`
- Updated the `MultiSelectField` render function to send `undefined` as the value when the selectedOption is `-1`.
  - Also make sure the selected `option` is also null in that situation
  - Added tests to detect that undefined is passed rather than -1
- Update the `Form` to receive an optional `ref` prop, removing the need to declare it on the `ThemeProps`
- Updated the `CHANGELOG.md` accordingly

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
