### PR TITLE
feature: reimplement #2473 by implementing a TimeWidget in core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,29 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 
 - `Reset` function added for `Programmatically Reset` action. `Reset` function will reset form data and validation errors. Form data will set to default values.
+- Implemented a new `TimeWidget` that works for all themes
 
 ## @rjsf/fluent-ui
 
-- Fix RadioWidget's onChange return value.
+- Fix `RadioWidget`'s onChange return value.
+
+## @rjsf/material-ui
+
+- Updated `BaseInputTemplate` so that it shrinks a `time` formatted input
+
+## @rjsf/mui
+
+- Updated `BaseInputTemplate` so that it shrinks a `time` formatted input
+
+## @rjsf/utils
+
+- Updated the widget matrix used by `getWidget()` to support the `time` to `TimeWidget` mapping
 
 ## Dev / docs / playground
 
-- Added `Programmatically Reset` button to clear states which are form data and validation errors.
+- Updated the playground to add a `Programmatically Reset` button to clear states which are form data and validation errors.
+- Updated the `Date & time` example to show off the new `TimeWidget`.
+- Updated the `custom-widgets-fields` and `widgets` documentation to mention the new `TimeWidget` and its support for the `time` format.
 
 # 5.2.1
 

--- a/packages/antd/test/Form.test.tsx
+++ b/packages/antd/test/Form.test.tsx
@@ -102,6 +102,14 @@ describe('single fields', () => {
     const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
     expect(tree).toMatchSnapshot();
   });
