### PR TITLE
fix: Fixed infinite ref recursion in some utils functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 - Added protections against infinite recursion of `$ref`s for the `toIdSchema()`, `toPathSchema()` and `getDefaultFormState()` functions, fixing [#3560](https://github.com/rjsf-team/react-jsonschema-form/issues/3560)
+- Updated `getDefaultFormState()` to handle object-based `additionalProperties` with defaults using `formData` in addition to values contained in a `default` object, fixing [#2593](https://github.com/rjsf-team/react-jsonschema-form/issues/2593) 
 
 ## Dev / playground
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 5.5.1
 
+## @rjsf/utils
+- Added protections against infinite recursion of `$ref`s for the `toIdSchema()`, `toPathSchema()` and `getDefaultFormState()` functions, fixing [#3560](https://github.com/rjsf-team/react-jsonschema-form/issues/3560)
+
 ## Dev / playground
 
 - Refactored some parts of `playground` to make it cleaner

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -103,6 +103,7 @@ function maybeAddDefaultToObject<T = any>(
  * @param [includeUndefinedValues=false] - Optional flag, if true, cause undefined values to be added as defaults.
  *          If "excludeObjectChildren", cause undefined values for this object and pass `includeUndefinedValues` as
  *          false when computing defaults for any nested object properties.
+ * @param [_recurseList=[]] - The list of ref names currently being recursed, used to prevent infinite recursion
  * @returns - The resulting `formData` with all the defaults provided
  */
 export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
@@ -111,7 +112,8 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
   parentDefaults?: T,
   rootSchema: S = {} as S,
   rawFormData?: T,
-  includeUndefinedValues: boolean | 'excludeObjectChildren' = false
+  includeUndefinedValues: boolean | 'excludeObjectChildren' = false,
+  _recurseList: string[] = []
 ): T | T[] | undefined {
   const formData: T = (isObject(rawFormData) ? rawFormData : {}) as T;
   let schema: S = isObject(rawSchema) ? rawSchema : ({} as S);
@@ -124,9 +126,20 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
   } else if (DEFAULT_KEY in schema) {
     defaults = schema.default as unknown as T;
   } else if (REF_KEY in schema) {
+    const refName = schema[REF_KEY];
     // Use referenced schema defaults for this node.
-    const refSchema = findSchemaDefinition<S>(schema[REF_KEY]!, rootSchema);
-    return computeDefaults<T, S, F>(validator, refSchema, defaults, rootSchema, formData as T, includeUndefinedValues);
+    if (!_recurseList.includes(refName!)) {
+      const refSchema = findSchemaDefinition<S>(refName, rootSchema);
+      return computeDefaults<T, S, F>(
+        validator,
+        refSchema,
+        defaults,
+        rootSchema,
+        formData as T,
+        includeUndefinedValues,
+        _recurseList.concat(refName!)
+      );
+    }
   } else if (DEPENDENCIES_KEY in schema) {
     const resolvedSchema = resolveDependencies<T, S, F>(validator, schema, rootSchema, formData);
     return computeDefaults<T, S, F>(
@@ -135,7 +148,8 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
       defaults,
       rootSchema,
       formData as T,
-      includeUndefinedValues
+      includeUndefinedValues,
+      _recurseList
     );
   } else if (isFixedItems(schema)) {
     defaults = (schema.items! as S[]).map((itemSchema: S, idx: number) =>
@@ -145,7 +159,8 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
         Array.isArray(parentDefaults) ? parentDefaults[idx] : undefined,
         rootSchema,
         formData as T,
-        includeUndefinedValues
+        includeUndefinedValues,
+        _recurseList
       )
     ) as T[];
   } else if (ONE_OF_KEY in schema) {
@@ -193,7 +208,8 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
           get(defaults, [key]),
           rootSchema,
           get(formData, [key]),
-          includeUndefinedValues === true
+          includeUndefinedValues === true,
+          _recurseList
         );
         maybeAddDefaultToObject<T>(acc, key, computedDefault, includeUndefinedValues, schema.required);
         return acc;
@@ -209,7 +225,8 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
               get(defaults, [key]),
               rootSchema,
               get(formData, [key]),
-              includeUndefinedValues === true
+              includeUndefinedValues === true,
+              _recurseList
             );
             maybeAddDefaultToObject<T>(
               objectDefaults as GenericObjectType,
@@ -226,7 +243,7 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
       if (Array.isArray(defaults)) {
         defaults = defaults.map((item, idx) => {
           const schemaItem: S = getInnerSchemaForArrayItem<S>(schema, AdditionalItemsHandling.Fallback, idx);
-          return computeDefaults<T, S, F>(validator, schemaItem, item, rootSchema);
+          return computeDefaults<T, S, F>(validator, schemaItem, item, rootSchema, undefined, undefined, _recurseList);
         }) as T[];
       }
 
@@ -234,7 +251,15 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
       if (Array.isArray(rawFormData)) {
         const schemaItem: S = getInnerSchemaForArrayItem<S>(schema);
         defaults = rawFormData.map((item: T, idx: number) => {
-          return computeDefaults<T, S, F>(validator, schemaItem, get(defaults, [idx]), rootSchema, item);
+          return computeDefaults<T, S, F>(
+            validator,
+            schemaItem,
+            get(defaults, [idx]),
+            rootSchema,
+            item,
+            undefined,
+            _recurseList
+          );
         }) as T[];
       }
       if (schema.minItems) {
@@ -246,7 +271,15 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
             const fillerSchema: S = getInnerSchemaForArrayItem<S>(schema, AdditionalItemsHandling.Invert);
             const fillerDefault = fillerSchema.default;
             const fillerEntries: T[] = new Array(schema.minItems - defaultsLength).fill(
-              computeDefaults<any, S, F>(validator, fillerSchema, fillerDefault, rootSchema)
+              computeDefaults<any, S, F>(
+                validator,
+                fillerSchema,
+                fillerDefault,
+                rootSchema,
+                undefined,
+                undefined,
+                _recurseList
+              )
             ) as T[];
             // then fill up the rest with either the item default or empty, up to minItems
             return defaultEntries.concat(fillerEntries);

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -198,7 +198,7 @@ export default function retrieveSchema<
         deep: false,
       } as Options) as S;
     } catch (e) {
-      console.warn('could not merge subschemas in allOf:\n' + e);
+      console.warn('could not merge subschemas in allOf:\n', e);
       const { allOf, ...resolvedSchemaWithoutAllOf } = resolvedSchema;
       return resolvedSchemaWithoutAllOf as S;
     }

