### PR TITLE
MUI5 label:false issue

### DIFF
--- a/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -79,7 +79,7 @@ export default function BaseInputTemplate<
         id={id}
         name={id}
         placeholder={placeholder}
-        label={displayLabel ? label || schema.title : false}
+        label={displayLabel ? label || schema.title : ''}
         autoFocus={autofocus}
         required={required}
         disabled={disabled || readonly}

--- a/packages/mui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/mui/src/RadioWidget/RadioWidget.tsx
@@ -28,6 +28,8 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
   disabled,
   readonly,
   label,
+  uiSchema,
+  registry,
   onChange,
   onBlur,
   onFocus,
@@ -43,11 +45,16 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
   const row = options ? options.inline : false;
   const selectedIndex = enumOptionsIndexForValue<S>(value, enumOptions);
 
+  const { schemaUtils } = registry;
+  const displayLabel = schemaUtils.getDisplayLabel(schema, uiSchema);
+
   return (
     <>
-      <FormLabel required={required} htmlFor={id}>
-        {label || schema.title}
-      </FormLabel>
+      {displayLabel && (
+        <FormLabel required={required} htmlFor={id}>
+          {label || schema.title}
+        </FormLabel>
+      )}
       <RadioGroup
         id={id}
         name={id}


### PR DESCRIPTION
### Reasons for making this change

**mui5 bug**

text field widget and required was showing ***** as a label ` if ui:options : {label :false }`

radio widget not hiding label ` if ui:options : {label :false }`
If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

If your PR is non-trivial and you'd like to schedule a synchronous review, please add it to the weekly meeting agenda: https://docs.google.com/document/d/12PjTvv21k6LIky6bNQVnsplMLLnmEuypTLQF8a-8Wss/edit

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