+  test('format time', () => {
+    const schema: RJSFSchema = {
+      type: 'string',
+      format: 'time',
+    };
+    const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
   test('password field', () => {
     const schema: RJSFSchema = {
       type: 'string',

--- a/packages/antd/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Form.test.tsx.snap
@@ -717,6 +717,47 @@ exports[`single fields format datetime 1`] = `
 </form>
 `;
 
+exports[`single fields format time 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <input
+      aria-describedby="root__error root__description root__help"
+      className="ant-input"
+      id="root"
+      name="root"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      placeholder=""
+      style={
+        Object {
+          "width": "100%",
+        }
+      }
+      type="time"
+      value=""
+    />
+  </div>
+  <button
+    className="ant-btn ant-btn-submit"
+    disabled={false}
+    onClick={[Function]}
+    type="submit"
+  >
+    <span>
+      Submit
+    </span>
+  </button>
+</form>
+`;
+
 exports[`single fields help and error display 1`] = `
 <form
   className="rjsf"

--- a/packages/bootstrap-4/test/Form.test.tsx
+++ b/packages/bootstrap-4/test/Form.test.tsx
@@ -101,6 +101,14 @@ describe('single fields', () => {
     const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
     expect(tree).toMatchSnapshot();
   });
+  test('format time', () => {
+    const schema: RJSFSchema = {
+      type: 'string',
+      format: 'time',
+    };
+    const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
   test('password field', () => {
     const schema: RJSFSchema = {
       type: 'string',

--- a/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
@@ -544,6 +544,54 @@ exports[`single fields format datetime 1`] = `
 </form>
 `;
 
+exports[`single fields format time 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <div
+      className="form-group"
+    >
+      <label
+        className="form-label"
+        htmlFor="root"
+      >
+        
+      </label>
+      <input
+        aria-describedby="root__error root__description root__help"
+        autoFocus={false}
+        className="form-control"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder=""
+        readOnly={false}
+        type="time"
+        value=""
+      />
+      
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields help and error display 1`] = `
 <form
   className="rjsf"

--- a/packages/chakra-ui/test/Form.test.tsx
+++ b/packages/chakra-ui/test/Form.test.tsx
@@ -103,6 +103,14 @@ describe('single fields', () => {
     const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
     expect(tree).toMatchSnapshot();
   });
+  test('format time', () => {
+    const schema: RJSFSchema = {
+      type: 'string',
+      format: 'time',
+    };
+    const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
   test('password field', () => {
     const schema: RJSFSchema = {
       type: 'string',

--- a/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
@@ -1212,6 +1212,93 @@ exports[`single fields format datetime 1`] = `
 </form>
 `;
 
+exports[`single fields format time 1`] = `
+.emotion-1 {
+  margin-bottom: 1px;
+}
+
+.emotion-3 {
+  margin-top: 3px;
+}
+
+.emotion-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  position: relative;
+  white-space: nowrap;
+  vertical-align: middle;
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  width: auto;
+}
+
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <div
+      className="chakra-form-control emotion-0"
+      role="group"
+    >
+      <div
+        className="chakra-form-control emotion-1"
+        role="group"
+      >
+        <input
+          aria-describedby="root__error root__description root__help"
+          autoFocus={false}
+          className="chakra-input emotion-0"
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          required={false}
+          type="time"
+          value=""
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className="emotion-3"
+  >
+    <button
+      className="chakra-button emotion-4"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields help and error display 1`] = `
 .emotion-0 {
   width: 100%;

--- a/packages/core/src/components/widgets/TimeWidget.tsx
+++ b/packages/core/src/components/widgets/TimeWidget.tsx
@@ -1,0 +1,17 @@
+import { useCallback } from 'react';
+import { getTemplate, FormContextType, RJSFSchema, StrictRJSFSchema, WidgetProps } from '@rjsf/utils';
+
+/** The `TimeWidget` component uses the `BaseInputTemplate` changing the type to `time` and transforms
+ * the value to undefined when it is falsy during the `onChange` handling.
+ *
+ * @param props - The `WidgetProps` for this component
+ */
+export default function TimeWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: WidgetProps<T, S, F>
+) {
+  const { onChange, options, registry } = props;
+  const BaseInputTemplate = getTemplate<'BaseInputTemplate', T, S, F>('BaseInputTemplate', registry, options);
+  const handleChange = useCallback((value: any) => onChange(value ? `${value}:00` : undefined), [onChange]);
+
+  return <BaseInputTemplate type='time' {...props} onChange={handleChange} />;
+}

--- a/packages/core/src/components/widgets/index.ts
+++ b/packages/core/src/components/widgets/index.ts
@@ -16,6 +16,7 @@ import RangeWidget from './RangeWidget';
 import SelectWidget from './SelectWidget';
 import TextareaWidget from './TextareaWidget';
 import TextWidget from './TextWidget';
+import TimeWidget from './TimeWidget';
 import URLWidget from './URLWidget';
 import UpDownWidget from './UpDownWidget';
 
@@ -25,24 +26,25 @@ function widgets<
   F extends FormContextType = any
 >(): RegistryWidgetsType<T, S, F> {
   return {
+    AltDateWidget,
+    AltDateTimeWidget,
+    CheckboxWidget,
+    CheckboxesWidget,
+    ColorWidget,
+    DateWidget,
+    DateTimeWidget,
+    EmailWidget,
+    FileWidget,
+    HiddenWidget,
     PasswordWidget,
     RadioWidget,
-    UpDownWidget,
     RangeWidget,
     SelectWidget,
     TextWidget,
-    DateWidget,
-    DateTimeWidget,
-    AltDateWidget,
-    AltDateTimeWidget,
-    EmailWidget,
-    URLWidget,
     TextareaWidget,
-    HiddenWidget,
-    ColorWidget,
-    FileWidget,
-    CheckboxWidget,
-    CheckboxesWidget,
+    TimeWidget,
+    UpDownWidget,
+    URLWidget,
   };
 }
 

--- a/packages/core/test/StringField.test.jsx
+++ b/packages/core/test/StringField.test.jsx
@@ -864,6 +864,133 @@ describe('StringField', () => {
     });
   });
 
+  describe('TimeWidget', () => {
+    it('should render a time field', () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: 'string',
+          format: 'time',
+        },
+      });
+
+      expect(node.querySelectorAll('.field [type=time]')).to.have.length.of(1);
+    });
+
+    it('should assign a default value', () => {
+      const time = '01:10:00';
+      const { node, onSubmit } = createFormComponent({
+        schema: {
+          type: 'string',
+          format: 'time',
+          default: time,
+        },
+      });
+      submitForm(node);
+      sinon.assert.calledWithMatch(onSubmit.lastCall, {
+        formData: time,
+      });
+    });
+
+    it('should reflect the change into the dom', () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: 'string',
+          format: 'time',
+        },
+      });
+
+      const newTime = '11:10';
+
+      Simulate.change(node.querySelector('[type=time]'), {
+        target: { value: newTime },
+      });
+
+      expect(node.querySelector('[type=time]').value).eql(`${newTime}:00`);
+    });
+
+    it('should fill field with data', () => {
+      const time = '13:10:00';
+      const { node, onSubmit } = createFormComponent({
+        schema: {
+          type: 'string',
+          format: 'time',
+        },
+        formData: time,
+      });
+      submitForm(node);
+      sinon.assert.calledWithMatch(onSubmit.lastCall, {
+        formData: time,
+      });
+    });
+
+    it('should render the widget with the expected id', () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: 'string',
+          format: 'time',
+        },
+      });
+
+      expect(node.querySelector('[type=time]').id).eql('root');
+    });
+
+    it('should reject an invalid entered time', () => {
+      const { node, onChange } = createFormComponent({
+        schema: {
+          type: 'string',
+          format: 'time',
+        },
+        liveValidate: true,
+      });
+
+      Simulate.change(node.querySelector('[type=time]'), {
+        target: { value: 'invalid' },
+      });
+
+      sinon.assert.calledWithMatch(onChange.lastCall, {
+        errorSchema: { __errors: ['must match format "time"'] },
+        errors: [
+          {
+            message: 'must match format "time"',
+            name: 'format',
+            params: { format: 'time' },
+            property: '',
+            schemaPath: '#/format',
+            stack: 'must match format "time"',
+          },
+        ],
+      });
+    });
+
+    it('should render customized TimeWidget', () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: 'string',
+          format: 'time',
+        },
+        widgets: {
+          TimeWidget: CustomWidget,
+        },
+      });
+
+      expect(node.querySelector('#custom')).to.exist;
+    });
+
+    it('should allow overriding of BaseInputTemplate', () => {
+      const { node } = createFormComponent({
+        schema: {
+          type: 'string',
+          format: 'time',
+        },
+        templates: {
+          BaseInputTemplate: CustomWidget,
+        },
+      });
+
+      expect(node.querySelector('#custom')).to.exist;
+    });
+  });
+
   describe('AltDateTimeWidget', () => {
     const uiSchema = { 'ui:widget': 'alt-datetime' };
 

--- a/packages/docs/docs/advanced-customization/custom-widgets-fields.md
+++ b/packages/docs/docs/advanced-customization/custom-widgets-fields.md
@@ -88,6 +88,7 @@ The default widgets you can override are:
 - `SelectWidget`
 - `TextareaWidget`
 - `TextWidget`
+- `TimeWidget`
 - `UpDownWidget`
 - `URLWidget`
 

--- a/packages/docs/docs/usage/widgets.md
+++ b/packages/docs/docs/usage/widgets.md
@@ -82,8 +82,7 @@ The built-in string field also supports the JSON Schema `format` property, and w
 
 ![](https://i.imgur.com/xqu6Lcp.png)
 
-Please note that, even though they are standardized, `datetime-local`, `date` and `time` input elements are not yet supported by IE.
-If you plan on targeting this platforms, two alternative widgets are available:
+Please note that, even though they are standardized, `datetime-local`, `date` and `time` input elements are not supported by IE. If you plan on targeting IE, two alternative widgets are available:
 
 - `alt-datetime`: Six `select` elements are used to select the year, the month, the day, the hour, the minute and the second;
 - `alt-date`: Three `select` elements are used to select the year, month and the day.

--- a/packages/docs/docs/usage/widgets.md
+++ b/packages/docs/docs/usage/widgets.md
@@ -78,15 +78,15 @@ The built-in string field also supports the JSON Schema `format` property, and w
 - `data-url`: By default, an `input[type=file]` element is used; in case the string is part of an array, multiple files will be handled automatically (see [File widgets](#file-widgets)).
 - `date`: By default, an `input[type=date]` element is used;
 - `date-time`: By default, an `input[type=datetime-local]` element is used.
+- `time`: By default an `input[type=time]` element is used;
 
 ![](https://i.imgur.com/xqu6Lcp.png)
 
-Please note that, even though they are standardized, `datetime-local` and `date` input elements are not yet supported by Firefox and IE. If you plan on targeting these platforms, two alternative widgets are available:
+Please note that, even though they are standardized, `datetime-local`, `date` and `time` input elements are not yet supported by IE.
+If you plan on targeting this platforms, two alternative widgets are available:
 
 - `alt-datetime`: Six `select` elements are used to select the year, the month, the day, the hour, the minute and the second;
 - `alt-date`: Three `select` elements are used to select the year, month and the day.
-
-> **Firefox 57 - 66**: Firefox partially supporting `date` and `time` input types, but not `datetime-local`, `month` or `week`
 
 ![](https://i.imgur.com/VF5tY60.png)
 

--- a/packages/fluent-ui/test/Form.test.tsx
+++ b/packages/fluent-ui/test/Form.test.tsx
@@ -101,6 +101,14 @@ describe('single fields', () => {
     const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
     expect(tree).toMatchSnapshot();
   });
+  test('format time', () => {
+    const schema: RJSFSchema = {
+      type: 'string',
+      format: 'time',
+    };
+    const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
   test('password field', () => {
     const schema: RJSFSchema = {
       type: 'string',

--- a/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`single fields checkbox field 1`] = `
           >
             <span
               className="ms-Button-label label-57"
-              id="id__106"
+              id="id__112"
             >
               Submit
             </span>
@@ -171,7 +171,7 @@ exports[`single fields checkbox field with label 1`] = `
           >
             <span
               className="ms-Button-label label-57"
-              id="id__109"
+              id="id__115"
             >
               Submit
             </span>
@@ -401,7 +401,7 @@ exports[`single fields checkboxes field 1`] = `
           >
             <span
               className="ms-Button-label label-57"
-              id="id__112"
+              id="id__118"
             >
               Submit
             </span>
@@ -414,125 +414,6 @@ exports[`single fields checkboxes field 1`] = `
 `;
 
 exports[`single fields field with description 1`] = `
-<form
-  className="rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
-  >
-    
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_my-field"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
-        >
-          <div
-            className="ms-TextField root-42"
-          >
-            <div
-              className="ms-TextField-wrapper"
-            >
-              <label
-                className="ms-Label root-61"
-                htmlFor="root_my-field"
-                id="TextFieldLabel129"
-              >
-                my-field
-              </label>
-              <div
-                className="ms-TextField-fieldGroup fieldGroup-43"
-              >
-                <input
-                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel129"
-                  autoFocus={false}
-                  className="ms-TextField-field field-44"
-                  disabled={false}
-                  id="root_my-field"
-                  name="root_my-field"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value=""
-                />
-              </div>
-            </div>
-          </div>
-          <span
-            className="css-153"
-          >
-            some description
-          </span>
-        </div>
-      </div>
-    </div>
-    
-  </div>
-  <div>
-    <br />
-    <div
-      className="ms-Grid-col ms-sm12"
-    >
-      <button
-        className="ms-Button ms-Button--primary root-53"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        type="submit"
-      >
-        <span
-          className="ms-Button-flexContainer flexContainer-54"
-          data-automationid="splitbuttonprimary"
-        >
-          <span
-            className="ms-Button-textContainer textContainer-55"
-          >
-            <span
-              className="ms-Button-label label-57"
-              id="id__130"
-            >
-              Submit
-            </span>
-          </span>
-        </span>
-      </button>
-    </div>
-  </div>
-</form>
-`;
-
-exports[`single fields field with description in uiSchema 1`] = `
 <form
   className="rjsf"
   noValidate={false}
@@ -607,7 +488,7 @@ exports[`single fields field with description in uiSchema 1`] = `
           <span
             className="css-153"
           >
-            some other description
+            some description
           </span>
         </div>
       </div>
@@ -640,6 +521,125 @@ exports[`single fields field with description in uiSchema 1`] = `
             <span
               className="ms-Button-label label-57"
               id="id__136"
+            >
+              Submit
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`single fields field with description in uiSchema 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "display": undefined,
+        "marginBottom": 15,
+      }
+    }
+  >
+    
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
+      <div
+        className="ms-Grid-row"
+      >
+        <div
+          className="ms-Grid-col ms-sm12  field field-string"
+          id="root_my-field"
+          style={
+            Object {
+              "display": undefined,
+              "marginBottom": 15,
+            }
+          }
+        >
+          <div
+            className="ms-TextField root-42"
+          >
+            <div
+              className="ms-TextField-wrapper"
+            >
+              <label
+                className="ms-Label root-61"
+                htmlFor="root_my-field"
+                id="TextFieldLabel141"
+              >
+                my-field
+              </label>
+              <div
+                className="ms-TextField-fieldGroup fieldGroup-43"
+              >
+                <input
+                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                  aria-invalid={false}
+                  aria-labelledby="TextFieldLabel141"
+                  autoFocus={false}
+                  className="ms-TextField-field field-44"
+                  disabled={false}
+                  id="root_my-field"
+                  name="root_my-field"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <span
+            className="css-153"
+          >
+            some other description
+          </span>
+        </div>
+      </div>
+    </div>
+    
+  </div>
+  <div>
+    <br />
+    <div
+      className="ms-Grid-col ms-sm12"
+    >
+      <button
+        className="ms-Button ms-Button--primary root-53"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="submit"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-54"
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className="ms-Button-textContainer textContainer-55"
+          >
+            <span
+              className="ms-Button-label label-57"
+              id="id__142"
             >
               Submit
             </span>
@@ -1205,6 +1205,90 @@ exports[`single fields format datetime 1`] = `
 </form>
 `;
 
+exports[`single fields format time 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
+    style={
+      Object {
+        "display": undefined,
+        "marginBottom": 15,
+      }
+    }
+  >
+    <div
+      className="ms-TextField root-42"
+    >
+      <div
+        className="ms-TextField-wrapper"
+      >
+        <div
+          className="ms-TextField-fieldGroup fieldGroup-43"
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            aria-invalid={false}
+            autoFocus={false}
+            className="ms-TextField-field field-44"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            placeholder=""
+            readOnly={false}
+            type="time"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+    
+  </div>
+  <div>
+    <br />
+    <div
+      className="ms-Grid-col ms-sm12"
+    >
+      <button
+        className="ms-Button ms-Button--primary root-53"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="submit"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-54"
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className="ms-Button-textContainer textContainer-55"
+          >
+            <span
+              className="ms-Button-label label-57"
+              id="id__83"
+            >
+              Submit
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</form>
+`;
+
 exports[`single fields help and error display 1`] = `
 <form
   className="rjsf"
@@ -1232,7 +1316,7 @@ exports[`single fields help and error display 1`] = `
       <div
         aria-live="assertive"
         className="ms-MessageBar-text text-159"
-        id="MessageBar163"
+        id="MessageBar169"
         role="status"
       >
         <span
@@ -1261,7 +1345,7 @@ exports[`single fields help and error display 1`] = `
           className="ms-TextField-fieldGroup fieldGroup-165"
         >
           <input
-            aria-describedby="TextFieldDescription165"
+            aria-describedby="TextFieldDescription171"
             aria-invalid={true}
             autoFocus={false}
             className="ms-TextField-field field-44"
@@ -1280,7 +1364,7 @@ exports[`single fields help and error display 1`] = `
         </div>
       </div>
       <span
-        id="TextFieldDescription165"
+        id="TextFieldDescription171"
       >
         <div
           role="alert"
@@ -1345,7 +1429,7 @@ exports[`single fields help and error display 1`] = `
           >
             <span
               className="ms-Button-label label-57"
-              id="id__167"
+              id="id__173"
             >
               Submit
             </span>
@@ -1428,7 +1512,7 @@ exports[`single fields hidden field 1`] = `
           >
             <span
               className="ms-Button-label label-57"
-              id="id__124"
+              id="id__130"
             >
               Submit
             </span>
@@ -1512,7 +1596,7 @@ exports[`single fields hidden label 1`] = `
           >
             <span
               className="ms-Button-label label-57"
-              id="id__148"
+              id="id__154"
             >
               Submit
             </span>
@@ -1821,7 +1905,7 @@ exports[`single fields password field 1`] = `
           >
             <span
               className="ms-Button-label label-57"
-              id="id__83"
+              id="id__89"
             >
               Submit
             </span>
@@ -1887,7 +1971,7 @@ exports[`single fields radio field 1`] = `
               >
                 <span
                   className="ms-ChoiceFieldLabel"
-                  id="ChoiceGroupLabel116-0"
+                  id="ChoiceGroupLabel122-0"
                 >
                   Yes
                 </span>
@@ -1918,7 +2002,7 @@ exports[`single fields radio field 1`] = `
               >
                 <span
                   className="ms-ChoiceFieldLabel"
-                  id="ChoiceGroupLabel116-1"
+                  id="ChoiceGroupLabel122-1"
                 >
                   No
                 </span>
@@ -1955,7 +2039,7 @@ exports[`single fields radio field 1`] = `
           >
             <span
               className="ms-Button-label label-57"
-              id="id__117"
+              id="id__123"
             >
               Submit
             </span>
@@ -2059,7 +2143,7 @@ exports[`single fields schema examples 1`] = `
           >
             <span
               className="ms-Button-label label-57"
-              id="id__160"
+              id="id__166"
             >
               Submit
             </span>
@@ -2152,7 +2236,7 @@ exports[`single fields select field 1`] = `
           >
             <span
               className="ms-Button-label label-57"
-              id="id__103"
+              id="id__109"
             >
               Submit
             </span>
@@ -2197,7 +2281,7 @@ exports[`single fields slider field 1`] = `
           aria-valuetext="42"
           className="ms-Slider-slideBox ms-Slider-showValue ms-Slider-showTransitions slideBox-144"
           data-is-focusable={true}
-          id="Slider120"
+          id="Slider126"
           onKeyDown={[Function]}
           onMouseDown={[Function]}
           onTouchStart={[Function]}
@@ -2267,7 +2351,7 @@ exports[`single fields slider field 1`] = `
           >
             <span
               className="ms-Button-label label-57"
-              id="id__121"
+              id="id__127"
             >
               Submit
             </span>
@@ -2773,7 +2857,7 @@ exports[`single fields textarea field 1`] = `
           >
             <span
               className="ms-Button-label label-57"
-              id="id__100"
+              id="id__106"
             >
               Submit
             </span>
@@ -2833,7 +2917,7 @@ exports[`single fields title field 1`] = `
               <label
                 className="ms-Label root-61"
                 htmlFor="root_title"
-                id="TextFieldLabel141"
+                id="TextFieldLabel147"
               >
                 title
               </label>
@@ -2843,7 +2927,7 @@ exports[`single fields title field 1`] = `
                 <input
                   aria-describedby="root_title__error root_title__description root_title__help"
                   aria-invalid={false}
-                  aria-labelledby="TextFieldLabel141"
+                  aria-labelledby="TextFieldLabel147"
                   autoFocus={false}
                   className="ms-TextField-field field-44"
                   disabled={false}
@@ -2893,7 +2977,7 @@ exports[`single fields title field 1`] = `
           >
             <span
               className="ms-Button-label label-57"
-              id="id__142"
+              id="id__148"
             >
               Submit
             </span>
@@ -3022,7 +3106,7 @@ exports[`single fields up/down field 1`] = `
           className="ms-spinButton-input css-99"
           data-lpignore={true}
           disabled={false}
-          id="input87"
+          id="input93"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -3130,7 +3214,7 @@ exports[`single fields up/down field 1`] = `
           >
             <span
               className="ms-Button-label label-57"
-              id="id__94"
+              id="id__100"
             >
               Submit
             </span>
@@ -3214,7 +3298,7 @@ exports[`single fields using custom tagName 1`] = `
           >
             <span
               className="ms-Button-label label-57"
-              id="id__154"
+              id="id__160"
             >
               Submit
             </span>

--- a/packages/material-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/material-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -10,7 +10,7 @@ import {
   StrictRJSFSchema,
 } from '@rjsf/utils';
 
-const TYPES_THAT_SHRINK_LABEL = ['date', 'datetime-local', 'file'];
+const TYPES_THAT_SHRINK_LABEL = ['date', 'datetime-local', 'file', 'time'];
 
 /** The `BaseInputTemplate` is the template to use to render the basic `<input>` component for the `core` theme.
  * It is used as the template for rendering many of the <input> based widgets that differ by `type` and callbacks only.

--- a/packages/material-ui/test/Form.test.tsx
+++ b/packages/material-ui/test/Form.test.tsx
@@ -108,6 +108,14 @@ describe('single fields', () => {
     const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
     expect(tree).toMatchSnapshot();
   });
+  test('format time', () => {
+    const schema: RJSFSchema = {
+      type: 'string',
+      format: 'time',
+    };
+    const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
   test('password field', () => {
     const schema: RJSFSchema = {
       type: 'string',

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`single fields checkbox field 1`] = `
         <span
           aria-describedby="root__error root__description root__help"
           aria-disabled={false}
-          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-18 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
           onBlur={[Function]}
           onDragLeave={[Function]}
           onFocus={[Function]}
@@ -38,104 +38,7 @@ exports[`single fields checkbox field 1`] = `
             <input
               autoFocus={false}
               checked={false}
-              className="PrivateSwitchBase-input-20"
-              data-indeterminate={false}
-              disabled={false}
-              id="root"
-              name="root"
-              onChange={[Function]}
-              required={false}
-              type="checkbox"
-            />
-            <svg
-              aria-hidden={true}
-              className="MuiSvgIcon-root"
-              focusable="false"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-              />
-            </svg>
-          </span>
-        </span>
-        <span
-          className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-        >
-          
-        </span>
-      </label>
-    </div>
-  </div>
-  <div
-    className="MuiBox-root MuiBox-root-21"
-  >
-    <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
-      disabled={false}
-      onBlur={[Function]}
-      onDragLeave={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      onMouseDown={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-      onTouchEnd={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
-      tabIndex={0}
-      type="submit"
-    >
-      <span
-        className="MuiButton-label"
-      >
-        Submit
-      </span>
-    </button>
-  </div>
-</form>
-`;
-
-exports[`single fields checkbox field with label 1`] = `
-<form
-  className="rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="form-group field field-boolean"
-  >
-    <div
-      className="MuiFormControl-root MuiFormControl-fullWidth"
-    >
-      <label
-        className="MuiFormControlLabel-root"
-      >
-        <span
-          aria-describedby="root__error root__description root__help"
-          aria-disabled={false}
-          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-          onBlur={[Function]}
-          onDragLeave={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-          onTouchEnd={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
-          tabIndex={null}
-        >
-          <span
-            className="MuiIconButton-label"
-          >
-            <input
-              autoFocus={false}
-              checked={false}
-              className="PrivateSwitchBase-input-20"
+              className="PrivateSwitchBase-input-21"
               data-indeterminate={false}
               disabled={false}
               id="root"
@@ -162,7 +65,7 @@ exports[`single fields checkbox field with label 1`] = `
         <span
           className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
         >
-          test
+          
         </span>
       </label>
     </div>
@@ -200,235 +103,71 @@ exports[`single fields checkbox field with label 1`] = `
 </form>
 `;
 
-exports[`single fields checkboxes field 1`] = `
+exports[`single fields checkbox field with label 1`] = `
 <form
   className="rjsf"
   noValidate={false}
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group field field-boolean"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <label
-        className="MuiFormLabel-root"
-        htmlFor="root"
-      />
-      <div
-        className="MuiFormGroup-root"
-        id="root"
+        className="MuiFormControlLabel-root"
       >
-        <label
-          className="MuiFormControlLabel-root"
+        <span
+          aria-describedby="root__error root__description root__help"
+          aria-disabled={false}
+          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-18 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+          onBlur={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={null}
         >
           <span
-            aria-describedby="root__error root__description root__help"
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-            onBlur={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={null}
+            className="MuiIconButton-label"
           >
-            <span
-              className="MuiIconButton-label"
+            <input
+              autoFocus={false}
+              checked={false}
+              className="PrivateSwitchBase-input-21"
+              data-indeterminate={false}
+              disabled={false}
+              id="root"
+              name="root"
+              onChange={[Function]}
+              required={false}
+              type="checkbox"
+            />
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              <input
-                autoFocus={false}
-                checked={false}
-                className="PrivateSwitchBase-input-20"
-                data-indeterminate={false}
-                disabled={false}
-                id="root-0"
-                name="root"
-                onChange={[Function]}
-                type="checkbox"
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
               />
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                />
-              </svg>
-            </span>
+            </svg>
           </span>
-          <span
-            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-          >
-            foo
-          </span>
-        </label>
-        <label
-          className="MuiFormControlLabel-root"
+        </span>
+        <span
+          className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
         >
-          <span
-            aria-describedby="root__error root__description root__help"
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-            onBlur={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={null}
-          >
-            <span
-              className="MuiIconButton-label"
-            >
-              <input
-                autoFocus={false}
-                checked={false}
-                className="PrivateSwitchBase-input-20"
-                data-indeterminate={false}
-                disabled={false}
-                id="root-1"
-                name="root"
-                onChange={[Function]}
-                type="checkbox"
-              />
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-          >
-            bar
-          </span>
-        </label>
-        <label
-          className="MuiFormControlLabel-root"
-        >
-          <span
-            aria-describedby="root__error root__description root__help"
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-            onBlur={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={null}
-          >
-            <span
-              className="MuiIconButton-label"
-            >
-              <input
-                autoFocus={false}
-                checked={false}
-                className="PrivateSwitchBase-input-20"
-                data-indeterminate={false}
-                disabled={false}
-                id="root-2"
-                name="root"
-                onChange={[Function]}
-                type="checkbox"
-              />
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-          >
-            fuzz
-          </span>
-        </label>
-        <label
-          className="MuiFormControlLabel-root"
-        >
-          <span
-            aria-describedby="root__error root__description root__help"
-            aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
-            onBlur={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            tabIndex={null}
-          >
-            <span
-              className="MuiIconButton-label"
-            >
-              <input
-                autoFocus={false}
-                checked={false}
-                className="PrivateSwitchBase-input-20"
-                data-indeterminate={false}
-                disabled={false}
-                id="root-3"
-                name="root"
-                onChange={[Function]}
-                type="checkbox"
-              />
-              <svg
-                aria-hidden={true}
-                className="MuiSvgIcon-root"
-                focusable="false"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
-                />
-              </svg>
-            </span>
-          </span>
-          <span
-            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
-          >
-            qux
-          </span>
-        </label>
-      </div>
+          test
+        </span>
+      </label>
     </div>
   </div>
   <div
@@ -456,6 +195,282 @@ exports[`single fields checkboxes field 1`] = `
       >
         Submit
       </span>
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields checkboxes field 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-array"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth"
+    >
+      <label
+        className="MuiFormLabel-root"
+        htmlFor="root"
+      />
+      <div
+        className="MuiFormGroup-root"
+        id="root"
+      >
+        <label
+          className="MuiFormControlLabel-root"
+        >
+          <span
+            aria-describedby="root__error root__description root__help"
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-18 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <input
+                autoFocus={false}
+                checked={false}
+                className="PrivateSwitchBase-input-21"
+                data-indeterminate={false}
+                disabled={false}
+                id="root-0"
+                name="root"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            foo
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root"
+        >
+          <span
+            aria-describedby="root__error root__description root__help"
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-18 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <input
+                autoFocus={false}
+                checked={false}
+                className="PrivateSwitchBase-input-21"
+                data-indeterminate={false}
+                disabled={false}
+                id="root-1"
+                name="root"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            bar
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root"
+        >
+          <span
+            aria-describedby="root__error root__description root__help"
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-18 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <input
+                autoFocus={false}
+                checked={false}
+                className="PrivateSwitchBase-input-21"
+                data-indeterminate={false}
+                disabled={false}
+                id="root-2"
+                name="root"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            fuzz
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root"
+        >
+          <span
+            aria-describedby="root__error root__description root__help"
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-18 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <input
+                autoFocus={false}
+                checked={false}
+                className="PrivateSwitchBase-input-21"
+                data-indeterminate={false}
+                disabled={false}
+                id="root-3"
+                name="root"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </span>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            qux
+          </span>
+        </label>
+      </div>
+    </div>
+  </div>
+  <div
+    className="MuiBox-root MuiBox-root-24"
+  >
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+      disabled={false}
+      onBlur={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="submit"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        Submit
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
     </button>
   </div>
 </form>
@@ -542,7 +557,7 @@ exports[`single fields field with description 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-35"
+    className="MuiBox-root MuiBox-root-36"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -566,6 +581,9 @@ exports[`single fields field with description 1`] = `
       >
         Submit
       </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
     </button>
   </div>
 </form>
@@ -652,7 +670,7 @@ exports[`single fields field with description in uiSchema 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-36"
+    className="MuiBox-root MuiBox-root-37"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -676,9 +694,6 @@ exports[`single fields field with description in uiSchema 1`] = `
       >
         Submit
       </span>
-      <span
-        className="MuiTouchRipple-root"
-      />
     </button>
   </div>
 </form>
@@ -900,6 +915,76 @@ exports[`single fields format datetime 1`] = `
 </form>
 `;
 
+exports[`single fields format time 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth"
+    >
+      <div
+        aria-describedby="root__error root__description root__help"
+        className="MuiFormControl-root MuiTextField-root"
+      >
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiInput-input"
+            disabled={false}
+            id="root"
+            name="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="time"
+            value=""
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="MuiBox-root MuiBox-root-13"
+  >
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+      disabled={false}
+      onBlur={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="submit"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        Submit
+      </span>
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields help and error display 1`] = `
 <form
   className="rjsf"
@@ -910,7 +995,7 @@ exports[`single fields help and error display 1`] = `
     className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
   >
     <div
-      className="MuiBox-root MuiBox-root-42"
+      className="MuiBox-root MuiBox-root-43"
     >
       <h6
         className="MuiTypography-root MuiTypography-h6"
@@ -1007,7 +1092,7 @@ exports[`single fields help and error display 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-43"
+    className="MuiBox-root MuiBox-root-44"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -1031,6 +1116,9 @@ exports[`single fields help and error display 1`] = `
       >
         Submit
       </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
     </button>
   </div>
 </form>
@@ -1075,7 +1163,7 @@ exports[`single fields hidden field 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-34"
+    className="MuiBox-root MuiBox-root-35"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -1099,9 +1187,6 @@ exports[`single fields hidden field 1`] = `
       >
         Submit
       </span>
-      <span
-        className="MuiTouchRipple-root"
-      />
     </button>
   </div>
 </form>
@@ -1148,7 +1233,7 @@ exports[`single fields hidden label 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-39"
+    className="MuiBox-root MuiBox-root-40"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -1172,9 +1257,6 @@ exports[`single fields hidden label 1`] = `
       >
         Submit
       </span>
-      <span
-        className="MuiTouchRipple-root"
-      />
     </button>
   </div>
 </form>
@@ -1412,7 +1494,7 @@ exports[`single fields password field 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-13"
+    className="MuiBox-root MuiBox-root-14"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -1436,6 +1518,9 @@ exports[`single fields password field 1`] = `
       >
         Submit
       </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
     </button>
   </div>
 </form>
@@ -1470,7 +1555,7 @@ exports[`single fields radio field 1`] = `
         >
           <span
             aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiRadio-root MuiRadio-colorPrimary MuiIconButton-colorPrimary"
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-18 MuiRadio-root MuiRadio-colorPrimary MuiIconButton-colorPrimary"
             onBlur={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
@@ -1489,7 +1574,7 @@ exports[`single fields radio field 1`] = `
             >
               <input
                 checked={false}
-                className="PrivateSwitchBase-input-20"
+                className="PrivateSwitchBase-input-21"
                 disabled={false}
                 id="root-0"
                 name="root"
@@ -1498,7 +1583,7 @@ exports[`single fields radio field 1`] = `
                 value="0"
               />
               <div
-                className="PrivateRadioButtonIcon-root-24"
+                className="PrivateRadioButtonIcon-root-25"
               >
                 <svg
                   aria-hidden={true}
@@ -1512,7 +1597,7 @@ exports[`single fields radio field 1`] = `
                 </svg>
                 <svg
                   aria-hidden={true}
-                  className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-25"
+                  className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-26"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -1522,9 +1607,6 @@ exports[`single fields radio field 1`] = `
                 </svg>
               </div>
             </span>
-            <span
-              className="MuiTouchRipple-root"
-            />
           </span>
           <span
             className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
@@ -1537,7 +1619,7 @@ exports[`single fields radio field 1`] = `
         >
           <span
             aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-17 MuiRadio-root MuiRadio-colorPrimary MuiIconButton-colorPrimary"
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-18 MuiRadio-root MuiRadio-colorPrimary MuiIconButton-colorPrimary"
             onBlur={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
@@ -1556,7 +1638,7 @@ exports[`single fields radio field 1`] = `
             >
               <input
                 checked={false}
-                className="PrivateSwitchBase-input-20"
+                className="PrivateSwitchBase-input-21"
                 disabled={false}
                 id="root-1"
                 name="root"
@@ -1565,7 +1647,7 @@ exports[`single fields radio field 1`] = `
                 value="1"
               />
               <div
-                className="PrivateRadioButtonIcon-root-24"
+                className="PrivateRadioButtonIcon-root-25"
               >
                 <svg
                   aria-hidden={true}
@@ -1579,7 +1661,7 @@ exports[`single fields radio field 1`] = `
                 </svg>
                 <svg
                   aria-hidden={true}
-                  className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-25"
+                  className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-26"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -1589,9 +1671,6 @@ exports[`single fields radio field 1`] = `
                 </svg>
               </div>
             </span>
-            <span
-              className="MuiTouchRipple-root"
-            />
           </span>
           <span
             className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
@@ -1603,7 +1682,7 @@ exports[`single fields radio field 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-27"
+    className="MuiBox-root MuiBox-root-28"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -1627,9 +1706,6 @@ exports[`single fields radio field 1`] = `
       >
         Submit
       </span>
-      <span
-        className="MuiTouchRipple-root"
-      />
     </button>
   </div>
 </form>
@@ -1696,7 +1772,7 @@ exports[`single fields schema examples 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-41"
+    className="MuiBox-root MuiBox-root-42"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -1720,9 +1796,6 @@ exports[`single fields schema examples 1`] = `
       >
         Submit
       </span>
-      <span
-        className="MuiTouchRipple-root"
-      />
     </button>
   </div>
 </form>
@@ -1795,7 +1868,7 @@ exports[`single fields select field 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-16"
+    className="MuiBox-root MuiBox-root-17"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -1819,9 +1892,6 @@ exports[`single fields select field 1`] = `
       >
         Submit
       </span>
-      <span
-        className="MuiTouchRipple-root"
-      />
     </button>
   </div>
 </form>
@@ -1874,7 +1944,7 @@ exports[`single fields slider field 1`] = `
           aria-valuemax={100}
           aria-valuemin={42}
           aria-valuenow={75}
-          className="MuiSlider-thumb MuiSlider-thumbColorPrimary PrivateValueLabel-thumb-28"
+          className="MuiSlider-thumb MuiSlider-thumbColorPrimary PrivateValueLabel-thumb-29"
           data-index={0}
           onBlur={[Function]}
           onFocus={[Function]}
@@ -1890,13 +1960,13 @@ exports[`single fields slider field 1`] = `
           tabIndex={0}
         >
           <span
-            className="PrivateValueLabel-offset-30 MuiSlider-valueLabel"
+            className="PrivateValueLabel-offset-31 MuiSlider-valueLabel"
           >
             <span
-              className="PrivateValueLabel-circle-31"
+              className="PrivateValueLabel-circle-32"
             >
               <span
-                className="PrivateValueLabel-label-32"
+                className="PrivateValueLabel-label-33"
               >
                 75
               </span>
@@ -1907,7 +1977,7 @@ exports[`single fields slider field 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-33"
+    className="MuiBox-root MuiBox-root-34"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -1931,6 +2001,9 @@ exports[`single fields slider field 1`] = `
       >
         Submit
       </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
     </button>
   </div>
 </form>
@@ -2335,7 +2408,7 @@ exports[`single fields textarea field 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-15"
+    className="MuiBox-root MuiBox-root-16"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -2359,6 +2432,9 @@ exports[`single fields textarea field 1`] = `
       >
         Submit
       </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
     </button>
   </div>
 </form>
@@ -2377,7 +2453,7 @@ exports[`single fields title field 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiBox-root MuiBox-root-37"
+        className="MuiBox-root MuiBox-root-38"
         id="root__title"
       >
         <h5
@@ -2452,7 +2528,7 @@ exports[`single fields title field 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-38"
+    className="MuiBox-root MuiBox-root-39"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -2476,6 +2552,9 @@ exports[`single fields title field 1`] = `
       >
         Submit
       </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
     </button>
   </div>
 </form>
@@ -2586,7 +2665,7 @@ exports[`single fields up/down field 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-14"
+    className="MuiBox-root MuiBox-root-15"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -2610,9 +2689,6 @@ exports[`single fields up/down field 1`] = `
       >
         Submit
       </span>
-      <span
-        className="MuiTouchRipple-root"
-      />
     </button>
   </div>
 </form>
@@ -2659,7 +2735,7 @@ exports[`single fields using custom tagName 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-40"
+    className="MuiBox-root MuiBox-root-41"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -2683,6 +2759,9 @@ exports[`single fields using custom tagName 1`] = `
       >
         Submit
       </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
     </button>
   </div>
 </div>

--- a/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -10,7 +10,7 @@ import {
   StrictRJSFSchema,
 } from '@rjsf/utils';
 
-const TYPES_THAT_SHRINK_LABEL = ['date', 'datetime-local', 'file'];
+const TYPES_THAT_SHRINK_LABEL = ['date', 'datetime-local', 'file', 'time'];
 
 /** The `BaseInputTemplate` is the template to use to render the basic `<input>` component for the `core` theme.
  * It is used as the template for rendering many of the <input> based widgets that differ by `type` and callbacks only.

--- a/packages/mui/test/Form.test.tsx
+++ b/packages/mui/test/Form.test.tsx
@@ -101,6 +101,14 @@ describe('single fields', () => {
     const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
     expect(tree).toMatchSnapshot();
   });
+  test('format time', () => {
+    const schema: RJSFSchema = {
+      type: 'string',
+      format: 'time',
+    };
+    const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
   test('password field', () => {
     const schema: RJSFSchema = {
       type: 'string',

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -3683,6 +3683,403 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
 </form>
 `;
 
+exports[`single fields format time 1`] = `
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
+.emotion-1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+}
+
+.emotion-2 {
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  color: rgba(0, 0, 0, 0.87);
+  box-sizing: border-box;
+  position: relative;
+  cursor: text;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border-radius: 4px;
+}
+
+.emotion-2.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+  cursor: default;
+}
+
+.emotion-2:hover .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.87);
+}
+
+@media (hover: none) {
+  .emotion-2:hover .MuiOutlinedInput-notchedOutline {
+    border-color: rgba(0, 0, 0, 0.23);
+  }
+}
+
+.emotion-2.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-color: #1976d2;
+  border-width: 2px;
+}
+
+.emotion-2.Mui-error .MuiOutlinedInput-notchedOutline {
+  border-color: #d32f2f;
+}
+
+.emotion-2.Mui-disabled .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-3 {
+  font: inherit;
+  letter-spacing: inherit;
+  color: currentColor;
+  padding: 4px 0 5px;
+  border: 0;
+  box-sizing: content-box;
+  background: none;
+  height: 1.4375em;
+  margin: 0;
+  -webkit-tap-highlight-color: transparent;
+  display: block;
+  min-width: 0;
+  width: 100%;
+  -webkit-animation-name: mui-auto-fill-cancel;
+  animation-name: mui-auto-fill-cancel;
+  -webkit-animation-duration: 10ms;
+  animation-duration: 10ms;
+  padding: 16.5px 14px;
+}
+
+.emotion-3::-webkit-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-3::-moz-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-3:-ms-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-3::-ms-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-3:focus {
+  outline: 0;
+}
+
+.emotion-3:invalid {
+  box-shadow: none;
+}
+
+.emotion-3::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3::-webkit-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3::-moz-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:-ms-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3::-ms-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-webkit-input-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-moz-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus:-ms-input-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-placeholder {
+  opacity: 0.42;
+}
+
+.emotion-3.Mui-disabled {
+  opacity: 1;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-3:-webkit-autofill {
+  -webkit-animation-duration: 5000s;
+  animation-duration: 5000s;
+  -webkit-animation-name: mui-auto-fill;
+  animation-name: mui-auto-fill;
+}
+
+.emotion-3:-webkit-autofill {
+  border-radius: inherit;
+}
+
+.emotion-4 {
+  text-align: left;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  top: -5px;
+  left: 0;
+  margin: 0;
+  padding: 0 8px;
+  pointer-events: none;
+  border-radius: inherit;
+  border-style: solid;
+  border-width: 1px;
+  overflow: hidden;
+  min-width: 0%;
+  border-color: rgba(0, 0, 0, 0.23);
+}
+
+.emotion-5 {
+  float: unset;
+  width: auto;
+  overflow: hidden;
+  padding: 0;
+  line-height: 11px;
+  -webkit-transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+}
+
+.emotion-6 {
+  margin-top: 24px;
+}
+
+.emotion-7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  letter-spacing: 0.02857em;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 6px 16px;
+  border-radius: 4px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  color: #fff;
+  background-color: #1976d2;
+  box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+}
+
+.emotion-7::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-7.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-7 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-7:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: #1565c0;
+  box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+}
+
+@media (hover: none) {
+  .emotion-7:hover {
+    background-color: #1976d2;
+  }
+}
+
+.emotion-7:active {
+  box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+}
+
+.emotion-7.Mui-focusVisible {
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+}
+
+.emotion-7.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    >
+      <div
+        aria-describedby="root__error root__description root__help"
+        className="MuiFormControl-root MuiTextField-root emotion-1"
+      >
+        <div
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-2"
+          onClick={[Function]}
+        >
+          <input
+            aria-invalid={false}
+            autoFocus={false}
+            className="MuiInputBase-input MuiOutlinedInput-input emotion-3"
+            disabled={false}
+            id="root"
+            name="root"
+            onAnimationStart={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            required={false}
+            type="time"
+            value=""
+          />
+          <fieldset
+            aria-hidden={true}
+            className="MuiOutlinedInput-notchedOutline emotion-4"
+          >
+            <legend
+              className="emotion-5"
+            >
+              <span
+                className="notranslate"
+              >
+                ​
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="MuiBox-root emotion-6"
+  >
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-7"
+      disabled={false}
+      onBlur={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields help and error display 1`] = `
 .emotion-0 {
   background-color: #fff;
@@ -6304,6 +6701,18 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   background-color: rgba(0, 0, 0, 0.12);
 }
 
+.emotion-8 {
+  overflow: hidden;
+  pointer-events: none;
+  position: absolute;
+  z-index: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  border-radius: inherit;
+}
+
 <form
   className="rjsf"
   noValidate={false}
@@ -6379,6 +6788,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       type="submit"
     >
       Submit
+      <span
+        className="MuiTouchRipple-root emotion-8"
+      />
     </button>
   </div>
 </form>
@@ -11857,18 +12269,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   background-color: rgba(0, 0, 0, 0.12);
 }
 
-.emotion-8 {
-  overflow: hidden;
-  pointer-events: none;
-  position: absolute;
-  z-index: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  border-radius: inherit;
-}
-
 <form
   className="rjsf"
   noValidate={false}
@@ -11944,9 +12344,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
       type="submit"
     >
       Submit
-      <span
-        className="MuiTouchRipple-root emotion-8"
-      />
     </button>
   </div>
 </form>

--- a/packages/playground/src/samples/date.js
+++ b/packages/playground/src/samples/date.js
@@ -16,6 +16,10 @@ export default {
             type: 'string',
             format: 'date',
           },
+          time: {
+            type: 'string',
+            format: 'time',
+          },
         },
       },
       alternative: {

--- a/packages/semantic-ui/test/Form.test.tsx
+++ b/packages/semantic-ui/test/Form.test.tsx
@@ -107,6 +107,14 @@ describe('single fields', () => {
     const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
     expect(tree).toMatchSnapshot();
   });
+  test('format time', () => {
+    const schema: RJSFSchema = {
+      type: 'string',
+      format: 'time',
+    };
+    const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
   test('password field', () => {
     const schema: RJSFSchema = {
       type: 'string',

--- a/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
@@ -693,6 +693,52 @@ exports[`single fields format datetime 1`] = `
 </form>
 `;
 
+exports[`single fields format time 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      <div
+        className="field"
+      >
+        <div
+          className="ui fluid input"
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            autoFocus={false}
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder=""
+            type="time"
+            value=""
+          />
+        </div>
+      </div>
+      
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
 exports[`single fields help and error display 1`] = `
 <form
   className="ui form rjsf"

--- a/packages/utils/src/getWidget.tsx
+++ b/packages/utils/src/getWidget.tsx
@@ -33,6 +33,7 @@ const widgetMap: { [k: string]: { [j: string]: string } } = {
     'date-time': 'DateTimeWidget',
     'alt-date': 'AltDateWidget',
     'alt-datetime': 'AltDateTimeWidget',
+    time: 'TimeWidget',
     color: 'ColorWidget',
     file: 'FileWidget',
   },


### PR DESCRIPTION
### Reasons for making this change

Added a new `TimeWidget` that supports entering in times as HH:mm AM/PM
- In `@rjsf/utils`, added a `time` to `TimeWidget` mapping for `string` in `getWidgets.ts`
- In `@rjsf/core`, reimplemented the `TimeWidget` based on #2473
  - Updated the tests to verify the new `TimeWidget` works appropriately
- In all the themes, updated the tests to verify the rendering of the time widget
- In `@rjsf/material-ui` and `@rjsf/mui` added `time` to the shrink list in `BaseInputTemplate`
- Updated the documentation for the new `TimeWidget` support
  - Also verified that the latest Firefox browsers support the native components
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
