### PR TITLE
fix: Fix #675 by reversing change made to Form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,16 +24,15 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed the `SelectWidget` to allow the proper display of the selected value, fixing [#3422](https://github.com/rjsf-team/react-jsonschema-form/issues/3422)
 
 ## @rjsf/core
-- Fixed `Form` to pass `allowEmptyObject` to `getDefaultFormState()`, fixing [#3424](https://github.com/rjsf-team/react-jsonschema-form/issues/3424)
+- Fixed `Form` to remove passing `excludeObjectChildren` to `getDefaultFormState()`, fixing [#3424](https://github.com/rjsf-team/react-jsonschema-form/issues/3424) and [#675](https://github.com/rjsf-team/react-jsonschema-form/issues/675)
 - Added new feature prop `focusOnFirstError`, that if true, will cause the first field with an error to be focused on when a submit has errors 
 
 ## @rjsf/utils
-- Updated `getDefaultFormState()` to add a new possible value for `includeUndefinedValues` called `allowEmptyObject` which prevents undefined values within an object but allows an empty object itself.
 - Updated `computeDefaults()` to fix additionalProperties defaults not being propagated, fixing [#2593](https://github.com/rjsf-team/react-jsonschema-form/issues/2593)
   - Also made sure to properly deal with empty `anyOf`/`oneOf` lists by simply returning undefined
+  - Add support for adding an empty object when that object is marked as required in a schema
 
 ## Dev / docs / playground
-- Updated the `utility-functions` documentation to describe the addition of `allowEmptyObject` to `getDefaultFormState()`'s `includeUndefinedValues` parameter.
 - Updated the playground to add a control for `focusOnFirstError` and the `form-props` documentation for it as well
 
 # 5.0.2

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -325,8 +325,7 @@ export default class Form<
     }
     const formData: T = schemaUtils.getDefaultFormState(
       schema,
-      inputFormData,
-      "allowEmptyObject"
+      inputFormData
     ) as T;
     const retrievedSchema = schemaUtils.retrieveSchema(schema, formData);
 

--- a/packages/docs/docs/api-reference/utility-functions.md
+++ b/packages/docs/docs/api-reference/utility-functions.md
@@ -526,7 +526,7 @@ Returns the superset of `formData` that includes the given set updated to includ
 - theSchema: S - The schema for which the default state is desired
 - [formData]: T | undefined - The current formData, if any, onto which to provide any missing defaults
 - [rootSchema]: S | undefined - The root schema, used to primarily to look up `$ref`s
-- [includeUndefinedValues=false]: boolean | "excludeObjectChildren" | "allowEmptyObject" - Optional flag, if true, cause undefined values to be added as defaults. If "excludeObjectChildren", cause undefined values for this object and pass `includeUndefinedValues` as false when computing defaults for any nested object properties. If "allowEmptyObject", prevents undefined values in this object while allow the object itself to be empty and passing `includeUndefinedValues` as false when computing defaults for any nested object properties.
+- [includeUndefinedValues=false]: boolean | "excludeObjectChildren" - Optional flag, if true, cause undefined values to be added as defaults. If "excludeObjectChildren", cause undefined values for this object and pass `includeUndefinedValues` as false when computing defaults for any nested object properties.
 
 #### Returns
 - T: The resulting `formData` with all the defaults provided

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1006,18 +1006,13 @@ export interface SchemaUtilsType<
    * @param [formData] - The current formData, if any, onto which to provide any missing defaults
    * @param [includeUndefinedValues=false] - Optional flag, if true, cause undefined values to be added as defaults.
    *          If "excludeObjectChildren", cause undefined values for this object and pass `includeUndefinedValues` as
-   *          false when computing defaults for any nested object properties. If "allowEmptyObject", prevents undefined
-   *          values in this object while allow the object itself to be empty and passing `includeUndefinedValues` as
    *          false when computing defaults for any nested object properties.
    * @returns - The resulting `formData` with all the defaults provided
    */
   getDefaultFormState(
     schema: S,
     formData?: T,
-    includeUndefinedValues?:
-      | boolean
-      | "excludeObjectChildren"
-      | "allowEmptyObject"
+    includeUndefinedValues?: boolean | "excludeObjectChildren"
   ): T | T[] | undefined;
   /** Determines whether the combination of `schema` and `uiSchema` properties indicates that the label for the `schema`
    * should be displayed in a UI.

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -149,49 +149,9 @@ export default function getDefaultFormStateTest(
           )
         ).toEqual({
           optionalNumberProperty: undefined,
-          optionalObjectProperty: {},
-          requiredProperty: "foo",
-        });
-      });
-      it("test an object with an optional property that has a nested required property and includeUndefinedValues is 'allowEmptyObject'", () => {
-        const schema: RJSFSchema = {
-          type: "object",
-          properties: {
-            optionalNumberProperty: {
-              type: "number",
-            },
-            optionalObjectProperty: {
-              type: "object",
-              properties: {
-                nestedRequiredProperty: {
-                  type: "object",
-                  properties: {
-                    undefinedProperty: {
-                      type: "string",
-                    },
-                  },
-                },
-              },
-              required: ["nestedRequiredProperty"],
-            },
-            requiredProperty: {
-              type: "string",
-              default: "foo",
-            },
+          optionalObjectProperty: {
+            nestedRequiredProperty: {},
           },
-          required: ["requiredProperty"],
-        };
-        expect(
-          computeDefaults(
-            testValidator,
-            schema,
-            undefined,
-            schema,
-            undefined,
-            "allowEmptyObject"
-          )
-        ).toEqual({
-          optionalObjectProperty: {},
           requiredProperty: "foo",
         });
       });


### PR DESCRIPTION
### Reasons for making this change

fixes: #675 by reverting the `allowEmptyObject` change on Form
- In `@rjsf/utils`, reverted the `allowEmptyObject` change as follows:
  - Removed the `allowEmptyObject` changes made to `getDefaultFormState`, `computeDefault` and `maybeAddDefaultToObject`
  - Updated `maybeAddDefaultToObject` to take the list of required fields and allow adding an empty object if the field is required
  - Updated the `SchemaUtilsType` to revert the `allowEmptyObject` change
  - Updated the tests to remove testing `allowEmptyObject` and to add testing the `required` field state
- In `@rjsf/core`, removed the passing of `allowEmptyObject` to `getDefaultFormState`
  - Updated the tests for form to include the test case from #675
- In `utility-functions` documentation, removed the documentation of `allowEmptyObject`
- Updated the `CHANGELOG.md` accordingly

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