--- a/packages/utils/src/schema/toIdSchema.ts
+++ b/packages/utils/src/schema/toIdSchema.ts
@@ -11,22 +11,22 @@ import retrieveSchema from './retrieveSchema';
  *
  * @param validator - An implementation of the `ValidatorType` interface that will be used when necessary
  * @param schema - The schema for which the `IdSchema` is desired
+ * @param idPrefix - The prefix to use for the id
+ * @param idSeparator - The separator to use for the path segments in the id
  * @param [id] - The base id for the schema
  * @param [rootSchema] - The root schema, used to primarily to look up `$ref`s
  * @param [formData] - The current formData, if any, to assist retrieving a schema
- * @param [idPrefix='root'] - The prefix to use for the id
- * @param [idSeparator='_'] - The separator to use for the path segments in the id
  * @param [_recurseList=[]] - The list of retrieved schemas currently being recursed, used to prevent infinite recursion
  * @returns - The `IdSchema` object for the `schema`
  */
 function toIdSchemaInternal<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   validator: ValidatorType<T, S, F>,
   schema: S,
+  idPrefix: string,
+  idSeparator: string,
   id?: string | null,
   rootSchema?: S,
   formData?: T,
-  idPrefix = 'root',
-  idSeparator = '_',
   _recurseList: S[] = []
 ): IdSchema<T> {
   if (REF_KEY in schema || DEPENDENCIES_KEY in schema || ALL_OF_KEY in schema) {
@@ -36,11 +36,11 @@ function toIdSchemaInternal<T = any, S extends StrictRJSFSchema = RJSFSchema, F 
       return toIdSchemaInternal<T, S, F>(
         validator,
         _schema,
+        idPrefix,
+        idSeparator,
         id,
         rootSchema,
         formData,
-        idPrefix,
-        idSeparator,
         _recurseList.concat(_schema)
       );
     }
@@ -49,11 +49,11 @@ function toIdSchemaInternal<T = any, S extends StrictRJSFSchema = RJSFSchema, F 
     return toIdSchemaInternal<T, S, F>(
       validator,
       get(schema, ITEMS_KEY) as S,
+      idPrefix,
+      idSeparator,
       id,
       rootSchema,
       formData,
-      idPrefix,
-      idSeparator,
       _recurseList
     );
   }
