### PR TITLE
fix: fluent-ui radio widget value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 - `Reset` function added for `Programmatically Reset` action. `Reset` function will reset form data and validation errors. Form data will set to default values.
 
+## @rjsf/fluent-ui
+
+- Fix RadioWidget's onChange return value.
+
 ## Dev / docs / playground
 
 - Added `Programmatically Reset` button to clear states which are form data and validation errors.

--- a/packages/fluent-ui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/fluent-ui/src/RadioWidget/RadioWidget.tsx
@@ -42,7 +42,7 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
 
   function _onChange(_ev?: FormEvent<HTMLElement | HTMLInputElement>, option?: IChoiceGroupOption): void {
     if (option) {
-      onChange(option.key);
+      onChange(enumOptionsValueForIndex<S>(option.key, enumOptions, emptyValue));
     }
   }
 


### PR DESCRIPTION
### Reasons for making this change

[Please describe them here]

Fluent UI's RadioWidget onChange value just currently just returns the key and is inconsistent with the other themes and also inconsistent with its own onBlur & onFocus events.

This PR fixes the return value to be consistent.

If your PR is non-trivial and you'd like to schedule a synchronous review, please add it to the weekly meeting agenda: https://docs.google.com/document/d/12PjTvv21k6LIky6bNQVnsplMLLnmEuypTLQF8a-8Wss/edit

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
