### PR TITLE
chore: Make React type imports consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,35 +19,44 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/antd
 - Updated `BaseInputTemplate` to favor the special `onChangeOverride` provided by the `core` `FileWidget`
+- Removed explicit import of `React`, switching imports to explicit ones after fixing linting rules to not require `React` for JSX
 
 ## @rjsf/bootstrap-4
 - Updated `BaseInputTemplate` to favor the special `onChangeOverride` provided by the `core` `FileWidget`, deleting the theme's `FileWidget`, fixing [#2095](https://github.com/rjsf-team/react-jsonschema-form/issues/2095)
+- Removed explicit import of `React`, switching imports to explicit ones after fixing linting rules to not require `React` for JSX
 
 ## @rjsf/chakra-ui
 - Updated `BaseInputTemplate` to favor the special `onChangeOverride` provided by the `core` `FileWidget`
+- Removed explicit import of `React`, switching imports to explicit ones after fixing linting rules to not require `React` for JSX
 
 ## @rjsf/core
 - Ensure that `name` is consistently passed to all `Widgets` through the field components, fixing [#1763](https://github.com/rjsf-team/react-jsonschema-form/issues/1763)
 - Updated the `FileWidget` to render the input using the `BaseInputTemplate` passing a special `onChangeOverride` function to deal with the file events, fixing [#2095](https://github.com/rjsf-team/react-jsonschema-form/issues/2095)
+- Removed explicit import of `React`, switching imports to explicit ones after fixing linting rules to not require `React` for JSX
 
 ## @rjsf/fluent-ui
 - Updated `BaseInputTemplate` to favor the special `onChangeOverride` provided by the `core` `FileWidget`
+- Removed explicit import of `React`, switching imports to explicit ones after fixing linting rules to not require `React` for JSX
 
 ## @rjsf/material-ui
 - Updated `BaseInputTemplate` to favor the special `onChangeOverride` provided by the `core` `FileWidget` and to support automatically shrinking the label for the `date`, `datetime-local` and `file` types
   - Removed the `DateWidget` and `DateTimeWidget` since they were only created to provide the label shrinking property
+- Removed explicit import of `React`, switching imports to explicit ones after fixing linting rules to not require `React` for JSX
 
 ## @rjsf/mui
 - Updated `BaseInputTemplate` to favor the special `onChangeOverride` provided by the `core` `FileWidget` and to support automatically shrinking the label for the `date`, `datetime-local` and `file` types
   - Removed the `DateWidget` and `DateTimeWidget` since they were only created to provide the label shrinking property
+- Removed explicit import of `React`, switching imports to explicit ones after fixing linting rules to not require `React` for JSX
 
 ## @rjsf/semantic-ui
 - Updated `BaseInputTemplate` to favor the special `onChangeOverride` provided by the `core` `FileWidget`
+- Removed explicit import of `React`, switching imports to explicit ones after fixing linting rules to not require `React` for JSX
 
 ## @rjsf/utils
 - Added the `name` prop to the `WidgetProps` type, fixing [#1763](https://github.com/rjsf-team/react-jsonschema-form/issues/1763)
 - Fixed `dataURItoBlob()` to handle the exception thrown by `atob()` when it is passed a malformed URL, returning an `blob` that indicates the error in the `type` prop
 - Fixed `replaceStringParameters()` to improve the replaceable parameters logic so that it works properly when a parameter also contains a replaceable parameter identifier
+- Removed explicit import of `React`, switching imports to explicit ones after fixing linting rules to not require `React` for JSX
 
 ## Dev / docs / playground
 - Updated the `custom-widgets-fields` documentation to ensure the new `WidgetProps` `name` prop is documented

--- a/packages/antd/src/templates/WrapIfAdditionalTemplate/index.tsx
+++ b/packages/antd/src/templates/WrapIfAdditionalTemplate/index.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import Col from "antd/lib/col";
 import Form from "antd/lib/form";
 import Input from "antd/lib/input";
@@ -67,7 +68,7 @@ export default function WrapIfAdditionalTemplate<
     );
   }
 
-  const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
+  const handleBlur = ({ target }: FocusEvent<HTMLInputElement>) =>
     onKeyChange(target.value);
 
   // The `block` prop is not part of the `IconButtonProps` defined in the template, so put it into the uiSchema instead

--- a/packages/antd/src/widgets/AltDateWidget/index.tsx
+++ b/packages/antd/src/widgets/AltDateWidget/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { MouseEvent, useEffect, useState } from "react";
 import Button from "antd/lib/button";
 import Col from "antd/lib/col";
 import Row from "antd/lib/row";
@@ -116,7 +116,7 @@ export default function AltDateWidget<
     }
   };
 
-  const handleNow = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleNow = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     if (disabled || readonly) {
       return;
@@ -125,7 +125,7 @@ export default function AltDateWidget<
     onChange(toDateString(nextState, showTime));
   };
 
