### PR TITLE
Fix: Revert part of fix for #1654 that was causing #3412

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Added `enumOptionsIndexForValue()`, `enumOptionsIsSelected()`, `enumOptionsValueForIndex()` functions to support fixing [#1494](https://github.com/rjsf-team/react-jsonschema-form/issues/1494)
   - Updated `enumOptionsDeselectValue()`, `enumOptionsSelectValue()` and `optionId()` to use indexes instead of values
   - Deleted the `processSelectValue()` that was added in the beta and is no longer needed
+- Updated `getSchemaType()` to remove the inference of type from `anyOf`/`oneOf`, fixing [#3412](https://github.com/rjsf-team/react-jsonschema-form/issues/3412)
 
 ## Dev / docs / playground
 - Updated the `utility-functions` documentation for the new and updated methods mentioned above, as well as deleting the documentation for `processSelectValue()`

--- a/packages/utils/src/getSchemaType.ts
+++ b/packages/utils/src/getSchemaType.ts
@@ -29,14 +29,6 @@ export default function getSchemaType<S extends StrictRJSFSchema = RJSFSchema>(
     return "object";
   }
 
-  if (!type && Array.isArray(schema.oneOf) && schema.oneOf.length) {
-    return getSchemaType<S>(schema.oneOf[0] as S);
-  }
-
-  if (!type && Array.isArray(schema.anyOf) && schema.anyOf.length) {
-    return getSchemaType<S>(schema.anyOf[0] as S);
-  }
-
   if (Array.isArray(type) && type.length === 2 && type.includes("null")) {
     type = type.find((type) => type !== "null");
   }

--- a/packages/utils/test/getSchemaType.test.ts
+++ b/packages/utils/test/getSchemaType.test.ts
@@ -62,22 +62,6 @@ const cases: { schema: object; expected: string | undefined }[] = [
     expected: "string",
   },
   {
-    schema: { oneOf: [] },
-    expected: undefined,
-  },
-  {
-    schema: { oneOf: [{ type: "string" }] },
-    expected: "string",
-  },
-  {
-    schema: { anyOf: [] },
-    expected: undefined,
-  },
-  {
-    schema: { anyOf: [{ type: "number" }] },
-    expected: "number",
-  },
-  {
     schema: {},
     expected: undefined,
   },


### PR DESCRIPTION
### Reasons for making this change

Fixes: #3412 by reverting the last change made to `getSchemaType()`

The type inference from `anyOf`/`oneOf` that was added to fix #1654 actually caused a worse bug, and without it the inference now happens properly due to other fixes somehow

- In `@rjsf/utils`, reverted the type inference from `anyOf`/`oneOf`
- Updated the `CHANGELOG.md` accordingly

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
