### PR TITLE
chore: Centralize the snapshot tests for objects under core

### DIFF
--- a/packages/antd/test/Object.test.tsx
+++ b/packages/antd/test/Object.test.tsx
@@ -1,28 +1,6 @@
-import renderer from 'react-test-renderer';
-import validator from '@rjsf/validator-ajv8';
-import { RJSFSchema } from '@rjsf/utils';
+import objectTests from '@rjsf/core/testSnap/objectTests';
 
 import '../__mocks__/matchMedia.mock';
 import Form from '../src';
 
-describe('object fields', () => {
-  test('object', () => {
-    const schema: RJSFSchema = {
-      type: 'object',
-      properties: {
-        a: { type: 'string', title: 'A' },
-        b: { type: 'number', title: 'B' },
-      },
-    };
-    const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-  test('additionalProperties', () => {
-    const schema: RJSFSchema = {
-      type: 'object',
-      additionalProperties: true,
-    };
-    const tree = renderer.create(<Form schema={schema} validator={validator} formData={{ foo: 'foo' }} />).toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-});
+objectTests(Form);

--- a/packages/bootstrap-4/test/Object.test.tsx
+++ b/packages/bootstrap-4/test/Object.test.tsx
@@ -1,27 +1,5 @@
-import { RJSFSchema } from '@rjsf/utils';
-import validator from '@rjsf/validator-ajv8';
-import renderer from 'react-test-renderer';
+import objectTests from '@rjsf/core/testSnap/objectTests';
 
-import Form from '../src/index';
+import Form from '../src';
 
-describe('object fields', () => {
-  test('object', () => {
-    const schema: RJSFSchema = {
-      type: 'object',
-      properties: {
-        a: { type: 'string', title: 'A' },
-        b: { type: 'number', title: 'B' },
-      },
-    };
-    const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-  test('additionalProperties', () => {
-    const schema: RJSFSchema = {
-      type: 'object',
-      additionalProperties: true,
-    };
-    const tree = renderer.create(<Form schema={schema} validator={validator} formData={{ foo: 'foo' }} />).toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-});
+objectTests(Form);

--- a/packages/chakra-ui/test/Object.test.tsx
+++ b/packages/chakra-ui/test/Object.test.tsx
@@ -1,29 +1,5 @@
-/** @jsx jsx */
+import objectTests from '@rjsf/core/testSnap/objectTests';
 
-import { RJSFSchema } from '@rjsf/utils';
-import validator from '@rjsf/validator-ajv8';
-import renderer from 'react-test-renderer';
+import Form from '../src';
 
-import Form from '../src/index';
-
-describe('object fields', () => {
-  test('object', () => {
-    const schema: RJSFSchema = {
-      type: 'object',
-      properties: {
-        a: { type: 'string', title: 'A' },
-        b: { type: 'number', title: 'B' },
-      },
-    };
-    const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-  test('additionalProperties', () => {
-    const schema: RJSFSchema = {
-      type: 'object',
-      additionalProperties: true,
-    };
-    const tree = renderer.create(<Form schema={schema} validator={validator} formData={{ foo: 'foo' }} />).toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-});
+objectTests(Form);

--- a/packages/core/testSnap/objectTests.tsx
+++ b/packages/core/testSnap/objectTests.tsx
@@ -1,0 +1,34 @@
+import { ComponentType } from 'react';
+import renderer from 'react-test-renderer';
+import { RJSFSchema } from '@rjsf/utils';
+import validator from '@rjsf/validator-ajv8';
+
+import { FormProps } from '../src';
+
+// export type ObjectRenderCustomOptions = {
+//  checkboxes?: TestRendererOptions;
+// }
+
+export default function arrayTests(Form: ComponentType<FormProps>) {
+  describe('object fields', () => {
+    test('object', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          a: { type: 'string', title: 'A' },
+          b: { type: 'number', title: 'B' },
+        },
+      };
+      const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+    test('additionalProperties', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        additionalProperties: true,
+      };
+      const tree = renderer.create(<Form schema={schema} validator={validator} formData={{ foo: 'foo' }} />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+}

--- a/packages/fluent-ui/test/Object.test.tsx
+++ b/packages/fluent-ui/test/Object.test.tsx
@@ -1,27 +1,5 @@
-import { RJSFSchema } from '@rjsf/utils';
-import validator from '@rjsf/validator-ajv8';
-import renderer from 'react-test-renderer';
+import objectTests from '@rjsf/core/testSnap/objectTests';
 
-import Form from '../src/index';
+import Form from '../src';
 
-describe('object fields', () => {
-  test('object', () => {
-    const schema: RJSFSchema = {
-      type: 'object',
-      properties: {
-        a: { type: 'string', title: 'A' },
-        b: { type: 'number', title: 'B' },
-      },
-    };
-    const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-  test('additionalProperties', () => {
-    const schema: RJSFSchema = {
-      type: 'object',
-      additionalProperties: true,
-    };
-    const tree = renderer.create(<Form schema={schema} validator={validator} formData={{ foo: 'foo' }} />).toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-});
+objectTests(Form);

--- a/packages/material-ui/test/Object.test.tsx
+++ b/packages/material-ui/test/Object.test.tsx
@@ -1,27 +1,5 @@
-import { RJSFSchema } from '@rjsf/utils';
-import validator from '@rjsf/validator-ajv8';
-import renderer from 'react-test-renderer';
+import objectTests from '@rjsf/core/testSnap/objectTests';
 
 import Form from '../src';
 
-describe('object fields', () => {
-  test('object', () => {
-    const schema: RJSFSchema = {
-      type: 'object',
-      properties: {
-        a: { type: 'string', title: 'A' },
-        b: { type: 'number', title: 'B' },
-      },
-    };
-    const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-  test('additionalProperties', () => {
-    const schema: RJSFSchema = {
-      type: 'object',
-      additionalProperties: true,
-    };
-    const tree = renderer.create(<Form schema={schema} validator={validator} formData={{ foo: 'foo' }} />).toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-});
+objectTests(Form);

--- a/packages/mui/test/Object.test.tsx
+++ b/packages/mui/test/Object.test.tsx
@@ -1,27 +1,5 @@
-import { RJSFSchema } from '@rjsf/utils';
-import validator from '@rjsf/validator-ajv8';
-import renderer from 'react-test-renderer';
+import objectTests from '@rjsf/core/testSnap/objectTests';
 
 import Form from '../src';
 
-describe('object fields', () => {
-  test('object', () => {
-    const schema: RJSFSchema = {
-      type: 'object',
-      properties: {
-        a: { type: 'string', title: 'A' },
-        b: { type: 'number', title: 'B' },
-      },
-    };
-    const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-  test('additionalProperties', () => {
-    const schema: RJSFSchema = {
-      type: 'object',
-      additionalProperties: true,
-    };
-    const tree = renderer.create(<Form schema={schema} validator={validator} formData={{ foo: 'foo' }} />).toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-});
+objectTests(Form);

--- a/packages/semantic-ui/test/Object.test.tsx
+++ b/packages/semantic-ui/test/Object.test.tsx
@@ -1,6 +1,4 @@
-import { RJSFSchema } from '@rjsf/utils';
-import validator from '@rjsf/validator-ajv8';
-import renderer from 'react-test-renderer';
+import objectTests from '@rjsf/core/testSnap/objectTests';
 
 import Form from '../src';
 
@@ -10,24 +8,4 @@ jest.mock('@fluentui/react-component-ref', () => ({
   Ref: jest.fn().mockImplementation(({ children }) => children),
 }));
 
-describe('object fields', () => {
-  test('object', () => {
-    const schema: RJSFSchema = {
-      type: 'object',
-      properties: {
-        a: { type: 'string', title: 'A' },
-        b: { type: 'number', title: 'B' },
-      },
-    };
-    const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-  test('additionalProperties', () => {
-    const schema: RJSFSchema = {
-      type: 'object',
-      additionalProperties: true,
-    };
-    const tree = renderer.create(<Form schema={schema} validator={validator} formData={{ foo: 'foo' }} />).toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-});
+objectTests(Form);


### PR DESCRIPTION
### Reasons for making this change

To minimize the duplication of snapshot testing code across themes, centralized the object ones in core in a manner similar to how schema tests work with utils and the validators.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
