### PR TITLE
fix: Removed infinite loop in AltDateWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.3.1
+
+## @rjsf/core
+
+- Updated `AltDateWidget` to remove an infinite loop caused by two conflicting effects by merging them with additional checking of original `value` against the current value, fixing [#3516](https://github.com/rjsf-team/react-jsonschema-form/issues/3516)
+
 # 5.3.0
 
 ## @rjsf/antd


### PR DESCRIPTION
### Reasons for making this change

Fixes #3516 by removing the infinite loop caused by two `useEffects()` by adding a new state for the `value` and combining the effects into one
- Updated `AltDateWidget` to stash the `value` in state and combining the two `useEffects()` into a single effect
  - The effect will call `onChange()` when the `state` is ready for change AND it causes a different string than the current `value`
  - If the `lastValue` recorded differs from the `value`, then we record the new `value` and set the `state` to it
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
