### PR TITLE
fix: Updated labelValue documentation to fix grammar error

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,8 +4,8 @@
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
     "build": "rimraf dist && dts build --rollupTypes --format cjs,esm,umd",
-    "cs-check": "prettier -l \"{src,test}/**/*.[jt]s?(x)\"",
-    "cs-format": "prettier \"{src,test}/**/*.[jt]s?(x)\" --write",
+    "cs-check": "prettier -l \"{src,test,testSnap}/**/*.[jt]s?(x)\"",
+    "cs-format": "prettier \"{src,test,testSnap}/**/*.[jt]s?(x)\" --write",
     "lint": "eslint src test",
     "precommit": "lint-staged",
     "publish-to-npm": "npm run build && npm publish",
@@ -16,7 +16,7 @@
     "test-coverage": "dts test --coverage"
   },
   "lint-staged": {
-    "{src,test}/**/*.[jt]s?(x)": [
+    "{src,test,testSnap}/**/*.[jt]s?(x)": [
       "eslint --fix",
       "prettier --write"
     ]

--- a/packages/docs/docs/api-reference/utility-functions.md
+++ b/packages/docs/docs/api-reference/utility-functions.md
@@ -447,7 +447,7 @@ In this case, `thing` is an object if it has the type `object` but is NOT null, 
 Helper function that will return the value to use for a widget `label` based on `hideLabel`.
 The `fallback` is used as the return value from the function when `hideLabel` is true.
 Due to the implementation of theme components, it may be necessary to return something other than `undefined` to cause the theme component to not render a label.
-Some themes require may `false` and others may require and empty string.
+Some themes require may `false` and others may require an empty string.
 
 #### Parameters
 

--- a/packages/utils/src/labelValue.ts
+++ b/packages/utils/src/labelValue.ts
@@ -3,7 +3,7 @@ import { ReactElement } from 'react';
 /** Helper function that will return the value to use for a widget `label` based on `hideLabel`. The `fallback` is used
  * as the return value from the function when `hideLabel` is true. Due to the implementation of theme components, it
  * may be necessary to return something other than `undefined` to cause the theme component to not render a label. Some
- * themes require may `false` and others may require and empty string.
+ * themes require may `false` and others may require an empty string.
  *
  * @param [label] - The label string or component to render when not hidden
  * @param [hideLabel] - Flag, if true, will cause the label to be hidden


### PR DESCRIPTION
### Reasons for making this change

Fixed grammar error in `labelValue()` documentation
- Also added the new `testSnap` directory to the `prettier` and `lint-staged` commands in `package.json`

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
