### PR TITLE
Fix: MUI radio widget initializes as uncontrolled when schema has no default value #3511

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,15 +41,15 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/chakra-ui
 
-- Fix: MUI radio widget initializes as uncontrolled when schema has no default value #3511
+- Fix: MUI radio widget initializes as uncontrolled when schema has no default value, fixing [#3511](https://github.com/rjsf-team/react-jsonschema-form/issues/3511)
 
 ## @rjsf/material-ui
 
-- Fix: MUI radio widget initializes as uncontrolled when schema has no default value #3511
+- Fix: MUI radio widget initializes as uncontrolled when schema has no default value, fixing [#3511](https://github.com/rjsf-team/react-jsonschema-form/issues/3511)
 
 ## @rjsf/mui
 
-- Fix: MUI radio widget initializes as uncontrolled when schema has no default value #3511
+- Fix: MUI radio widget initializes as uncontrolled when schema has no default value, fixing [#3511](https://github.com/rjsf-team/react-jsonschema-form/issues/3511)
 
 # 5.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,18 @@ should change the heading of the (upcoming) version to include a major version b
 - Added a new `AntD Customization` documentation with references to it in the `form-props` and `uiSchema` documentation
 - Updated the `uiSchema` documentation to add the `filePreview` option
 
+## @rjsf/chakra-ui
+
+- Fix: MUI radio widget initializes as uncontrolled when schema has no default value #3511
+
+## @rjsf/material-ui
+
+- Fix: MUI radio widget initializes as uncontrolled when schema has no default value #3511
+
+## @rjsf/mui
+
+- Fix: MUI radio widget initializes as uncontrolled when schema has no default value #3511
+
 # 5.3.1
 
 ## @rjsf/core

--- a/packages/chakra-ui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/chakra-ui/src/RadioWidget/RadioWidget.tsx
@@ -36,7 +36,7 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
     onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
 
   const row = options ? options.inline : false;
-  const selectedIndex = enumOptionsIndexForValue<S>(value, enumOptions) as string;
+  const selectedIndex = (enumOptionsIndexForValue<S>(value, enumOptions) as string) ?? null;
 
   return (
     <FormControl mb={1} {...chakraProps} isDisabled={disabled || readonly} isRequired={required} isReadOnly={readonly}>

--- a/packages/material-ui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/material-ui/src/RadioWidget/RadioWidget.tsx
@@ -41,7 +41,7 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
     onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
 
   const row = options ? options.inline : false;
-  const selectedIndex = enumOptionsIndexForValue<S>(value, enumOptions);
+  const selectedIndex = enumOptionsIndexForValue<S>(value, enumOptions) ?? null;
 
   return (
     <>

--- a/packages/mui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/mui/src/RadioWidget/RadioWidget.tsx
@@ -41,7 +41,7 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
     onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
 
   const row = options ? options.inline : false;
-  const selectedIndex = enumOptionsIndexForValue<S>(value, enumOptions);
+  const selectedIndex = enumOptionsIndexForValue<S>(value, enumOptions) ?? null;
 
   return (
     <>


### PR DESCRIPTION
### Reasons for making this change

Fixes #3511 

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
