### PR TITLE
fix: Remove JSFiddle template that uses ancient 1.x release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,7 +15,7 @@ body:
           required: true
         - label: I have read the [documentation](https://rjsf-team.github.io/react-jsonschema-form/docs)
           required: true
-        - label: Ideally, I'm providing a [sample JSFiddle](https://jsfiddle.net/n1k0/f2y3fq7L/6/) or a [shared playground link](https://rjsf-team.github.io/react-jsonschema-form/) demonstrating the issue.
+        - label: Ideally, I'm providing a [sample JSFiddle](https://jsfiddle.net), [Codesandbox.io](https://codesandbox.io) or preferably a [shared playground link](https://rjsf-team.github.io/react-jsonschema-form/) demonstrating the issue.
           required: false
   - type: dropdown
     id: theme


### PR DESCRIPTION
### Reasons for making this change

One of our [issues](https://github.com/rjsf-team/react-jsonschema-form/issues/3480) shared that our JSFiddle template caused them to use an ancient version of RJSF

- Updated the `bug_report.yml` to remove the template on `JSFiddle` and to add `Codesandbox.io` as another choice

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
