### PR TITLE
fix a few remaining links to readthedocs.io

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,7 @@ body:
     attributes:
       label: Prerequisites
       options:
-        - label: I have read the [documentation](https://react-jsonschema-form.readthedocs.io/)
+        - label: I have read the [documentation](https://rjsf-team.github.io/react-jsonschema-form/docs)
           required: true
   - type: dropdown
     id: theme

--- a/.github/ISSUE_TEMPLATE/question_issue.yml
+++ b/.github/ISSUE_TEMPLATE/question_issue.yml
@@ -9,7 +9,7 @@ body:
     attributes:
       label: Prerequisites
       options:
-        - label: I have read the [documentation](https://react-jsonschema-form.readthedocs.io/)
+        - label: I have read the [documentation](https://rjsf-team.github.io/react-jsonschema-form/docs)
           required: true
   - type: dropdown
     id: theme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1187,7 +1187,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/semantic-ui
 
 - "semantic-ui-react" dependency updated to v1.3.1 (https://github.com/rjsf-team/react-jsonschema-form/pull/2590)
-- fixed an issue where all semantic props overwritten when a single [semantic theme-specific prop](https://react-jsonschema-form.readthedocs.io/en/latest/api-reference/themes/semantic-ui/uiSchema/) is passed in ([issue 2619](https://github.com/rjsf-team/react-jsonschema-form/issues/2619)) (https://github.com/rjsf-team/react-jsonschema-form/pull/2590)
+- fixed an issue where all semantic props overwritten when a single [semantic theme-specific prop](https://rjsf-team.github.io/react-jsonschema-form/docs/api-reference/themes/semantic-ui/uiSchema/) is passed in ([issue 2619](https://github.com/rjsf-team/react-jsonschema-form/issues/2619)) (https://github.com/rjsf-team/react-jsonschema-form/pull/2590)
 
 # v3.2.1
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -9,10 +9,10 @@ If your PR is non-trivial and you'd like to schedule a synchronous review, pleas
 ### Checklist
 
 - [ ] **I'm updating documentation**
-  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
+  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
 - [ ] **I'm adding or updating code**
   - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
-  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
+  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
   - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
 - [ ] **I'm adding a new feature**
   - [ ] I've updated the playground with an example use of the feature

--- a/packages/utils/src/isCustomWidget.ts
+++ b/packages/utils/src/isCustomWidget.ts
@@ -13,7 +13,7 @@ export default function isCustomWidget<
 >(uiSchema: UiSchema<T, S, F> = {}) {
   return (
     // TODO: Remove the `&& uiSchema['ui:widget'] !== 'hidden'` once we support hidden widgets for arrays.
-    // https://react-jsonschema-form.readthedocs.io/en/latest/usage/widgets/#hidden-widgets
+    // https://rjsf-team.github.io/react-jsonschema-form/docs/usage/widgets/#hidden-widgets
     'widget' in getUiOptions<T, S, F>(uiSchema) && getUiOptions<T, S, F>(uiSchema)['widget'] !== 'hidden'
   );
 }


### PR DESCRIPTION
### Reasons for making this change

Docs were moved to GitHub pages

### Checklist

- [X] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
