### PR TITLE
fix: update Simple example so that lastName fails required field validation

### DIFF
--- a/packages/playground/src/samples/simple.js
+++ b/packages/playground/src/samples/simple.js
@@ -38,10 +38,11 @@ export default {
     firstName: {
       "ui:autofocus": true,
       "ui:emptyValue": "",
+      "ui:placeholder":
+        "ui:emptyValue causes this field to always be valid despite being required",
       "ui:autocomplete": "family-name",
     },
     lastName: {
-      "ui:emptyValue": "",
       "ui:autocomplete": "given-name",
     },
     age: {


### PR DESCRIPTION
### Reasons for making this change

Issue #3440 describes the required field validation for `firstName` and `lastName` not working for the simple example
- Updated the simple example to remove the `ui:emptyValue` for the `lastName` field so that required field validation works for it.
  - Also added a placeholder for `firstName` indicating that it will never fail validation due to `ui:emptyValue`

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

<img width="695" alt="Screenshot 2023-02-20 at 10 17 13 AM" src="https://user-images.githubusercontent.com/51679588/220176967-63fe2ebb-a857-41d2-9bc8-78d930fc9984.png">
