### PR TITLE
fix: Add new feature to focus on first error on submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
-# 5.0.3
+# 5.1.0
 
 ## @rjsf/bootstrap-4
 - Updated the `AltDateTimeWidget` in `@rjsf/core` to add `className="list-inline-item"` to the `LI` tags
@@ -25,12 +25,14 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 - Fixed `Form` to pass `allowEmptyObject` to `getDefaultFormState()`, fixing [#3424](https://github.com/rjsf-team/react-jsonschema-form/issues/3424)
+- Added new feature prop `focusOnFirstError`, that if true, will cause the first field with an error to be focused on when a submit has errors 
 
 ## @rjsf/utils
 - Updated `getDefaultFormState()` to add a new possible value for `includeUndefinedValues` called `allowEmptyObject` which prevents undefined values within an object but allows an empty object itself.  
 
 ## Dev / docs / playground
 - Updated the `utility-functions` documentation to describe the addition of `allowEmptyObject` to `getDefaultFormState()`'s `includeUndefinedValues` parameter.
+- Updated the playground to add a control for `focusOnFirstError` and the `form-props` documentation for it as well
 
 # 5.0.2
 

--- a/packages/core/test/BooleanField_test.js
+++ b/packages/core/test/BooleanField_test.js
@@ -261,6 +261,35 @@ describe("BooleanField", () => {
     });
   });
 
+  it("should focus on required radio missing data when focusOnFirstField", () => {
+    const { node, onError } = createFormComponent({
+      schema: {
+        type: "object",
+        properties: {
+          bool: {
+            type: "boolean",
+          },
+        },
+        required: ["bool"],
+      },
+      focusOnFirstError: true,
+      uiSchema: { bool: { "ui:widget": "radio" } },
+    });
+    const focusSpys = [sinon.spy(), sinon.spy()];
+    console.log(node.innerHTML);
+    const inputs = node.querySelectorAll("input[id^=root_bool]");
+    expect(inputs.length).eql(2);
+    // Since programmatically triggering focus does not call onFocus, change the focus method to a spy
+    inputs[0].focus = focusSpys[0];
+    inputs[1].focus = focusSpys[1];
+    submitForm(node);
+    sinon.assert.calledWithMatch(onError.lastCall, {
+      formData: undefined,
+    });
+    sinon.assert.calledOnce(focusSpys[0]);
+    sinon.assert.notCalled(focusSpys[1]);
+  });
+
   it("should handle a change event", () => {
     const { node, onChange } = createFormComponent({
       schema: {

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -112,6 +112,10 @@ You can pass a React component to this prop to customize how form errors are dis
 
 Dictionary of registered fields in the form. See [Custom Widgets and Fields](../advanced-customization/custom-widgets-fields.md) for more information.
 
+## focusOnFirstError
+
+If set to true, then the first field with an error will receive the focus when the form is submitted with errors.
+
 ## formContext
 
 You can provide a `formContext` object to the Form, which is passed down to all fields and widgets. Useful for implementing context aware fields and widgets.

--- a/packages/playground/src/app.jsx
+++ b/packages/playground/src/app.jsx
@@ -16,12 +16,13 @@ const toJson = (val) => JSON.stringify(val, null, 2);
 const liveSettingsSchema = {
   type: "object",
   properties: {
-    validate: { type: "boolean", title: "Live validation" },
+    liveValidate: { type: "boolean", title: "Live validation" },
     disable: { type: "boolean", title: "Disable whole form" },
     readonly: { type: "boolean", title: "Readonly whole form" },
     omitExtraData: { type: "boolean", title: "Omit extra data" },
     liveOmit: { type: "boolean", title: "Live omit" },
     noValidate: { type: "boolean", title: "Disable validation" },
+    focusOnFirstError: { type: "boolean", title: "Focus on 1st Error" },
     showErrorList:{ type: "string", "default": "top", title: "Show Error List", enum:[false,"top","bottom"] }
   },
 };
@@ -644,13 +645,7 @@ class Playground extends Component {
               >
                 <FormComponent
                   {...templateProps}
-                  liveValidate={liveSettings.validate}
-                  disabled={liveSettings.disable}
-                  readonly={liveSettings.readonly}
-                  omitExtraData={liveSettings.omitExtraData}
-                  liveOmit={liveSettings.liveOmit}
-                  noValidate={liveSettings.noValidate}
-                  showErrorList={liveSettings.showErrorList}
+                  {...liveSettings}
                   schema={schema}
                   uiSchema={uiSchema}
                   formData={formData}


### PR DESCRIPTION
### Reasons for making this change

Reimplemented #1798

- In `@rjsf/core`, added new optional `focusOnFirstError` prop and a new `focusOnError()` function
  - Updated `validateForm()` to call `focusOnError()` with the first error in the `errors` list from schema validation when the new flag is true
  - Updated the tests to ensure that `focus()` is called on a simple field, an array input and radio buttons
- In `@rjsf/docs`, updated the `form-props` documentation to add the new prop
- In `@rjsf/playground`, updated the `liveSettingsSchema` to add a control for the new prop, and to fix the name of `validate` to `liveValidate` to match the actual Form prop
  - Simplified the passing of the `liveSettings` props by making it a spread
- Updated the `CHANGELOG.md` accordingly

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