-  const handleClear = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleClear = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     if (disabled || readonly) {
       return;

--- a/packages/antd/src/widgets/CheckboxWidget/index.tsx
+++ b/packages/antd/src/widgets/CheckboxWidget/index.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import Checkbox, { CheckboxChangeEvent } from "antd/lib/checkbox";
 import {
   ariaDescribedByIds,
@@ -35,10 +36,10 @@ export default function CheckboxWidget<
   const handleChange = ({ target }: CheckboxChangeEvent) =>
     onChange(target.checked);
 
-  const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
+  const handleBlur = ({ target }: FocusEvent<HTMLInputElement>) =>
     onBlur(id, target.checked);
 
-  const handleFocus = ({ target }: React.FocusEvent<HTMLInputElement>) =>
+  const handleFocus = ({ target }: FocusEvent<HTMLInputElement>) =>
     onFocus(id, target.checked);
 
   // Antd's typescript definitions do not contain the following props that are actually necessary and, if provided,

--- a/packages/antd/src/widgets/CheckboxesWidget/index.tsx
+++ b/packages/antd/src/widgets/CheckboxesWidget/index.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import Checkbox from "antd/lib/checkbox";
 import {
   ariaDescribedByIds,
@@ -39,13 +40,13 @@ export default function CheckboxesWidget<
   const handleChange = (nextValue: any) =>
     onChange(enumOptionsValueForIndex<S>(nextValue, enumOptions, emptyValue));
 
-  const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
+  const handleBlur = ({ target }: FocusEvent<HTMLInputElement>) =>
     onBlur(
       id,
       enumOptionsValueForIndex<S>(target.value, enumOptions, emptyValue)
     );
 
-  const handleFocus = ({ target }: React.FocusEvent<HTMLInputElement>) =>
+  const handleFocus = ({ target }: FocusEvent<HTMLInputElement>) =>
     onFocus(
       id,
       enumOptionsValueForIndex<S>(target.value, enumOptions, emptyValue)

--- a/packages/antd/src/widgets/PasswordWidget/index.tsx
+++ b/packages/antd/src/widgets/PasswordWidget/index.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent, FocusEvent } from "react";
 import Input from "antd/lib/input";
 import {
   ariaDescribedByIds,
@@ -33,13 +34,13 @@ export default function PasswordWidget<
 
   const emptyValue = options.emptyValue || "";
 
-  const handleChange = ({ target }: React.ChangeEvent<HTMLInputElement>) =>
+  const handleChange = ({ target }: ChangeEvent<HTMLInputElement>) =>
     onChange(target.value === "" ? emptyValue : target.value);
 
-  const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
+  const handleBlur = ({ target }: FocusEvent<HTMLInputElement>) =>
     onBlur(id, target.value);
 
-  const handleFocus = ({ target }: React.FocusEvent<HTMLInputElement>) =>
+  const handleFocus = ({ target }: FocusEvent<HTMLInputElement>) =>
     onFocus(id, target.value);
 
   return (

--- a/packages/antd/src/widgets/RadioWidget/index.tsx
+++ b/packages/antd/src/widgets/RadioWidget/index.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import Radio, { RadioChangeEvent } from "antd/lib/radio";
 import {
   ariaDescribedByIds,
@@ -39,13 +40,13 @@ export default function RadioWidget<
   const handleChange = ({ target: { value: nextValue } }: RadioChangeEvent) =>
     onChange(enumOptionsValueForIndex<S>(nextValue, enumOptions, emptyValue));
 
-  const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
+  const handleBlur = ({ target }: FocusEvent<HTMLInputElement>) =>
     onBlur(
       id,
       enumOptionsValueForIndex<S>(target.value, enumOptions, emptyValue)
     );
 
-  const handleFocus = ({ target }: React.FocusEvent<HTMLInputElement>) =>
+  const handleFocus = ({ target }: FocusEvent<HTMLInputElement>) =>
     onFocus(
       id,
       enumOptionsValueForIndex<S>(target.value, enumOptions, emptyValue)

--- a/packages/antd/src/widgets/TextareaWidget/index.tsx
+++ b/packages/antd/src/widgets/TextareaWidget/index.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent, FocusEvent } from "react";
 import Input from "antd/lib/input";
 import {
   ariaDescribedByIds,
@@ -34,13 +35,13 @@ export default function TextareaWidget<
 }: WidgetProps<T, S, F>) {
   const { readonlyAsDisabled = true } = formContext as GenericObjectType;
 
-  const handleChange = ({ target }: React.ChangeEvent<HTMLTextAreaElement>) =>
+  const handleChange = ({ target }: ChangeEvent<HTMLTextAreaElement>) =>
     onChange(target.value === "" ? options.emptyValue : target.value);
 
-  const handleBlur = ({ target }: React.FocusEvent<HTMLTextAreaElement>) =>
+  const handleBlur = ({ target }: FocusEvent<HTMLTextAreaElement>) =>
     onBlur(id, target.value);
 
-  const handleFocus = ({ target }: React.FocusEvent<HTMLTextAreaElement>) =>
+  const handleFocus = ({ target }: FocusEvent<HTMLTextAreaElement>) =>
     onFocus(id, target.value);
 
   // Antd's typescript definitions do not contain the following props that are actually necessary and, if provided,

--- a/packages/bootstrap-4/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/bootstrap-4/src/CheckboxWidget/CheckboxWidget.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import {
   ariaDescribedByIds,
   WidgetProps,
@@ -30,15 +31,12 @@ export default function CheckboxWidget<
   // "const" or "enum" keywords
   const required = schemaRequiresTrueValue<S>(schema);
 
-  const _onChange = ({
-    target: { checked },
-  }: React.FocusEvent<HTMLInputElement>) => onChange(checked);
-  const _onBlur = ({
-    target: { checked },
-  }: React.FocusEvent<HTMLInputElement>) => onBlur(id, checked);
-  const _onFocus = ({
-    target: { checked },
-  }: React.FocusEvent<HTMLInputElement>) => onFocus(id, checked);
+  const _onChange = ({ target: { checked } }: FocusEvent<HTMLInputElement>) =>
+    onChange(checked);
+  const _onBlur = ({ target: { checked } }: FocusEvent<HTMLInputElement>) =>
+    onBlur(id, checked);
+  const _onFocus = ({ target: { checked } }: FocusEvent<HTMLInputElement>) =>
+    onFocus(id, checked);
 
   const desc = label || schema.description;
   return (

--- a/packages/bootstrap-4/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/bootstrap-4/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent, FocusEvent } from "react";
 import Form from "react-bootstrap/Form";
 import {
   ariaDescribedByIds,
@@ -33,7 +34,7 @@ export default function CheckboxesWidget<
 
   const _onChange =
     (index: number) =>
-    ({ target: { checked } }: React.ChangeEvent<HTMLInputElement>) => {
+    ({ target: { checked } }: ChangeEvent<HTMLInputElement>) => {
       if (checked) {
         onChange(
           enumOptionsSelectValue<S>(index, checkboxesValues, enumOptions)
@@ -45,11 +46,9 @@ export default function CheckboxesWidget<
       }
     };
 
-  const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onBlur(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLInputElement>) =>
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
 
   return (

--- a/packages/bootstrap-4/src/RadioWidget/RadioWidget.tsx
+++ b/packages/bootstrap-4/src/RadioWidget/RadioWidget.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent, FocusEvent } from "react";
 import Form from "react-bootstrap/Form";
 import {
   ariaDescribedByIds,
@@ -27,15 +28,11 @@ export default function RadioWidget<
 }: WidgetProps<T, S, F>) {
   const { enumOptions, enumDisabled, emptyValue } = options;
 
-  const _onChange = ({
-    target: { value },
-  }: React.ChangeEvent<HTMLInputElement>) =>
+  const _onChange = ({ target: { value } }: ChangeEvent<HTMLInputElement>) =>
     onChange(enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
-  const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onBlur(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLInputElement>) =>
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
 
   const inline = Boolean(options && options.inline);

--- a/packages/bootstrap-4/src/SelectWidget/SelectWidget.tsx
+++ b/packages/bootstrap-4/src/SelectWidget/SelectWidget.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent, FocusEvent } from "react";
 import Form from "react-bootstrap/Form";
 import {
   ariaDescribedByIds,
@@ -33,10 +34,7 @@ export default function SelectWidget<
 
   const emptyValue = multiple ? [] : "";
 
-  function getValue(
-    event: React.FocusEvent | React.ChangeEvent | any,
-    multiple?: boolean
-  ) {
+  function getValue(event: FocusEvent | ChangeEvent | any, multiple?: boolean) {
     if (multiple) {
       return [].slice
         .call(event.target.options as any)
@@ -68,7 +66,7 @@ export default function SelectWidget<
       className={rawErrors.length > 0 ? "is-invalid" : ""}
       onBlur={
         onBlur &&
-        ((event: React.FocusEvent) => {
+        ((event: FocusEvent) => {
           const newValue = getValue(event, multiple);
           onBlur(
             id,
@@ -78,7 +76,7 @@ export default function SelectWidget<
       }
       onFocus={
         onFocus &&
-        ((event: React.FocusEvent) => {
+        ((event: FocusEvent) => {
           const newValue = getValue(event, multiple);
           onFocus(
             id,
@@ -86,7 +84,7 @@ export default function SelectWidget<
           );
         })
       }
-      onChange={(event: React.ChangeEvent) => {
+      onChange={(event: ChangeEvent) => {
         const newValue = getValue(event, multiple);
         onChange(
           enumOptionsValueForIndex<S>(newValue, enumOptions, optEmptyValue)

--- a/packages/bootstrap-4/src/TextareaWidget/TextareaWidget.tsx
+++ b/packages/bootstrap-4/src/TextareaWidget/TextareaWidget.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent, FocusEvent } from "react";
 import {
   ariaDescribedByIds,
   FormContextType,
@@ -33,16 +34,12 @@ export default function TextareaWidget<
   onChange,
   options,
 }: CustomWidgetProps<T, S, F>) {
-  const _onChange = ({
-    target: { value },
-  }: React.ChangeEvent<HTMLTextAreaElement>) =>
+  const _onChange = ({ target: { value } }: ChangeEvent<HTMLTextAreaElement>) =>
     onChange(value === "" ? options.emptyValue : value);
-  const _onBlur = ({
-    target: { value },
-  }: React.FocusEvent<HTMLTextAreaElement>) => onBlur(id, value);
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLTextAreaElement>) => onFocus(id, value);
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLTextAreaElement>) =>
+    onBlur(id, value);
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLTextAreaElement>) =>
+    onFocus(id, value);
 
   return (
     <InputGroup>

--- a/packages/bootstrap-4/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/bootstrap-4/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import {
   ADDITIONAL_PROPERTY_FLAG,
   FormContextType,
@@ -44,7 +45,7 @@ export default function WrapIfAdditionalTemplate<
     );
   }
 
-  const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
+  const handleBlur = ({ target }: FocusEvent<HTMLInputElement>) =>
     onKeyChange(target.value);
   const keyId = `${id}-key`;
 

--- a/packages/chakra-ui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/chakra-ui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent, FocusEvent } from "react";
 import { Checkbox, FormControl, Text } from "@chakra-ui/react";
 import {
   ariaDescribedByIds,
@@ -32,15 +33,13 @@ export default function CheckboxWidget<
   // "const" or "enum" keywords
   const required = schemaRequiresTrueValue<S>(schema);
 
-  const _onChange = ({
-    target: { checked },
-  }: React.ChangeEvent<HTMLInputElement>) => onChange(checked);
-  const _onBlur = ({
-    target: { value },
-  }: React.FocusEvent<HTMLInputElement | any>) => onBlur(id, value);
+  const _onChange = ({ target: { checked } }: ChangeEvent<HTMLInputElement>) =>
+    onChange(checked);
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement | any>) =>
+    onBlur(id, value);
   const _onFocus = ({
     target: { value },
-  }: React.FocusEvent<HTMLInputElement | any>) => onFocus(id, value);
+  }: FocusEvent<HTMLInputElement | any>) => onFocus(id, value);
 
   return (
     <FormControl mb={1} {...chakraProps} isRequired={required}>

--- a/packages/chakra-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/chakra-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import {
   CheckboxGroup,
   Checkbox,
@@ -43,13 +44,11 @@ export default function CheckboxesWidget<
   const chakraProps = getChakra({ uiSchema });
   const checkboxesValues = Array.isArray(value) ? value : [value];
 
-  const _onBlur = ({
-    target: { value },
-  }: React.FocusEvent<HTMLInputElement | any>) =>
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement | any>) =>
     onBlur(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
   const _onFocus = ({
     target: { value },
-  }: React.FocusEvent<HTMLInputElement | any>) =>
+  }: FocusEvent<HTMLInputElement | any>) =>
     onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
 
   const row = options ? options.inline : false;

--- a/packages/chakra-ui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/chakra-ui/src/RadioWidget/RadioWidget.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import {
   FormControl,
   FormLabel,
@@ -40,11 +41,9 @@ export default function RadioWidget<
 
   const _onChange = (nextValue: any) =>
     onChange(enumOptionsValueForIndex<S>(nextValue, enumOptions, emptyValue));
-  const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onBlur(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLInputElement>) =>
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
 
   const row = options ? options.inline : false;

--- a/packages/chakra-ui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/chakra-ui/src/RangeWidget/RangeWidget.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import {
   FormControl,
   FormLabel,
@@ -45,11 +46,10 @@ export default function RangeWidget<
 
   const _onChange = (value: undefined | number) =>
     onChange(value === undefined ? options.emptyValue : value);
-  const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onBlur(id, value);
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLInputElement>) => onFocus(id, value);
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
+    onFocus(id, value);
 
   return (
     <FormControl mb={1} {...chakraProps}>

--- a/packages/chakra-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/chakra-ui/src/SelectWidget/SelectWidget.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import { FormControl, FormLabel } from "@chakra-ui/react";
 import {
   ariaDescribedByIds,
@@ -56,12 +57,10 @@ export default function SelectWidget<
     );
   };
 
-  const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onBlur(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
 
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLInputElement>) =>
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
 
   const _valueLabelMap: any = {};

--- a/packages/chakra-ui/src/TextareaWidget/TextareaWidget.tsx
+++ b/packages/chakra-ui/src/TextareaWidget/TextareaWidget.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent, FocusEvent } from "react";
 import { FormControl, FormLabel, Textarea } from "@chakra-ui/react";
 import {
   ariaDescribedByIds,
@@ -36,16 +37,12 @@ export default function TextareaWidget<
     schemaUtils.getDisplayLabel(schema, uiSchema) &&
     (!!label || !!schema.title);
 
-  const _onChange = ({
-    target: { value },
-  }: React.ChangeEvent<HTMLTextAreaElement>) =>
+  const _onChange = ({ target: { value } }: ChangeEvent<HTMLTextAreaElement>) =>
     onChange(value === "" ? options.emptyValue : value);
-  const _onBlur = ({
-    target: { value },
-  }: React.FocusEvent<HTMLTextAreaElement>) => onBlur(id, value);
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLTextAreaElement>) => onFocus(id, value);
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLTextAreaElement>) =>
+    onBlur(id, value);
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLTextAreaElement>) =>
+    onFocus(id, value);
 
   return (
     <FormControl

--- a/packages/chakra-ui/src/UpDownWidget/UpDownWidget.tsx
+++ b/packages/chakra-ui/src/UpDownWidget/UpDownWidget.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import {
   NumberInput,
   NumberDecrementStepper,
@@ -45,12 +46,11 @@ export default function UpDownWidget<
   const chakraProps = getChakra({ uiSchema });
 
   const _onChange = (value: string | number) => onChange(value);
-  const _onBlur = ({
-    target: { value },
-  }: React.FocusEvent<HTMLInputElement | any>) => onBlur(id, value);
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement | any>) =>
+    onBlur(id, value);
   const _onFocus = ({
     target: { value },
-  }: React.FocusEvent<HTMLInputElement | any>) => onFocus(id, value);
+  }: FocusEvent<HTMLInputElement | any>) => onFocus(id, value);
 
   return (
     <FormControl

--- a/packages/chakra-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/chakra-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import {
   ADDITIONAL_PROPERTY_FLAG,
   FormContextType,
@@ -47,7 +48,7 @@ export default function WrapIfAdditionalTemplate<
     );
   }
 
-  const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
+  const handleBlur = ({ target }: FocusEvent<HTMLInputElement>) =>
     onKeyChange(target.value);
 
   return (

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -1,4 +1,12 @@
-import { Component, createRef } from "react";
+import {
+  Component,
+  ElementType,
+  FormEvent,
+  ReactNode,
+  Ref,
+  RefObject,
+  createRef,
+} from "react";
 import {
   createSchemaUtils,
   CustomValidator,
@@ -46,7 +54,7 @@ export interface FormProps<
   /** An implementation of the `ValidatorType` interface that is needed for form validation to work */
   validator: ValidatorType<T, S, F>;
   /** The optional children for the form, if provided, it will replace the default `SubmitButton` */
-  children?: React.ReactNode;
+  children?: ReactNode;
   /** The uiSchema for the form */
   uiSchema?: UiSchema<T, S, F>;
   /** The data for the form, used to prefill a form with existing data */
@@ -99,7 +107,7 @@ export interface FormProps<
    * and its data are valid. It will be passed a result object having a `formData` attribute, which is the valid form
    * data you're usually after. The original event will also be passed as a second parameter
    */
-  onSubmit?: (data: IChangeEvent<T, S, F>, event: React.FormEvent<any>) => void;
+  onSubmit?: (data: IChangeEvent<T, S, F>, event: FormEvent<any>) => void;
   /** Sometimes you may want to trigger events or modify external state when a field has been touched, so you can pass
    * an `onBlur` handler, which will receive the id of the input that was blurred and the field value
    */
@@ -134,7 +142,7 @@ export interface FormProps<
    * nesting forms. However, native browser form behaviour, such as submitting when the `Enter` key is pressed, may no
    * longer work
    */
-  tagName?: React.ElementType;
+  tagName?: ElementType;
   /** The value of this prop will be passed to the `target` HTML attribute on the form */
   target?: string;
   // Errors and validation
@@ -196,10 +204,10 @@ export interface FormProps<
    *
    * Use at your own risk as this prop is private and may change at any time without notice.
    */
-  _internalFormWrapper?: React.ElementType;
+  _internalFormWrapper?: ElementType;
   /** Support receiving a React ref to the Form
    */
-  ref?: React.Ref<Form<T, S, F>>;
+  ref?: Ref<Form<T, S, F>>;
 }
 
 /** The data that is contained within the state for the `Form` */
@@ -258,7 +266,7 @@ export default class Form<
   /** The ref used to hold the `form` element, this needs to be `any` because `tagName` or `_internalFormWrapper` can
    * provide any possible type here
    */
-  formElement: React.RefObject<any>;
+  formElement: RefObject<any>;
 
   /** Constructs the `Form` from the `props`. Will setup the initial state from the props. It will also call the
    * `onChange` handler if the initially provided `formData` is modified to add missing default values as part of the
@@ -655,7 +663,7 @@ export default class Form<
    *
    * @param event - The submit HTML form event
    */
-  onSubmit = (event: React.FormEvent<any>) => {
+  onSubmit = (event: FormEvent<any>) => {
     event.preventDefault();
     if (event.target !== event.currentTarget) {
       return;

--- a/packages/core/src/components/fields/ArrayField.tsx
+++ b/packages/core/src/components/fields/ArrayField.tsx
@@ -1,4 +1,4 @@
-import { Component } from "react";
+import { Component, MouseEvent } from "react";
 import {
   getTemplate,
   getWidget,
@@ -302,7 +302,7 @@ class ArrayField<
    * @param newIndex - The index to where the item is to be moved
    */
   onReorderClick = (index: number, newIndex: number) => {
-    return (event: React.MouseEvent<HTMLButtonElement>) => {
+    return (event: MouseEvent<HTMLButtonElement>) => {
       if (event) {
         event.preventDefault();
         event.currentTarget.blur();

--- a/packages/core/src/components/widgets/CheckboxWidget.tsx
+++ b/packages/core/src/components/widgets/CheckboxWidget.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { ChangeEvent, FocusEvent, useCallback } from "react";
 import {
   ariaDescribedByIds,
   descriptionId,
@@ -46,20 +46,17 @@ function CheckboxWidget<
   const required = schemaRequiresTrueValue<S>(schema);
 
   const handleChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) =>
-      onChange(event.target.checked),
+    (event: ChangeEvent<HTMLInputElement>) => onChange(event.target.checked),
     [onChange]
   );
 
   const handleBlur = useCallback(
-    (event: React.FocusEvent<HTMLInputElement>) =>
-      onBlur(id, event.target.checked),
+    (event: FocusEvent<HTMLInputElement>) => onBlur(id, event.target.checked),
     [onBlur, id]
   );
 
   const handleFocus = useCallback(
-    (event: React.FocusEvent<HTMLInputElement>) =>
-      onFocus(id, event.target.checked),
+    (event: FocusEvent<HTMLInputElement>) => onFocus(id, event.target.checked),
     [onFocus, id]
   );
 

--- a/packages/core/src/components/widgets/DateWidget.tsx
+++ b/packages/core/src/components/widgets/DateWidget.tsx
@@ -24,7 +24,7 @@ export default function DateWidget<
     options
   );
   const handleChange = useCallback(
-    (value: React.ChangeEvent) => onChange(value || undefined),
+    (value: any) => onChange(value || undefined),
     [onChange]
   );
 

--- a/packages/core/src/components/widgets/SelectWidget.tsx
+++ b/packages/core/src/components/widgets/SelectWidget.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FocusEvent, useCallback } from "react";
+import { ChangeEvent, FocusEvent, SyntheticEvent, useCallback } from "react";
 import {
   ariaDescribedByIds,
   enumOptionsIndexForValue,
@@ -9,10 +9,7 @@ import {
   WidgetProps,
 } from "@rjsf/utils";
 
-function getValue(
-  event: React.SyntheticEvent<HTMLSelectElement>,
-  multiple: boolean
-) {
+function getValue(event: SyntheticEvent<HTMLSelectElement>, multiple: boolean) {
   if (multiple) {
     return Array.from((event.target as HTMLSelectElement).options)
       .slice()

--- a/packages/core/src/components/widgets/TextareaWidget.tsx
+++ b/packages/core/src/components/widgets/TextareaWidget.tsx
@@ -1,4 +1,4 @@
-import { FocusEvent, useCallback } from "react";
+import { ChangeEvent, FocusEvent, useCallback } from "react";
 import {
   ariaDescribedByIds,
   FormContextType,
@@ -29,7 +29,7 @@ function TextareaWidget<
   onFocus,
 }: WidgetProps<T, S, F>) {
   const handleChange = useCallback(
-    ({ target: { value } }: React.ChangeEvent<HTMLTextAreaElement>) =>
+    ({ target: { value } }: ChangeEvent<HTMLTextAreaElement>) =>
       onChange(value === "" ? options.emptyValue : value),
     [onChange, options.emptyValue]
   );

--- a/packages/core/src/withTheme.tsx
+++ b/packages/core/src/withTheme.tsx
@@ -1,4 +1,4 @@
-import { ForwardedRef, forwardRef } from "react";
+import { ComponentType, ForwardedRef, forwardRef } from "react";
 import Form, { FormProps } from "./components/Form";
 import { FormContextType, RJSFSchema, StrictRJSFSchema } from "@rjsf/utils";
 
@@ -19,7 +19,7 @@ export default function withTheme<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any
->(themeProps: ThemeProps<T, S, F>): React.ComponentType<FormProps<T, S, F>> {
+>(themeProps: ThemeProps<T, S, F>): ComponentType<FormProps<T, S, F>> {
   return forwardRef(
     (
       { fields, widgets, templates, ...directProps }: FormProps<T, S, F>,

--- a/packages/fluent-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/fluent-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -1,3 +1,4 @@
+import { CSSProperties } from "react";
 import {
   getTemplate,
   getUiOptions,
@@ -10,7 +11,7 @@ import {
 
 const rightJustify = {
   float: "right",
-} as React.CSSProperties;
+} as CSSProperties;
 
 export default function ArrayFieldTemplate<
   T = any,

--- a/packages/fluent-ui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/fluent-ui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { FocusEvent, useCallback } from "react";
 import { Checkbox } from "@fluentui/react";
 import {
   ariaDescribedByIds,
@@ -60,12 +60,10 @@ export default function CheckboxWidget<
     [onChange]
   );
 
-  const _onBlur = ({
-    target: { value },
-  }: React.FocusEvent<HTMLButtonElement>) => onBlur(id, value);
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLButtonElement>) => onFocus(id, value);
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLButtonElement>) =>
+    onBlur(id, value);
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLButtonElement>) =>
+    onFocus(id, value);
 
   const uiProps = _pick((options.props as object) || {}, allowedProps);
 

--- a/packages/fluent-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/fluent-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -1,3 +1,4 @@
+import { FormEvent, FocusEvent } from "react";
 import { Checkbox, Label } from "@fluentui/react";
 import {
   ariaDescribedByIds,
@@ -45,8 +46,7 @@ export default function CheckboxesWidget<
   const checkboxesValues = Array.isArray(value) ? value : [value];
 
   const _onChange =
-    (index: number) =>
-    (_ev?: React.FormEvent<HTMLElement>, checked?: boolean) => {
+    (index: number) => (_ev?: FormEvent<HTMLElement>, checked?: boolean) => {
       if (checked) {
         onChange(
           enumOptionsSelectValue<S>(index, checkboxesValues, enumOptions)
@@ -58,14 +58,10 @@ export default function CheckboxesWidget<
       }
     };
 
-  const _onBlur = ({
-    target: { value },
-  }: React.FocusEvent<HTMLButtonElement>) =>
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLButtonElement>) =>
     onBlur(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
 
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLButtonElement>) =>
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLButtonElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
 
   const uiProps = _pick((options.props as object) || {}, allowedProps);

--- a/packages/fluent-ui/src/DateWidget/DateWidget.tsx
+++ b/packages/fluent-ui/src/DateWidget/DateWidget.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import {
   ariaDescribedByIds,
   pad,
@@ -105,11 +106,10 @@ export default function DateWidget<
       formatted && onChange(formatted);
     }
   };
-  const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onBlur(id, value);
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLInputElement>) => onFocus(id, value);
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
+    onFocus(id, value);
 
   const uiProps = _pick((options.props as object) || {}, allowedProps);
   return (

--- a/packages/fluent-ui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/fluent-ui/src/RadioWidget/RadioWidget.tsx
@@ -1,3 +1,4 @@
+import { FormEvent, FocusEvent } from "react";
 import {
   ChoiceGroup,
   IChoiceGroupOption,
@@ -48,7 +49,7 @@ export default function RadioWidget<
   const { enumOptions, enumDisabled, emptyValue } = options;
 
   function _onChange(
-    _ev?: React.FormEvent<HTMLElement | HTMLInputElement>,
+    _ev?: FormEvent<HTMLElement | HTMLInputElement>,
     option?: IChoiceGroupOption
   ): void {
     if (option) {
@@ -56,11 +57,9 @@ export default function RadioWidget<
     }
   }
 
-  const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onBlur(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLInputElement>) =>
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
 
   const newOptions = Array.isArray(enumOptions)

--- a/packages/fluent-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/fluent-ui/src/SelectWidget/SelectWidget.tsx
@@ -1,3 +1,4 @@
+import { FormEvent } from "react";
 import { Dropdown, IDropdownOption } from "@fluentui/react";
 import {
   ariaDescribedByIds,
@@ -78,10 +79,7 @@ export default function SelectWidget<
 }: WidgetProps<T, S, F>) {
   const { enumOptions, enumDisabled, emptyValue } = options;
 
-  const _onChange = (
-    _ev?: React.FormEvent<HTMLElement>,
-    item?: IDropdownOption
-  ) => {
+  const _onChange = (_ev?: FormEvent<HTMLElement>, item?: IDropdownOption) => {
     if (!item) {
       return;
     }

--- a/packages/fluent-ui/src/UpDownWidget/UpDownWidget.tsx
+++ b/packages/fluent-ui/src/UpDownWidget/UpDownWidget.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent, FocusEvent } from "react";
 import { Label, SpinButton } from "@fluentui/react";
 import {
   ariaDescribedByIds,
@@ -69,9 +70,8 @@ export default function UpDownWidget<
   registry,
 }: WidgetProps<T, S, F>) {
   const { translateString } = registry;
-  const _onChange = ({
-    target: { value },
-  }: React.ChangeEvent<HTMLInputElement>) => onChange(Number(value));
+  const _onChange = ({ target: { value } }: ChangeEvent<HTMLInputElement>) =>
+    onChange(Number(value));
 
   let { min, max, step } = rangeSpec<S>(schema);
   if (min === undefined) {
@@ -96,11 +96,10 @@ export default function UpDownWidget<
     }
   };
 
-  const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onBlur(id, value);
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLInputElement>) => onFocus(id, value);
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
+    onFocus(id, value);
 
   const requiredSymbol = required ? "*" : "";
 

--- a/packages/material-ui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/material-ui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import Checkbox from "@material-ui/core/Checkbox";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import {
@@ -37,12 +38,10 @@ export default function CheckboxWidget<
   const required = schemaRequiresTrueValue<S>(schema);
 
   const _onChange = (_: any, checked: boolean) => onChange(checked);
-  const _onBlur = ({
-    target: { value },
-  }: React.FocusEvent<HTMLButtonElement>) => onBlur(id, value);
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLButtonElement>) => onFocus(id, value);
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLButtonElement>) =>
+    onBlur(id, value);
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLButtonElement>) =>
+    onFocus(id, value);
 
   return (
     <FormControlLabel

--- a/packages/material-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/material-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent, FocusEvent } from "react";
 import Checkbox from "@material-ui/core/Checkbox";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import FormGroup from "@material-ui/core/FormGroup";
@@ -43,7 +44,7 @@ export default function CheckboxesWidget<
 
   const _onChange =
     (index: number) =>
-    ({ target: { checked } }: React.ChangeEvent<HTMLInputElement>) => {
+    ({ target: { checked } }: ChangeEvent<HTMLInputElement>) => {
       if (checked) {
         onChange(
           enumOptionsSelectValue<S>(index, checkboxesValues, enumOptions)
@@ -55,13 +56,9 @@ export default function CheckboxesWidget<
       }
     };
 
-  const _onBlur = ({
-    target: { value },
-  }: React.FocusEvent<HTMLButtonElement>) =>
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLButtonElement>) =>
     onBlur(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLButtonElement>) =>
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLButtonElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
 
   return (

--- a/packages/material-ui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/material-ui/src/RadioWidget/RadioWidget.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import FormLabel from "@material-ui/core/FormLabel";
 import Radio from "@material-ui/core/Radio";
@@ -39,11 +40,9 @@ export default function RadioWidget<
 
   const _onChange = (_: any, value: any) =>
     onChange(enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
-  const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onBlur(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLInputElement>) =>
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
 
   const row = options ? options.inline : false;

--- a/packages/material-ui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/material-ui/src/RangeWidget/RangeWidget.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import FormLabel from "@material-ui/core/FormLabel";
 import Slider from "@material-ui/core/Slider";
 import {
@@ -37,11 +38,10 @@ export default function RangeWidget<
   const _onChange = (_: any, value?: number | number[]) => {
     onChange(value ?? options.emptyValue);
   };
-  const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onBlur(id, value);
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLInputElement>) => onFocus(id, value);
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
+    onFocus(id, value);
 
   return (
     <>

--- a/packages/material-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/material-ui/src/SelectWidget/SelectWidget.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent, FocusEvent } from "react";
 import MenuItem from "@material-ui/core/MenuItem";
 import TextField, { TextFieldProps } from "@material-ui/core/TextField";
 import {
@@ -52,15 +53,11 @@ export default function SelectWidget<
     (multiple && value.length < 1) ||
     (!multiple && value === emptyValue);
 
-  const _onChange = ({
-    target: { value },
-  }: React.ChangeEvent<{ value: string }>) =>
+  const _onChange = ({ target: { value } }: ChangeEvent<{ value: string }>) =>
     onChange(enumOptionsValueForIndex<S>(value, enumOptions, optEmptyVal));
-  const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onBlur(id, enumOptionsValueForIndex<S>(value, enumOptions, optEmptyVal));
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLInputElement>) =>
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, optEmptyVal));
   const selectedIndexes = enumOptionsIndexForValue<S>(
     value,

--- a/packages/material-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/material-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties } from "react";
+import { CSSProperties, FocusEvent } from "react";
 import FormControl from "@material-ui/core/FormControl";
 import Grid from "@material-ui/core/Grid";
 import InputLabel from "@material-ui/core/InputLabel";
@@ -57,7 +57,7 @@ export default function WrapIfAdditionalTemplate<
     );
   }
 
-  const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
+  const handleBlur = ({ target }: FocusEvent<HTMLInputElement>) =>
     onKeyChange(target.value);
 
   return (

--- a/packages/mui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/mui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import Checkbox from "@mui/material/Checkbox";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import {
@@ -37,12 +38,10 @@ export default function CheckboxWidget<
   const required = schemaRequiresTrueValue<S>(schema);
 
   const _onChange = (_: any, checked: boolean) => onChange(checked);
-  const _onBlur = ({
-    target: { value },
-  }: React.FocusEvent<HTMLButtonElement>) => onBlur(id, value);
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLButtonElement>) => onFocus(id, value);
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLButtonElement>) =>
+    onBlur(id, value);
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLButtonElement>) =>
+    onFocus(id, value);
 
   return (
     <FormControlLabel

--- a/packages/mui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/mui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent, FocusEvent } from "react";
 import Checkbox from "@mui/material/Checkbox";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import FormGroup from "@mui/material/FormGroup";
@@ -43,7 +44,7 @@ export default function CheckboxesWidget<
 
   const _onChange =
     (index: number) =>
-    ({ target: { checked } }: React.ChangeEvent<HTMLInputElement>) => {
+    ({ target: { checked } }: ChangeEvent<HTMLInputElement>) => {
       if (checked) {
         onChange(enumOptionsSelectValue(index, checkboxesValues, enumOptions));
       } else {
@@ -53,13 +54,9 @@ export default function CheckboxesWidget<
       }
     };
 
-  const _onBlur = ({
-    target: { value },
-  }: React.FocusEvent<HTMLButtonElement>) =>
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLButtonElement>) =>
     onBlur(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLButtonElement>) =>
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLButtonElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
 
   return (

--- a/packages/mui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/mui/src/RadioWidget/RadioWidget.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import FormLabel from "@mui/material/FormLabel";
 import Radio from "@mui/material/Radio";
@@ -39,11 +40,9 @@ export default function RadioWidget<
 
   const _onChange = (_: any, value: any) =>
     onChange(enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
-  const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onBlur(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLInputElement>) =>
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
 
   const row = options ? options.inline : false;

--- a/packages/mui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/mui/src/RangeWidget/RangeWidget.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import FormLabel from "@mui/material/FormLabel";
 import Slider from "@mui/material/Slider";
 import {
@@ -37,11 +38,10 @@ export default function RangeWidget<
   const _onChange = (_: any, value?: number | number[]) => {
     onChange(value ?? options.emptyValue);
   };
-  const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onBlur(id, value);
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLInputElement>) => onFocus(id, value);
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
+    onFocus(id, value);
 
   return (
     <>

--- a/packages/mui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/mui/src/SelectWidget/SelectWidget.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent, FocusEvent } from "react";
 import MenuItem from "@mui/material/MenuItem";
 import TextField, { TextFieldProps } from "@mui/material/TextField";
 import {
@@ -52,15 +53,11 @@ export default function SelectWidget<
     (multiple && value.length < 1) ||
     (!multiple && value === emptyValue);
 
-  const _onChange = ({
-    target: { value },
-  }: React.ChangeEvent<{ value: string }>) =>
+  const _onChange = ({ target: { value } }: ChangeEvent<{ value: string }>) =>
     onChange(enumOptionsValueForIndex<S>(value, enumOptions, optEmptyVal));
-  const _onBlur = ({ target: { value } }: React.FocusEvent<HTMLInputElement>) =>
+  const _onBlur = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onBlur(id, enumOptionsValueForIndex<S>(value, enumOptions, optEmptyVal));
-  const _onFocus = ({
-    target: { value },
-  }: React.FocusEvent<HTMLInputElement>) =>
+  const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, optEmptyVal));
   const selectedIndexes = enumOptionsIndexForValue<S>(
     value,

--- a/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties } from "react";
+import { CSSProperties, FocusEvent } from "react";
 import FormControl from "@mui/material/FormControl";
 import Grid from "@mui/material/Grid";
 import InputLabel from "@mui/material/InputLabel";
@@ -57,7 +57,7 @@ export default function WrapIfAdditionalTemplate<
     );
   }
 
-  const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
+  const handleBlur = ({ target }: FocusEvent<HTMLInputElement>) =>
     onKeyChange(target.value);
 
   return (

--- a/packages/semantic-ui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/semantic-ui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -1,3 +1,4 @@
+import { FormEvent } from "react";
 import {
   ariaDescribedByIds,
   schemaRequiresTrueValue,
@@ -47,10 +48,8 @@ export default function CheckboxWidget<
   // the "required" attribute if the field value must be "true", due to the
   // "const" or "enum" keywords
   const required = schemaRequiresTrueValue<S>(schema);
-  const _onChange = (
-    _: React.FormEvent<HTMLInputElement>,
-    data: CheckboxProps
-  ) => onChange && onChange(data.checked);
+  const _onChange = (_: FormEvent<HTMLInputElement>, data: CheckboxProps) =>
+    onChange && onChange(data.checked);
   const _onBlur = () => onBlur && onBlur(id, value);
   const _onFocus = () => onFocus && onFocus(id, value);
   const checked = value == "true" || value == true;

--- a/packages/semantic-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/semantic-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent } from "react";
 import { Form } from "semantic-ui-react";
 import {
   ariaDescribedByIds,
@@ -58,7 +59,7 @@ export default function CheckboxesWidget<
   });
   const _onChange =
     (index: number) =>
-    ({ target: { checked } }: React.ChangeEvent<HTMLInputElement>) => {
+    ({ target: { checked } }: ChangeEvent<HTMLInputElement>) => {
       // eslint-disable-next-line no-shadow
       if (checked) {
         onChange(

--- a/packages/semantic-ui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/semantic-ui/src/RadioWidget/RadioWidget.tsx
@@ -1,3 +1,4 @@
+import { FormEvent } from "react";
 import {
   ariaDescribedByIds,
   enumOptionsIsSelected,
@@ -42,7 +43,7 @@ export default function RadioWidget<
     uiSchema,
   });
   const _onChange = (
-    _: React.FormEvent<HTMLInputElement>,
+    _: FormEvent<HTMLInputElement>,
     { value: eventValue }: CheckboxProps
   ) => {
     return onChange(

--- a/packages/semantic-ui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/semantic-ui/src/RangeWidget/RangeWidget.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent } from "react";
 import { Input } from "semantic-ui-react";
 import {
   ariaDescribedByIds,
@@ -44,9 +45,7 @@ export default function RangeWidget<
   });
 
   // eslint-disable-next-line no-shadow
-  const _onChange = ({
-    target: { value },
-  }: React.ChangeEvent<HTMLInputElement>) =>
+  const _onChange = ({ target: { value } }: ChangeEvent<HTMLInputElement>) =>
     onChange && onChange(value === "" ? options.emptyValue : value);
   const _onBlur = () => onBlur && onBlur(id, value);
   const _onFocus = () => onFocus && onFocus(id, value);

--- a/packages/semantic-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/semantic-ui/src/SelectWidget/SelectWidget.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent, SyntheticEvent } from "react";
 import {
   ariaDescribedByIds,
   enumOptionsIndexForValue,
@@ -83,7 +84,7 @@ export default function SelectWidget<
     enumDisabled
   );
   const _onChange = (
-    _: React.SyntheticEvent<HTMLElement>,
+    _: SyntheticEvent<HTMLElement>,
     { value }: DropdownProps
   ) =>
     onChange(
@@ -91,11 +92,11 @@ export default function SelectWidget<
     );
   // eslint-disable-next-line no-shadow
   const _onBlur = (
-    _: React.FocusEvent<HTMLElement>,
+    _: FocusEvent<HTMLElement>,
     { target: { value } }: DropdownProps
   ) => onBlur(id, enumOptionsValueForIndex<S>(value, enumOptions, optEmptyVal));
   const _onFocus = (
-    _: React.FocusEvent<HTMLElement>,
+    _: FocusEvent<HTMLElement>,
     { target: { value } }: DropdownProps
   ) =>
     onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, optEmptyVal));

--- a/packages/semantic-ui/src/TextareaWidget/TextareaWidget.tsx
+++ b/packages/semantic-ui/src/TextareaWidget/TextareaWidget.tsx
@@ -1,3 +1,4 @@
+import { ChangeEvent } from "react";
 import {
   ariaDescribedByIds,
   FormContextType,
@@ -43,9 +44,7 @@ export default function TextareaWidget<
   });
   const { schemaUtils } = registry;
   // eslint-disable-next-line no-shadow
-  const _onChange = ({
-    target: { value },
-  }: React.ChangeEvent<HTMLTextAreaElement>) =>
+  const _onChange = ({ target: { value } }: ChangeEvent<HTMLTextAreaElement>) =>
     onChange && onChange(value === "" ? options.emptyValue : value);
   const _onBlur = () => onBlur && onBlur(id, value);
   const _onFocus = () => onFocus && onFocus(id, value);

--- a/packages/semantic-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/semantic-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -1,3 +1,4 @@
+import { FocusEvent } from "react";
 import {
   ADDITIONAL_PROPERTY_FLAG,
   FormContextType,
@@ -49,7 +50,7 @@ export default function WrapIfAdditionalTemplate<
     );
   }
 
-  const handleBlur = ({ target }: React.FocusEvent<HTMLInputElement>) =>
+  const handleBlur = ({ target }: FocusEvent<HTMLInputElement>) =>
     onKeyChange(target.value);
 
   return (

--- a/packages/semantic-ui/src/util.tsx
+++ b/packages/semantic-ui/src/util.tsx
@@ -1,3 +1,4 @@
+import { ElementType } from "react";
 import {
   UiSchema,
   GenericObjectType,
@@ -33,7 +34,7 @@ export type SemanticErrorPropsType<
 
 export type WrapProps = GenericObjectType & {
   wrap: boolean;
-  component?: React.ElementType;
+  component?: ElementType;
 };
 
 /**


### PR DESCRIPTION
### Reasons for making this change

In some places react types were imported directly, others are inferred from `React.xxx`
- Updated all places to import react types directly to maintain consistency
- Updated the `CHANGELOG.md` file accordingly

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