@@ -66,13 +66,13 @@ function toIdSchemaInternal<T = any, S extends StrictRJSFSchema = RJSFSchema, F 
       idSchema[name] = toIdSchemaInternal<T, S, F>(
         validator,
         isObject(field) ? field : {},
+        idPrefix,
+        idSeparator,
         fieldId,
         rootSchema,
         // It's possible that formData is not an object -- this can happen if an
         // array item has just been added, but not populated with data yet
         get(formData, [name]),
-        idPrefix,
-        idSeparator,
         _recurseList
       );
     }
@@ -100,5 +100,5 @@ export default function toIdSchema<T = any, S extends StrictRJSFSchema = RJSFSch
   idPrefix = 'root',
   idSeparator = '_'
 ): IdSchema<T> {
-  return toIdSchemaInternal<T, S, F>(validator, schema, id, rootSchema, formData, idPrefix, idSeparator);
+  return toIdSchemaInternal<T, S, F>(validator, schema, idPrefix, idSeparator, id, rootSchema, formData);
 }

--- a/packages/utils/src/schema/toIdSchema.ts
+++ b/packages/utils/src/schema/toIdSchema.ts
@@ -1,9 +1,84 @@
 import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
 
 import { ALL_OF_KEY, DEPENDENCIES_KEY, ID_KEY, ITEMS_KEY, PROPERTIES_KEY, REF_KEY } from '../constants';
 import isObject from '../isObject';
 import { FormContextType, IdSchema, RJSFSchema, StrictRJSFSchema, ValidatorType } from '../types';
 import retrieveSchema from './retrieveSchema';
