### PR TITLE
fix: Fix #3391 and #3393

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,32 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # 5.0.0
 
+## @rjsf/antd
+- Fixed `schema.examples` to deduplicate when `schema.default` exists in the examples, fixing [#3393](https://github.com/rjsf-team/react-jsonschema-form/issues/3393)
+
+## @rjsf/bootstrap-4
+- Fixed `schema.examples` to deduplicate when `schema.default` exists in the examples, fixing [#3393](https://github.com/rjsf-team/react-jsonschema-form/issues/3393)
+
+## @rjsf/chakra-ui
+- Fixed `schema.examples` to deduplicate when `schema.default` exists in the examples, fixing [#3393](https://github.com/rjsf-team/react-jsonschema-form/issues/3393)
+
 ## @rjsf/core
 - Updated `MultiSchemaField` to pass `undefined` as the value to the widget when the `selectedOption` is -1, supporting `SelectWidget` implementations that allow the user to clear the selected value of the `anyOf`/`oneOf` field.
 - Updated `Form` to support receiving an optional `ref` prop.
 - Updated `Form` to restore providing empty root level objects, fixing [#3391](https://github.com/rjsf-team/react-jsonschema-form/issues/3391)
+- Fixed `schema.examples` to deduplicate when `schema.default` exists in the examples, fixing [#3393](https://github.com/rjsf-team/react-jsonschema-form/issues/3393)
+
+## @rjsf/fluent-ui
+- Fixed `schema.examples` to deduplicate when `schema.default` exists in the examples, fixing [#3393](https://github.com/rjsf-team/react-jsonschema-form/issues/3393)
+
+## @rjsf/material-ui
+- Fixed `schema.examples` to deduplicate when `schema.default` exists in the examples, fixing [#3393](https://github.com/rjsf-team/react-jsonschema-form/issues/3393)
+
+## @rjsf/mui
+- Fixed `schema.examples` to deduplicate when `schema.default` exists in the examples, fixing [#3393](https://github.com/rjsf-team/react-jsonschema-form/issues/3393)
+
+## @rjsf/semantic-ui
+- Fixed `schema.examples` to deduplicate when `schema.default` exists in the examples, fixing [#3393](https://github.com/rjsf-team/react-jsonschema-form/issues/3393)
 
 # 5.0.0-beta.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 - Updated `MultiSchemaField` to pass `undefined` as the value to the widget when the `selectedOption` is -1, supporting `SelectWidget` implementations that allow the user to clear the selected value of the `anyOf`/`oneOf` field.
+- Updated `Form` to support receiving an optional `ref` prop.
+- Updated `Form` to restore providing empty root level objects, fixing [#3391](https://github.com/rjsf-team/react-jsonschema-form/issues/3391)
 
 # 5.0.0-beta.19
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,9 +3,12 @@
 ## Supported Versions
 
 | Version | Supported          |
-| ------- | ------------------ |
-| 2.x   | :white_check_mark: |
-| 1.x   | :white_check_mark: |
+|---------|--------------------|
+| 5.x     | :white_check_mark: |
+| 4.x     | :warning:          |
+| 3.x     | :x:                |
+| 2.x     | :x:                |
+| 1.x     | :x:                |
 
 
 ## Reporting a Vulnerability

--- a/packages/antd/src/templates/BaseInputTemplate/index.tsx
+++ b/packages/antd/src/templates/BaseInputTemplate/index.tsx
@@ -91,10 +91,14 @@ export default function BaseInputTemplate<
   return (
     <>
       {input}
-      {schema.examples && (
+      {Array.isArray(schema.examples) && (
         <datalist id={examplesId<T>(id)}>
           {(schema.examples as string[])
-            .concat(schema.default ? ([schema.default] as string[]) : [])
+            .concat(
+              schema.default && !schema.examples.includes(schema.default)
+                ? ([schema.default] as string[])
+                : []
+            )
             .map((example) => {
               return <option key={example} value={example} />;
             })}

--- a/packages/bootstrap-4/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/bootstrap-4/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -67,10 +67,14 @@ export default function BaseInputTemplate<
         aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
       />
       {children}
-      {schema.examples ? (
+      {Array.isArray(schema.examples) ? (
         <datalist id={examplesId<T>(id)}>
           {(schema.examples as string[])
-            .concat(schema.default ? ([schema.default] as string[]) : [])
+            .concat(
+              schema.default && !schema.examples.includes(schema.default)
+                ? ([schema.default] as string[])
+                : []
+            )
             .map((example: any) => {
               return <option key={example} value={example} />;
             })}

--- a/packages/chakra-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/chakra-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -80,10 +80,14 @@ export default function BaseInputTemplate<
         list={schema.examples ? examplesId<T>(id) : undefined}
         aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
       />
-      {schema.examples ? (
+      {Array.isArray(schema.examples) ? (
         <datalist id={examplesId<T>(id)}>
           {(schema.examples as string[])
-            .concat(schema.default ? ([schema.default] as string[]) : [])
+            .concat(
+              schema.default && !schema.examples.includes(schema.default)
+                ? ([schema.default] as string[])
+                : []
+            )
             .map((example: any) => {
               return <option key={example} value={example} />;
             })}

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -321,7 +321,8 @@ export default class Form<
     }
     const formData: T = schemaUtils.getDefaultFormState(
       schema,
-      inputFormData
+      inputFormData,
+      "excludeObjectChildren"
     ) as T;
     const retrievedSchema = schemaUtils.retrieveSchema(schema, formData);
 

--- a/packages/core/src/components/templates/BaseInputTemplate.tsx
+++ b/packages/core/src/components/templates/BaseInputTemplate.tsx
@@ -92,13 +92,15 @@ export default function BaseInputTemplate<
       />
       {Array.isArray(schema.examples) && (
         <datalist key={`datalist_${id}`} id={examplesId<T>(id)}>
-          {[
-            ...new Set(
-              schema.examples.concat(schema.default ? [schema.default] : [])
-            ),
-          ].map((example: any) => (
-            <option key={example} value={example} />
-          ))}
+          {(schema.examples as string[])
+            .concat(
+              schema.default && !schema.examples.includes(schema.default)
+                ? ([schema.default] as string[])
+                : []
+            )
+            .map((example: any) => {
+              return <option key={example} value={example} />;
+            })}
         </datalist>
       )}
     </>

--- a/packages/fluent-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/fluent-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -111,10 +111,14 @@ export default function BaseInputTemplate<
         {...uiProps}
         aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
       />
-      {schema.examples && (
+      {Array.isArray(schema.examples) && (
         <datalist id={examplesId<T>(id)}>
           {(schema.examples as string[])
-            .concat(schema.default ? ([schema.default] as string[]) : [])
+            .concat(
+              schema.default && !schema.examples.includes(schema.default)
+                ? ([schema.default] as string[])
+                : []
+            )
             .map((example: any) => {
               return <option key={example} value={example} />;
             })}

--- a/packages/material-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/material-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -86,10 +86,14 @@ export default function BaseInputTemplate<
         {...(textFieldProps as TextFieldProps)}
         aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
       />
-      {schema.examples && (
+      {Array.isArray(schema.examples) && (
         <datalist id={examplesId<T>(id)}>
           {(schema.examples as string[])
-            .concat(schema.default ? ([schema.default] as string[]) : [])
+            .concat(
+              schema.default && !schema.examples.includes(schema.default)
+                ? ([schema.default] as string[])
+                : []
+            )
             .map((example: any) => {
               return <option key={example} value={example} />;
             })}

--- a/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -86,10 +86,14 @@ export default function BaseInputTemplate<
         {...(textFieldProps as TextFieldProps)}
         aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
       />
-      {schema.examples && (
+      {Array.isArray(schema.examples) && (
         <datalist id={examplesId<T>(id)}>
           {(schema.examples as string[])
-            .concat(schema.default ? ([schema.default] as string[]) : [])
+            .concat(
+              schema.default && !schema.examples.includes(schema.default)
+                ? ([schema.default] as string[])
+                : []
+            )
             .map((example: any) => {
               return <option key={example} value={example} />;
             })}

--- a/packages/semantic-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/semantic-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -78,10 +78,14 @@ export default function BaseInputTemplate<
         onFocus={_onFocus}
         aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
       />
-      {schema.examples && (
+      {Array.isArray(schema.examples) && (
         <datalist id={examplesId<T>(id)}>
           {(schema.examples as string[])
-            .concat(schema.default ? ([schema.default] as string[]) : [])
+            .concat(
+              schema.default && !schema.examples.includes(schema.default)
+                ? ([schema.default] as string[])
+                : []
+            )
             .map((example) => {
               return <option key={example} value={example} />;
             })}


### PR DESCRIPTION
### Reasons for making this change

Fixes #3391 by adding the `excludeObjectChildren` third parameter to the main `getDefaultFormState()`
Fixes #3393 by properly deduplicating when `schema.default` exists in `schema.examples`

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
