### PR TITLE
fix(docs): typo in api-reference/uiSchema.md

### DIFF
--- a/packages/docs/docs/api-reference/uiSchema.md
+++ b/packages/docs/docs/api-reference/uiSchema.md
@@ -92,7 +92,7 @@ NOTE: The properties specific to array items can be found [here](../usage/arrays
 
 ### widget
 
-The `ui:field` property overrides the `Widget` implementation used for rendering any field in the form's hierarchy.
+The `ui:widget` property overrides the `Widget` implementation used for rendering any field in the form's hierarchy.
 Specify either the name of a widget that is used to look up an implementation from the `widgets` list or an actual one-off `Widget` component implementation itself.
 
 See [Custom Widgets and Fields](../advanced-customization/custom-widgets-fields) for more information about how to use this property.


### PR DESCRIPTION
### Reasons for making this change

Wrong ui schema property specified in the docs.

### Checklist

- [x] **I'm updating documentation**

