### PR TITLE
fix: remove required prop on FileWidget input once a file is chosen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,19 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 5.4.1
 
+## @rjsf/core
+
+- Updated `FileWidget` to pass false for `required` once a value has been specified, fixing [#3504](https://github.com/rjsf-team/react-jsonschema-form/issues/3504)
+- Updated `ObjectField` to pass the `errorSchema` to the `ObjectFieldTemplate` to allow custom templates access to the errors
+
+## @rjsf/utils
+
+- Added `errorSchema` as an optional prop on `ObjectFieldTemplateProps`
+
 ## Dev / docs / playground
 
 - Converted the `playground` to use Typescript, including some refactoring of code to make that job easier
+- Updated the `custom-templates` documentation to add `errorSchema` to the props for `ObjectFieldTemplate`
 
 # 5.4.0
 

--- a/packages/core/src/components/fields/ObjectField.tsx
+++ b/packages/core/src/components/fields/ObjectField.tsx
@@ -318,6 +318,7 @@ class ObjectField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
       required,
       idSchema,
       uiSchema,
+      errorSchema,
       schema,
       formData,
       formContext,

--- a/packages/core/src/components/widgets/FileWidget.tsx
+++ b/packages/core/src/components/widgets/FileWidget.tsx
@@ -131,7 +131,7 @@ function extractFileInfo(dataURLs: string[]) {
 function FileWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   props: WidgetProps<T, S, F>
 ) {
-  const { disabled, readonly, multiple, onChange, value, options, registry } = props;
+  const { disabled, readonly, required, multiple, onChange, value, options, registry } = props;
   const BaseInputTemplate = getTemplate<'BaseInputTemplate', T, S, F>('BaseInputTemplate', registry, options);
   const extractedFilesInfo = useMemo(
     () => (Array.isArray(value) ? extractFileInfo(value) : extractFileInfo([value])),
@@ -163,6 +163,7 @@ function FileWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends 
         {...props}
         disabled={disabled || readonly}
         type='file'
+        required={value ? false : required} // this turns off HTML required validation when a value exists
         onChangeOverride={handleChange}
         value=''
         accept={options.accept ? String(options.accept) : undefined}

--- a/packages/docs/docs/advanced-customization/custom-templates.md
+++ b/packages/docs/docs/advanced-customization/custom-templates.md
@@ -696,6 +696,7 @@ The following props are passed to each `ObjectFieldTemplate` as defined by the `
 - `schema`: The schema object for this object.
 - `uiSchema`: The uiSchema object for this object field.
 - `idSchema`: An object containing the id for this object & ids for its properties.
+- `errorSchema`: The optional validation errors in the form of an `ErrorSchema`
 - `formData`: The form data for the object.
 - `formContext`: The `formContext` object that you passed to Form.
 - `registry`: The `registry` object.

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -607,6 +607,8 @@ export type ObjectFieldTemplateProps<
   uiSchema?: UiSchema<T, S, F>;
   /** An object containing the id for this object & ids for its properties */
   idSchema: IdSchema<T>;
+  /** The optional validation errors in the form of an `ErrorSchema` */
+  errorSchema?: ErrorSchema<T>;
   /** The form data for the object */
   formData?: T;
   /** The `formContext` object that was passed to Form */
@@ -929,7 +931,7 @@ export interface ValidatorType<T = any, S extends StrictRJSFSchema = RJSFSchema,
   /** Runs the pure validation of the `schema` and `formData` without any of the RJSF functionality. Provided for use
    * by the playground. Returns the `errors` from the validation
    *
-   * @param schema - The schema against which to validate the form data   * @param schema
+   * @param schema - The schema against which to validate the form data
    * @param formData - The form data to validate
    */
   rawValidation<Result = any>(schema: S, formData?: T): { errors?: Result[]; validationError?: Error };


### PR DESCRIPTION
### Reasons for making this change

Fixes #3504 and #3550 by setting the `required` prop to false once a file is chosen. Also enhanced the `ObjectFieldTemplate` to be able to receive the `errorSchema`
- In `@rjsf/utils`, added `errorSchema` to the `ObjectFieldTemplateProps`
- In `@rjsf/core`, updated `ObjectField` to pass the `errorSchema` to the `ObjectFieldTemplate`
  - Also updated `FileWidget` to pass false as the `required` prop once a file has been chosen

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
