### PR TITLE
feature: Reimplement and improve #1719 to Add array field copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,32 +18,63 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 5.3.0
 
+## @rjsf/antd
+
+- Added support to make a copy of an array item directly after the item selected to be copied (feature is off by default), fixing [#1261](https://github.com/rjsf-team/react-jsonschema-form/issues/1261) and [#1712](https://github.com/rjsf-team/react-jsonschema-form/issues/1712)
+
+## @rjsf/bootstrap-4
+
+- Added support to make a copy of an array item directly after the item selected to be copied (feature is off by default), fixing [#1261](https://github.com/rjsf-team/react-jsonschema-form/issues/1261) and [#1712](https://github.com/rjsf-team/react-jsonschema-form/issues/1712)
+
+## @rjsf/chakra-ui
+
+- Added support to make a copy of an array item directly after the item selected to be copied (feature is off by default), fixing [#1261](https://github.com/rjsf-team/react-jsonschema-form/issues/1261) and [#1712](https://github.com/rjsf-team/react-jsonschema-form/issues/1712)
+
 ## @rjsf/core
 
 - `Reset` function added for `Programmatically Reset` action. `Reset` function will reset form data and validation errors. Form data will set to default values.
 - Implemented a new `TimeWidget` that works for all themes
+- Added support to make a copy of an array item directly after the item selected to be copied (feature is off by default), fixing [#1261](https://github.com/rjsf-team/react-jsonschema-form/issues/1261) and [#1712](https://github.com/rjsf-team/react-jsonschema-form/issues/1712)
+- Also added the missing translation for the `InvalidObjectField` error in `ObjectField`
+- Added support for the handling of the global UiSchema options in `Form`, `ArrayField`, `ObjectField` and `SchemaField`
 
 ## @rjsf/fluent-ui
 
 - Fix `RadioWidget`'s onChange return value.
+- Added support to make a copy of an array item directly after the item selected to be copied (feature is off by default), fixing [#1261](https://github.com/rjsf-team/react-jsonschema-form/issues/1261) and [#1712](https://github.com/rjsf-team/react-jsonschema-form/issues/1712)
 
 ## @rjsf/material-ui
 
 - Updated `BaseInputTemplate` so that it shrinks a `time` formatted input
+- Added support to make a copy of an array item directly after the item selected to be copied (feature is off by default), fixing [#1261](https://github.com/rjsf-team/react-jsonschema-form/issues/1261) and [#1712](https://github.com/rjsf-team/react-jsonschema-form/issues/1712)
 
 ## @rjsf/mui
 
 - Updated `BaseInputTemplate` so that it shrinks a `time` formatted input
+- Added support to make a copy of an array item directly after the item selected to be copied (feature is off by default), fixing [#1261](https://github.com/rjsf-team/react-jsonschema-form/issues/1261) and [#1712](https://github.com/rjsf-team/react-jsonschema-form/issues/1712)
+
+## @rjsf/semantic-ui
+
+- Added support to make a copy of an array item directly after the item selected to be copied (feature is off by default), fixing [#1261](https://github.com/rjsf-team/react-jsonschema-form/issues/1261) and [#1712](https://github.com/rjsf-team/react-jsonschema-form/issues/1712)
 
 ## @rjsf/utils
 
 - Updated the widget matrix used by `getWidget()` to support the `time` to `TimeWidget` mapping
+- Added a new `TranslatableString` enums `CopyButton` and `InvalidObjectField` that localizes the information extracted from `ObjectField` as markdown
+- Updated the `ArrayFieldTemplateItemType` to add support for copying array items
+- Refactored `UIOptionsBaseType` to extract the `addable`, `orderable`, `removable`, `label` and `duplicateKeySuffixSeparator` into a new `GlobalUISchemaOptions` type that adds `copyable`
+  - Extended `UIOptionsBaseType` from `GlobalUISchemaOptions`
+  - In `UiSchema` added a new optional `ui:globalOptions` prop of type `GlobalUISchemaOptions` and a new `UI_GLOBAL_OPTIONS_KEY` constant
+  - Added a new optional prop `globalUiOptions` object of type `GlobalUISchemaOptions` in `Registry` as well as `CopyButton` in `ButtonTemplates`
+- Updated `getUiOptions()` and `getDisplayLabel()` (and its `SchemaUtilsType` counterpart) to take an optional `GlobalUISchemaOptions` parameter that is used to include global options into the returned `uiOptions`
 
 ## Dev / docs / playground
 
 - Updated the playground to add a `Programmatically Reset` button to clear states which are form data and validation errors.
 - Updated the `Date & time` example to show off the new `TimeWidget`.
 - Updated the `custom-widgets-fields` and `widgets` documentation to mention the new `TimeWidget` and its support for the `time` format.
+- Updated the documentation for `custom-templates`, `internals`, `uiSchema`, `utility-functions` and `arrays` for the new copy array feature as well as the global UI Schema options support
+- Updated the `arrays` example to add examples for the new `copyable` feature
 
 # 5.2.1
 

--- a/packages/antd/src/templates/ArrayFieldItemTemplate/index.tsx
+++ b/packages/antd/src/templates/ArrayFieldItemTemplate/index.tsx
@@ -8,7 +8,7 @@ const BTN_GRP_STYLE = {
 };
 
 const BTN_STYLE = {
-  width: 'calc(100% / 3)',
+  width: 'calc(100% / 4)',
 };
 
 /** The `ArrayFieldItemTemplate` component is the template used to render an items of an array.
@@ -23,18 +23,20 @@ export default function ArrayFieldItemTemplate<
   const {
     children,
     disabled,
+    hasCopy,
     hasMoveDown,
     hasMoveUp,
     hasRemove,
     hasToolbar,
     index,
+    onCopyIndexClick,
     onDropIndexClick,
     onReorderClick,
     readonly,
     registry,
     uiSchema,
   } = props;
-  const { MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates;
+  const { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates;
   const { rowGutter = 24, toolbarAlign = 'top' } = registry.formContext;
 
   return (
@@ -57,6 +59,15 @@ export default function ArrayFieldItemTemplate<
               <MoveDownButton
                 disabled={disabled || readonly || !hasMoveDown}
                 onClick={onReorderClick(index, index + 1)}
+                style={BTN_STYLE}
+                uiSchema={uiSchema}
+                registry={registry}
+              />
+            )}
+            {hasCopy && (
+              <CopyButton
+                disabled={disabled || readonly}
+                onClick={onCopyIndexClick(index)}
                 style={BTN_STYLE}
                 uiSchema={uiSchema}
                 registry={registry}

--- a/packages/antd/src/templates/IconButton/index.tsx
+++ b/packages/antd/src/templates/IconButton/index.tsx
@@ -1,6 +1,7 @@
 import Button, { ButtonProps, ButtonType } from 'antd/lib/button';
 import ArrowDownOutlined from '@ant-design/icons/ArrowDownOutlined';
 import ArrowUpOutlined from '@ant-design/icons/ArrowUpOutlined';
+import CopyOutlined from '@ant-design/icons/CopyOutlined';
 import DeleteOutlined from '@ant-design/icons/DeleteOutlined';
 import PlusCircleOutlined from '@ant-design/icons/PlusCircleOutlined';
 import {
@@ -41,6 +42,15 @@ export function AddButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F ex
       icon={<PlusCircleOutlined />}
     />
   );
+}
+
+export function CopyButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: AntdIconButtonProps<T, S, F>
+) {
+  const {
+    registry: { translateString },
+  } = props;
+  return <IconButton title={translateString(TranslatableString.CopyButton)} {...props} icon={<CopyOutlined />} />;
 }
 
 export function MoveDownButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(

--- a/packages/antd/src/templates/index.ts
+++ b/packages/antd/src/templates/index.ts
@@ -5,7 +5,7 @@ import ArrayFieldTemplate from './ArrayFieldTemplate';
 import BaseInputTemplate from './BaseInputTemplate';
 import DescriptionField from './DescriptionField';
 import ErrorList from './ErrorList';
-import { AddButton, MoveDownButton, MoveUpButton, RemoveButton } from './IconButton';
+import { AddButton, CopyButton, MoveDownButton, MoveUpButton, RemoveButton } from './IconButton';
 import FieldErrorTemplate from './FieldErrorTemplate';
 import FieldTemplate from './FieldTemplate';
 import ObjectFieldTemplate from './ObjectFieldTemplate';
@@ -24,6 +24,7 @@ export function generateTemplates<
     BaseInputTemplate,
     ButtonTemplates: {
       AddButton,
+      CopyButton,
       MoveDownButton,
       MoveUpButton,
       RemoveButton,

--- a/packages/antd/test/Array.test.tsx
+++ b/packages/antd/test/Array.test.tsx
@@ -1,5 +1,5 @@
 import renderer from 'react-test-renderer';
-import { RJSFSchema, ErrorSchema } from '@rjsf/utils';
+import { RJSFSchema, ErrorSchema, UiSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 
 import '../__mocks__/matchMedia.mock';
@@ -62,7 +62,12 @@ describe('array fields', () => {
         type: 'string',
       },
     };
-    const tree = renderer.create(<Form schema={schema} validator={validator} formData={['a', 'b']} />).toJSON();
+    const uiSchema: UiSchema = {
+      'ui:options': { copyable: true },
+    };
+    const tree = renderer
+      .create(<Form schema={schema} uiSchema={uiSchema} validator={validator} formData={['a', 'b']} />)
+      .toJSON();
     expect(tree).toMatchSnapshot();
   });
 

--- a/packages/antd/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Array.test.tsx.snap
@@ -239,7 +239,7 @@ exports[`array fields array icons 1`] = `
                   onClick={[Function]}
                   style={
                     Object {
-                      "width": "calc(100% / 3)",
+                      "width": "calc(100% / 4)",
                     }
                   }
                   title="Move up"
@@ -271,7 +271,7 @@ exports[`array fields array icons 1`] = `
                   onClick={[Function]}
                   style={
                     Object {
-                      "width": "calc(100% / 3)",
+                      "width": "calc(100% / 4)",
                     }
                   }
                   title="Move down"
@@ -298,12 +298,44 @@ exports[`array fields array icons 1`] = `
                   </span>
                 </button>
                 <button
+                  className="ant-btn ant-btn-default ant-btn-icon-only"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "width": "calc(100% / 4)",
+                    }
+                  }
+                  title="Copy"
+                  type="button"
+                >
+                  <span
+                    aria-label="copy"
+                    className="anticon anticon-copy"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="copy"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+                <button
                   className="ant-btn ant-btn-primary ant-btn-icon-only ant-btn-dangerous"
                   disabled={false}
                   onClick={[Function]}
                   style={
                     Object {
-                      "width": "calc(100% / 3)",
+                      "width": "calc(100% / 4)",
                     }
                   }
                   title="Remove"
@@ -430,7 +462,7 @@ exports[`array fields array icons 1`] = `
                   onClick={[Function]}
                   style={
                     Object {
-                      "width": "calc(100% / 3)",
+                      "width": "calc(100% / 4)",
                     }
                   }
                   title="Move up"
@@ -462,7 +494,7 @@ exports[`array fields array icons 1`] = `
                   onClick={[Function]}
                   style={
                     Object {
-                      "width": "calc(100% / 3)",
+                      "width": "calc(100% / 4)",
                     }
                   }
                   title="Move down"
@@ -489,12 +521,44 @@ exports[`array fields array icons 1`] = `
                   </span>
                 </button>
                 <button
+                  className="ant-btn ant-btn-default ant-btn-icon-only"
+                  disabled={false}
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "width": "calc(100% / 4)",
+                    }
+                  }
+                  title="Copy"
+                  type="button"
+                >
+                  <span
+                    aria-label="copy"
+                    className="anticon anticon-copy"
+                    role="img"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      data-icon="copy"
+                      fill="currentColor"
+                      focusable="false"
+                      height="1em"
+                      viewBox="64 64 896 896"
+                      width="1em"
+                    >
+                      <path
+                        d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+                <button
                   className="ant-btn ant-btn-primary ant-btn-icon-only ant-btn-dangerous"
                   disabled={false}
                   onClick={[Function]}
                   style={
                     Object {
-                      "width": "calc(100% / 3)",
+                      "width": "calc(100% / 4)",
                     }
                   }
                   title="Remove"

--- a/packages/bootstrap-4/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
+++ b/packages/bootstrap-4/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
@@ -12,17 +12,19 @@ export default function ArrayFieldItemTemplate<
     children,
     disabled,
     hasToolbar,
+    hasCopy,
     hasMoveDown,
     hasMoveUp,
     hasRemove,
     index,
+    onCopyIndexClick,
     onDropIndexClick,
     onReorderClick,
     readonly,
     registry,
     uiSchema,
   } = props;
-  const { MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates;
+  const { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates;
   const btnStyle: CSSProperties = {
     flex: 1,
     paddingLeft: 6,
@@ -56,6 +58,17 @@ export default function ArrayFieldItemTemplate<
                     style={btnStyle}
                     disabled={disabled || readonly || !hasMoveDown}
                     onClick={onReorderClick(index, index + 1)}
+                    uiSchema={uiSchema}
+                    registry={registry}
+                  />
+                </div>
+              )}
+              {hasCopy && (
+                <div className='m-0 p-0'>
+                  <CopyButton
+                    style={btnStyle}
+                    disabled={disabled || readonly}
+                    onClick={onCopyIndexClick(index)}
                     uiSchema={uiSchema}
                     registry={registry}
                   />

--- a/packages/bootstrap-4/src/IconButton/IconButton.tsx
+++ b/packages/bootstrap-4/src/IconButton/IconButton.tsx
@@ -1,5 +1,6 @@
 import { FormContextType, IconButtonProps, RJSFSchema, StrictRJSFSchema, TranslatableString } from '@rjsf/utils';
 import Button, { ButtonProps } from 'react-bootstrap/Button';
+import { IoIosCopy } from '@react-icons/all-files/io/IoIosCopy';
 import { IoIosRemove } from '@react-icons/all-files/io/IoIosRemove';
 import { AiOutlineArrowUp } from '@react-icons/all-files/ai/AiOutlineArrowUp';
 import { AiOutlineArrowDown } from '@react-icons/all-files/ai/AiOutlineArrowDown';
@@ -13,6 +14,15 @@ export default function IconButton<T = any, S extends StrictRJSFSchema = RJSFSch
       {icon}
     </Button>
   );
+}
+
+export function CopyButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: IconButtonProps<T, S, F>
+) {
+  const {
+    registry: { translateString },
+  } = props;
+  return <IconButton title={translateString(TranslatableString.CopyButton)} {...props} icon={<IoIosCopy />} />;
 }
 
 export function MoveDownButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(

--- a/packages/bootstrap-4/src/Templates/Templates.ts
+++ b/packages/bootstrap-4/src/Templates/Templates.ts
@@ -4,7 +4,7 @@ import ArrayFieldTemplate from '../ArrayFieldTemplate';
 import BaseInputTemplate from '../BaseInputTemplate/BaseInputTemplate';
 import DescriptionField from '../DescriptionField';
 import ErrorList from '../ErrorList';
-import { MoveDownButton, MoveUpButton, RemoveButton } from '../IconButton';
+import { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } from '../IconButton';
 import FieldErrorTemplate from '../FieldErrorTemplate';
 import FieldHelpTemplate from '../FieldHelpTemplate';
 import FieldTemplate from '../FieldTemplate';
@@ -25,6 +25,7 @@ export function generateTemplates<
     BaseInputTemplate,
     ButtonTemplates: {
       AddButton,
+      CopyButton,
       MoveDownButton,
       MoveUpButton,
       RemoveButton,

--- a/packages/bootstrap-4/test/Array.test.tsx
+++ b/packages/bootstrap-4/test/Array.test.tsx
@@ -1,4 +1,4 @@
-import { RJSFSchema, ErrorSchema } from '@rjsf/utils';
+import { RJSFSchema, ErrorSchema, UiSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 import renderer from 'react-test-renderer';
 
@@ -49,7 +49,12 @@ describe('array fields', () => {
         type: 'string',
       },
     };
-    const tree = renderer.create(<Form schema={schema} validator={validator} formData={['a', 'b']} />).toJSON();
+    const uiSchema: UiSchema = {
+      'ui:options': { copyable: true },
+    };
+    const tree = renderer
+      .create(<Form schema={schema} uiSchema={uiSchema} validator={validator} formData={['a', 'b']} />)
+      .toJSON();
     expect(tree).toMatchSnapshot();
   });
   test('no errors', () => {

--- a/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Array.test.tsx.snap
@@ -241,6 +241,50 @@ exports[`array fields array icons 1`] = `
                         className="m-0 p-0"
                       >
                         <button
+                          className="btn btn-light btn-sm"
+                          disabled={false}
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "flex": 1,
+                              "fontWeight": "bold",
+                              "paddingLeft": 6,
+                              "paddingRight": 6,
+                            }
+                          }
+                          title="Copy"
+                          type="button"
+                        >
+                          <svg
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            strokeWidth="0"
+                            style={
+                              Object {
+                                "color": undefined,
+                              }
+                            }
+                            viewBox="0 0 512 512"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M352 115h90c3.3 0 6-2.7 6-6 0-8.2-3.7-16-10-21.3l-77.1-64.2c-4.9-4.1-14.2-7.4-20.6-7.4-4.1 0-7.4 3.3-7.4 7.4V96c.1 10.5 8.6 19 19.1 19z"
+                            />
+                            <path
+                              d="M307 96V16H176c-17.6 0-32 14.4-32 32v336c0 17.6 14.4 32 32 32h240c17.6 0 32-14.4 32-32V141h-96c-24.8 0-45-20.2-45-45z"
+                            />
+                            <path
+                              d="M116 412V80H96c-17.6 0-32 14.4-32 32v352c0 17.6 14.4 32 32 32h256c17.6 0 32-14.4 32-32v-20H148c-17.6 0-32-14.4-32-32z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                      <div
+                        className="m-0 p-0"
+                      >
+                        <button
                           className="btn btn-danger btn-sm"
                           disabled={false}
                           onClick={[Function]}
@@ -397,6 +441,50 @@ exports[`array fields array icons 1`] = `
                           >
                             <path
                               d="M862 465.3h-81c-4.6 0-9 2-12.1 5.5L550 723.1V160c0-4.4-3.6-8-8-8h-60c-4.4 0-8 3.6-8 8v563.1L255.1 470.8c-3-3.5-7.4-5.5-12.1-5.5h-81c-6.8 0-10.5 8.1-6 13.2L487.9 861a31.96 31.96 0 0 0 48.3 0L868 478.5c4.5-5.2.8-13.2-6-13.2z"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                      <div
+                        className="m-0 p-0"
+                      >
+                        <button
+                          className="btn btn-light btn-sm"
+                          disabled={false}
+                          onClick={[Function]}
+                          style={
+                            Object {
+                              "flex": 1,
+                              "fontWeight": "bold",
+                              "paddingLeft": 6,
+                              "paddingRight": 6,
+                            }
+                          }
+                          title="Copy"
+                          type="button"
+                        >
+                          <svg
+                            fill="currentColor"
+                            height="1em"
+                            stroke="currentColor"
+                            strokeWidth="0"
+                            style={
+                              Object {
+                                "color": undefined,
+                              }
+                            }
+                            viewBox="0 0 512 512"
+                            width="1em"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M352 115h90c3.3 0 6-2.7 6-6 0-8.2-3.7-16-10-21.3l-77.1-64.2c-4.9-4.1-14.2-7.4-20.6-7.4-4.1 0-7.4 3.3-7.4 7.4V96c.1 10.5 8.6 19 19.1 19z"
+                            />
+                            <path
+                              d="M307 96V16H176c-17.6 0-32 14.4-32 32v336c0 17.6 14.4 32 32 32h240c17.6 0 32-14.4 32-32V141h-96c-24.8 0-45-20.2-45-45z"
+                            />
+                            <path
+                              d="M116 412V80H96c-17.6 0-32 14.4-32 32v352c0 17.6 14.4 32 32 32h256c17.6 0 32-14.4 32-32v-20H148c-17.6 0-32-14.4-32-32z"
                             />
                           </svg>
                         </button>

--- a/packages/chakra-ui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
+++ b/packages/chakra-ui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
@@ -11,17 +11,21 @@ export default function ArrayFieldItemTemplate<
     children,
     disabled,
     hasToolbar,
+    hasCopy,
     hasMoveDown,
     hasMoveUp,
     hasRemove,
     index,
+    onCopyIndexClick,
     onDropIndexClick,
     onReorderClick,
     readonly,
     uiSchema,
     registry,
   } = props;
-  const { MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates;
+  const { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates;
+  const onCopyClick = useMemo(() => onCopyIndexClick(index), [index, onCopyIndexClick]);
+
   const onRemoveClick = useMemo(() => onDropIndexClick(index), [index, onDropIndexClick]);
 
   const onArrowUpClick = useMemo(() => onReorderClick(index, index - 1), [index, onReorderClick]);
@@ -46,6 +50,14 @@ export default function ArrayFieldItemTemplate<
               <MoveDownButton
                 disabled={disabled || readonly || !hasMoveDown}
                 onClick={onArrowDownClick}
+                uiSchema={uiSchema}
+                registry={registry}
+              />
+            )}
+            {hasCopy && (
+              <CopyButton
+                disabled={disabled || readonly}
+                onClick={onCopyClick}
                 uiSchema={uiSchema}
                 registry={registry}
               />

--- a/packages/chakra-ui/src/IconButton/IconButton.tsx
+++ b/packages/chakra-ui/src/IconButton/IconButton.tsx
@@ -1,7 +1,18 @@
 import { FormContextType, IconButtonProps, RJSFSchema, StrictRJSFSchema, TranslatableString } from '@rjsf/utils';
 
-import { ArrowUpIcon, ArrowDownIcon, DeleteIcon } from '@chakra-ui/icons';
+import { ArrowUpIcon, ArrowDownIcon, CopyIcon, DeleteIcon } from '@chakra-ui/icons';
 import ChakraIconButton from './ChakraIconButton';
+
+export function CopyButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: IconButtonProps<T, S, F>
+) {
+  const {
+    registry: { translateString },
+  } = props;
+  return (
+    <ChakraIconButton<T, S, F> title={translateString(TranslatableString.CopyButton)} {...props} icon={<CopyIcon />} />
+  );
+}
 
 export function MoveDownButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   props: IconButtonProps<T, S, F>

--- a/packages/chakra-ui/src/Templates/Templates.ts
+++ b/packages/chakra-ui/src/Templates/Templates.ts
@@ -4,7 +4,7 @@ import ArrayFieldTemplate from '../ArrayFieldTemplate';
 import BaseInputTemplate from '../BaseInputTemplate/BaseInputTemplate';
 import DescriptionField from '../DescriptionField';
 import ErrorList from '../ErrorList';
-import { MoveDownButton, MoveUpButton, RemoveButton } from '../IconButton';
+import { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } from '../IconButton';
 import FieldErrorTemplate from '../FieldErrorTemplate';
 import FieldHelpTemplate from '../FieldHelpTemplate';
 import FieldTemplate from '../FieldTemplate';
@@ -24,6 +24,7 @@ export function generateTemplates<
     ArrayFieldTemplate,
     BaseInputTemplate,
     ButtonTemplates: {
+      CopyButton,
       AddButton,
       MoveDownButton,
       MoveUpButton,

--- a/packages/chakra-ui/test/Array.test.tsx
+++ b/packages/chakra-ui/test/Array.test.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import { RJSFSchema, ErrorSchema } from '@rjsf/utils';
+import { RJSFSchema, ErrorSchema, UiSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 import renderer from 'react-test-renderer';
 
@@ -51,7 +51,12 @@ describe('array fields', () => {
         type: 'string',
       },
     };
-    const tree = renderer.create(<Form schema={schema} validator={validator} formData={['a', 'b']} />).toJSON();
+    const uiSchema: UiSchema = {
+      'ui:options': { copyable: true },
+    };
+    const tree = renderer
+      .create(<Form schema={schema} uiSchema={uiSchema} validator={validator} formData={['a', 'b']} />)
+      .toJSON();
     expect(tree).toMatchSnapshot();
   });
   test('no errors', () => {

--- a/packages/chakra-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Array.test.tsx.snap
@@ -250,15 +250,15 @@ exports[`array fields array icons 1`] = `
   vertical-align: middle;
 }
 
-.emotion-30 {
+.emotion-34 {
   justify-self: flex-end;
 }
 
-.emotion-31 {
+.emotion-35 {
   margin-top: 2px;
 }
 
-.emotion-32 {
+.emotion-36 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -287,7 +287,7 @@ exports[`array fields array icons 1`] = `
   width: auto;
 }
 
-.emotion-33 {
+.emotion-37 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -302,7 +302,7 @@ exports[`array fields array icons 1`] = `
   margin-inline-end: 0.5rem;
 }
 
-.emotion-35 {
+.emotion-39 {
   margin-top: 3px;
 }
 
@@ -408,6 +408,26 @@ exports[`array fields array icons 1`] = `
                     >
                       <path
                         d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </button>
+                  <button
+                    aria-label="Copy"
+                    className="chakra-button emotion-11"
+                    disabled={false}
+                    onClick={[Function]}
+                    title="Copy"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="chakra-icon emotion-12"
+                      focusable={false}
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
                         fill="currentColor"
                       />
                     </svg>
@@ -524,6 +544,26 @@ exports[`array fields array icons 1`] = `
                     </svg>
                   </button>
                   <button
+                    aria-label="Copy"
+                    className="chakra-button emotion-11"
+                    disabled={false}
+                    onClick={[Function]}
+                    title="Copy"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="chakra-icon emotion-12"
+                      focusable={false}
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                        fill="currentColor"
+                      />
+                    </svg>
+                  </button>
+                  <button
                     aria-label="Remove"
                     className="chakra-button emotion-11"
                     disabled={false}
@@ -551,19 +591,19 @@ exports[`array fields array icons 1`] = `
             </div>
           </div>
           <div
-            className="emotion-30"
+            className="emotion-34"
           >
             <div
-              className="emotion-31"
+              className="emotion-35"
             >
               <button
-                className="chakra-button array-item-add emotion-32"
+                className="chakra-button array-item-add emotion-36"
                 disabled={false}
                 onClick={[Function]}
                 type="button"
               >
                 <span
-                  className="chakra-button__icon emotion-33"
+                  className="chakra-button__icon emotion-37"
                 >
                   <svg
                     aria-hidden={true}
@@ -586,10 +626,10 @@ exports[`array fields array icons 1`] = `
     </div>
   </div>
   <div
-    className="emotion-35"
+    className="emotion-39"
   >
     <button
-      className="chakra-button emotion-32"
+      className="chakra-button emotion-36"
       disabled={false}
       type="submit"
     >

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -25,6 +25,7 @@ import {
   shouldRender,
   TemplatesType,
   UiSchema,
+  UI_GLOBAL_OPTIONS_KEY,
   ValidationData,
   ValidatorType,
 } from '@rjsf/utils';
@@ -634,7 +635,7 @@ export default class Form<
 
   /** Returns the registry for the form */
   getRegistry(): Registry<T, S, F> {
-    const { translateString: customTranslateString } = this.props;
+    const { translateString: customTranslateString, uiSchema = {} } = this.props;
     const { schemaUtils } = this.state;
     const { fields, templates, widgets, formContext, translateString } = getDefaultRegistry<T, S, F>();
     return {
@@ -652,6 +653,7 @@ export default class Form<
       formContext: this.props.formContext || formContext,
       schemaUtils,
       translateString: customTranslateString || translateString,
+      globalUiOptions: uiSchema[UI_GLOBAL_OPTIONS_KEY],
     };
   }
 

--- a/packages/core/src/components/fields/ArrayField.tsx
+++ b/packages/core/src/components/fields/ArrayField.tsx
@@ -811,7 +811,7 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
     const has: { [key: string]: boolean } = {
       moveUp: orderable && canMoveUp,
       moveDown: orderable && canMoveDown,
-      copy: canAdd && copyable,
+      copy: copyable && canAdd,
       remove: removable && canRemove,
       toolbar: false,
     };

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -114,8 +114,8 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
     registry,
     wasPropertyKeyModified = false,
   } = props;
-  const { formContext, schemaUtils } = registry;
-  const uiOptions = getUiOptions<T, S, F>(uiSchema);
+  const { formContext, schemaUtils, globalUiOptions } = registry;
+  const uiOptions = getUiOptions<T, S, F>(uiSchema, globalUiOptions);
   const FieldTemplate = getTemplate<'FieldTemplate', T, S, F>('FieldTemplate', registry, uiOptions);
   const DescriptionFieldTemplate = getTemplate<'DescriptionFieldTemplate', T, S, F>(
     'DescriptionFieldTemplate',
@@ -153,7 +153,7 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
     return null;
   }
 
-  const displayLabel = schemaUtils.getDisplayLabel(schema, uiSchema);
+  const displayLabel = schemaUtils.getDisplayLabel(schema, uiSchema, globalUiOptions);
 
   const { __errors, ...fieldErrorSchema } = errorSchema || {};
   // See #439: uiSchema: Don't pass consumed class names or style to child components

--- a/packages/core/src/components/templates/ArrayFieldItemTemplate.tsx
+++ b/packages/core/src/components/templates/ArrayFieldItemTemplate.tsx
@@ -18,14 +18,16 @@ export default function ArrayFieldItemTemplate<
     hasMoveDown,
     hasMoveUp,
     hasRemove,
+    hasCopy,
     index,
+    onCopyIndexClick,
     onDropIndexClick,
     onReorderClick,
     readonly,
     registry,
     uiSchema,
   } = props;
-  const { MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates;
+  const { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates;
   const btnStyle: CSSProperties = {
     flex: 1,
     paddingLeft: 6,
@@ -58,6 +60,15 @@ export default function ArrayFieldItemTemplate<
                 style={btnStyle}
                 disabled={disabled || readonly || !hasMoveDown}
                 onClick={onReorderClick(index, index + 1)}
+                uiSchema={uiSchema}
+                registry={registry}
+              />
+            )}
+            {hasCopy && (
+              <CopyButton
+                style={btnStyle}
+                disabled={disabled || readonly}
+                onClick={onCopyIndexClick(index)}
                 uiSchema={uiSchema}
                 registry={registry}
               />

--- a/packages/core/src/components/templates/ButtonTemplates/IconButton.tsx
+++ b/packages/core/src/components/templates/ButtonTemplates/IconButton.tsx
@@ -11,6 +11,22 @@ export default function IconButton<T = any, S extends StrictRJSFSchema = RJSFSch
   );
 }
 
+export function CopyButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: IconButtonProps<T, S, F>
+) {
+  const {
+    registry: { translateString },
+  } = props;
+  return (
+    <IconButton
+      title={translateString(TranslatableString.CopyButton)}
+      className='array-item-copy'
+      {...props}
+      icon='copy'
+    />
+  );
+}
+
 export function MoveDownButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   props: IconButtonProps<T, S, F>
 ) {

--- a/packages/core/src/components/templates/ButtonTemplates/index.ts
+++ b/packages/core/src/components/templates/ButtonTemplates/index.ts
@@ -2,7 +2,7 @@ import { FormContextType, RJSFSchema, StrictRJSFSchema, TemplatesType } from '@r
 
 import SubmitButton from './SubmitButton';
 import AddButton from './AddButton';
-import { RemoveButton, MoveDownButton, MoveUpButton } from './IconButton';
+import { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } from './IconButton';
 
 function buttonTemplates<
   T = any,
@@ -12,6 +12,7 @@ function buttonTemplates<
   return {
     SubmitButton,
     AddButton,
+    CopyButton,
     MoveDownButton,
     MoveUpButton,
     RemoveButton,

--- a/packages/core/test/ArrayField.test.jsx
+++ b/packages/core/test/ArrayField.test.jsx
@@ -26,6 +26,11 @@ const ExposedArrayKeyTemplate = function (props) {
                 Up
               </button>
             )}
+            {element.hasCopy && (
+              <button className='array-item-copy' onClick={element.onCopyIndexClick(element.index)}>
+                Copy
+              </button>
+            )}
             {element.hasRemove && (
               <button className='array-item-remove' onClick={element.onDropIndexClick(element.index)}>
                 Remove
@@ -677,6 +682,19 @@ describe('ArrayField', () => {
       expect(moveDownBtns[1].disabled).eql(true);
     });
 
+    it('should not show move up/down buttons if global orderable is false', () => {
+      const { node } = createFormComponent({
+        schema,
+        formData: ['foo', 'bar'],
+        uiSchema: { 'ui:globalOptions': { orderable: false } },
+      });
+      const moveUpBtns = node.querySelector('.array-item-move-up');
+      const moveDownBtns = node.querySelector('.array-item-move-down');
+
+      expect(moveUpBtns).to.be.null;
+      expect(moveDownBtns).to.be.null;
+    });
+
     it('should not show move up/down buttons if orderable is false', () => {
       const { node } = createFormComponent({
         schema,
@@ -754,6 +772,17 @@ describe('ArrayField', () => {
       expect(endRows[0].hasAttribute(ArrayKeyDataAttr)).to.be.true;
     });
 
+    it('should not show remove button if global removable is false', () => {
+      const { node } = createFormComponent({
+        schema,
+        formData: ['foo', 'bar'],
+        uiSchema: { 'ui:globalOptions': { removable: false } },
+      });
+      const dropBtn = node.querySelector('.array-item-remove');
+
+      expect(dropBtn).to.be.null;
+    });
+
     it('should not show remove button if removable is false', () => {
       const { node } = createFormComponent({
         schema,
@@ -799,6 +828,66 @@ describe('ArrayField', () => {
       Simulate.click(dropBtns[0]);
 
       expect(node.querySelectorAll('.has-error .error-detail')).to.have.length.of(0);
+    });
+
+    it('should not show copy button by default', () => {
+      const { node } = createFormComponent({
+        schema,
+        formData: ['foo', 'bar'],
+      });
+      const dropBtn = node.querySelector('.array-item-copy');
+
+      expect(dropBtn).to.be.null;
+    });
+
+    it('should show copy button if global options copyable is true', () => {
+      const { node } = createFormComponent({
+        schema,
+        formData: ['foo', 'bar'],
+        uiSchema: { 'ui:globalOptions': { copyable: true } },
+      });
+      const dropBtn = node.querySelector('.array-item-copy');
+
+      expect(dropBtn).not.to.be.null;
+    });
+
+    it('should show copy button if copyable is true', () => {
+      const { node } = createFormComponent({
+        schema,
+        formData: ['foo', 'bar'],
+        uiSchema: { 'ui:options': { copyable: true } },
+      });
+      const dropBtn = node.querySelector('.array-item-copy');
+
+      expect(dropBtn).not.to.be.null;
+    });
+
+    it('should show copy button if ui:copyable is true', () => {
+      const { node } = createFormComponent({
+        schema,
+        formData: ['foo', 'bar'],
+        uiSchema: { 'ui:copyable': true },
+      });
+      const dropBtn = node.querySelector('.array-item-copy');
+
+      expect(dropBtn).not.to.be.null;
+    });
+
+    it('should copy a field in the list just below the item clicked', () => {
+      const { node } = createFormComponent({
+        schema,
+        formData: ['foo', 'bar'],
+        uiSchema: { 'ui:copyable': true },
+      });
+      const copyBtns = node.querySelectorAll('.array-item-copy');
+
+      Simulate.click(copyBtns[0]);
+
+      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      expect(inputs).to.have.length.of(3);
+      expect(inputs[0].value).eql('foo');
+      expect(inputs[1].value).eql('foo');
+      expect(inputs[2].value).eql('bar');
     });
 
     it('should handle cleared field values in the array', () => {
@@ -1708,6 +1797,14 @@ describe('ArrayField', () => {
 
     it('should not have an add button if additionalItems is not set', () => {
       const { node } = createFormComponent({ schema });
+      expect(node.querySelector('.array-item-add button')).to.be.null;
+    });
+
+    it('should not have an add button if global addable is false', () => {
+      const { node } = createFormComponent({
+        schema,
+        uiSchema: { 'ui:globalOptions': { addable: false } },
+      });
       expect(node.querySelector('.array-item-add button')).to.be.null;
     });
 

--- a/packages/core/test/ObjectField.test.jsx
+++ b/packages/core/test/ObjectField.test.jsx
@@ -395,7 +395,6 @@ describe('ObjectField', () => {
     });
   });
 
-  // TODO label with additionalProperties and arrays
   describe('additionalProperties', () => {
     const schema = {
       type: 'object',

--- a/packages/core/test/ObjectField.test.jsx
+++ b/packages/core/test/ObjectField.test.jsx
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { Simulate } from 'react-dom/test-utils';
 import sinon from 'sinon';
+import { UI_GLOBAL_OPTIONS_KEY } from '@rjsf/utils';
 
 import SchemaField from '../src/components/fields/SchemaField';
 import { createFormComponent, createSandbox, submitForm } from './test_utils';
@@ -394,6 +395,7 @@ describe('ObjectField', () => {
     });
   });
 
+  // TODO label with additionalProperties and arrays
   describe('additionalProperties', () => {
     const schema = {
       type: 'object',
@@ -712,6 +714,35 @@ describe('ObjectField', () => {
         formData,
         uiSchema: {
           'ui:duplicateKeySuffixSeparator': '_',
+        },
+      });
+
+      const textNode = node.querySelector('#root_first-key');
+      Simulate.blur(textNode, {
+        target: { value: 'second' },
+      });
+
+      sinon.assert.calledWithMatch(
+        onChange.lastCall,
+        {
+          formData: { second: 2, second_1: 1 },
+        },
+        'root'
+      );
+    });
+
+    it('uses a global custom separator between the duplicate key name and the suffix', () => {
+      const formData = {
+        first: 1,
+        second: 2,
+      };
+      const { node, onChange } = createFormComponent({
+        schema,
+        formData,
+        uiSchema: {
+          [UI_GLOBAL_OPTIONS_KEY]: {
+            duplicateKeySuffixSeparator: '_',
+          },
         },
       });
 

--- a/packages/core/test/SchemaField.test.jsx
+++ b/packages/core/test/SchemaField.test.jsx
@@ -51,6 +51,41 @@ describe('SchemaField', () => {
         formContext: {},
         schemaUtils,
         translateString: englishStringTranslator,
+        globalUiOptions: undefined,
+      });
+    });
+    it('should provide expected registry with globalUiOptions as prop', () => {
+      let receivedProps;
+      const schema = {
+        type: 'object',
+        definitions: {
+          a: { type: 'string' },
+        },
+      };
+      const schemaUtils = createSchemaUtils(validator, schema);
+
+      createFormComponent({
+        schema,
+        uiSchema: {
+          'ui:globalOptions': { copyable: true },
+          'ui:field': (props) => {
+            receivedProps = props;
+            return null;
+          },
+        },
+      });
+
+      const { registry } = receivedProps;
+      const defaultRegistry = getDefaultRegistry();
+      expect(registry).eql({
+        fields: defaultRegistry.fields,
+        templates: defaultRegistry.templates,
+        widgets: defaultRegistry.widgets,
+        rootSchema: schema,
+        formContext: {},
+        schemaUtils,
+        translateString: englishStringTranslator,
+        globalUiOptions: { copyable: true },
       });
     });
   });
@@ -249,6 +284,24 @@ describe('SchemaField', () => {
     it('should render label by default', () => {
       const { node } = createFormComponent({ schema });
       expect(node.querySelectorAll('label')).to.have.length.of(1);
+    });
+
+    it('should render label if ui:globaLOptions label is set to true', () => {
+      const uiSchema = {
+        'ui:globalOptions': { label: true },
+      };
+
+      const { node } = createFormComponent({ schema, uiSchema });
+      expect(node.querySelectorAll('label')).to.have.length.of(1);
+    });
+
+    it('should not render label if ui:globalOptions label is set to false', () => {
+      const uiSchema = {
+        'ui:globalOptions': { label: false },
+      };
+
+      const { node } = createFormComponent({ schema, uiSchema });
+      expect(node.querySelectorAll('label')).to.have.length.of(0);
     });
 
     it('should render label if ui:options label is set to true', () => {

--- a/packages/docs/docs/advanced-customization/custom-templates.md
+++ b/packages/docs/docs/advanced-customization/custom-templates.md
@@ -112,6 +112,7 @@ The following props are part of each element in `items`:
 - `children`: The html for the item's content.
 - `className`: The className string.
 - `disabled`: A boolean value stating if the array item is disabled.
+- `hasCopy`: A boolean value stating whether the array item can be copied.
 - `hasMoveDown`: A boolean value stating whether the array item can be moved down.
 - `hasMoveUp`: A boolean value stating whether the array item can be moved up.
 - `hasRemove`: A boolean value stating whether the array item can be removed.
@@ -214,6 +215,7 @@ The following props are passed to each `ArrayFieldItemTemplate`:
 - `className`: The className string.
 - `disabled`: A boolean value stating if the array item is disabled.
 - `canAdd`: A boolean value stating whether new items can be added to the array.
+- `hasCopy`: A boolean value stating whether the array item can be copied.
 - `hasMoveDown`: A boolean value stating whether the array item can be moved down.
 - `hasMoveUp`: A boolean value stating whether the array item can be moved up.
 - `hasRemove`: A boolean value stating whether the array item can be removed.

--- a/packages/docs/docs/advanced-customization/internals.md
+++ b/packages/docs/docs/advanced-customization/internals.md
@@ -47,7 +47,10 @@ For arrays this is not the case. Defining an array, when a parent also defines a
 
 ## Custom array field buttons
 
-The `ArrayField` component provides a UI to add, remove and reorder array items, and these buttons use [Bootstrap glyphicons](http://getbootstrap.com/components/#glyphicons). If you don't use glyphicons but still want to provide your own icons or texts for these buttons, you can easily do so using CSS:
+The `ArrayField` component provides a UI to add, copy, remove and reorder array items, and these buttons use [Bootstrap glyphicons](http://getbootstrap.com/components/#glyphicons).
+If you don't use glyphicons but still want to provide your own icons or texts for these buttons, you can easily do so using CSS:
+
+> NOTE this only applies to the `@rjsf/core` theme
 
 ```css
 i.glyphicon {
@@ -55,6 +58,9 @@ i.glyphicon {
 }
 .btn-add::after {
   content: 'Add';
+}
+.array-item-copy::after {
+  content: 'Copy';
 }
 .array-item-move-up::after {
   content: 'Move Up';

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -257,7 +257,7 @@ When this prop is set to `top` or `bottom`, a list of errors (or the custom erro
 
 It's possible to change the default `form` tag name to a different HTML tag, which can be helpful if you are nesting forms. However, native browser form behaviour, such as submitting when the `Enter` key is pressed, may no longer work.
 
-```jsx
+```tsx
 <Form
   tagName="div"
   ...
@@ -266,7 +266,7 @@ It's possible to change the default `form` tag name to a different HTML tag, whi
 
 You can also provide a class/function component.
 
-```jsx
+```tsx
 const CustomForm = props => <form {...props} style={...} className={...} />
 // ...
 <Form

--- a/packages/docs/docs/api-reference/themes/semantic-ui/uiSchema.md
+++ b/packages/docs/docs/api-reference/themes/semantic-ui/uiSchema.md
@@ -106,7 +106,7 @@ wrapContent: wrap all inputs  field content in a div, for custom styling
 wrapLabel: wrap all labels in a div, for custom styling via CSS
 ```
 
-```jsx
+```tsx
 <Form
   formContext={{
     semantic: {

--- a/packages/docs/docs/api-reference/uiSchema.md
+++ b/packages/docs/docs/api-reference/uiSchema.md
@@ -49,7 +49,19 @@ Be sure to pay attention to the hierarchical intersection to these other types: 
 
 ## Exceptions to the equivalence
 
-There are 3 properties that exist in a `UiSchema` that will not be found in an inner `ui:options` object.
+There are 4 properties that exist in a `UiSchema` that will not be found in an inner `ui:options` object.
+
+### ui:globalOptions
+
+The set of Globally relevant UI Schema options that are read from the root-level UiSchema and stored in the Registry for use everywhere.
+
+```ts
+import { UiSchema } from '@rjsf/utils';
+
+const uiSchema: UiSchema = {
+  'ui:globalOptions': { copyable: true },
+};
+```
 
 ### ui:rootFieldId
 
@@ -259,7 +271,8 @@ const uiSchema: UiSchema = {
 
 ### label
 
-Field labels are rendered by default. Labels may be omitted by setting the `label` option to `false` in the `ui:options` uiSchema directive.
+Field labels are rendered by default.
+Labels may be omitted on a per-field by setting the `label` option to `false` in the `ui:options` uiSchema directive.
 
 ```tsx
 import { RJSFSchema, UiSchema } from '@rjsf/utils';
@@ -268,6 +281,22 @@ import validator from '@rjsf/validator-ajv8';
 const schema: RJSFSchema = { type: 'string' };
 const uiSchema: UiSchema = {
   'ui:options': {
+    label: false,
+  },
+};
+
+render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />, document.getElementById('app'));
+```
+
+They can also be omitted globally by setting the `label` option to `false` in the `ui:globalOptions` uiSchema directive.
+
+```tsx
+import { RJSFSchema, UiSchema } from '@rjsf/utils';
+import validator from '@rjsf/validator-ajv8';
+
+const schema: RJSFSchema = { type: 'string' };
+const uiSchema: UiSchema = {
+  'ui:globalOptions': {
     label: false,
   },
 };
@@ -391,8 +420,21 @@ const uiSchema: UiSchema = {
 
 ## `duplicateKeySuffixSeparator` option
 
-When using `additionalProperties`, key collision is prevented by appending a unique integer suffix to the duplicate key. For example, when you add a key named `myKey` to a form where `myKey` is already defined, then your new key will become `myKey-1`.
-You can use `ui:duplicateKeySuffixSeparator` to override the default separator, `"-"` with a string of your choice.
+When using `additionalProperties`, key collision is prevented by appending a unique integer suffix to the duplicate key.
+For example, when you add a key named `myKey` to a form where `myKey` is already defined, then your new key will become `myKey-1`.
+You can use `ui:duplicateKeySuffixSeparator` to override the default separator, `"-"` with a string of your choice on a per-field basis.
+
+You can also set this into the `ui:globalOptions` to have the same separator used everywhere.
+
+```ts
+import { UiSchema } from '@rjsf/utils';
+
+const uiSchema = {
+  'ui:globalOptions': {
+    duplicateKeySuffixSeparator: '_'
+  }
+};
+```
 
 ## Theme Options
 

--- a/packages/docs/docs/api-reference/uiSchema.md
+++ b/packages/docs/docs/api-reference/uiSchema.md
@@ -53,7 +53,7 @@ There are 4 properties that exist in a `UiSchema` that will not be found in an i
 
 ### ui:globalOptions
 
-The set of Globally relevant UI Schema options that are read from the root-level UiSchema and stored in the Registry for use everywhere.
+The set of globally relevant `UiSchema` options that are read from the root-level `UiSchema` and stored in the `registry` for use everywhere.
 
 ```ts
 import { UiSchema } from '@rjsf/utils';
@@ -424,7 +424,7 @@ When using `additionalProperties`, key collision is prevented by appending a uni
 For example, when you add a key named `myKey` to a form where `myKey` is already defined, then your new key will become `myKey-1`.
 You can use `ui:duplicateKeySuffixSeparator` to override the default separator, `"-"` with a string of your choice on a per-field basis.
 
-You can also set this into the `ui:globalOptions` to have the same separator used everywhere.
+You can also set this in the `ui:globalOptions` to have the same separator used everywhere.
 
 ```ts
 import { UiSchema } from '@rjsf/utils';

--- a/packages/docs/docs/api-reference/utility-functions.md
+++ b/packages/docs/docs/api-reference/utility-functions.md
@@ -305,14 +305,15 @@ Extracts any `ui:submitButtonOptions` from the `uiSchema` and merges them onto t
 ### getUiOptions<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>()
 
 Get all passed options from ui:options, and ui:&lt;optionName>, returning them in an object with the `ui:` stripped off.
+Any `globalOptions` will always be returned, unless they are overridden by options in the `uiSchema`.
 
 #### Parameters
 
 - [uiSchema={}]: UiSchema<T, S, F> - The UI Schema from which to get any `ui:xxx` options
-
+- [globalOptions={}]: GlobalUISchemaOptions - The optional Global UI Schema from which to get any fallback `xxx` options
 #### Returns
 
-- UIOptionsType<T, S, F> An object containing all of the `ui:xxx` options with the stripped off
+- UIOptionsType<T, S, F> An object containing all of the `ui:xxx` options with the `ui:` stripped off along with all `globalOptions`
 
 ### getTemplate<Name extends keyof TemplatesType<T, S, F>, T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>()
 
@@ -721,6 +722,7 @@ Determines whether the combination of `schema` and `uiSchema` properties indicat
 - schema: S - The schema for which the display label flag is desired
 - [uiSchema={}]: UiSchema<T, S, F> - The UI schema from which to derive potentially displayable information
 - [rootSchema]: S | undefined - The root schema, used to primarily to look up `$ref`s
+- [globalOptions={}]: GlobalUISchemaOptions - The optional Global UI Schema from which to get any fallback `xxx` options
 
 #### Returns
 

--- a/packages/docs/docs/api-reference/utility-functions.md
+++ b/packages/docs/docs/api-reference/utility-functions.md
@@ -311,6 +311,7 @@ Any `globalOptions` will always be returned, unless they are overridden by optio
 
 - [uiSchema={}]: UiSchema<T, S, F> - The UI Schema from which to get any `ui:xxx` options
 - [globalOptions={}]: GlobalUISchemaOptions - The optional Global UI Schema from which to get any fallback `xxx` options
+
 #### Returns
 
 - UIOptionsType<T, S, F> An object containing all of the `ui:xxx` options with the `ui:` stripped off along with all `globalOptions`

--- a/packages/docs/docs/index.mdx
+++ b/packages/docs/docs/index.mdx
@@ -32,7 +32,7 @@ $ npm install @rjsf/core @rjsf/utils @rjsf/validator-ajv8 --save
 
 Then import the dependencies as follows:
 
-```js
+```ts
 import validator from '@rjsf/validator-ajv8';
 import Form from '@rjsf/core';
 ```
@@ -51,7 +51,7 @@ Source maps are available at [this url](https://unpkg.com/@rjsf/core/dist/core.c
 
 You'll also need to alias the default export property to use the Form component:
 
-```js
+```ts
 const Form = JSONSchemaForm.default;
 // or
 const { default: Form } = JSONSchemaForm;

--- a/packages/docs/docs/migration-guides/v5.x upgrade guide.md
+++ b/packages/docs/docs/migration-guides/v5.x upgrade guide.md
@@ -448,15 +448,17 @@ This was fixed in version 5 to be consistent with all the other properties in th
 
 If you are using `classNames` as follows, simply add the `ui:` prefix to it to remove the deprecation warning that will be displayed for each `uiSchema.classNames` you have:
 
-```jsx
+```tsx
+import { UiSchema } from '@rjsf/utils';
+
 // This uiSchema will log a deprecation warning to the console
-const uiSchema = {
+const uiSchemaLog: UiSchema = {
   title: {
     classNames: 'myClass',
   },
 };
 // This uiSchema will not
-const uiSchema = {
+const uiSchemaNoLog: UiSchema = {
   title: {
     'ui:classNames': 'myClass',
   },
@@ -526,19 +528,19 @@ If you modified your Jest configuration for the `/v5` sub-package, remove the fo
 
 ##### Before
 
-```jsx
+```tsx
 import Form5 from '@rjsf/material-ui';
 ```
 
 or
 
-```jsx
+```tsx
 import Form from '@rjsf/material-ui/v5';
 ```
 
 or
 
-```jsx
+```tsx
 import { withTheme } from '@rjsf/core';
 import Theme from '@rjsf/material-ui/v5';
 // Make modifications to the theme with your own fields and widgets
@@ -547,7 +549,7 @@ const Form = withTheme(Theme);
 
 or
 
-```jsx
+```tsx
 import { withTheme } from '@rjsf/core';
 import Theme5 from '@rjsf/material-ui';
 // Make modifications to the theme with your own fields and widgets
@@ -556,13 +558,13 @@ const Form = withTheme(Theme5);
 
 ##### After
 
-```jsx
+```tsx
 import Form from '@rjsf/mui';
 ```
 
 or
 
-```jsx
+```tsx
 import { withTheme } from '@rjsf/core';
 import Theme from '@rjsf/mui';
 // Make modifications to the theme with your own fields and widgets

--- a/packages/docs/docs/usage/arrays.md
+++ b/packages/docs/docs/usage/arrays.md
@@ -90,6 +90,9 @@ render(<Form schema={schema} validator={validator} />, document.getElementById('
 
 ## Array item uiSchema options
 
+Any of these options can be set globally if they are contained within the `ui:globalOptions` block.
+They can also be overridden on a per-field basis inside a `ui:options` block as shown below.
+
 ### `orderable` option
 
 Array items are orderable by default, and react-jsonschema-form renders move up/down buttons alongside them. The uiSchema `orderable` options allows you to disable ordering:
@@ -138,6 +141,31 @@ const uiSchema: UiSchema = {
 render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />, document.getElementById('app'));
 ```
 
+### `copyable` option
+
+A copy button is **NOT** shown by default for an item if `items` contains a schema object, or the item is an `additionalItems` instance.
+You can turn this **ON** with the `copyable` option in `uiSchema`:
+
+```tsx
+import { RJSFSchema, UiSchema } from '@rjsf/utils';
+import validator from '@rjsf/validator-ajv8';
+
+const schema: RJSFSchema = {
+  type: 'array',
+  items: {
+    type: 'string',
+  },
+};
+
+const uiSchema: UiSchema = {
+  'ui:options': {
+    removable: true,
+  },
+};
+
+render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />, document.getElementById('app'));
+```
+
 ### `removable` option
 
 A remove button is shown by default for an item if `items` contains a schema object, or the item is an `additionalItems` instance. You can turn this off with the `removable` option in `uiSchema`:
@@ -168,7 +196,7 @@ The default behavior for array fields is a list of text inputs with add/remove b
 
 Example:
 
-```jsx
+```tsx
 import { RJSFSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 

--- a/packages/docs/docs/usage/arrays.md
+++ b/packages/docs/docs/usage/arrays.md
@@ -159,7 +159,7 @@ const schema: RJSFSchema = {
 
 const uiSchema: UiSchema = {
   'ui:options': {
-    removable: true,
+    copyable: true,
   },
 };
 

--- a/packages/docs/docs/usage/themes.md
+++ b/packages/docs/docs/usage/themes.md
@@ -21,7 +21,7 @@ meaning that you must load the Bootstrap stylesheet on the page to view the form
 To use a theme from a package, just import the `<Form />` component from that package. For example, to use the material ui form,
 first install both `@rjsf/core` and `@rjsf/material-ui`. Then you can import the form by doing:
 
-```js
+```ts
 import Form from '@rjsf/material-ui';
 ```
 
@@ -35,13 +35,13 @@ The default theme is bootstrap 3. In order to use another theme, you must first 
 
 For example, to use the standard bootstrap 3 form, you can run:
 
-```js
+```ts
 import Form from '@rjsf/core';
 ```
 
 To use the material-ui form, you should first install both `@rjsf/core` and `@rjsf/material-ui`. Then, you can run:
 
-```js
+```ts
 import Form from '@rjsf/material-ui';
 ```
 

--- a/packages/fluent-ui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
+++ b/packages/fluent-ui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
@@ -9,17 +9,19 @@ export default function ArrayFieldItemTemplate<
     children,
     disabled,
     hasToolbar,
+    hasCopy,
     hasMoveDown,
     hasMoveUp,
     hasRemove,
     index,
+    onCopyIndexClick,
     onDropIndexClick,
     onReorderClick,
     readonly,
     uiSchema,
     registry,
   } = props;
-  const { MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates;
+  const { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates;
   return (
     <div className='ms-Grid' dir='ltr'>
       <div className='ms-Grid-row'>
@@ -40,6 +42,14 @@ export default function ArrayFieldItemTemplate<
               <MoveDownButton
                 disabled={disabled || readonly || !hasMoveDown}
                 onClick={onReorderClick(index, index + 1)}
+                uiSchema={uiSchema}
+                registry={registry}
+              />
+            )}
+            {hasCopy && (
+              <CopyButton
+                disabled={disabled || readonly}
+                onClick={onCopyIndexClick(index)}
                 uiSchema={uiSchema}
                 registry={registry}
               />

--- a/packages/fluent-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/fluent-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -20,7 +20,7 @@ const styles_red = {
   color: 'rgb(164, 38, 44)',
   fontSize: 12,
   fontWeight: 'normal' as any,
-  fontFamily: `"Segoe UI", "Segoe UI Web (West European)", "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;`,
+  fontFamily: `"Segoe UI", "Segoe UI Web (West European)", "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif`,
 };
 
 export default function CheckboxesWidget<

--- a/packages/fluent-ui/src/ColorWidget/ColorWidget.tsx
+++ b/packages/fluent-ui/src/ColorWidget/ColorWidget.tsx
@@ -7,7 +7,7 @@ const styles_red = {
   color: 'rgb(164, 38, 44)',
   fontSize: 12,
   fontWeight: 'normal' as any,
-  fontFamily: `"Segoe UI", "Segoe UI Web (West European)", "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;`,
+  fontFamily: `"Segoe UI", "Segoe UI Web (West European)", "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif`,
 };
 
 const allowedProps: (keyof IColorPickerProps)[] = [

--- a/packages/fluent-ui/src/IconButton/IconButton.tsx
+++ b/packages/fluent-ui/src/IconButton/IconButton.tsx
@@ -13,6 +13,15 @@ export default function FluentIconButton<
   return <IconButton disabled={props.disabled} onClick={props.onClick} iconProps={iconProps} color='secondary' />;
 }
 
+export function CopyButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: IconButtonProps<T, S, F>
+) {
+  const {
+    registry: { translateString },
+  } = props;
+  return <FluentIconButton<T, S, F> title={translateString(TranslatableString.CopyButton)} {...props} icon='Copy' />;
+}
+
 export function MoveDownButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   props: IconButtonProps<T, S, F>
 ) {

--- a/packages/fluent-ui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/fluent-ui/src/RangeWidget/RangeWidget.tsx
@@ -7,7 +7,7 @@ const styles_red = {
   color: 'rgb(164, 38, 44)',
   fontSize: 12,
   fontWeight: 'normal' as any,
-  fontFamily: `"Segoe UI", "Segoe UI Web (West European)", "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif;`,
+  fontFamily: `"Segoe UI", "Segoe UI Web (West European)", "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif`,
 };
 
 // Keys of ISliderProps from @fluentui/react

--- a/packages/fluent-ui/src/Templates/Templates.ts
+++ b/packages/fluent-ui/src/Templates/Templates.ts
@@ -4,7 +4,7 @@ import ArrayFieldTemplate from '../ArrayFieldTemplate';
 import BaseInputTemplate from '../BaseInputTemplate/BaseInputTemplate';
 import DescriptionField from '../DescriptionField';
 import ErrorList from '../ErrorList';
-import { MoveDownButton, MoveUpButton, RemoveButton } from '../IconButton';
+import { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } from '../IconButton';
 import FieldErrorTemplate from '../FieldErrorTemplate';
 import FieldHelpTemplate from '../FieldHelpTemplate';
 import FieldTemplate from '../FieldTemplate';
@@ -24,6 +24,7 @@ export function generateTemplates<
     ArrayFieldTemplate,
     BaseInputTemplate,
     ButtonTemplates: {
+      CopyButton,
       AddButton,
       MoveDownButton,
       MoveUpButton,

--- a/packages/fluent-ui/test/Array.test.tsx
+++ b/packages/fluent-ui/test/Array.test.tsx
@@ -1,4 +1,4 @@
-import { RJSFSchema, ErrorSchema } from '@rjsf/utils';
+import { RJSFSchema, ErrorSchema, UiSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 import renderer from 'react-test-renderer';
 
@@ -49,7 +49,12 @@ describe('array fields', () => {
         type: 'string',
       },
     };
-    const tree = renderer.create(<Form schema={schema} validator={validator} formData={['a', 'b']} />).toJSON();
+    const uiSchema: UiSchema = {
+      'ui:options': { copyable: true },
+    };
+    const tree = renderer
+      .create(<Form schema={schema} uiSchema={uiSchema} validator={validator} formData={['a', 'b']} />)
+      .toJSON();
     expect(tree).toMatchSnapshot();
   });
   test('no errors', () => {

--- a/packages/fluent-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Array.test.tsx.snap
@@ -265,6 +265,35 @@ exports[`array fields array icons 1`] = `
             >
               <i
                 aria-hidden={true}
+                className="ms-Icon root-37 css-89 ms-Button-icon icon-51"
+                data-icon-name="Copy"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-88"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-42"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
                 className="ms-Icon root-37 css-49 ms-Button-icon icon-51"
                 data-icon-name="Delete"
                 style={
@@ -422,6 +451,35 @@ exports[`array fields array icons 1`] = `
             >
               <i
                 aria-hidden={true}
+                className="ms-Icon root-37 css-89 ms-Button-icon icon-51"
+                data-icon-name="Copy"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-88"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-42"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
                 className="ms-Icon root-37 css-49 ms-Button-icon icon-51"
                 data-icon-name="Delete"
                 style={
@@ -481,7 +539,7 @@ exports[`array fields array icons 1`] = `
           >
             <span
               className="ms-Button-label label-45"
-              id="id__42"
+              id="id__48"
             >
               Add Item
             </span>
@@ -516,7 +574,7 @@ exports[`array fields array icons 1`] = `
           >
             <span
               className="ms-Button-label label-52"
-              id="id__45"
+              id="id__51"
             >
               Submit
             </span>
@@ -663,19 +721,19 @@ exports[`array fields empty errors array 1`] = `
               className="ms-TextField-wrapper"
             >
               <label
-                className="ms-Label root-90"
+                className="ms-Label root-91"
                 htmlFor="root_name"
-                id="TextFieldLabel56"
+                id="TextFieldLabel62"
               >
                 name
               </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-89"
+                className="ms-TextField-fieldGroup fieldGroup-90"
               >
                 <input
                   aria-describedby="root_name__error root_name__description root_name__help"
                   aria-invalid={false}
-                  aria-labelledby="TextFieldLabel56"
+                  aria-labelledby="TextFieldLabel62"
                   autoFocus={false}
                   className="ms-TextField-field field-57"
                   disabled={false}
@@ -725,7 +783,7 @@ exports[`array fields empty errors array 1`] = `
           >
             <span
               className="ms-Button-label label-52"
-              id="id__57"
+              id="id__63"
             >
               Submit
             </span>
@@ -952,19 +1010,19 @@ exports[`array fields no errors 1`] = `
               className="ms-TextField-wrapper"
             >
               <label
-                className="ms-Label root-90"
+                className="ms-Label root-91"
                 htmlFor="root_name"
-                id="TextFieldLabel50"
+                id="TextFieldLabel56"
               >
                 name
               </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-89"
+                className="ms-TextField-fieldGroup fieldGroup-90"
               >
                 <input
                   aria-describedby="root_name__error root_name__description root_name__help"
                   aria-invalid={false}
-                  aria-labelledby="TextFieldLabel50"
+                  aria-labelledby="TextFieldLabel56"
                   autoFocus={false}
                   className="ms-TextField-field field-57"
                   disabled={false}
@@ -1014,7 +1072,7 @@ exports[`array fields no errors 1`] = `
           >
             <span
               className="ms-Button-label label-52"
-              id="id__51"
+              id="id__57"
             >
               Submit
             </span>

--- a/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
@@ -366,7 +366,7 @@ exports[`single fields checkboxes field 1`] = `
       style={
         Object {
           "color": "rgb(164, 38, 44)",
-          "fontFamily": "\\"Segoe UI\\", \\"Segoe UI Web (West European)\\", \\"Segoe UI\\", -apple-system, BlinkMacSystemFont, Roboto, \\"Helvetica Neue\\", sans-serif;",
+          "fontFamily": "\\"Segoe UI\\", \\"Segoe UI Web (West European)\\", \\"Segoe UI\\", -apple-system, BlinkMacSystemFont, Roboto, \\"Helvetica Neue\\", sans-serif",
           "fontSize": 12,
           "fontWeight": "normal",
         }

--- a/packages/material-ui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
+++ b/packages/material-ui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
@@ -17,17 +17,19 @@ export default function ArrayFieldItemTemplate<
     children,
     disabled,
     hasToolbar,
+    hasCopy,
     hasMoveDown,
     hasMoveUp,
     hasRemove,
     index,
+    onCopyIndexClick,
     onDropIndexClick,
     onReorderClick,
     readonly,
     uiSchema,
     registry,
   } = props;
-  const { MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates;
+  const { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates;
   const btnStyle: CSSProperties = {
     flex: 1,
     paddingLeft: 6,
@@ -61,6 +63,15 @@ export default function ArrayFieldItemTemplate<
               style={btnStyle}
               disabled={disabled || readonly || !hasMoveDown}
               onClick={onReorderClick(index, index + 1)}
+              uiSchema={uiSchema}
+              registry={registry}
+            />
+          )}
+          {hasCopy && (
+            <CopyButton
+              style={btnStyle}
+              disabled={disabled || readonly}
+              onClick={onCopyIndexClick(index)}
               uiSchema={uiSchema}
               registry={registry}
             />

--- a/packages/material-ui/src/IconButton/IconButton.tsx
+++ b/packages/material-ui/src/IconButton/IconButton.tsx
@@ -1,6 +1,7 @@
 import IconButton, { IconButtonProps as MuiIconButtonProps } from '@material-ui/core/IconButton';
 import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
+import CopyIcon from '@material-ui/icons/FileCopy';
 import RemoveIcon from '@material-ui/icons/Remove';
 import { FormContextType, IconButtonProps, RJSFSchema, StrictRJSFSchema, TranslatableString } from '@rjsf/utils';
 
@@ -14,6 +15,21 @@ export default function MuiIconButton<
     <IconButton {...otherProps} size='small' color={color as MuiIconButtonProps['color']}>
       {icon}
     </IconButton>
+  );
+}
+
+export function CopyButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: IconButtonProps<T, S, F>
+) {
+  const {
+    registry: { translateString },
+  } = props;
+  return (
+    <MuiIconButton
+      title={translateString(TranslatableString.CopyButton)}
+      {...props}
+      icon={<CopyIcon fontSize='small' />}
+    />
   );
 }
 

--- a/packages/material-ui/src/Templates/Templates.ts
+++ b/packages/material-ui/src/Templates/Templates.ts
@@ -6,7 +6,7 @@ import ArrayFieldTemplate from '../ArrayFieldTemplate';
 import BaseInputTemplate from '../BaseInputTemplate';
 import DescriptionField from '../DescriptionField';
 import ErrorList from '../ErrorList';
-import { MoveDownButton, MoveUpButton, RemoveButton } from '../IconButton';
+import { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } from '../IconButton';
 import FieldErrorTemplate from '../FieldErrorTemplate';
 import FieldHelpTemplate from '../FieldHelpTemplate';
 import FieldTemplate from '../FieldTemplate';
@@ -26,6 +26,7 @@ export function generateTemplates<
     BaseInputTemplate,
     ButtonTemplates: {
       AddButton,
+      CopyButton,
       MoveDownButton,
       MoveUpButton,
       RemoveButton,

--- a/packages/material-ui/test/Array.test.tsx
+++ b/packages/material-ui/test/Array.test.tsx
@@ -1,4 +1,4 @@
-import { RJSFSchema, ErrorSchema } from '@rjsf/utils';
+import { RJSFSchema, ErrorSchema, UiSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 import renderer from 'react-test-renderer';
 
@@ -49,7 +49,12 @@ describe('array fields', () => {
         type: 'string',
       },
     };
-    const tree = renderer.create(<Form schema={schema} validator={validator} formData={['a', 'b']} />).toJSON();
+    const uiSchema: UiSchema = {
+      'ui:options': { copyable: true },
+    };
+    const tree = renderer
+      .create(<Form schema={schema} uiSchema={uiSchema} validator={validator} formData={['a', 'b']} />)
+      .toJSON();
     expect(tree).toMatchSnapshot();
   });
   test('no errors', () => {

--- a/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
@@ -274,6 +274,52 @@ exports[`array fields array icons 1`] = `
                   />
                 </button>
                 <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "flex": 1,
+                      "fontWeight": "bold",
+                      "minWidth": 0,
+                      "paddingLeft": 6,
+                      "paddingRight": 6,
+                    }
+                  }
+                  tabIndex={0}
+                  title="Copy"
+                  type="button"
+                >
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
+                  />
+                </button>
+                <button
                   className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
                   disabled={false}
                   onBlur={[Function]}
@@ -470,6 +516,52 @@ exports[`array fields array icons 1`] = `
                       />
                     </svg>
                   </span>
+                </button>
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "flex": 1,
+                      "fontWeight": "bold",
+                      "minWidth": 0,
+                      "paddingLeft": 6,
+                      "paddingRight": 6,
+                    }
+                  }
+                  tabIndex={0}
+                  title="Copy"
+                  type="button"
+                >
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
+                  />
                 </button>
                 <button
                   className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"

--- a/packages/mui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
+++ b/packages/mui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
@@ -17,17 +17,19 @@ export default function ArrayFieldItemTemplate<
     children,
     disabled,
     hasToolbar,
+    hasCopy,
     hasMoveDown,
     hasMoveUp,
     hasRemove,
     index,
+    onCopyIndexClick,
     onDropIndexClick,
     onReorderClick,
     readonly,
     uiSchema,
     registry,
   } = props;
-  const { MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates;
+  const { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates;
   const btnStyle: CSSProperties = {
     flex: 1,
     paddingLeft: 6,
@@ -60,6 +62,15 @@ export default function ArrayFieldItemTemplate<
               style={btnStyle}
               disabled={disabled || readonly || !hasMoveDown}
               onClick={onReorderClick(index, index + 1)}
+              uiSchema={uiSchema}
+              registry={registry}
+            />
+          )}
+          {hasCopy && (
+            <CopyButton
+              style={btnStyle}
+              disabled={disabled || readonly}
+              onClick={onCopyIndexClick(index)}
               uiSchema={uiSchema}
               registry={registry}
             />

--- a/packages/mui/src/IconButton/IconButton.tsx
+++ b/packages/mui/src/IconButton/IconButton.tsx
@@ -1,6 +1,7 @@
 import IconButton, { IconButtonProps as MuiIconButtonProps } from '@mui/material/IconButton';
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
+import CopyIcon from '@mui/icons-material/ContentCopy';
 import RemoveIcon from '@mui/icons-material/Remove';
 import { FormContextType, IconButtonProps, RJSFSchema, StrictRJSFSchema, TranslatableString } from '@rjsf/utils';
 
@@ -14,6 +15,21 @@ export default function MuiIconButton<
     <IconButton {...otherProps} size='small' color={color as MuiIconButtonProps['color']}>
       {icon}
     </IconButton>
+  );
+}
+
+export function CopyButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: IconButtonProps<T, S, F>
+) {
+  const {
+    registry: { translateString },
+  } = props;
+  return (
+    <MuiIconButton
+      title={translateString(TranslatableString.CopyButton)}
+      {...props}
+      icon={<CopyIcon fontSize='small' />}
+    />
   );
 }
 

--- a/packages/mui/src/Templates/Templates.ts
+++ b/packages/mui/src/Templates/Templates.ts
@@ -6,7 +6,7 @@ import ArrayFieldTemplate from '../ArrayFieldTemplate';
 import BaseInputTemplate from '../BaseInputTemplate';
 import DescriptionField from '../DescriptionField';
 import ErrorList from '../ErrorList';
-import { MoveDownButton, MoveUpButton, RemoveButton } from '../IconButton';
+import { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } from '../IconButton';
 import FieldErrorTemplate from '../FieldErrorTemplate';
 import FieldHelpTemplate from '../FieldHelpTemplate';
 import FieldTemplate from '../FieldTemplate';
@@ -26,6 +26,7 @@ export function generateTemplates<
     BaseInputTemplate,
     ButtonTemplates: {
       AddButton,
+      CopyButton,
       MoveDownButton,
       MoveUpButton,
       RemoveButton,

--- a/packages/mui/test/Array.test.tsx
+++ b/packages/mui/test/Array.test.tsx
@@ -1,4 +1,4 @@
-import { RJSFSchema, ErrorSchema } from '@rjsf/utils';
+import { RJSFSchema, ErrorSchema, UiSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 import renderer from 'react-test-renderer';
 
@@ -49,7 +49,12 @@ describe('array fields', () => {
         type: 'string',
       },
     };
-    const tree = renderer.create(<Form schema={schema} validator={validator} formData={['a', 'b']} />).toJSON();
+    const uiSchema: UiSchema = {
+      'ui:options': { copyable: true },
+    };
+    const tree = renderer
+      .create(<Form schema={schema} uiSchema={uiSchema} validator={validator} formData={['a', 'b']} />)
+      .toJSON();
     expect(tree).toMatchSnapshot();
   });
   test('no errors', () => {

--- a/packages/mui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Array.test.tsx.snap
@@ -834,7 +834,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   border-radius: inherit;
 }
 
-.emotion-21 {
+.emotion-24 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -883,48 +883,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   font-size: 1.125rem;
 }
 
-.emotion-21::-moz-focus-inner {
+.emotion-24::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-21.Mui-disabled {
+.emotion-24.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-21 {
+  .emotion-24 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-21:hover {
+.emotion-24:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-21:hover {
+  .emotion-24:hover {
     background-color: transparent;
   }
 }
 
-.emotion-21:hover {
+.emotion-24:hover {
   background-color: rgba(211, 47, 47, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-21:hover {
+  .emotion-24:hover {
     background-color: transparent;
   }
 }
 
-.emotion-21.Mui-disabled {
+.emotion-24.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-44 {
+.emotion-50 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -944,11 +944,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   justify-content: flex-end;
 }
 
-.emotion-46 {
+.emotion-52 {
   margin-top: 16px;
 }
 
-.emotion-47 {
+.emotion-53 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -995,48 +995,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   color: #1976d2;
 }
 
-.emotion-47::-moz-focus-inner {
+.emotion-53::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-47.Mui-disabled {
+.emotion-53.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-47 {
+  .emotion-53 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-47:hover {
+.emotion-53:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-47:hover {
+  .emotion-53:hover {
     background-color: transparent;
   }
 }
 
-.emotion-47:hover {
+.emotion-53:hover {
   background-color: rgba(25, 118, 210, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-47:hover {
+  .emotion-53:hover {
     background-color: transparent;
   }
 }
 
-.emotion-47.Mui-disabled {
+.emotion-53.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-48 {
+.emotion-54 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1053,11 +1053,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   font-size: 1.5rem;
 }
 
-.emotion-50 {
+.emotion-56 {
   margin-top: 24px;
 }
 
-.emotion-51 {
+.emotion-57 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1106,23 +1106,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-51::-moz-focus-inner {
+.emotion-57::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-51.Mui-disabled {
+.emotion-57.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-51 {
+  .emotion-57 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-51:hover {
+.emotion-57:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: #1565c0;
@@ -1130,20 +1130,20 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
 }
 
 @media (hover: none) {
-  .emotion-51:hover {
+  .emotion-57:hover {
     background-color: #1976d2;
   }
 }
 
-.emotion-51:active {
+.emotion-57:active {
   box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
 }
 
-.emotion-51.Mui-focusVisible {
+.emotion-57.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-51.Mui-disabled {
+.emotion-57.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
@@ -1330,7 +1330,51 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
                   />
                 </button>
                 <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-21"
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-16"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "flex": 1,
+                      "fontWeight": "bold",
+                      "minWidth": 0,
+                      "paddingLeft": 6,
+                      "paddingRight": 6,
+                    }
+                  }
+                  tabIndex={0}
+                  title="Copy"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
+                    data-testid="ContentCopyIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                    />
+                  </svg>
+                  <span
+                    className="MuiTouchRipple-root emotion-20"
+                  />
+                </button>
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-24"
                   disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -1536,7 +1580,51 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
                   </svg>
                 </button>
                 <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-21"
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-16"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  style={
+                    Object {
+                      "flex": 1,
+                      "fontWeight": "bold",
+                      "minWidth": 0,
+                      "paddingLeft": 6,
+                      "paddingRight": 6,
+                    }
+                  }
+                  tabIndex={0}
+                  title="Copy"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
+                    data-testid="ContentCopyIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                    />
+                  </svg>
+                  <span
+                    className="MuiTouchRipple-root emotion-20"
+                  />
+                </button>
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-24"
                   disabled={false}
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -1582,16 +1670,16 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container emotion-44"
+              className="MuiGrid-root MuiGrid-container emotion-50"
             >
               <div
                 className="MuiGrid-root MuiGrid-item emotion-15"
               >
                 <div
-                  className="MuiBox-root emotion-46"
+                  className="MuiBox-root emotion-52"
                 >
                   <button
-                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-47"
+                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-53"
                     disabled={false}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -1612,7 +1700,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
                   >
                     <svg
                       aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-48"
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-54"
                       data-testid="AddIcon"
                       focusable="false"
                       viewBox="0 0 24 24"
@@ -1634,10 +1722,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
     </div>
   </div>
   <div
-    className="MuiBox-root emotion-50"
+    className="MuiBox-root emotion-56"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-51"
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-57"
       disabled={false}
       onBlur={[Function]}
       onContextMenu={[Function]}

--- a/packages/playground/src/samples/arrays.js
+++ b/packages/playground/src/samples/arrays.js
@@ -87,6 +87,14 @@ export default {
           default: 'lorem ipsum',
         },
       },
+      copyable: {
+        title: 'Copyable items',
+        type: 'array',
+        items: {
+          type: 'string',
+          default: 'lorem ipsum',
+        },
+      },
       unremovable: {
         title: 'Unremovable items',
         type: 'array',
@@ -144,6 +152,11 @@ export default {
         orderable: false,
       },
     },
+    copyable: {
+      'ui:options': {
+        copyable: true,
+      },
+    },
     unremovable: {
       'ui:options': {
         removable: false,
@@ -170,6 +183,7 @@ export default {
     fixedItemsList: ['Some text', true, 123],
     nestedList: [['lorem', 'ipsum'], ['dolor']],
     unorderable: ['one', 'two'],
+    copyable: ['one', 'two'],
     unremovable: ['one', 'two'],
     noToolbar: ['one', 'two'],
     fixedNoToolbar: [42, true, 'additional item one', 'additional item two'],

--- a/packages/semantic-ui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
+++ b/packages/semantic-ui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
@@ -12,7 +12,7 @@ import { MaybeWrap } from '../util';
 
 const gridStyle = (vertical: boolean) => ({
   display: 'grid',
-  gridTemplateColumns: `1fr ${vertical ? 65 : 110}px`,
+  gridTemplateColumns: `1fr ${vertical ? 65 : 150}px`,
 });
 
 /** The `ArrayFieldItemTemplate` component is the template used to render an items of an array.
@@ -28,28 +28,26 @@ export default function ArrayFieldItemTemplate<
     children,
     disabled,
     hasToolbar,
+    hasCopy,
     hasMoveDown,
     hasMoveUp,
     hasRemove,
     index,
+    onCopyIndexClick,
     onDropIndexClick,
     onReorderClick,
     readonly,
     uiSchema,
     registry,
   } = props;
-  const { MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates;
+  const { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } = registry.templates.ButtonTemplates;
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
   // Pull the semantic props out of the uiOptions that were put in via the ArrayFieldTemplate
-  const { horizontalButtons = false, wrapItem = false } = uiOptions.semantic as GenericObjectType;
+  const { horizontalButtons = true, wrapItem = false } = uiOptions.semantic as GenericObjectType;
   return (
     <div className='array-item'>
       <MaybeWrap wrap={wrapItem} component={Segment}>
-        <Grid
-          style={
-            index !== 0 ? { ...gridStyle(!horizontalButtons), alignItems: 'center' } : gridStyle(!horizontalButtons)
-          }
-        >
+        <Grid style={{ ...gridStyle(!horizontalButtons), alignItems: 'center' }}>
           <Grid.Column width={16} verticalAlign='middle'>
             {children}
           </Grid.Column>
@@ -71,6 +69,15 @@ export default function ArrayFieldItemTemplate<
                       className='array-item-move-down'
                       disabled={disabled || readonly || !hasMoveDown}
                       onClick={onReorderClick(index, index + 1)}
+                      uiSchema={uiSchema}
+                      registry={registry}
+                    />
+                  )}
+                  {hasCopy && (
+                    <CopyButton
+                      className='array-item-copy'
+                      disabled={disabled || readonly}
+                      onClick={onCopyIndexClick(index)}
                       uiSchema={uiSchema}
                       registry={registry}
                     />

--- a/packages/semantic-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/semantic-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -41,7 +41,7 @@ export default function ArrayFieldTemplate<
   const semanticProps = getSemanticProps<T, S, F>({
     uiSchema,
     formContext,
-    defaultSchemaProps: { horizontalButtons: false, wrapItem: false },
+    defaultSchemaProps: { horizontalButtons: true, wrapItem: false },
   });
   const { horizontalButtons, wrapItem } = semanticProps;
   const semantic = { horizontalButtons, wrapItem };

--- a/packages/semantic-ui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/semantic-ui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -41,7 +41,7 @@ export default function CheckboxWidget<
     formContext,
     uiSchema,
     defaultSchemaProps: {
-      inverted: false,
+      inverted: 'false',
     },
   });
   // Because an unchecked checkbox will cause html5 validation to fail, only add

--- a/packages/semantic-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/semantic-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -50,7 +50,7 @@ export default function CheckboxesWidget<
     formContext,
     uiSchema,
     defaultSchemaProps: {
-      inverted: false,
+      inverted: 'false',
     },
   });
   const _onChange =

--- a/packages/semantic-ui/src/IconButton/IconButton.tsx
+++ b/packages/semantic-ui/src/IconButton/IconButton.tsx
@@ -18,6 +18,15 @@ function IconButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends 
 
 export default IconButton;
 
+export function CopyButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: IconButtonProps<T, S, F>
+) {
+  const {
+    registry: { translateString },
+  } = props;
+  return <IconButton title={translateString(TranslatableString.CopyButton)} {...props} icon='copy' />;
+}
+
 export function MoveDownButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   props: IconButtonProps<T, S, F>
 ) {

--- a/packages/semantic-ui/src/Templates/Templates.ts
+++ b/packages/semantic-ui/src/Templates/Templates.ts
@@ -6,7 +6,7 @@ import ArrayFieldTemplate from '../ArrayFieldTemplate';
 import BaseInputTemplate from '../BaseInputTemplate';
 import DescriptionField from '../DescriptionField';
 import ErrorList from '../ErrorList';
-import { MoveDownButton, MoveUpButton, RemoveButton } from '../IconButton';
+import { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } from '../IconButton';
 import FieldErrorTemplate from '../FieldErrorTemplate';
 import FieldHelpTemplate from '../FieldHelpTemplate';
 import FieldTemplate from '../FieldTemplate';
@@ -26,6 +26,7 @@ export function generateTemplates<
     BaseInputTemplate,
     ButtonTemplates: {
       AddButton,
+      CopyButton,
       MoveDownButton,
       MoveUpButton,
       RemoveButton,

--- a/packages/semantic-ui/src/TextareaWidget/TextareaWidget.tsx
+++ b/packages/semantic-ui/src/TextareaWidget/TextareaWidget.tsx
@@ -34,7 +34,7 @@ export default function TextareaWidget<
   const semanticProps = getSemanticProps<T, S, F>({
     formContext,
     options,
-    defaultSchemaProps: { inverted: false },
+    defaultSchemaProps: { inverted: 'false' },
   });
   const { schemaUtils } = registry;
   // eslint-disable-next-line no-shadow

--- a/packages/semantic-ui/test/Array.test.tsx
+++ b/packages/semantic-ui/test/Array.test.tsx
@@ -1,4 +1,4 @@
-import { ErrorSchema, RJSFSchema } from '@rjsf/utils';
+import { ErrorSchema, RJSFSchema, UiSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 import renderer from 'react-test-renderer';
 
@@ -55,7 +55,12 @@ describe('array fields', () => {
         type: 'string',
       },
     };
-    const tree = renderer.create(<Form schema={schema} validator={validator} formData={['a', 'b']} />).toJSON();
+    const uiSchema: UiSchema = {
+      'ui:options': { copyable: true },
+    };
+    const tree = renderer
+      .create(<Form schema={schema} uiSchema={uiSchema} validator={validator} formData={['a', 'b']} />)
+      .toJSON();
     expect(tree).toMatchSnapshot();
   });
   test('no errors', () => {

--- a/packages/semantic-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Array.test.tsx.snap
@@ -80,8 +80,9 @@ exports[`array fields array icons 1`] = `
                 className="ui grid"
                 style={
                   Object {
+                    "alignItems": "center",
                     "display": "grid",
-                    "gridTemplateColumns": "1fr 65px",
+                    "gridTemplateColumns": "1fr 150px",
                   }
                 }
               >
@@ -124,7 +125,7 @@ exports[`array fields array icons 1`] = `
                   className="column"
                 >
                   <div
-                    className="ui mini vertical buttons"
+                    className="ui mini buttons"
                   >
                     <button
                       className="ui icon disabled button array-item-move-up"
@@ -147,6 +148,17 @@ exports[`array fields array icons 1`] = `
                       <i
                         aria-hidden="true"
                         className="angle down icon"
+                        onClick={[Function]}
+                      />
+                    </button>
+                    <button
+                      className="ui icon button array-item-copy"
+                      onClick={[Function]}
+                      title="Copy"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="copy icon"
                         onClick={[Function]}
                       />
                     </button>
@@ -174,7 +186,7 @@ exports[`array fields array icons 1`] = `
                   Object {
                     "alignItems": "center",
                     "display": "grid",
-                    "gridTemplateColumns": "1fr 65px",
+                    "gridTemplateColumns": "1fr 150px",
                   }
                 }
               >
@@ -217,7 +229,7 @@ exports[`array fields array icons 1`] = `
                   className="column"
                 >
                   <div
-                    className="ui mini vertical buttons"
+                    className="ui mini buttons"
                   >
                     <button
                       className="ui icon button array-item-move-up"
@@ -240,6 +252,17 @@ exports[`array fields array icons 1`] = `
                       <i
                         aria-hidden="true"
                         className="angle down icon"
+                        onClick={[Function]}
+                      />
+                    </button>
+                    <button
+                      className="ui icon button array-item-copy"
+                      onClick={[Function]}
+                      title="Copy"
+                    >
+                      <i
+                        aria-hidden="true"
+                        className="copy icon"
                         onClick={[Function]}
                       />
                     </button>
@@ -498,8 +521,9 @@ exports[`array fields fixed array 1`] = `
                 className="ui grid"
                 style={
                   Object {
+                    "alignItems": "center",
                     "display": "grid",
-                    "gridTemplateColumns": "1fr 65px",
+                    "gridTemplateColumns": "1fr 150px",
                   }
                 }
               >
@@ -549,7 +573,7 @@ exports[`array fields fixed array 1`] = `
                   Object {
                     "alignItems": "center",
                     "display": "grid",
-                    "gridTemplateColumns": "1fr 65px",
+                    "gridTemplateColumns": "1fr 150px",
                   }
                 }
               >

--- a/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`single fields checkbox field 1`] = `
       >
         <div
           className="ui checkbox"
-          inverted={false}
+          inverted="false"
           onBlur={[Function]}
           onChange={[Function]}
           onClick={[Function]}
@@ -74,7 +74,7 @@ exports[`single fields checkbox field with label 1`] = `
       >
         <div
           className="ui checkbox"
-          inverted={false}
+          inverted="false"
           onBlur={[Function]}
           onChange={[Function]}
           onClick={[Function]}
@@ -136,7 +136,7 @@ exports[`single fields checkboxes field 1`] = `
         >
           <div
             className="ui checkbox"
-            inverted={false}
+            inverted="false"
             onBlur={[Function]}
             onChange={[Function]}
             onClick={[Function]}
@@ -168,7 +168,7 @@ exports[`single fields checkboxes field 1`] = `
         >
           <div
             className="ui checkbox"
-            inverted={false}
+            inverted="false"
             onBlur={[Function]}
             onChange={[Function]}
             onClick={[Function]}
@@ -200,7 +200,7 @@ exports[`single fields checkboxes field 1`] = `
         >
           <div
             className="ui checkbox"
-            inverted={false}
+            inverted="false"
             onBlur={[Function]}
             onChange={[Function]}
             onClick={[Function]}
@@ -232,7 +232,7 @@ exports[`single fields checkboxes field 1`] = `
         >
           <div
             className="ui checkbox"
-            inverted={false}
+            inverted="false"
             onBlur={[Function]}
             onChange={[Function]}
             onClick={[Function]}
@@ -1646,7 +1646,7 @@ exports[`single fields textarea field 1`] = `
           autoFocus={false}
           disabled={false}
           id="root"
-          inverted={false}
+          inverted="false"
           name="root"
           onBlur={[Function]}
           onChange={[Function]}

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -25,3 +25,4 @@ export const RJSF_ADDITONAL_PROPERTIES_FLAG = '__rjsf_additionalProperties';
 export const UI_FIELD_KEY = 'ui:field';
 export const UI_WIDGET_KEY = 'ui:widget';
 export const UI_OPTIONS_KEY = 'ui:options';
+export const UI_GLOBAL_OPTIONS_KEY = 'ui:globalOptions';

--- a/packages/utils/src/createSchemaUtils.ts
+++ b/packages/utils/src/createSchemaUtils.ts
@@ -2,6 +2,7 @@ import deepEquals from './deepEquals';
 import {
   ErrorSchema,
   FormContextType,
+  GlobalUISchemaOptions,
   IdSchema,
   PathSchema,
   RJSFSchema,
@@ -94,10 +95,11 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
    *
    * @param schema - The schema for which the display label flag is desired
    * @param [uiSchema] - The UI schema from which to derive potentially displayable information
+   * @param [globalOptions={}] - The optional Global UI Schema from which to get any fallback `xxx` options
    * @returns - True if the label should be displayed or false if it should not
    */
-  getDisplayLabel(schema: S, uiSchema?: UiSchema<T, S, F>) {
-    return getDisplayLabel<T, S, F>(this.validator, schema, uiSchema, this.rootSchema);
+  getDisplayLabel(schema: S, uiSchema?: UiSchema<T, S, F>, globalOptions?: GlobalUISchemaOptions) {
+    return getDisplayLabel<T, S, F>(this.validator, schema, uiSchema, this.rootSchema, globalOptions);
   }
 
   /** Determines which of the given `options` provided most closely matches the `formData`.

--- a/packages/utils/src/enums.ts
+++ b/packages/utils/src/enums.ts
@@ -23,6 +23,8 @@ export enum TranslatableString {
   AddButton = 'Add',
   /** Add button title, used by AddButton */
   AddItemButton = 'Add Item',
+  /** Copy button title, used by IconButton */
+  CopyButton = 'Copy',
   /** Move down button title, used by IconButton */
   MoveDownButton = 'Move down',
   /** Move up button title, used by IconButton */
@@ -51,6 +53,8 @@ export enum TranslatableString {
   /** Key label, where %1 will be replaced by the label as provided by WrapIfAdditionalTemplate */
   KeyLabel = '%1 Key',
   // Strings with replaceable parameters AND/OR that support markdown and html
+  /** Invalid object field configuration as provided by the ObjectField */
+  InvalidObjectField = 'Invalid "%1" object field configuration: <em>%2</em>.',
   /** Unsupported field schema, used by UnsupportedField */
   UnsupportedField = 'Unsupported field schema.',
   /** Unsupported field schema, where %1 will be replaced by the idSchema.$id as provided by UnsupportedField */

--- a/packages/utils/src/getUiOptions.ts
+++ b/packages/utils/src/getUiOptions.ts
@@ -25,5 +25,5 @@ export default function getUiOptions<T = any, S extends StrictRJSFSchema = RJSFS
         return { ...options, ...value };
       }
       return { ...options, [key.substring(3)]: value };
-    }, globalOptions);
+    }, { ...globalOptions });
 }

--- a/packages/utils/src/getUiOptions.ts
+++ b/packages/utils/src/getUiOptions.ts
@@ -1,15 +1,17 @@
 import { UI_OPTIONS_KEY, UI_WIDGET_KEY } from './constants';
 import isObject from './isObject';
-import { FormContextType, RJSFSchema, StrictRJSFSchema, UIOptionsType, UiSchema } from './types';
+import { FormContextType, GlobalUISchemaOptions, RJSFSchema, StrictRJSFSchema, UIOptionsType, UiSchema } from './types';
 
 /** Get all passed options from ui:options, and ui:<optionName>, returning them in an object with the `ui:`
- * stripped off.
+ * stripped off. Any `globalOptions` will always be returned, unless they are overridden by options in the `uiSchema`.
  *
  * @param [uiSchema={}] - The UI Schema from which to get any `ui:xxx` options
- * @returns - An object containing all the `ui:xxx` options with the stripped off
+ * @param [globalOptions={}] - The optional Global UI Schema from which to get any fallback `xxx` options
+ * @returns - An object containing all the `ui:xxx` options with the `ui:` stripped off along with all `globalOptions`
  */
 export default function getUiOptions<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
-  uiSchema: UiSchema<T, S, F> = {}
+  uiSchema: UiSchema<T, S, F> = {},
+  globalOptions: GlobalUISchemaOptions = {}
 ): UIOptionsType<T, S, F> {
   return Object.keys(uiSchema)
     .filter((key) => key.indexOf('ui:') === 0)
@@ -23,5 +25,5 @@ export default function getUiOptions<T = any, S extends StrictRJSFSchema = RJSFS
         return { ...options, ...value };
       }
       return { ...options, [key.substring(3)]: value };
-    }, {});
+    }, globalOptions);
 }

--- a/packages/utils/src/getUiOptions.ts
+++ b/packages/utils/src/getUiOptions.ts
@@ -15,15 +15,18 @@ export default function getUiOptions<T = any, S extends StrictRJSFSchema = RJSFS
 ): UIOptionsType<T, S, F> {
   return Object.keys(uiSchema)
     .filter((key) => key.indexOf('ui:') === 0)
-    .reduce((options, key) => {
-      const value = uiSchema[key];
-      if (key === UI_WIDGET_KEY && isObject(value)) {
-        console.error('Setting options via ui:widget object is no longer supported, use ui:options instead');
-        return options;
-      }
-      if (key === UI_OPTIONS_KEY && isObject(value)) {
-        return { ...options, ...value };
-      }
-      return { ...options, [key.substring(3)]: value };
-    }, { ...globalOptions });
+    .reduce(
+      (options, key) => {
+        const value = uiSchema[key];
+        if (key === UI_WIDGET_KEY && isObject(value)) {
+          console.error('Setting options via ui:widget object is no longer supported, use ui:options instead');
+          return options;
+        }
+        if (key === UI_OPTIONS_KEY && isObject(value)) {
+          return { ...options, ...value };
+        }
+        return { ...options, [key.substring(3)]: value };
+      },
+      { ...globalOptions }
+    );
 }

--- a/packages/utils/src/schema/getDisplayLabel.ts
+++ b/packages/utils/src/schema/getDisplayLabel.ts
@@ -2,7 +2,14 @@ import { UI_FIELD_KEY, UI_WIDGET_KEY } from '../constants';
 import getSchemaType from '../getSchemaType';
 import getUiOptions from '../getUiOptions';
 import isCustomWidget from '../isCustomWidget';
-import { FormContextType, RJSFSchema, StrictRJSFSchema, UiSchema, ValidatorType } from '../types';
+import {
+  FormContextType,
+  GlobalUISchemaOptions,
+  RJSFSchema,
+  StrictRJSFSchema,
+  UiSchema,
+  ValidatorType,
+} from '../types';
 import isFilesArray from './isFilesArray';
 import isMultiSelect from './isMultiSelect';
 
@@ -13,14 +20,21 @@ import isMultiSelect from './isMultiSelect';
  * @param schema - The schema for which the display label flag is desired
  * @param [uiSchema={}] - The UI schema from which to derive potentially displayable information
  * @param [rootSchema] - The root schema, used to primarily to look up `$ref`s
+ * @param [globalOptions={}] - The optional Global UI Schema from which to get any fallback `xxx` options
  * @returns - True if the label should be displayed or false if it should not
  */
 export default function getDisplayLabel<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any
->(validator: ValidatorType<T, S, F>, schema: S, uiSchema: UiSchema<T, S, F> = {}, rootSchema?: S): boolean {
-  const uiOptions = getUiOptions<T, S, F>(uiSchema);
+>(
+  validator: ValidatorType<T, S, F>,
+  schema: S,
+  uiSchema: UiSchema<T, S, F> = {},
+  rootSchema?: S,
+  globalOptions?: GlobalUISchemaOptions
+): boolean {
+  const uiOptions = getUiOptions<T, S, F>(uiSchema, globalOptions);
   const { label = true } = uiOptions;
   let displayLabel = !!label;
   const schemaType = getSchemaType<S>(schema);

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -252,13 +252,13 @@ export interface TemplatesType<T = any, S extends StrictRJSFSchema = RJSFSchema,
  * widget level when no field-level value of the option is provided.
  */
 export type GlobalUISchemaOptions = {
-  /** Flag, if set to `false`, will mark array fields as NOT being able to be added to (defaults to true) */
+  /** Flag, if set to `false`, new items cannot be added to array fields, unless overridden (defaults to true) */
   addable?: boolean;
-  /** Flag, if set to `true`, will mark array fields as being able to be copied (defaults to false) */
+  /** Flag, if set to `true`, array items can be copied (defaults to false) */
   copyable?: boolean;
-  /** Flag, if set to `false`, will mark array fields as NOT being able to be ordered (defaults to true) */
+  /** Flag, if set to `false`, array items cannot be ordered (defaults to true) */
   orderable?: boolean;
-  /** Flag, if set to `false`, will mark array fields as NOT being able to be removed (defaults to true) */
+  /** Flag, if set to `false`, array items will not be removable (defaults to true) */
   removable?: boolean;
   /** Field labels are rendered by default. Labels may be omitted by setting the `label` option to `false` */
   label?: boolean;
@@ -507,7 +507,7 @@ export type ArrayFieldTemplateItemType<
   totalItems: number;
   /** Returns a function that adds a new item at `index` */
   onAddIndexClick: (index: number) => (event?: any) => void;
-  /** Returns a function that copyies the item at `index` into the position at `index + 1` */
+  /** Returns a function that copies the item at `index` into the position at `index + 1` */
   onCopyIndexClick: (index: number) => (event?: any) => void;
   /** Returns a function that removes the item at `index` */
   onDropIndexClick: (index: number) => (event?: any) => void;
@@ -840,7 +840,7 @@ export type UiSchema<
      * Registry for use everywhere.
      */
     'ui:globalOptions'?: GlobalUISchemaOptions;
-    /** Allows the form to generate a unique prefix for the `Form`'s root prefix, deprecated in favor of  */
+    /** Allows the form to generate a unique prefix for the `Form`'s root prefix  */
     'ui:rootFieldId'?: string;
     /** Allows RJSF to override the default field implementation by specifying either the name of a field that is used
      * to look up an implementation from the `fields` list or an actual one-off `Field` component implementation itself

--- a/packages/utils/test/getTemplate.test.ts
+++ b/packages/utils/test/getTemplate.test.ts
@@ -26,6 +26,7 @@ const registry: Registry = {
     BaseInputTemplate: FakeTemplate,
     ButtonTemplates: {
       AddButton: FakeTemplate,
+      CopyButton: FakeTemplate,
       MoveDownButton: FakeTemplate,
       MoveUpButton: FakeTemplate,
       RemoveButton: FakeTemplate,

--- a/packages/utils/test/getUiOptions.test.ts
+++ b/packages/utils/test/getUiOptions.test.ts
@@ -1,4 +1,4 @@
-import { UIOptionsType, UiSchema, getUiOptions } from '../src';
+import { GlobalUISchemaOptions, UIOptionsType, UiSchema, getUiOptions } from '../src';
 
 const uiSchema: UiSchema = {
   widgetText: {
@@ -8,6 +8,9 @@ const uiSchema: UiSchema = {
     'ui:widget': {
       component: 'radio',
     },
+  },
+  arrayObject: {
+    'ui:addable': true,
   },
   optionsObject: {
     'ui:options': {
@@ -25,9 +28,15 @@ const uiSchema: UiSchema = {
   },
 };
 
+const globalOptions: GlobalUISchemaOptions = {
+  addable: false,
+  copyable: true,
+};
+
 const results: { [key: string]: UIOptionsType } = {
   widgetText: { widget: 'select' },
   widgetObject: {},
+  arrayObject: { addable: true, copyable: true },
   optionsObject: { widget: 'hidden', disabled: true },
   multiOptions: {
     submitButtonProps: { norender: true },
@@ -47,6 +56,10 @@ describe('getUiOptions()', () => {
   });
   it('returns empty options with no uiSchema', () => {
     expect(getUiOptions()).toEqual({});
+  });
+  it('returns array object as options', () => {
+    expect(getUiOptions(uiSchema.arrayObject, globalOptions)).toEqual(results.arrayObject);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
   it('returns widget text as options', () => {
     expect(getUiOptions(uiSchema.widgetText)).toEqual(results.widgetText);

--- a/packages/utils/test/schema/getDisplayLabelTest.ts
+++ b/packages/utils/test/schema/getDisplayLabelTest.ts
@@ -3,6 +3,20 @@ import { TestValidatorType } from './types';
 
 export default function getDisplayLabelTest(testValidator: TestValidatorType) {
   describe('getDisplayLabel()', () => {
+    it('with global uiSchema "label" set to true', () => {
+      expect(getDisplayLabel(testValidator, { type: 'string' }, {}, undefined, { label: true })).toEqual(true);
+    });
+    it('with global uiSchema "label" set to false', () => {
+      const schema: RJSFSchema = { type: 'string' };
+      const schemaUtils = createSchemaUtils(testValidator, schema);
+      expect(schemaUtils.getDisplayLabel(schema, {}, { label: false })).toEqual(false);
+    });
+    it('with local uiSchema "label" set to true', () => {
+      expect(getDisplayLabel(testValidator, { type: 'string' }, { 'ui:options': { label: true } })).toEqual(true);
+    });
+    it('with local uiSchema "label" set to false', () => {
+      expect(getDisplayLabel(testValidator, { type: 'string' }, { 'ui:label': false })).toEqual(false);
+    });
     it('object type', () => {
       expect(getDisplayLabel(testValidator, { type: 'object' })).toEqual(false);
     });


### PR DESCRIPTION
### Reasons for making this change

Fixes #1261 and #1712 by adding copy array item capability as well as global `UiSchema` options

- In `@rjsf/utils`, updated types and functions to support array field copy AND global options in the `UiSchema` as follows:
- Added a new `TranslatableString` enums `CopyButton` and `InvalidObjectField` that localizes the information extracted from `ObjectField` as markdown
- Updated the `ArrayFieldTemplateItemType` to add support for copying array items
  - Refactored `UIOptionsBaseType` to extract the `addable`, `orderable`, `removable`, `label` and `duplicateKeySuffixSeparator` into a new `GlobalUISchemaOptions` type that adds `copyable` - Extended `UIOptionsBaseType` from `GlobalUISchemaOptions` - In `UiSchema` added a new optional `ui:globalOptions` prop of type `GlobalUISchemaOptions` and a new `UI_GLOBAL_OPTIONS_KEY` constant - Added a new optional prop `globalUiOptions` object of type `GlobalUISchemaOptions` in `Registry` as well as `CopyButton` in `ButtonTemplates`
  - Updated `getUiOptions()` and `getDisplayLabel()` (and its `SchemaUtilsType` counterpart) to take an optional `GlobalUISchemaOptions` parameter that is used to include global options into the returned `uiOptions`
- In `@rjsf/core`, added support for array field copy and global options in the `UiSchema` as follows:
  - Updated `ArrayField` to handle global UI Options by passing in `registry.globalUiOptions` into `getUiOptions()` and by exposing the new `hasCopy` flag and `onCopyIndexClick` callback
  - Updated `ObjectField` to handle global UI Options for `duplicateKeySuffixSeparator` and also added support for the new `TranslatableString.InvalidObjectField` translation into a `Markdown`
  - Updated `SchemaField` to handle global UI Options for `label`
  - Added a new `CopyButton` implementation that was registered in the `ButtonTemplates`
  - Updated `ArrayFieldItemTemplate` to render the `CopyButton` when `hasCopy` is true, calling `onCopyIndexClick` on click
  - Updated `Form` to extract the `ui:globalOptions` from the `uiSchema` and set it into the `registry` as `globalUiOptions`
  - Updated tests to verify all the new functionality
- In all the themes, added support for array field copy as follows:
  - Added a new `CopyButton` implementation that was registered in the `ButtonTemplates`
  - Updated `ArrayFieldItemTemplate` to render the `CopyButton` when `hasCopy` is true, calling `onCopyIndexClick` on click
  - Updated the Array tests to verify that copy shows up when `copyable` is true
- In `@rjsf/antd` and `@rjsf/semantic-ui` updated the styles to support the additional button in `ArrayFieldItemTemplate`
- In `@rjsf/fluent-ui`, fixed some bad style errors in the console by removing the `;` at the end of the `fontFamily` custom styles
- In `@rjsf/semantic-ui`, removed some bad property warnings by changing the `inverted` prop from `false` to `'false'`
- In `@rjsf/docs`, updated the documentation for all the copy feature and global `UiSchema` options type updates
  - Also replaced all `js(x)` code blocks with `ts(x)` code blocks to be complete
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
