### PR TITLE
Fix broken/brittle docs links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,12 @@ should change the heading of the (upcoming) version to include a major version b
 - Added protections against infinite recursion of `$ref`s for the `toIdSchema()`, `toPathSchema()` and `getDefaultFormState()` functions, fixing [#3560](https://github.com/rjsf-team/react-jsonschema-form/issues/3560)
 - Updated `getDefaultFormState()` to handle object-based `additionalProperties` with defaults using `formData` in addition to values contained in a `default` object, fixing [#2593](https://github.com/rjsf-team/react-jsonschema-form/issues/2593) 
 
-## Dev / playground
+## Dev / docs / playground
 
 - Refactored some parts of `playground` to make it cleaner
 - Formatted the entire monorepo which included 6 unformatted files outside of `playground`
 - Removed `react-app-polyfill` package from `playgound`. This ends IE11 support
+- Fix a handful of broken docs links
 
 # 5.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## Dev / docs / playground
 
 - Refactored some parts of `playground` to make it cleaner
+  - This includes fixing the spelling `disabled` flag being passed into the `Form`
 - Formatted the entire monorepo which included 6 unformatted files outside of `playground`
 - Removed `react-app-polyfill` package from `playgound`. This ends IE11 support
 - Fix a handful of broken docs links, fixing [#3553](https://github.com/rjsf-team/react-jsonschema-form/issues/3553)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Refactored some parts of `playground` to make it cleaner
 - Formatted the entire monorepo which included 6 unformatted files outside of `playground`
 - Removed `react-app-polyfill` package from `playgound`. This ends IE11 support
-- Fix a handful of broken docs links
+- Fix a handful of broken docs links, fixing [#3553](https://github.com/rjsf-team/react-jsonschema-form/issues/3553)
 
 # 5.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## Dev / docs / playground
 
 - Refactored some parts of `playground` to make it cleaner
-  - This includes fixing the spelling `disabled` flag being passed into the `Form`
+  - This includes fixing the spelling of the `disabled` flag being passed into the `Form` from the incorrect `disable` spelling
 - Formatted the entire monorepo which included 6 unformatted files outside of `playground`
 - Removed `react-app-polyfill` package from `playgound`. This ends IE11 support
 - Fix a handful of broken docs links, fixing [#3553](https://github.com/rjsf-team/react-jsonschema-form/issues/3553)

--- a/packages/docs/docs/advanced-customization/custom-templates.md
+++ b/packages/docs/docs/advanced-customization/custom-templates.md
@@ -610,7 +610,7 @@ The following props are passed to a custom field template component:
 - `classNames`: A string containing the base Bootstrap CSS classes, merged with any [custom ones](../api-reference/uiSchema.md#classnames) defined in your uiSchema.
 - `style`: An object containing the `StyleHTMLAttributes` defined in the `uiSchema`.
 - `label`: The computed label for this field, as a string.
-- `description`: A component instance rendering the field description, if one is defined (this will use any custom `DescriptionField` defined).
+- `description`: A component instance rendering the field description, if one is defined (this will use any [custom `DescriptionFieldTemplate`](#descriptionfieldtemplate) defined in the `templates` passed to the `Form`).
 - `rawDescription`: A string containing any `ui:description` uiSchema directive defined.
 - `children`: The field or widget component instance for this field row.
 - `hideError`: A boolean value stating if the field is hiding its errors.

--- a/packages/docs/docs/advanced-customization/custom-templates.md
+++ b/packages/docs/docs/advanced-customization/custom-templates.md
@@ -380,7 +380,7 @@ The following props are passed to the `BaseInputTemplate`:
 - `onKeyChange`: The key change event handler (only called for fields with `additionalProperties`); pass the new value every time it changes;
 - `onBlur`: The input blur event handler; call it with the widget id and value;
 - `onFocus`: The input focus event handler; call it with the widget id and value;
-- `options`: A map of options passed as a prop to the component (see [Custom widget options](#custom-widget-options)).
+- `options`: A map of options passed as a prop to the component (see [Custom widget options](./custom-widgets-fields.md#custom-widget-options)).
 - `options.enumOptions`: For enum fields, this property contains the list of options for the enum as an array of { label, value } objects. If the enum is defined using the oneOf/anyOf syntax, the entire schema object for each option is appended onto the { schema, label, value } object.
 - `formContext`: The `formContext` object that you passed to `Form`.
 - `rawErrors`: An array of strings listing all generated error messages from encountered errors for this widget.
@@ -607,10 +607,10 @@ If you want to handle the rendering of each element yourself, you can use the pr
 The following props are passed to a custom field template component:
 
 - `id`: The id of the field in the hierarchy. You can use it to render a label targeting the wrapped widget.
-- `classNames`: A string containing the base Bootstrap CSS classes, merged with any [custom ones](#custom-css-class-names) defined in your uiSchema.
+- `classNames`: A string containing the base Bootstrap CSS classes, merged with any [custom ones](../api-reference/uiSchema.md#classnames) defined in your uiSchema.
 - `style`: An object containing the `StyleHTMLAttributes` defined in the `uiSchema`.
 - `label`: The computed label for this field, as a string.
-- `description`: A component instance rendering the field description, if one is defined (this will use any [custom `DescriptionField`](#custom-descriptions) defined).
+- `description`: A component instance rendering the field description, if one is defined (this will use any custom `DescriptionField` defined).
 - `rawDescription`: A string containing any `ui:description` uiSchema directive defined.
 - `children`: The field or widget component instance for this field row.
 - `hideError`: A boolean value stating if the field is hiding its errors.
@@ -843,7 +843,7 @@ The following props are passed to the `WrapIfAdditionalTemplate`:
 - `children`: The children of the component, typically specified by the `FieldTemplate`.
 
 - `id`: The id of the field in the hierarchy. You can use it to render a label targeting the wrapped widget.
-- `classNames`: A string containing the base Bootstrap CSS classes, merged with any [custom ones](#custom-css-class-names) defined in your uiSchema.
+- `classNames`: A string containing the base Bootstrap CSS classes, merged with any [custom ones](../api-reference/uiSchema#classnames) defined in your uiSchema.
 - `style`: An object containing the `StyleHTMLAttributes` defined in the `uiSchema`.
 - `label`: The computed label for this field, as a string.
 - `required`: A boolean value stating if the field is required.

--- a/packages/docs/docs/advanced-customization/custom-templates.md
+++ b/packages/docs/docs/advanced-customization/custom-templates.md
@@ -86,7 +86,7 @@ const uiSchema: UiSchema = {
 };
 ```
 
-Please see the [customArray.jsx sample](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/playground/src/samples/customArray.jsx) from the [playground](https://rjsf-team.github.io/react-jsonschema-form/) for another example.
+Please see the [customArray.tsx sample](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/playground/src/samples/customArray.tsx) from the [playground](https://rjsf-team.github.io/react-jsonschema-form/) for another example.
 
 The following props are passed to each `ArrayFieldTemplate`:
 
@@ -681,7 +681,7 @@ const uiSchema: UiSchema = {
 };
 ```
 
-Please see the [customObject.jsx sample](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/playground/src/samples/customObject.jsx) from the [playground](https://rjsf-team.github.io/react-jsonschema-form/) for a better example.
+Please see the [customObject.tsx sample](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/playground/src/samples/customObject.tsx) from the [playground](https://rjsf-team.github.io/react-jsonschema-form/) for a better example.
 
 The following props are passed to each `ObjectFieldTemplate` as defined by the `ObjectFieldTemplateProps` in `@rjsf/utils`:
 
@@ -992,7 +992,7 @@ render(
 The `SubmitButton` is already very customizable via the `UISchemaSubmitButtonOptions` capabilities in the `uiSchema` but it can also be fully customized as you see fit.
 
 > NOTE: However you choose to implement this, making it something other than a `submit` type `button` may result in the `Form` not submitting when pressed.
-> You could also choose to provide your own submit button as the [children prop](../api-reference/form-props#children) of the `Form` should you so choose.
+> You could also choose to provide your own submit button as the [children prop](../api-reference/form-props.md#children) of the `Form` should you so choose.
 
 ```tsx
 import React from 'react';

--- a/packages/docs/docs/advanced-customization/custom-templates.md
+++ b/packages/docs/docs/advanced-customization/custom-templates.md
@@ -843,7 +843,7 @@ The following props are passed to the `WrapIfAdditionalTemplate`:
 - `children`: The children of the component, typically specified by the `FieldTemplate`.
 
 - `id`: The id of the field in the hierarchy. You can use it to render a label targeting the wrapped widget.
-- `classNames`: A string containing the base Bootstrap CSS classes, merged with any [custom ones](../api-reference/uiSchema#classnames) defined in your uiSchema.
+- `classNames`: A string containing the base Bootstrap CSS classes, merged with any [custom ones](../api-reference/uiSchema.md#classnames) defined in your uiSchema.
 - `style`: An object containing the `StyleHTMLAttributes` defined in the `uiSchema`.
 - `label`: The computed label for this field, as a string.
 - `required`: A boolean value stating if the field is required.

--- a/packages/docs/docs/advanced-customization/custom-themes.md
+++ b/packages/docs/docs/advanced-customization/custom-themes.md
@@ -28,7 +28,7 @@ you can essentially redefine the default Form by simply doing `const Form = with
 
 ### Widgets and fields
 
-**widgets** and **fields** should be in the same format as shown [here](/advanced-customization/#custom-widgets-and-fields).
+**widgets** and **fields** should be in the same format as shown [here](./custom-widgets-fields.md).
 
 Example theme with custom widget:
 
@@ -60,7 +60,7 @@ The above can be similarly done for **fields** and **templates**.
 
 ### Templates
 
-Each template should be passed into the theme object via the **templates** object just as you would into the rjsf Form component. Here is an example of how to use a custom [ArrayFieldTemplate](/advanced-customization/#array-field-template) and [ErrorListTemplate](/advanced-customization/#error-list-template) in the theme object:
+Each template should be passed into the theme object via the **templates** object just as you would into the rjsf Form component. Here is an example of how to use a custom [ArrayFieldTemplate](./custom-templates.md#arrayfieldtemplate) and [ErrorListTemplate](./custom-templates.md#errorlisttemplate) in the theme object:
 
 ```tsx
 import { ArrayFieldTemplateProps, ErrorListProps } from '@rjsf/utils';

--- a/packages/docs/docs/advanced-customization/custom-widgets-fields.md
+++ b/packages/docs/docs/advanced-customization/custom-widgets-fields.md
@@ -233,7 +233,7 @@ render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />, docum
 
 ### Customizing widgets' text input
 
-All the widgets that render a text input use the `BaseInputTemplate` component internally. If you need to customize all text inputs without customizing all widgets individually, you can provide a `BaseInputTemplate` component in the `templates` property of `Form` (see [Custom Templates](advanced-customization/custom-templates#baseinputtemplate)).
+All the widgets that render a text input use the `BaseInputTemplate` component internally. If you need to customize all text inputs without customizing all widgets individually, you can provide a `BaseInputTemplate` component in the `templates` property of `Form` (see [Custom Templates](./custom-templates.md#baseinputtemplate)).
 
 ## Custom field components
 
@@ -305,12 +305,12 @@ render(
 A field component will always be passed the following props:
 
 - `schema`: The JSON subschema object for this field;
-- `uiSchema`: The [uiSchema](#the-uischema-object) for this field;
+- `uiSchema`: The [uiSchema](../api-reference/uiSchema.md) for this field;
 - `idSchema`: The tree of unique ids for every child field;
 - `formData`: The data for this field;
 - `errorSchema`: The tree of errors for this field and its children;
 - `registry`: A [registry](#the-registry-object) object (read next).
-- `formContext`: A [formContext](#the-formcontext-object) object (read next).
+- `formContext`: A [formContext](../api-reference/form-props.md#formcontext) object (read next).
 - `required`: The required status of this field;
 - `disabled`: A boolean value stating if the field is disabled;
 - `readonly`: A boolean value stating if the field is read-only;
@@ -328,9 +328,9 @@ A field component will always be passed the following props:
 The `registry` is an object containing the registered core, theme and custom fields and widgets as well as the root schema, form context, schema utils.
 
 - `fields`: The set of all fields used by the `Form`. Includes fields from `core`, theme-specific fields and any [custom registered fields](#custom-field-components);
-- `widgets`: The set of all widgets used by the `Form`. Includes widgets from `core`, theme-specific widgets and any [custom registered widgets](#custom-widget-components), if any;
-- `rootSchema`: The root schema, as passed to the `Form`, which can contain referenced [definitions](#schema-definitions-and-references);
-- `formContext`: The [formContext](#the-formcontext-object) that was passed to `Form`;
+- `widgets`: The set of all widgets used by the `Form`. Includes widgets from `core`, theme-specific widgets and any [custom registered widgets](#custom-component-registration), if any;
+- `rootSchema`: The root schema, as passed to the `Form`, which can contain referenced [definitions](../usage/definitions.md);
+- `formContext`: The [formContext](../api-reference/form-props.md#formcontext) that was passed to `Form`;
 - `schemaUtils`: The current implementation of the `SchemaUtilsType` (from `@rjsf/utils`) in use by the `Form`. Used to call any of the validation-schema-based utility functions.
 
 The registry is passed down the component tree, so you can access it from your custom field, custom widget, custom template and `SchemaField` components.

--- a/packages/docs/docs/advanced-customization/internals.md
+++ b/packages/docs/docs/advanced-customization/internals.md
@@ -4,7 +4,7 @@ Miscellaneous internals of react-jsonschema-form are listed here.
 
 ## JSON Schema supporting status
 
-This component follows [JSON Schema](http://json-schema.org/documentation.html) specs. We currently support JSON Schema-07 by default, but we also support other JSON schema versions through the [custom schema validation](../usage/validation#custom-meta-schema-validation) feature. Due to the limitation of form widgets, there are some exceptions as follows:
+This component follows [JSON Schema](http://json-schema.org/documentation.html) specs. We currently support JSON Schema-07 by default, but we also support other JSON schema versions through the [custom schema validation](../usage/validation.md#custom-meta-schema-validation) feature. Due to the limitation of form widgets, there are some exceptions as follows:
 
 - `additionalItems` keyword for arrays
 
@@ -14,15 +14,15 @@ This component follows [JSON Schema](http://json-schema.org/documentation.html) 
 
   The `anyOf` and `oneOf` keywords are supported; however, properties declared inside the `anyOf/oneOf` should not overlap with properties "outside" of the `anyOf/oneOf`.
 
-  You can also use `oneOf` with [schema dependencies](../usage/dependencies#schema-dependencies) to dynamically add schema properties based on input data.
+  You can also use `oneOf` with [schema dependencies](../usage/dependencies.md#schema-dependencies) to dynamically add schema properties based on input data.
 
   The `allOf` keyword is supported; it uses [json-schema-merge-allof](https://github.com/mokkabonna/json-schema-merge-allof) to merge subschemas to render the final combined schema in the form. When these subschemas are incompatible, though (or if the library has an error merging it), the `allOf` keyword is dropped from the schema.
 
-- `"additionalProperties":false` produces incorrect schemas when used with [schema dependencies](../usage/dependencies#schema-dependencies). This library does not remove extra properties, which causes validation to fail. It is recommended to avoid setting `"additionalProperties":false` when you use schema dependencies. See [#848](https://github.com/rjsf-team/react-jsonschema-form/issues/848) [#902](https://github.com/rjsf-team/rjsf-team/issues/902) [#992](https://github.com/rjsf-team/rjsf-team/issues/992)
+- `"additionalProperties":false` produces incorrect schemas when used with [schema dependencies](../usage/dependencies.md#schema-dependencies). This library does not remove extra properties, which causes validation to fail. It is recommended to avoid setting `"additionalProperties":false` when you use schema dependencies. See [#848](https://github.com/rjsf-team/react-jsonschema-form/issues/848) [#902](https://github.com/rjsf-team/react-jsonschema-form/issues/902) [#992](https://github.com/rjsf-team/react-jsonschema-form/issues/992)
 
 ## Handling of schema defaults
 
-This library automatically fills default values defined in the [JSON Schema](http://json-schema.org/documentation.html) as initial values in your form. This also works for complex structures in the schema. If a field has a default defined, it should always appear as default value in form. This also works when using [schema dependencies](../usage/dependencies/#schema-dependencies).
+This library automatically fills default values defined in the [JSON Schema](http://json-schema.org/documentation.html) as initial values in your form. This also works for complex structures in the schema. If a field has a default defined, it should always appear as default value in form. This also works when using [schema dependencies](../usage/dependencies.md#schema-dependencies).
 
 Since there is a complex interaction between any supplied original form data and any injected defaults, this library tries to do the injection in a way which keeps the original intention of the original form data.
 

--- a/packages/docs/docs/api-reference/uiSchema.md
+++ b/packages/docs/docs/api-reference/uiSchema.md
@@ -83,7 +83,7 @@ This will make all widgets have an id prefixed with `myform`.
 The `ui:field` property overrides the `Field` implementation used for rendering any field in the form's hierarchy.
 Specify either the name of a field that is used to look up an implementation from the `fields` list or an actual one-off `Field` component implementation itself.
 
-See [Custom Widgets and Fields](../advanced-customization/custom-widgets-fields#custom-field-components) for more information about how to use this property.
+See [Custom Widgets and Fields](../advanced-customization/custom-widgets-fields.md#custom-field-components) for more information about how to use this property.
 
 ### ui:fieldReplacesAnyOrOneOf
 
@@ -100,14 +100,14 @@ The `ui:options` property cannot be nested inside itself and thus is the last ex
 
 All the properties that follow can be specified in the `uiSchema` in either of the two equivalent ways.
 
-NOTE: The properties specific to array items can be found [here](../usage/arrays#array-item-uiSchema-options)
+NOTE: The properties specific to array items can be found [here](../usage/arrays.md#array-item-uiSchema-options)
 
 ### widget
 
 The `ui:widget` property overrides the `Widget` implementation used for rendering any field in the form's hierarchy.
 Specify either the name of a widget that is used to look up an implementation from the `widgets` list or an actual one-off `Widget` component implementation itself.
 
-See [Custom Widgets and Fields](../advanced-customization/custom-widgets-fields) for more information about how to use this property.
+See [Custom Widgets and Fields](../advanced-customization/custom-widgets-fields.md) for more information about how to use this property.
 
 ### classNames
 
@@ -456,6 +456,6 @@ const uiSchema = {
 
 ## Theme Options
 
-[AntD Customization](themes/antd/uiSchema.md)
-[Chakra-UI Customization](themes/chakra-ui/uiSchema.md)
-[Semantic-UI Customization](themes/semantic-ui/uiSchema.md)
+- [AntD Customization](themes/antd/uiSchema.md)
+- [Chakra-UI Customization](themes/chakra-ui/uiSchema.md)
+- [Semantic-UI Customization](themes/semantic-ui/uiSchema.md)

--- a/packages/docs/docs/contributing.md
+++ b/packages/docs/docs/contributing.md
@@ -68,7 +68,7 @@ In order to support the various themes, the code for the tests are actually func
 - `Form`: ComponentType&lt;FormProps> - The component from the theme implementation
 - `[customOptions]`: { [key: string]: TestRendererOptions } - an optional map of `react-test-renderer` `TestRendererOptions` implementations that some themes need to be able properly run
 
-There are functions in the `testSnap` directory: `arrayTests`, `formTests` and `objectTests`, each with it's own definition of `customOptions`
+There are functions in the `testSnap` directory: `arrayTests`, `formTests` and `objectTests`, each with its own definition of `customOptions`
 
 Each theme will basically run these functions by creating a `Xxx.test.tsx` file (where `Xxx` is `Array`, `Form` or `Object`) that looks like the following:
 
@@ -148,7 +148,7 @@ Note that if you are releasing a new major version, you should bump the peer dep
 Then, make a PR to main. Merge the PR into main -- make sure you use "merge commit", not squash and merge, so that
 the original commit where the tag was based on is still present in the main branch.
 
-Then, create a release in the Github "Releases" tab, select the new tag that you have added,
+Then, create a release in the GitHub "Releases" tab, select the new tag that you have added,
 and add a description of the changes in the new release. You can copy
 the latest changelog entry in `CHANGELOG.md` to make the release notes, and update as necessary.
 

--- a/packages/docs/docs/migration-guides/v3.x upgrade guide.md
+++ b/packages/docs/docs/migration-guides/v3.x upgrade guide.md
@@ -12,7 +12,7 @@ Dropped support for Node 8, 9, 10. Minimum supported version of Node.js is now 1
 
 ### Help field IDs
 
-IDs for [Help fields](../api-reference/uiSchema#help) are now suffixed by `__help` so that the IDs are unique. Previously, their IDs would be nonexistent or the same as the fields that they were describing.
+IDs for [Help fields](../api-reference/uiSchema.md#help) are now suffixed by `__help` so that the IDs are unique. Previously, their IDs would be nonexistent or the same as the fields that they were describing.
 
 ### Bring your own polyfills
 

--- a/packages/docs/docs/migration-guides/v5.x upgrade guide.md
+++ b/packages/docs/docs/migration-guides/v5.x upgrade guide.md
@@ -27,7 +27,7 @@ Unfortunately, there is required work pending to properly support React 18, so u
 
 There are four new packages added in RJSF version 5:
 
-- `@rjsf/utils`: All of the [utility functions](../api-reference/utility-functions) previously imported from `@rjsf/core/utils` as well as the Typescript types for RJSF version 5.
+- `@rjsf/utils`: All of the [utility functions](../api-reference/utility-functions.md) previously imported from `@rjsf/core/utils` as well as the Typescript types for RJSF version 5.
   - The following new utility functions were added: `ariaDescribedByIds()`, `createSchemaUtils()`, `descriptionId()`, `enumOptionsDeselectValue()`, `enumOptionsIndexForValue()`, `enumOptionsIsSelected()`, `enumOptionsSelectValue()`, `enumOptionsValueForIndex()`, `errorId()`, `examplesId()`, `getClosestMatchingOption()`, `getFirstMatchingOption()`, `getInputProps()`, `helpId()`, `mergeValidationData()`, `optionId()`, `sanitizeDataForNewSchema()` and `titleId()`
 - `@rjsf/validator-ajv6`: The [ajv](https://github.com/ajv-validator/ajv)-v6-based validator refactored out of `@rjsf/core@4.x`, that implements the `ValidatorType` interface defined in `@rjsf/utils`.
 - `@rjsf/validator-ajv8`: The [ajv](https://github.com/ajv-validator/ajv)-v8-based validator that is an upgrade of the `@rjsf/validator-ajv6`, that implements the `ValidatorType` interface defined in `@rjsf/utils`. See the ajv 6 to 8 [migration guide](https://ajv.js.org/v6-to-v8-migration.html) for more information.
@@ -212,7 +212,7 @@ render((
 
 NOTE: In version 5, the `ArrayField` implementation was refactored to add 3 additional templates for presenting arrays along with the `ArrayFieldTemplate`.
 If you were updating the `ArrayFieldTemplate` to modify just a subset of the UI, it may be easier for you to implement one of the other new templates instead.
-See the [Custom Templates](../advanced-customization/custom-templates) documentation for more details.
+See the [Custom Templates](../advanced-customization/custom-templates.md) documentation for more details.
 
 ##### `widgets` prop change
 
@@ -246,7 +246,7 @@ render((
 #### utils.js
 
 In version 5, all the utility functions that were previously accessed via `import { utils } from '@rjsf/core';` are now available via `import utils from '@rjsf/utils';`.
-Because of the decoupling of validation from `@rjsf/core` there is a breaking change for all the [validator-based utility functions](../api-reference/utility-functions#validator-based-utility-functions), since they now require an additional `ValidatorType` parameter.
+Because of the decoupling of validation from `@rjsf/core` there is a breaking change for all the [validator-based utility functions](../api-reference/utility-functions.md#validator-based-utility-functions), since they now require an additional `ValidatorType` parameter.
 More over, one previously exported function `resolveSchema()` is no longer exposed in the `@rjsf/utils`, so use `retrieveSchema()` instead.
 Finally, the function `getMatchingOption()` has been deprecated in favor of `getFirstMatchingOption()`.
 

--- a/packages/docs/docs/quickstart.md
+++ b/packages/docs/docs/quickstart.md
@@ -131,7 +131,7 @@ render(<Form schema={schema} formData={formData} validator={validator} />, docum
 
 ### Form event handlers
 
-You can use event handlers such as `onChange`, `onError`, `onSubmit`, `onFocus`, and `onBlur` on the `<Form />` component; see the [Form Props Reference](/docs/api-reference/form-props.md) for more details.
+You can use event handlers such as `onChange`, `onError`, `onSubmit`, `onFocus`, and `onBlur` on the `<Form />` component; see the [Form Props Reference](./api-reference/form-props.md) for more details.
 
 ### Controlled component
 

--- a/packages/docs/docs/usage/arrays.md
+++ b/packages/docs/docs/usage/arrays.md
@@ -192,7 +192,7 @@ render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />, docum
 
 ## Multiple-choice list
 
-The default behavior for array fields is a list of text inputs with add/remove buttons. There are two alternative widgets for picking multiple elements from a list of choices. Typically this applies when a schema has an `enum` list for the `items` property of an `array` field, and the `uniqueItems` property set to `true`.
+The default behavior for array fields is a list of text inputs with add/remove buttons. There are two alternative widgets for picking multiple elements from a list of choices. Typically, this applies when a schema has an `enum` list for the `items` property of an `array` field, and the `uniqueItems` property set to `true`.
 
 Example:
 

--- a/packages/docs/docs/usage/definitions.md
+++ b/packages/docs/docs/usage/definitions.md
@@ -1,6 +1,6 @@
 # Schema definitions and references
 
-This library partially supports [inline schema definition dereferencing](http://json-schema.org/draft/2019-09/json-schema-core.html#ref), which is Barbarian for _avoiding to copy and paste commonly used field schemas_:
+This library partially supports [inline schema definition dereferencing](http://json-schema.org/draft/2019-09/json-schema-core.html#ref), which allows you to re-use parts of your schema:
 
 ```tsx
 import { RJSFSchema } from '@rjsf/utils';

--- a/packages/docs/docs/usage/validation.md
+++ b/packages/docs/docs/usage/validation.md
@@ -269,7 +269,7 @@ const schema: RJSFSchema = {
 return <Form schema={schema} validator={validator} />;
 ```
 
-NOTE: This syntax works only for the `@rjsf/validator-ajv6` validator; if you only use the `draft-04` schema and you want to use the `@rjsf/validator-ajv8` you can do the following:
+NOTE: This syntax works only for the `@rjsf/validator-ajv6` validator; if you only use the `draft-04` schema, and you want to use the `@rjsf/validator-ajv8` you can do the following:
 
 ```tsx
 import { RJSFSchema } from '@rjsf/utils';
@@ -289,7 +289,7 @@ return <Form schema={schema} validator={validator} />;
 ### customFormats
 
 [Pre-defined semantic formats](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.7) are limited.
-react-jsonschema-form adds two formats, `color` and `data-url`, to support certain [alternative widgets](docs/usage/widgets.md).
+react-jsonschema-form adds two formats, `color` and `data-url`, to support certain [alternative widgets](./widgets.md).
 To add formats of your own, you can create and pass to the `Form` component a customized `@rjsf/validator-ajv8`:
 
 ```tsx

--- a/packages/docs/docs/usage/widgets.md
+++ b/packages/docs/docs/usage/widgets.md
@@ -89,7 +89,7 @@ Please note that, even though they are standardized, `datetime-local`, `date` an
 
 ![](https://i.imgur.com/VF5tY60.png)
 
-You can customize the list of years displayed in the `year` dropdown by providing a `yearsRange` property to `ui:options` in your uiSchema. Its also possible to remove the `Now` and `Clear` buttons with the `hideNowButton` and `hideClearButton` options.
+You can customize the list of years displayed in the `year` dropdown by providing a `yearsRange` property to `ui:options` in your uiSchema. It's also possible to remove the `Now` and `Clear` buttons with the `hideNowButton` and `hideClearButton` options.
 
 ```tsx
 import { RJSFSchema, UiSchema } from '@rjsf/utils';


### PR DESCRIPTION
### Reasons for making this change

Fixes #3553 

GitHub pages automatically adds a trailing slash onto our statically generated page names. This causes relative links to break where the trailing slash is only sometimes added, which can happen with a hash URL.

If we write our relative links using the full file name (including extension), Docusaurus should generate an absolute link to the document that always works.

### Checklist

- [X] **I'm updating documentation**
  - [X] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
