### PR TITLE
fix: Switch to using isValid() for oneOf schema detection in retrieveSchema()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 - Added protections against infinite recursion of `$ref`s for the `toIdSchema()`, `toPathSchema()` and `getDefaultFormState()` functions, fixing [#3560](https://github.com/rjsf-team/react-jsonschema-form/issues/3560)
-- Updated `getDefaultFormState()` to handle object-based `additionalProperties` with defaults using `formData` in addition to values contained in a `default` object, fixing [#2593](https://github.com/rjsf-team/react-jsonschema-form/issues/2593) 
+- Updated `getDefaultFormState()` to handle object-based `additionalProperties` with defaults using `formData` in addition to values contained in a `default` object, fixing [#2593](https://github.com/rjsf-team/react-jsonschema-form/issues/2593)
+- Updated internal helper `withExactlyOneSubschema()` inside of `retrieveSchema()` to use the `isValid()` function rather than `validateFormData()` when determining the one-of branch 
 
 ## Dev / docs / playground
 

--- a/packages/core/test/Form.test.jsx
+++ b/packages/core/test/Form.test.jsx
@@ -209,7 +209,6 @@ describeRepeated('Form common', (createFormComponent) => {
 
     it('should work with oneOf', function () {
       const schema = {
-        $schema: 'http://json-schema.org/draft-06/schema#',
         type: 'object',
         properties: {
           connector: {

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -375,8 +375,7 @@ export function withExactlyOneSubschema<
           [dependencyKey]: conditionPropertySchema,
         },
       } as S;
-      const { errors } = validator.validateFormData(formData, conditionSchema);
-      return errors.length === 0;
+      return validator.isValid(conditionSchema, formData, rootSchema);
     }
     return false;
   });

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -1185,13 +1185,13 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         ]);
       });
       it('should populate defaults for nested dependencies in arrays when matching enum values in oneOf', () => {
-        // Mock errors so that withExactlyOneSubschema works as expected
+        // Mock isValid so that withExactlyOneSubschema works as expected
         testValidator.setReturnValues({
-          data: [
-            { errors: [], errorSchema: {} }, // First oneOf... first === first
-            { errors: [{ stack: 'error' }], errorSchema: {} }, // Second oneOf... second !== first
-            { errors: [{ stack: 'error' }], errorSchema: {} }, // First oneOf... first !== second
-            { errors: [], errorSchema: {} }, // Second oneOf... second === second
+          isValid: [
+            true, // First oneOf... first === first
+            false, // Second oneOf... second !== first
+            false, // First oneOf... first !== second
+            true, // Second oneOf... second === second
           ],
         });
         const schema: RJSFSchema = {

--- a/packages/utils/test/schema/retrieveSchemaTest.ts
+++ b/packages/utils/test/schema/retrieveSchemaTest.ts
@@ -482,11 +482,11 @@ export default function retrieveSchemaTest(testValidator: TestValidatorType) {
 
         describe('with $ref in oneOf', () => {
           it('should retrieve referenced schemas', () => {
-            // Mock errors so that withExactlyOneSubschema works as expected
+            // Mock isValid so that withExactlyOneSubschema works as expected
             testValidator.setReturnValues({
-              data: [
-                { errors: [{ stack: 'error' }], errorSchema: {} }, // First oneOf... second !== first
-                { errors: [], errorSchema: {} }, // Second oneOf... second === second
+              isValid: [
+                false, // First oneOf... second !== first
+                true, // Second oneOf... second === second
               ],
             });
             const schema: RJSFSchema = {
@@ -568,11 +568,11 @@ export default function retrieveSchemaTest(testValidator: TestValidatorType) {
 
         describe('true condition', () => {
           it('should add `first` properties given `first` data', () => {
-            // Mock errors so that withExactlyOneSubschema works as expected
+            // Mock isValid so that withExactlyOneSubschema works as expected
             testValidator.setReturnValues({
-              data: [
-                { errors: [], errorSchema: {} }, // First dependency... first === first
-                { errors: [{ stack: 'error' }], errorSchema: {} }, // Second dependency... second !== first
+              isValid: [
+                true, // First dependency... first === first
+                false, // Second dependency... second !== first
               ],
             });
             const schema: RJSFSchema = {
@@ -611,11 +611,11 @@ export default function retrieveSchemaTest(testValidator: TestValidatorType) {
           });
 
           it('should add `second` properties given `second` data', () => {
-            // Mock errors so that withExactlyOneSubschema works as expected
+            // Mock isValid so that withExactlyOneSubschema works as expected
             testValidator.setReturnValues({
-              data: [
-                { errors: [{ stack: 'error' }], errorSchema: {} }, // First dependency... first !== second
-                { errors: [], errorSchema: {} }, // Second dependency... second === second
+              isValid: [
+                false, // First dependency... first !== second
+                true, // Second dependency... second === second
               ],
             });
             const schema: RJSFSchema = {
@@ -730,13 +730,13 @@ export default function retrieveSchemaTest(testValidator: TestValidatorType) {
             });
 
             it('should not include nested dependencies that should be hidden', () => {
-              // Mock errors so that withExactlyOneSubschema works as expected
+              // Mock isValid so that withExactlyOneSubschema works as expected
               testValidator.setReturnValues({
-                data: [
-                  { errors: [{ stack: 'error' }], errorSchema: {} }, // employee_accounts oneOf ... - fail
-                  { errors: [], errorSchema: {} }, // update_absences first oneOf... success
-                  { errors: [{ stack: 'error' }], errorSchema: {} }, // update_absences second oneOf... fail
-                  { errors: [{ stack: 'error' }], errorSchema: {} }, // update_absences third oneOf... fail
+                isValid: [
+                  false, // employee_accounts oneOf ... - fail
+                  true, // update_absences first oneOf... success
+                  false, // update_absences second oneOf... fail
+                  false, // update_absences third oneOf... fail
                 ],
               });
               const formData = {
@@ -758,13 +758,13 @@ export default function retrieveSchemaTest(testValidator: TestValidatorType) {
             });
 
             it('should include nested dependencies that should not be hidden', () => {
-              // Mock errors so that withExactlyOneSubschema works as expected
+              // Mock isValid so that withExactlyOneSubschema works as expected
               testValidator.setReturnValues({
-                data: [
-                  { errors: [], errorSchema: {} }, // employee_accounts oneOf... success
-                  { errors: [], errorSchema: {} }, // update_absences first oneOf... success
-                  { errors: [{ stack: 'error' }], errorSchema: {} }, // update_absences second oneOf... fail
-                  { errors: [{ stack: 'error' }], errorSchema: {} }, // update_absences third oneOf... fail
+                isValid: [
+                  true, // employee_accounts oneOf... success
+                  true, // update_absences first oneOf... success
+                  false, // update_absences second oneOf... fail
+                  false, // update_absences third oneOf... fail
                 ],
               });
               const formData = {
@@ -800,11 +800,11 @@ export default function retrieveSchemaTest(testValidator: TestValidatorType) {
 
         describe('with $ref in dependency', () => {
           it('should retrieve the referenced schema', () => {
-            // Mock errors so that withExactlyOneSubschema works as expected
+            // Mock isValid so that withExactlyOneSubschema works as expected
             testValidator.setReturnValues({
-              data: [
-                { errors: [{ stack: 'error' }], errorSchema: {} }, // First oneOf... fail
-                { errors: [], errorSchema: {} }, // Second oneOf... success
+              isValid: [
+                false, // First oneOf... fail
+                true, // Second oneOf... success
               ],
             });
             const schema: RJSFSchema = {


### PR DESCRIPTION
### Reasons for making this change

Added an optimization in `retrieveSchema()` to use the `isValid()` function rather than `validateFormData()`

- In `@rjsf/utils`, switched the `withExactlyOneSubschema()` to use `isValid()`
  - Updated the test mocks accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
