### PR TITLE
fix: Got playground working after some issue were introduced

### DIFF
--- a/packages/playground/src/app.tsx
+++ b/packages/playground/src/app.tsx
@@ -12,13 +12,13 @@ import Ajv2019 from 'ajv/dist/2019.js';
 import Ajv2020 from 'ajv/dist/2020.js';
 
 import Layout from './layout';
-import Playground from './components';
+import Playground, { PlaygroundProps } from './components';
 
 const esV8Validator = customizeValidator({}, localize_es);
 const AJV8_2019 = customizeValidator({ AjvClass: Ajv2019 });
 const AJV8_2020 = customizeValidator({ AjvClass: Ajv2020 });
 
-const validators = {
+const validators: PlaygroundProps['validators'] = {
   AJV8: v8Validator,
   AJV8_es: esV8Validator,
   AJV8_2019,
@@ -26,7 +26,7 @@ const validators = {
   'AJV6 (deprecated)': v6Validator,
 };
 
-const themes = {
+const themes: PlaygroundProps['themes'] = {
   default: {
     stylesheet: '//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css',
     theme: {},
@@ -117,12 +117,10 @@ const themes = {
   },
 };
 
-const App: React.FC = () => {
+export default function App() {
   return (
     <Layout>
       <Playground themes={themes} validators={validators} />
     </Layout>
   );
-};
-
-export default App;
+}

--- a/packages/playground/src/components/CopyLink.tsx
+++ b/packages/playground/src/components/CopyLink.tsx
@@ -1,6 +1,11 @@
-import { memo, useRef } from 'react';
+import { useRef } from 'react';
 
-const CopyLink: React.FC<{ shareURL: string | null; onShare: () => void }> = memo(({ shareURL, onShare }) => {
+interface CopyLinkProps {
+  shareURL: string | null;
+  onShare: () => void;
+}
+
+export default function CopyLink({ shareURL, onShare }: CopyLinkProps) {
   const input = useRef<HTMLInputElement>(null);
 
   function onCopyClick() {
@@ -26,6 +31,4 @@ const CopyLink: React.FC<{ shareURL: string | null; onShare: () => void }> = mem
       </span>
     </div>
   );
-});
-
-export default CopyLink;
+}

--- a/packages/playground/src/components/Editor.tsx
+++ b/packages/playground/src/components/Editor.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import MonacoEditor from '@monaco-editor/react';
 
 const monacoEditorOptions = {
@@ -8,50 +8,49 @@ const monacoEditorOptions = {
   automaticLayout: true,
 };
 
-const Editor: React.FC<{ title: string; code: string; onChange: (code: string) => void }> = memo(
-  ({ title, code: initialCode, onChange }) => {
-    const [valid, setValid] = useState(true);
-    const [code, setCode] = useState(initialCode);
+interface EditorProps {
+  title: string;
+  code: string;
+  onChange: (code: string) => void;
+}
 
-    const onCodeChange = useCallback(
-      (code: string | undefined) => {
-        if (!code) {
-          return;
-        }
+export default function Editor({ title, code, onChange }: EditorProps) {
+  const [valid, setValid] = useState(true);
 
-        try {
-          const parsedCode = JSON.parse(code);
-          setValid(true);
-          setCode(code);
-          onChange(parsedCode);
-        } catch (err) {
-          setValid(false);
-          setCode(code);
-        }
-      },
-      [setValid, setCode, onChange]
-    );
+  const onCodeChange = useCallback(
+    (code: string | undefined) => {
+      if (!code) {
+        return;
+      }
 
-    const icon = valid ? 'ok' : 'remove';
-    const cls = valid ? 'valid' : 'invalid';
+      try {
+        const parsedCode = JSON.parse(code);
+        setValid(true);
+        onChange(parsedCode);
+      } catch (err) {
+        setValid(false);
+      }
+    },
+    [setValid, onChange]
+  );
 
-    return (
-      <div className='panel panel-default'>
-        <div className='panel-heading'>
-          <span className={`${cls} glyphicon glyphicon-${icon}`} />
-          {' ' + title}
-        </div>
-        <MonacoEditor
-          language='json'
-          value={code}
-          theme='vs-light'
-          onChange={onCodeChange}
-          height={400}
-          options={monacoEditorOptions}
-        />
+  const icon = valid ? 'ok' : 'remove';
+  const cls = valid ? 'valid' : 'invalid';
+
+  return (
+    <div className='panel panel-default'>
+      <div className='panel-heading'>
+        <span className={`${cls} glyphicon glyphicon-${icon}`} />
+        {' ' + title}
       </div>
-    );
-  }
-);
-
-export default Editor;
+      <MonacoEditor
+        language='json'
+        value={code}
+        theme='vs-light'
+        onChange={onCodeChange}
+        height={400}
+        options={monacoEditorOptions}
+      />
+    </div>
+  );
+}

--- a/packages/playground/src/components/GeoPosition.tsx
+++ b/packages/playground/src/components/GeoPosition.tsx
@@ -1,6 +1,6 @@
-import { memo, useState } from 'react';
+import { useState } from 'react';
 
-const GeoPosition: React.FC = memo(() => {
+export default function GeoPosition() {
   const [lat, setLat] = useState<number>(0);
   const [lon, setLon] = useState<number>(0);
 
@@ -35,6 +35,4 @@ const GeoPosition: React.FC = memo(() => {
       </div>
     </div>
   );
-});
-
-export default GeoPosition;
+}

--- a/packages/playground/src/components/RawValidatorTest.tsx
+++ b/packages/playground/src/components/RawValidatorTest.tsx
@@ -1,47 +1,50 @@
-import { memo, useState } from 'react';
+import { useState } from 'react';
+import { ValidatorType, RJSFSchema } from '@rjsf/utils';
 
-const RawValidatorTest: React.FC<{ validator: any; schema: object; formData: object }> = memo(
-  ({ validator, schema, formData }) => {
-    const [rawValidation, setRawValidation] = useState<{ errors: any; validationError: any } | undefined>();
-    const handleClearClick = () => setRawValidation(undefined);
-    const handleRawClick = () => setRawValidation(validator.rawValidation(schema, formData));
+interface RawValidatorTestProps {
+  validator: ValidatorType;
+  schema: RJSFSchema;
+  formData: object;
+}
 
-    let displayErrors = 'Validation not run';
-    if (rawValidation) {
-      displayErrors =
-        rawValidation.errors || rawValidation.validationError
-          ? JSON.stringify(rawValidation, null, 2)
-          : 'No AJV errors encountered';
-    }
-    return (
-      <div>
-        <details style={{ marginBottom: '10px' }}>
-          <summary style={{ display: 'list-item' }}>Raw Ajv Validation</summary>
-          To determine whether a validation issue is really a BUG in Ajv use the button to trigger the raw Ajv
-          validation. This will run your schema and formData through Ajv without involving any react-jsonschema-form
-          specific code. If there is an unexpected error, then{' '}
-          <a href='https://github.com/ajv-validator/ajv/issues/new/choose' target='_blank' rel='noreferrer'>
-            file an issue
-          </a>{' '}
-          with Ajv instead.
-        </details>
-        <div style={{ marginBottom: '10px' }}>
-          <button className='btn btn-default' type='button' onClick={handleRawClick}>
-            Raw Validate
-          </button>
-          {rawValidation && (
-            <>
-              <span> </span>
-              <button className='btn btn-default' type='button' onClick={handleClearClick}>
-                Clear
-              </button>
-            </>
-          )}
-        </div>
-        <textarea rows={4} readOnly disabled={!rawValidation} value={displayErrors} />
-      </div>
-    );
+export default function RawValidatorTest({ validator, schema, formData }: RawValidatorTestProps) {
+  const [rawValidation, setRawValidation] = useState<{ errors?: any[]; validationError?: Error } | undefined>();
+  const handleClearClick = () => setRawValidation(undefined);
+  const handleRawClick = () => setRawValidation(validator.rawValidation(schema, formData));
+
+  let displayErrors = 'Validation not run';
+  if (rawValidation) {
+    displayErrors =
+      rawValidation.errors || rawValidation.validationError
+        ? JSON.stringify(rawValidation, null, 2)
+        : 'No AJV errors encountered';
   }
-);
-
-export default RawValidatorTest;
+  return (
+    <div>
+      <details style={{ marginBottom: '10px' }}>
+        <summary style={{ display: 'list-item' }}>Raw Ajv Validation</summary>
+        To determine whether a validation issue is really a BUG in Ajv use the button to trigger the raw Ajv validation.
+        This will run your schema and formData through Ajv without involving any react-jsonschema-form specific code. If
+        there is an unexpected error, then{' '}
+        <a href='https://github.com/ajv-validator/ajv/issues/new/choose' target='_blank' rel='noreferrer'>
+          file an issue
+        </a>{' '}
+        with Ajv instead.
+      </details>
+      <div style={{ marginBottom: '10px' }}>
+        <button className='btn btn-default' type='button' onClick={handleRawClick}>
+          Raw Validate
+        </button>
+        {rawValidation && (
+          <>
+            <span> </span>
+            <button className='btn btn-default' type='button' onClick={handleClearClick}>
+              Clear
+            </button>
+          </>
+        )}
+      </div>
+      <textarea rows={4} readOnly disabled={!rawValidation} value={displayErrors} />
+    </div>
+  );
+}

--- a/packages/playground/src/components/Selector.tsx
+++ b/packages/playground/src/components/Selector.tsx
@@ -1,7 +1,11 @@
-import { memo, useState, type MouseEvent } from 'react';
-import { type Sample, samples } from '../samples';
+import { useState, MouseEvent } from 'react';
+import { Sample, samples } from '../samples';
 
-const Selector: React.FC<{ onSelected: (data: any) => void }> = memo(({ onSelected }) => {
+interface SelectorProps {
+  onSelected: (data: any) => void;
+}
+
+export default function Selector({ onSelected }: SelectorProps) {
   const [current, setCurrent] = useState<Sample>('Simple');
 
   function onLabelClick(label: Sample) {
@@ -25,6 +29,4 @@ const Selector: React.FC<{ onSelected: (data: any) => void }> = memo(({ onSelect
       })}
     </ul>
   );
-});
-
-export default Selector;
+}

--- a/packages/playground/src/components/SubthemeSelector.tsx
+++ b/packages/playground/src/components/SubthemeSelector.tsx
@@ -1,22 +1,22 @@
-import { memo } from 'react';
 import Form, { IChangeEvent } from '@rjsf/core';
 import { RJSFSchema, UiSchema } from '@rjsf/utils';
 import localValidator from '@rjsf/validator-ajv8';
 
-interface Props {
-  subtheme: any;
-  subthemes: any;
-  select: (
-    subtheme: any,
-    {
-      stylesheet,
-    }: {
-      stylesheet: any;
-    }
-  ) => void;
+interface SubthemeTypes {
+  stylesheet: string;
 }
 
-const SubthemeSelector: React.FC<Props> = memo(({ subtheme, subthemes, select }) => {
+export interface SubthemesType {
+  [subtheme: string]: SubthemeTypes;
+}
+
+interface SubthemeSelectorProps {
+  subtheme: string;
+  subthemes: SubthemesType;
+  select: (subthemeName: string, subtheme: SubthemeTypes) => void;
+}
+
+export default function SubthemeSelector({ subtheme, subthemes, select }: SubthemeSelectorProps) {
   const schema: RJSFSchema = {
     type: 'string',
     enum: Object.keys(subthemes),
@@ -39,6 +39,4 @@ const SubthemeSelector: React.FC<Props> = memo(({ subtheme, subthemes, select })
       <div />
     </Form>
   );
-});
-
-export default SubthemeSelector;
+}

--- a/packages/playground/src/components/ThemeSelector.tsx
+++ b/packages/playground/src/components/ThemeSelector.tsx
@@ -1,33 +1,41 @@
-import { memo } from 'react';
 import Form, { IChangeEvent } from '@rjsf/core';
 import { RJSFSchema, UiSchema } from '@rjsf/utils';
 import localValidator from '@rjsf/validator-ajv8';
+import { SubthemesType } from './SubthemeSelector';
 
-const ThemeSelector: React.FC<{ theme: any; themes: any; select: (...args: any[]) => void }> = memo(
-  ({ theme, themes, select }) => {
-    const schema: RJSFSchema = {
-      type: 'string',
-      enum: Object.keys(themes),
-    };
+export interface ThemesType {
+  theme: any;
+  stylesheet: string;
+  subthemes?: SubthemesType;
+}
 
-    const uiSchema: UiSchema = {
-      'ui:placeholder': 'Select theme',
-    };
+interface ThemeSelectorProps {
+  theme: string;
+  themes: { [themeName: string]: ThemesType };
+  select: (themeName: string, theme: ThemesType) => void;
+}
 
-    return (
-      <Form
-        className='form_rjsf_themeSelector'
-        idPrefix='rjsf_themeSelector'
-        schema={schema}
-        uiSchema={uiSchema}
-        formData={theme}
-        validator={localValidator}
-        onChange={({ formData }: IChangeEvent) => formData && select(formData, themes[formData])}
-      >
-        <div />
-      </Form>
-    );
-  }
-);
+export default function ThemeSelector({ theme, themes, select }: ThemeSelectorProps) {
+  const schema: RJSFSchema = {
+    type: 'string',
+    enum: Object.keys(themes),
+  };
 
-export default ThemeSelector;
+  const uiSchema: UiSchema = {
+    'ui:placeholder': 'Select theme',
+  };
+
+  return (
+    <Form
+      className='form_rjsf_themeSelector'
+      idPrefix='rjsf_themeSelector'
+      schema={schema}
+      uiSchema={uiSchema}
+      formData={theme}
+      validator={localValidator}
+      onChange={({ formData }: IChangeEvent) => formData && select(formData, themes[formData])}
+    >
+      <div />
+    </Form>
+  );
+}

--- a/packages/playground/src/components/ValidatorSelector.tsx
+++ b/packages/playground/src/components/ValidatorSelector.tsx
@@ -1,33 +1,34 @@
-import { memo } from 'react';
 import Form, { IChangeEvent } from '@rjsf/core';
-import { RJSFSchema, UiSchema } from '@rjsf/utils';
+import { GenericObjectType, RJSFSchema, UiSchema } from '@rjsf/utils';
 import localValidator from '@rjsf/validator-ajv8';
 
-const ValidatorSelector: React.FC<{ validator: string; validators: any; select: (validator: any) => void }> = memo(
-  ({ validator, validators, select }) => {
-    const schema: RJSFSchema = {
-      type: 'string',
-      enum: Object.keys(validators),
-    };
+interface ValidatorSelectorProps {
+  validator: string;
+  validators: GenericObjectType;
+  select: (validator: string) => void;
+}
 
-    const uiSchema: UiSchema = {
-      'ui:placeholder': 'Select validator',
-    };
+export default function ValidatorSelector({ validator, validators, select }: ValidatorSelectorProps) {
+  const schema: RJSFSchema = {
+    type: 'string',
+    enum: Object.keys(validators),
+  };
 
-    return (
-      <Form
-        className='form_rjsf_validatorSelector'
-        idPrefix='rjsf_validatorSelector'
-        schema={schema}
-        uiSchema={uiSchema}
-        formData={validator}
-        validator={localValidator}
-        onChange={({ formData }: IChangeEvent) => formData && select(formData)}
-      >
-        <div />
-      </Form>
-    );
-  }
-);
+  const uiSchema: UiSchema = {
+    'ui:placeholder': 'Select validator',
+  };
 
-export default ValidatorSelector;
+  return (
+    <Form
+      className='form_rjsf_validatorSelector'
+      idPrefix='rjsf_validatorSelector'
+      schema={schema}
+      uiSchema={uiSchema}
+      formData={validator}
+      validator={localValidator}
+      onChange={({ formData }: IChangeEvent) => formData && select(formData)}
+    >
+      <div />
+    </Form>
+  );
+}

--- a/packages/playground/src/components/index.ts
+++ b/packages/playground/src/components/index.ts
@@ -1,1 +1,4 @@
-export { Playground as default } from './Playground';
+import Playground, { PlaygroundProps } from './Playground';
+
+export type { PlaygroundProps };
+export default Playground;

--- a/packages/playground/src/layout/Footer.tsx
+++ b/packages/playground/src/layout/Footer.tsx
@@ -1,4 +1,4 @@
-const Footer: React.FC = () => {
+export default function Footer() {
   return (
     <div className='col-sm-12'>
       <p style={{ textAlign: 'center' }}>
@@ -13,6 +13,4 @@ const Footer: React.FC = () => {
       </p>
     </div>
   );
-};
-
-export default Footer;
+}


### PR DESCRIPTION
### Reasons for making this change

The playground had some issues with not properly loading  urls or changing options
- Updated most of the `React.FC` components to stateless functional components
- Also removed the `code` state in the Editor as it was not updating based on outside prop changes
- Added more types where necessary
- Ensured that the load also saves the schema and formdata and only runs once by introducing a new state variable

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
