### PR TITLE
fix: reimplement #1588 and #2816

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ should change the heading of the (upcoming) version to include a major version b
 - Added new feature prop `focusOnFirstError`, that if true, will cause the first field with an error to be focused on when a submit has errors 
 
 ## @rjsf/utils
-- Updated `getDefaultFormState()` to add a new possible value for `includeUndefinedValues` called `allowEmptyObject` which prevents undefined values within an object but allows an empty object itself.  
+- Updated `getDefaultFormState()` to add a new possible value for `includeUndefinedValues` called `allowEmptyObject` which prevents undefined values within an object but allows an empty object itself.
+- Updated `computeDefaults()` to fix additionalProperties defaults not being propagated, fixing [#2593](https://github.com/rjsf-team/react-jsonschema-form/issues/2593)
+  - Also made sure to properly deal with empty `anyOf`/`oneOf` lists by simply returning undefined
 
 ## Dev / docs / playground
 - Updated the `utility-functions` documentation to describe the addition of `allowEmptyObject` to `getDefaultFormState()`'s `includeUndefinedValues` parameter.

--- a/packages/core/test/Form_test.js
+++ b/packages/core/test/Form_test.js
@@ -932,6 +932,199 @@ describeRepeated("Form common", (createFormComponent) => {
       });
     });
   });
