### PR TITLE
feature: Add support for File preview in the FileWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,18 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Added the ability to use a tooltip for a description
 
+## @rjsf/core
+
+- Updated `FileWidget` to show a preview of images and a download link for non-images when the `filePreview` options is set to true in the `UiSchema`
+
+## @rjsf/utils
+
+- Updated the `UiSchema` to support the optional `filePreview?: boolean` option and to add a new `TranslatableString.PreviewLabel` to the `enums`
+
 ## Dev / docs / playground
 
 - Added a new `AntD Customization` documentation with references to it in the `form-props` and `uiSchema` documentation
+- Updated the `uiSchema` documentation to add the `filePreview` option
 
 # 5.3.1
 

--- a/packages/core/test/StringField.test.jsx
+++ b/packages/core/test/StringField.test.jsx
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { act, Simulate } from 'react-dom/test-utils';
 import sinon from 'sinon';
-import { parseDateString, toDateString, utcToLocal } from '@rjsf/utils';
+import { parseDateString, toDateString, TranslatableString, utcToLocal } from '@rjsf/utils';
 
 import { createFormComponent, createSandbox, getSelectedOptionValue, submitForm } from './test_utils';
 
@@ -2010,6 +2010,44 @@ describe('StringField', () => {
       });
 
       expect(node.querySelector('#custom')).to.exist;
+    });
+
+    it('should render the file widget with preview attribute', () => {
+      const formData =
+        'data:image/png;name=test.png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAABg2lDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AYht+mSkUqDmYQcchQnSyIijhqFYpQIdQKrTqYXPoHTRqSFBdHwbXg4M9i1cHFWVcHV0EQ/AFxdXFSdJESv0sKLWK847iH97735e47QGhUmG53jQO64VjpZELK5lalyCvCECHQjCvMNudkOYXA8XWPEN/v4jwruO7P0aflbQaEJOJZZloO8Qbx9KZjct4nFllJ0YjPiccsuiDxI9dVn984Fz0WeKZoZdLzxCKxVOxgtYNZydKJp4hjmm5QvpD1WeO8xVmv1FjrnvyF0byxssx1WsNIYhFLkCFBRQ1lVOAgTrtBio00nScC/EOeXyaXSq4yGDkWUIUOxfOD/8Hv3tqFyQk/KZoAul9c92MEiOwCzbrrfh+7bvMECD8DV0bbX20AM5+k19ta7Ajo3wYurtuaugdc7gCDT6ZiKZ4UpiUUCsD7GX1TDhi4BXrX/L61znH6AGSoV6kb4OAQGC1S9nrAu3s6+/ZvTat/PyV4cojSYDGVAAAACXBIWXMAAC4jAAAuIwF4pT92AAAAB3RJTUUH5wMUAgM6setlnQAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAAAWSURBVAjXY/z//z8DAwMTAwMDAwMDACQGAwG9HuO6AAAAAElFTkSuQmCC';
+      const { node } = createFormComponent({
+        schema: {
+          type: 'string',
+          format: 'data-url',
+        },
+        uiSchema: {
+          'ui:options': { filePreview: true },
+        },
+        formData,
+      });
+
+      const preview = node.querySelector('img.file-preview');
+      expect(preview).to.exist;
+      expect(preview.src).eql(formData);
+    });
+
+    it('should render the file widget with download link', () => {
+      const formData = 'data:text/plain;name=file1.txt;base64,x=';
+      const { node } = createFormComponent({
+        schema: {
+          type: 'string',
+          format: 'data-url',
+        },
+        uiSchema: {
+          'ui:options': { filePreview: true },
+        },
+        formData,
+      });
+
+      const download = node.querySelector('a.file-download');
+      expect(download).to.exist;
+      expect(download.href).eql(formData);
+      expect(download.textContent).eql(TranslatableString.PreviewLabel);
     });
   });
 

--- a/packages/docs/docs/api-reference/uiSchema.md
+++ b/packages/docs/docs/api-reference/uiSchema.md
@@ -228,6 +228,24 @@ const uiSchema: UiSchema = {
 };
 ```
 
+### filePreview
+
+The `FileWidget` can be configured to show a preview of an image or a download link for non-images using this flag.
+
+```tsx
+import { RJSFSchema, UiSchema } from '@rjsf/utils';
+
+const schema: RJSFSchema = {
+  type: 'string',
+  format: 'data-url',
+};
+const uiSchema: UiSchema = {
+  'ui:options': {
+    filePreview: true,
+  },
+};
+```
+
 ### help
 
 Sometimes it's convenient to add text next to a field to guide the end user filling it. This is the purpose of the `ui:help` uiSchema directive:

--- a/packages/utils/src/enums.ts
+++ b/packages/utils/src/enums.ts
@@ -37,6 +37,8 @@ export enum TranslatableString {
   ClearLabel = 'Clear',
   /** Aria date label, used by DateWidget */
   AriaDateLabel = 'Select a date',
+  /** File preview label, used by FileWidget */
+  PreviewLabel = 'Preview',
   /** Decrement button aria label, used by UpDownWidget */
   DecrementAriaLabel = 'Decrease value by 1',
   /** Increment button aria label, used by UpDownWidget */

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -803,6 +803,8 @@ type UIOptionsBaseType<T = any, S extends StrictRJSFSchema = RJSFSchema, F exten
     readonly?: boolean;
     /** This property allows you to reorder the properties that are shown for a particular object */
     order?: string[];
+    /** Flag, if set to `true`, will cause the `FileWidget` to show a preview (with download for non-image files) */
+    filePreview?: boolean;
     /** Flag, if set to `true`, will mark a list of checkboxes as displayed all on one line instead of one per row */
     inline?: boolean;
     /** Used to change the input type (for example, `tel` or `email`) for an <input> */


### PR DESCRIPTION
### Reasons for making this change

Reimplement #2630 to add support to file preview for images and download preview for non-images when the new `filePreview` option is added to the `uiSchema`
- Updated `@rjsf/utils` to update the `UIOptionsBaseType` to add `filePreview?: boolean` and the `enums` file to add `TranslatableString.PreviewLabel`
- Updated `@rjsf/core` to update the `FileWidget` to support an image preview or download link for non-images when `filePreview` is true
- Updated the `uiSchema` documentation to document the new `filePreview` option
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

<img width="718" alt="Screenshot 2023-03-19 at 6 39 53 PM" src="https://user-images.githubusercontent.com/51679588/226233171-40844aa9-68a1-481b-9c3c-89aa95a0e1e6.png">
<img width="716" alt="Screenshot 2023-03-19 at 6 38 31 PM" src="https://user-images.githubusercontent.com/51679588/226233172-41d6d0fa-89c2-4bd7-84fe-0d659b6a182f.png">
