### PR TITLE
Fix: Update `FieldProps` to add missing props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.0.2
+
+## @rjsf/utils
+- Added the `idPrefix`, `idSeparator` and `rawErrors` optional props to `FieldProps` since they were missing
+
+## Dev / docs / playground
+- Updated the `custom-widgets-field` documentation for the new `FieldProps`
+
 # 5.0.1
 - Updated the `peerDependencies` in all packages to remove the `-beta.x` tags from the `@rjsf/xxxx` packages
 

--- a/docs/advanced-customization/custom-widgets-fields.md
+++ b/docs/advanced-customization/custom-widgets-fields.md
@@ -308,6 +308,9 @@ A field component will always be passed the following props:
  - `readonly`: A boolean value stating if the field is read-only;
  - `autofocus`: A boolean value stating if the field should autofocus;
  - `name`: The unique name of the field, usually derived from the name of the property in the JSONSchema
+ - `idPrefix`: To avoid collisions with existing ids in the DOM, it is possible to change the prefix used for ids; Default is `root`
+ - `idSeparator`: To avoid using a path separator that is present in field names, it is possible to change the separator used for ids (Default is `_`)
+ - `rawErrors`: `An array of strings listing all generated error messages from encountered errors for this field
  - `onChange`: The field change event handler; called with the updated form data and an optional `ErrorSchema`
  - `onBlur`: The input blur event handler; call it with the field id and value;
  - `onFocus`: The input focus event handler; call it with the field id and value;

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -341,6 +341,16 @@ export interface FieldProps<
   required?: boolean;
   /** The unique name of the field, usually derived from the name of the property in the JSONSchema */
   name: string;
+  /** To avoid collisions with existing ids in the DOM, it is possible to change the prefix used for ids;
+   * Default is `root`
+   */
+  idPrefix?: string;
+  /** To avoid using a path separator that is present in field names, it is possible to change the separator used for
+   * ids (Default is `_`)
+   */
+  idSeparator?: string;
+  /** An array of strings listing all generated error messages from encountered errors for this field */
+  rawErrors?: string[];
   /** The `registry` object */
   registry: Registry<T, S, F>;
 }


### PR DESCRIPTION
### Reasons for making this change

- Added the `idPrefix`, `idSeparator` and `rawErrors` optional props to `FieldProps` since they were missing
- Updated the documentation for `FieldProps` as well

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