+  describe("Defaults additionalProperties propagation", () => {
+    it("should submit string string map defaults", () => {
+      const schema = {
+        type: "object",
+        additionalProperties: {
+          type: "string",
+        },
+        default: {
+          foo: "bar",
+        },
+      };
+
+      const { node, onSubmit } = createFormComponent({ schema });
+      Simulate.submit(node);
+
+      sinon.assert.calledWithMatch(onSubmit.lastCall, {
+        formData: {
+          foo: "bar",
+        },
+      });
+    });
+
+    it("should submit a combination of properties and additional properties defaults", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          x: {
+            type: "string",
+          },
+        },
+        additionalProperties: {
+          type: "string",
+        },
+        default: {
+          x: "x default value",
+          y: "y default value",
+        },
+      };
+
+      const { node, onSubmit } = createFormComponent({ schema });
+      Simulate.submit(node);
+
+      sinon.assert.calledWithMatch(onSubmit.lastCall, {
+        formData: {
+          x: "x default value",
+          y: "y default value",
+        },
+      });
+    });
+
+    it("should submit a properties and additional properties defaults when properties default is nested", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          x: {
+            type: "string",
+            default: "x default value",
+          },
+        },
+        additionalProperties: {
+          type: "string",
+        },
+        default: {
+          y: "y default value",
+        },
+      };
+
+      const { node, onSubmit } = createFormComponent({ schema });
+      Simulate.submit(node);
+
+      sinon.assert.calledWithMatch(onSubmit.lastCall, {
+        formData: {
+          x: "x default value",
+          y: "y default value",
+        },
+      });
+    });
+
+    it("should submit defaults when nested map has map values", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          x: {
+            additionalProperties: {
+              $ref: "#/definitions/objectDef",
+            },
+          },
+        },
+        definitions: {
+          objectDef: {
+            type: "object",
+            additionalProperties: {
+              type: "string",
+            },
+          },
+        },
+        default: {
+          x: {
+            y: {
+              z: "x.y.z default value",
+            },
+          },
+        },
+      };
+
+      const { node, onSubmit } = createFormComponent({ schema });
+      Simulate.submit(node);
+
+      sinon.assert.calledWithMatch(onSubmit.lastCall, {
+        formData: {
+          x: {
+            y: {
+              z: "x.y.z default value",
+            },
+          },
+        },
+      });
+    });
+
+    it("should submit defaults when they are defined in a nested additionalProperties", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          x: {
+            additionalProperties: {
+              type: "string",
+              default: "x.y default value",
+            },
+          },
+        },
+        default: {
+          x: {
+            y: {},
+          },
+        },
+      };
+
+      const { node, onSubmit } = createFormComponent({ schema });
+      Simulate.submit(node);
+
+      sinon.assert.calledWithMatch(onSubmit.lastCall, {
+        formData: {
+          x: {
+            y: "x.y default value",
+          },
+        },
+      });
+    });
+
+    it("should submit defaults when additionalProperties is a boolean value", () => {
+      const schema = {
+        type: "object",
+        additionalProperties: true,
+        default: {
+          foo: "bar",
+        },
+      };
+
+      const { node, onSubmit } = createFormComponent({ schema });
+      Simulate.submit(node);
+
+      sinon.assert.calledWithMatch(onSubmit.lastCall, {
+        formData: {
+          foo: "bar",
+        },
+      });
+    });
+
+    it("should NOT submit default values when additionalProperties is false", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          foo: {
+            type: "string",
+          },
+        },
+        additionalProperties: false,
+        default: {
+          foo: "I'm the only one",
+          bar: "I don't belong here",
+        },
+      };
+
+      const { node, onSubmit } = createFormComponent({ schema });
+      Simulate.submit(node);
+
+      sinon.assert.calledWithMatch(onSubmit.lastCall, {
+        formData: {
+          foo: "I'm the only one",
+        },
+      });
+    });
+  });
 
   describe("Submit handler", () => {
     it("should call provided submit handler with form state", () => {

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -242,8 +242,7 @@ export function computeDefaults<
 
   switch (getSchemaType<S>(schema)) {
     // We need to recur for object schema inner default values.
-    case "object":
-      // eslint-disable-next-line no-case-declarations
+    case "object": {
       const objectDefaults = Object.keys(schema.properties || {}).reduce(
         (acc: GenericObjectType, key: string) => {
           // Compute the defaults for this node, with the parent defaults we might
@@ -290,6 +289,7 @@ export function computeDefaults<
           });
       }
       return objectDefaults;
+    }
     case "array":
       // Inject defaults into existing array defaults
       if (Array.isArray(defaults)) {

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -43,7 +43,7 @@ export default function getDefaultFormStateTest(
           foo: 42,
         });
       });
-      it("test computeDefaults that is passed an object with an optional object property that has a nested required property", () => {
+      it("test an object with an optional property that has a nested required property", () => {
         const schema: RJSFSchema = {
           type: "object",
           properties: {
@@ -67,7 +67,7 @@ export default function getDefaultFormStateTest(
           computeDefaults(testValidator, schema, undefined, schema)
         ).toEqual({ requiredProperty: "foo" });
       });
-      it("test computeDefaults that is passed an object with an optional object property that has a nested required property and includeUndefinedValues", () => {
+      it("test an object with an optional property that has a nested required property and includeUndefinedValues", () => {
         const schema: RJSFSchema = {
           type: "object",
           properties: {
@@ -110,7 +110,7 @@ export default function getDefaultFormStateTest(
           requiredProperty: "foo",
         });
       });
-      it("test computeDefaults that is passed an object with an optional object property that has a nested required property and includeUndefinedValues is 'excludeObjectChildren'", () => {
+      it("test an object with an optional property that has a nested required property and includeUndefinedValues is 'excludeObjectChildren'", () => {
         const schema: RJSFSchema = {
           type: "object",
           properties: {
@@ -153,7 +153,7 @@ export default function getDefaultFormStateTest(
           requiredProperty: "foo",
         });
       });
-      it("test computeDefaults that is passed an object with an optional object property that has a nested required property and includeUndefinedValues is 'allowEmptyObject'", () => {
+      it("test an object with an optional property that has a nested required property and includeUndefinedValues is 'allowEmptyObject'", () => {
         const schema: RJSFSchema = {
           type: "object",
           properties: {
@@ -194,6 +194,53 @@ export default function getDefaultFormStateTest(
           optionalObjectProperty: {},
           requiredProperty: "foo",
         });
+      });
+      it("test an object with an additionalProperties", () => {
+        const schema: RJSFSchema = {
+          type: "object",
+          properties: {
+            requiredProperty: {
+              type: "string",
+              default: "foo",
+            },
+          },
+          additionalProperties: true,
+          required: ["requiredProperty"],
+          default: {
+            foo: "bar",
+          },
+        };
+        expect(
+          computeDefaults(testValidator, schema, undefined, schema)
+        ).toEqual({ requiredProperty: "foo", foo: "bar" });
+      });
+      it("test an object with an additionalProperties and includeUndefinedValues", () => {
+        const schema: RJSFSchema = {
+          type: "object",
+          properties: {
+            requiredProperty: {
+              type: "string",
+              default: "foo",
+            },
+          },
+          additionalProperties: {
+            type: "string",
+          },
+          required: ["requiredProperty"],
+          default: {
+            foo: "bar",
+          },
+        };
+        expect(
+          computeDefaults(
+            testValidator,
+            schema,
+            undefined,
+            schema,
+            undefined,
+            true
+          )
+        ).toEqual({ requiredProperty: "foo", foo: "bar" });
       });
       it("test computeDefaults handles an invalid property schema", () => {
         const schema: RJSFSchema = {
@@ -834,6 +881,18 @@ export default function getDefaultFormStateTest(
       });
     });
     describe("defaults with oneOf", () => {
+      it("should not populate defaults for empty oneOf", () => {
+        const schema: RJSFSchema = {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              oneOf: [],
+            },
+          },
+        };
+        expect(getDefaultFormState(testValidator, schema, {})).toEqual({});
+      });
       it("should populate defaults for oneOf", () => {
         const schema: RJSFSchema = {
           type: "object",
@@ -949,6 +1008,18 @@ export default function getDefaultFormStateTest(
       });
     });
     describe("defaults with anyOf", () => {
+      it("should not populate defaults for empty oneOf", () => {
+        const schema: RJSFSchema = {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              anyOf: [],
+            },
+          },
+        };
+        expect(getDefaultFormState(testValidator, schema, {})).toEqual({});
+      });
       it("should populate defaults for anyOf", () => {
         const schema: RJSFSchema = {
           type: "object",


### PR DESCRIPTION
### Reasons for making this change

Fixes: #2593 by reimplementing #2816. Also reimplemented the empty `anyOf`/`oneOf` handling of #1588

- In `@rjsf/utils`, reimplemented the `additionalProperties` handling logic of #2816 into `computeDefault()`, refactoring some common code into `maybeAddDefaultToObject()`
  - Also deal with empty `anyOf`/`oneOf` arrays by returning undefined, reimplementing #1588
- In `@rjsf/core`, added the `additionalProperties` tests from #2816
- Updated the `CHANGELOG.md` accordingly

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