+
+/** An internal helper that generates an `IdSchema` object for the `schema`, recursively with protection against
+ * infinite recursion
+ *
+ * @param validator - An implementation of the `ValidatorType` interface that will be used when necessary
+ * @param schema - The schema for which the `IdSchema` is desired
+ * @param [id] - The base id for the schema
+ * @param [rootSchema] - The root schema, used to primarily to look up `$ref`s
+ * @param [formData] - The current formData, if any, to assist retrieving a schema
+ * @param [idPrefix='root'] - The prefix to use for the id
+ * @param [idSeparator='_'] - The separator to use for the path segments in the id
+ * @param [_recurseList=[]] - The list of retrieved schemas currently being recursed, used to prevent infinite recursion
+ * @returns - The `IdSchema` object for the `schema`
+ */
+function toIdSchemaInternal<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  validator: ValidatorType<T, S, F>,
+  schema: S,
+  id?: string | null,
+  rootSchema?: S,
+  formData?: T,
+  idPrefix = 'root',
+  idSeparator = '_',
+  _recurseList: S[] = []
+): IdSchema<T> {
+  if (REF_KEY in schema || DEPENDENCIES_KEY in schema || ALL_OF_KEY in schema) {
+    const _schema = retrieveSchema<T, S, F>(validator, schema, rootSchema, formData);
+    const sameSchemaIndex = _recurseList.findIndex((item) => isEqual(item, _schema));
+    if (sameSchemaIndex === -1) {
+      return toIdSchemaInternal<T, S, F>(
+        validator,
+        _schema,
+        id,
+        rootSchema,
+        formData,
+        idPrefix,
+        idSeparator,
+        _recurseList.concat(_schema)
+      );
+    }
+  }
+  if (ITEMS_KEY in schema && !get(schema, [ITEMS_KEY, REF_KEY])) {
+    return toIdSchemaInternal<T, S, F>(
+      validator,
+      get(schema, ITEMS_KEY) as S,
+      id,
+      rootSchema,
+      formData,
+      idPrefix,
+      idSeparator,
+      _recurseList
+    );
+  }
+  const $id = id || idPrefix;
+  const idSchema: IdSchema = { $id } as IdSchema<T>;
+  if (schema.type === 'object' && PROPERTIES_KEY in schema) {
+    for (const name in schema.properties) {
+      const field = get(schema, [PROPERTIES_KEY, name]);
+      const fieldId = idSchema[ID_KEY] + idSeparator + name;
+      idSchema[name] = toIdSchemaInternal<T, S, F>(
+        validator,
+        isObject(field) ? field : {},
+        fieldId,
+        rootSchema,
+        // It's possible that formData is not an object -- this can happen if an
+        // array item has just been added, but not populated with data yet
+        get(formData, [name]),
+        idPrefix,
+        idSeparator,
+        _recurseList
+      );
+    }
+  }
+  return idSchema as IdSchema<T>;
+}
 
 /** Generates an `IdSchema` object for the `schema`, recursively
  *
@@ -25,31 +100,5 @@ export default function toIdSchema<T = any, S extends StrictRJSFSchema = RJSFSch
   idPrefix = 'root',
   idSeparator = '_'
 ): IdSchema<T> {
-  if (REF_KEY in schema || DEPENDENCIES_KEY in schema || ALL_OF_KEY in schema) {
-    const _schema = retrieveSchema<T, S, F>(validator, schema, rootSchema, formData);
-    return toIdSchema<T, S, F>(validator, _schema, id, rootSchema, formData, idPrefix, idSeparator);
-  }
-  if (ITEMS_KEY in schema && !get(schema, [ITEMS_KEY, REF_KEY])) {
-    return toIdSchema<T, S, F>(validator, get(schema, ITEMS_KEY) as S, id, rootSchema, formData, idPrefix, idSeparator);
-  }
-  const $id = id || idPrefix;
-  const idSchema: IdSchema = { $id } as IdSchema<T>;
-  if (schema.type === 'object' && PROPERTIES_KEY in schema) {
-    for (const name in schema.properties) {
-      const field = get(schema, [PROPERTIES_KEY, name]);
-      const fieldId = idSchema[ID_KEY] + idSeparator + name;
-      idSchema[name] = toIdSchema<T, S, F>(
-        validator,
-        isObject(field) ? field : {},
-        fieldId,
-        rootSchema,
-        // It's possible that formData is not an object -- this can happen if an
-        // array item has just been added, but not populated with data yet
-        get(formData, [name]),
-        idPrefix,
-        idSeparator
-      );
-    }
-  }
-  return idSchema as IdSchema<T>;
+  return toIdSchemaInternal<T, S, F>(validator, schema, id, rootSchema, formData, idPrefix, idSeparator);
 }

--- a/packages/utils/src/schema/toPathSchema.ts
+++ b/packages/utils/src/schema/toPathSchema.ts
@@ -1,4 +1,5 @@
 import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
 import set from 'lodash/set';
 
 import {
@@ -17,6 +18,89 @@ import { FormContextType, PathSchema, RJSFSchema, StrictRJSFSchema, ValidatorTyp
 import { getClosestMatchingOption } from './index';
 import retrieveSchema from './retrieveSchema';
 
+/** An internal helper that generates an `PathSchema` object for the `schema`, recursively with protection against
+ * infinite recursion
+ *
+ * @param validator - An implementation of the `ValidatorType` interface that will be used when necessary
+ * @param schema - The schema for which the `PathSchema` is desired
+ * @param [name=''] - The base name for the schema
+ * @param [rootSchema] - The root schema, used to primarily to look up `$ref`s
+ * @param [formData] - The current formData, if any, to assist retrieving a schema
+ * @param [_recurseList=[]] - The list of retrieved schemas currently being recursed, used to prevent infinite recursion
+ * @returns - The `PathSchema` object for the `schema`
+ */
+function toPathSchemaInternal<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  validator: ValidatorType<T, S, F>,
+  schema: S,
+  name = '',
+  rootSchema?: S,
+  formData?: T,
+  _recurseList: S[] = []
+): PathSchema<T> {
+  if (REF_KEY in schema || DEPENDENCIES_KEY in schema || ALL_OF_KEY in schema) {
+    const _schema = retrieveSchema<T, S, F>(validator, schema, rootSchema, formData);
+    const sameSchemaIndex = _recurseList.findIndex((item) => isEqual(item, _schema));
+    if (sameSchemaIndex === -1) {
+      return toPathSchemaInternal<T, S, F>(
+        validator,
+        _schema,
+        name,
+        rootSchema,
+        formData,
+        _recurseList.concat(_schema)
+      );
+    }
+  }
+
+  const pathSchema: PathSchema = {
+    [NAME_KEY]: name.replace(/^\./, ''),
+  } as PathSchema;
+
+  if (ONE_OF_KEY in schema) {
+    const index = getClosestMatchingOption<T, S, F>(validator, rootSchema!, formData, schema.oneOf as S[], 0);
+    const _schema: S = schema.oneOf![index] as S;
+    return toPathSchemaInternal<T, S, F>(validator, _schema, name, rootSchema, formData, _recurseList);
+  }
+
+  if (ANY_OF_KEY in schema) {
+    const index = getClosestMatchingOption<T, S, F>(validator, rootSchema!, formData, schema.anyOf as S[], 0);
+    const _schema: S = schema.anyOf![index] as S;
+    return toPathSchemaInternal<T, S, F>(validator, _schema, name, rootSchema, formData, _recurseList);
+  }
+
+  if (ADDITIONAL_PROPERTIES_KEY in schema && schema[ADDITIONAL_PROPERTIES_KEY] !== false) {
+    set(pathSchema, RJSF_ADDITONAL_PROPERTIES_FLAG, true);
+  }
+
+  if (ITEMS_KEY in schema && Array.isArray(formData)) {
+    formData.forEach((element, i: number) => {
+      pathSchema[i] = toPathSchemaInternal<T, S, F>(
+        validator,
+        schema.items as S,
+        `${name}.${i}`,
+        rootSchema,
+        element,
+        _recurseList
+      );
+    });
+  } else if (PROPERTIES_KEY in schema) {
+    for (const property in schema.properties) {
+      const field = get(schema, [PROPERTIES_KEY, property]);
+      pathSchema[property] = toPathSchemaInternal<T, S, F>(
+        validator,
+        field,
+        `${name}.${property}`,
+        rootSchema,
+        // It's possible that formData is not an object -- this can happen if an
+        // array item has just been added, but not populated with data yet
+        get(formData, [property]),
+        _recurseList
+      );
+    }
+  }
+  return pathSchema as PathSchema<T>;
+}
+
 /** Generates an `PathSchema` object for the `schema`, recursively
  *
  * @param validator - An implementation of the `ValidatorType` interface that will be used when necessary
@@ -33,48 +117,5 @@ export default function toPathSchema<T = any, S extends StrictRJSFSchema = RJSFS
   rootSchema?: S,
   formData?: T
 ): PathSchema<T> {
-  if (REF_KEY in schema || DEPENDENCIES_KEY in schema || ALL_OF_KEY in schema) {
-    const _schema = retrieveSchema<T, S, F>(validator, schema, rootSchema, formData);
-    return toPathSchema<T, S, F>(validator, _schema, name, rootSchema, formData);
-  }
-
-  const pathSchema: PathSchema = {
-    [NAME_KEY]: name.replace(/^\./, ''),
-  } as PathSchema;
-
-  if (ONE_OF_KEY in schema) {
-    const index = getClosestMatchingOption<T, S, F>(validator, rootSchema!, formData, schema.oneOf as S[], 0);
-    const _schema: S = schema.oneOf![index] as S;
-    return toPathSchema<T, S, F>(validator, _schema, name, rootSchema, formData);
-  }
-
-  if (ANY_OF_KEY in schema) {
-    const index = getClosestMatchingOption<T, S, F>(validator, rootSchema!, formData, schema.anyOf as S[], 0);
-    const _schema: S = schema.anyOf![index] as S;
-    return toPathSchema<T, S, F>(validator, _schema, name, rootSchema, formData);
-  }
-
-  if (ADDITIONAL_PROPERTIES_KEY in schema && schema[ADDITIONAL_PROPERTIES_KEY] !== false) {
-    set(pathSchema, RJSF_ADDITONAL_PROPERTIES_FLAG, true);
-  }
-
-  if (ITEMS_KEY in schema && Array.isArray(formData)) {
-    formData.forEach((element, i: number) => {
-      pathSchema[i] = toPathSchema<T, S, F>(validator, schema.items as S, `${name}.${i}`, rootSchema, element);
-    });
-  } else if (PROPERTIES_KEY in schema) {
-    for (const property in schema.properties) {
-      const field = get(schema, [PROPERTIES_KEY, property]);
-      pathSchema[property] = toPathSchema<T, S, F>(
-        validator,
-        field,
-        `${name}.${property}`,
-        rootSchema,
-        // It's possible that formData is not an object -- this can happen if an
-        // array item has just been added, but not populated with data yet
-        get(formData, [property])
-      );
-    }
-  }
-  return pathSchema as PathSchema<T>;
+  return toPathSchemaInternal(validator, schema, name, rootSchema, formData);
 }

--- a/packages/utils/src/schema/toPathSchema.ts
+++ b/packages/utils/src/schema/toPathSchema.ts
@@ -32,7 +32,7 @@ import retrieveSchema from './retrieveSchema';
 function toPathSchemaInternal<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   validator: ValidatorType<T, S, F>,
   schema: S,
-  name = '',
+  name: string,
   rootSchema?: S,
   formData?: T,
   _recurseList: S[] = []

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -1,5 +1,6 @@
 import { createSchemaUtils, getDefaultFormState, RJSFSchema } from '../../src';
 import { computeDefaults } from '../../src/schema/getDefaultFormState';
+import { RECURSIVE_REF, RECURSIVE_REF_ALLOF } from '../testUtils/testData';
 import { TestValidatorType } from './types';
 
 export default function getDefaultFormStateTest(testValidator: TestValidatorType) {
@@ -181,6 +182,16 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         expect(computeDefaults(testValidator, schema, undefined, schema, undefined, 'excludeObjectChildren')).toEqual(
           {}
         );
+      });
+      it('test with a recursive schema', () => {
+        expect(computeDefaults(testValidator, RECURSIVE_REF, undefined, RECURSIVE_REF)).toEqual({
+          name: '',
+        });
+      });
+      it('test with a recursive allof schema', () => {
+        expect(computeDefaults(testValidator, RECURSIVE_REF_ALLOF, undefined, RECURSIVE_REF_ALLOF)).toEqual({
+          value: [undefined],
+        });
       });
     });
     describe('root default', () => {

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -172,6 +172,45 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           foo: 'bar',
         });
       });
+      it('test an object with additionalProperties type object with and formdata', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            test: {
+              title: 'Test',
+              type: 'object',
+              properties: {
+                foo: {
+                  type: 'string',
+                },
+              },
+              additionalProperties: {
+                type: 'object',
+                properties: {
+                  host: {
+                    title: 'Host',
+                    type: 'string',
+                    default: 'localhost',
+                  },
+                  port: {
+                    title: 'Port',
+                    type: 'integer',
+                    default: 389,
+                  },
+                },
+              },
+            },
+          },
+        };
+        expect(computeDefaults(testValidator, schema, undefined, schema, { test: { foo: 'x', newKey: {} } })).toEqual({
+          test: {
+            newKey: {
+              host: 'localhost',
+              port: 389,
+            },
+          },
+        });
+      });
       it('test computeDefaults handles an invalid property schema', () => {
         const schema: RJSFSchema = {
           type: 'object',

--- a/packages/utils/test/schema/toIdSchemaTest.ts
+++ b/packages/utils/test/schema/toIdSchemaTest.ts
@@ -1,4 +1,5 @@
 import { toIdSchema, RJSFSchema, createSchemaUtils } from '../../src';
+import { RECURSIVE_REF, RECURSIVE_REF_ALLOF } from '../testUtils/testData';
 import { TestValidatorType } from './types';
 
 export default function toIdSchemaTest(testValidator: TestValidatorType) {
@@ -274,12 +275,48 @@ export default function toIdSchemaTest(testValidator: TestValidatorType) {
         },
       };
       const formData = null;
-      const result = toIdSchema(testValidator, schema, null, {}, formData, 'rjsf');
+      const result = toIdSchema(testValidator, schema, undefined, {}, formData, 'rjsf');
 
       expect(result).toEqual({
         $id: 'rjsf',
         foo: { $id: 'rjsf_foo' },
         bar: { $id: 'rjsf_bar' },
+      });
+    });
+    it('should handle recursive ref to two levels', () => {
+      const result = toIdSchema(testValidator, RECURSIVE_REF, undefined, RECURSIVE_REF);
+      expect(result).toEqual({
+        $id: 'root',
+        name: {
+          $id: 'root_name',
+        },
+        children: {
+          $id: 'root_children',
+          name: {
+            $id: 'root_children_name',
+          },
+          children: {
+            $id: 'root_children_children',
+          },
+        },
+      });
+    });
+    it('should handle recursive allof ref to one level', () => {
+      const result = toIdSchema(testValidator, RECURSIVE_REF_ALLOF, null, RECURSIVE_REF_ALLOF);
+      expect(result).toEqual({
+        $id: 'root',
+        value: {
+          $id: 'root_value',
+          _id: {
+            $id: 'root_value__id',
+          },
+          children: {
+            $id: 'root_value_children',
+          },
+          name: {
+            $id: 'root_value_name',
+          },
+        },
       });
     });
   });

--- a/packages/utils/test/schema/toPathSchemaTest.ts
+++ b/packages/utils/test/schema/toPathSchemaTest.ts
@@ -1,4 +1,5 @@
 import { toPathSchema, RJSFSchema, createSchemaUtils } from '../../src';
+import { RECURSIVE_REF, RECURSIVE_REF_ALLOF } from '../testUtils/testData';
 import { TestValidatorType } from './types';
 
 export default function toPathSchemaTest(testValidator: TestValidatorType) {
@@ -657,6 +658,33 @@ export default function toPathSchemaTest(testValidator: TestValidatorType) {
         $name: '',
         ipsum: {
           $name: 'ipsum',
+        },
+      });
+    });
+    it('should handle recursive ref to one level', () => {
+      const result = toPathSchema(testValidator, RECURSIVE_REF, undefined, RECURSIVE_REF);
+      expect(result).toEqual({
+        $name: '',
+        name: {
+          $name: 'name',
+        },
+        children: {
+          $name: 'children',
+          name: {
+            $name: 'children.name',
+          },
+          children: {
+            $name: 'children.children',
+          },
+        },
+      });
+    });
+    it('should handle recursive allof ref to one level, based on formData', () => {
+      const result = toPathSchema(testValidator, RECURSIVE_REF_ALLOF, undefined, RECURSIVE_REF_ALLOF);
+      expect(result).toEqual({
+        $name: '',
+        value: {
+          $name: 'value',
         },
       });
     });

--- a/packages/utils/test/testUtils/testData.ts
+++ b/packages/utils/test/testUtils/testData.ts
@@ -274,3 +274,66 @@ export const ALL_OPTIONS: EnumOptionsType[] = [
   { value: 'baz', label: 'Baz' },
   { value: 'boo', label: 'Boo' },
 ];
+
+export const RECURSIVE_REF_ALLOF: RJSFSchema = {
+  definitions: {
+    '@enum': {
+      type: 'object',
+      properties: {
+        name: {
+          title: 'Name',
+          type: 'string',
+          default: '',
+        },
+        _id: {
+          title: 'Value',
+          type: 'number',
+        },
+        children: {
+          title: 'Subvalues',
+          type: 'array',
+          items: {
+            allOf: [
+              {
+                $ref: '#/definitions/@enum',
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+  type: 'object',
+  properties: {
+    value: {
+      type: 'array',
+      items: {
+        allOf: [
+          {
+            $ref: '#/definitions/@enum',
+          },
+        ],
+      },
+      minItems: 1,
+    },
+  },
+};
+
+export const RECURSIVE_REF: RJSFSchema = {
+  definitions: {
+    '@enum': {
+      type: 'object',
+      properties: {
+        name: {
+          title: 'Name',
+          type: 'string',
+          default: '',
+        },
+        children: {
+          $ref: '#/definitions/@enum',
+        },
+      },
+    },
+  },
+  $ref: '#/definitions/@enum',
+};


### PR DESCRIPTION
### Reasons for making this change

Fixes #3560 by preventing infinite recursion on `$ref`s
Fixes #2593 by also supporting data in `formData` in addition to data in `default` when dealing with `additionalProperties`

- In `@rjsf/utils` added infinite recursion protection in the `toIdSchema()`, `toPathSchema()` and `getDefaultFormState()` functions
  - Added tests to verify that no infinite recursion due to `$ref`s happen for those three functions along with `retrieveSchema()`
  - Fixed the console.log() call for the `mergeAllOf` exceptions to log the whole error rather than the toString of it
  - Also updated `getDefaultFormState()` to support data in `formData` in addition to data in `default` when dealing with `additionalProperties`

- Updated the `CHANGELOG.md` file accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
