### PR TITLE
fix: reimplement stronger type checking from #2581

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Updated the `UiSchema` to support the optional `filePreview?: boolean` option and to add a new `TranslatableString.PreviewLabel` to the `enums`
 
+## @rjsf/validator-ajv8
+
+- Improve `toErrorList()` and `unwrapErrorHandler()` by ensuring objects before recursing
+
 ## Dev / docs / playground
 
 - Added a new `AntD Customization` documentation with references to it in the `form-props` and `uiSchema` documentation


### PR DESCRIPTION
### Reasons for making this change

Reimplemented the stronger type checking from #2581
- Updated `@rjsf/validator-ajv8` to check for plain object types before recursing in `toErrorList()` and `unwrapErrorHandler()`
  - Switched from using `isObject` to `isPlainObject` since the other places it was used were also checking plain objects
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
