### PR TITLE
fix: Fixes broken playground form display and small mui bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,28 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.5.2
+
+## @rjsf/material-ui
+
+- Switched to using `TextField` for the `WrapIfAdditionalTemplate` label key input to match the `@rjsf/mui` fix
+
+## @rjsf/mui
+
+- Switched to using `TextField` for the `WrapIfAdditionalTemplate` label key input, fixing [#3578](https://github.com/rjsf-team/react-jsonschema-form/issues/3578)
+
+## Dev / docs / playground
+
+- Updated the `templates` passed into the main `Form` to not include undefined values, fixing [#3576](https://github.com/rjsf-team/react-jsonschema-form/issues/3576) and [#3579](https://github.com/rjsf-team/react-jsonschema-form/issues/3579)
+
 # 5.5.1
 
 ## @rjsf/core
+
 - Updated `Form` to include the top `disabled` property in the `ui:submitButtonOptions` so the submit button will be disabled when the whole form is disabled. Fixes [#3264](https://github.com/rjsf-team/react-jsonschema-form/issues/3264). 
 
 ## @rjsf/utils
+
 - Added protections against infinite recursion of `$ref`s for the `toIdSchema()`, `toPathSchema()` and `getDefaultFormState()` functions, fixing [#3560](https://github.com/rjsf-team/react-jsonschema-form/issues/3560)
 - Updated `getDefaultFormState()` to handle object-based `additionalProperties` with defaults using `formData` in addition to values contained in a `default` object, fixing [#2593](https://github.com/rjsf-team/react-jsonschema-form/issues/2593)
 - Updated internal helper `withExactlyOneSubschema()` inside of `retrieveSchema()` to use the `isValid()` function rather than `validateFormData()` when determining the one-of branch 

--- a/packages/material-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/material-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -1,8 +1,6 @@
 import { CSSProperties, FocusEvent } from 'react';
-import FormControl from '@material-ui/core/FormControl';
 import Grid from '@material-ui/core/Grid';
-import InputLabel from '@material-ui/core/InputLabel';
-import Input from '@material-ui/core/Input';
+import TextField from '@material-ui/core/TextField';
 import {
   ADDITIONAL_PROPERTY_FLAG,
   FormContextType,
@@ -62,17 +60,17 @@ export default function WrapIfAdditionalTemplate<
   return (
     <Grid container key={`${id}-key`} alignItems='center' spacing={2} className={classNames} style={style}>
       <Grid item xs>
-        <FormControl fullWidth={true} required={required}>
-          <InputLabel>{keyLabel}</InputLabel>
-          <Input
-            defaultValue={label}
-            disabled={disabled || readonly}
-            id={`${id}-key`}
-            name={`${id}-key`}
-            onBlur={!readonly ? handleBlur : undefined}
-            type='text'
-          />
-        </FormControl>
+        <TextField
+          fullWidth={true}
+          required={required}
+          label={keyLabel}
+          defaultValue={label}
+          disabled={disabled || readonly}
+          id={`${id}-key`}
+          name={`${id}-key`}
+          onBlur={!readonly ? handleBlur : undefined}
+          type='text'
+        />
       </Grid>
       <Grid item={true} xs>
         {children}

--- a/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Object.test.tsx.snap
@@ -36,20 +36,23 @@ exports[`object fields additionalProperties 1`] = `
               className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
             >
               <div
-                className="MuiFormControl-root MuiFormControl-fullWidth"
+                className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
               >
                 <label
                   className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
                   data-shrink={false}
+                  htmlFor="root_foo-key"
+                  id="root_foo-key-label"
                 >
                   foo Key
                 </label>
                 <div
-                  className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                  className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
                   onClick={[Function]}
                 >
                   <input
                     aria-invalid={false}
+                    autoFocus={false}
                     className="MuiInputBase-input MuiInput-input"
                     defaultValue="foo"
                     disabled={false}
@@ -455,20 +458,23 @@ exports[`object fields with title and description additionalProperties 1`] = `
               className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
             >
               <div
-                className="MuiFormControl-root MuiFormControl-fullWidth"
+                className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
               >
                 <label
                   className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
                   data-shrink={false}
+                  htmlFor="root_foo-key"
+                  id="root_foo-key-label"
                 >
                   foo Key
                 </label>
                 <div
-                  className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                  className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
                   onClick={[Function]}
                 >
                   <input
                     aria-invalid={false}
+                    autoFocus={false}
                     className="MuiInputBase-input MuiInput-input"
                     defaultValue="foo"
                     disabled={false}
@@ -717,20 +723,23 @@ exports[`object fields with title and description from both additionalProperties
               className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
             >
               <div
-                className="MuiFormControl-root MuiFormControl-fullWidth"
+                className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
               >
                 <label
                   className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
                   data-shrink={false}
+                  htmlFor="root_foo-key"
+                  id="root_foo-key-label"
                 >
                   foo Key
                 </label>
                 <div
-                  className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                  className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
                   onClick={[Function]}
                 >
                   <input
                     aria-invalid={false}
+                    autoFocus={false}
                     className="MuiInputBase-input MuiInput-input"
                     defaultValue="foo"
                     disabled={false}
@@ -1169,20 +1178,23 @@ exports[`object fields with title and description from uiSchema additionalProper
               className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
             >
               <div
-                className="MuiFormControl-root MuiFormControl-fullWidth"
+                className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
               >
                 <label
                   className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
                   data-shrink={false}
+                  htmlFor="root_foo-key"
+                  id="root_foo-key-label"
                 >
                   foo Key
                 </label>
                 <div
-                  className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                  className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
                   onClick={[Function]}
                 >
                   <input
                     aria-invalid={false}
+                    autoFocus={false}
                     className="MuiInputBase-input MuiInput-input"
                     defaultValue="foo"
                     disabled={false}
@@ -1788,20 +1800,23 @@ exports[`object fields with title and description with global label off addition
               className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
             >
               <div
-                className="MuiFormControl-root MuiFormControl-fullWidth"
+                className="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
               >
                 <label
                   className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
                   data-shrink={false}
+                  htmlFor="root_foo-key"
+                  id="root_foo-key-label"
                 >
                   foo Key
                 </label>
                 <div
-                  className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                  className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl"
                   onClick={[Function]}
                 >
                   <input
                     aria-invalid={false}
+                    autoFocus={false}
                     className="MuiInputBase-input MuiInput-input"
                     defaultValue="foo"
                     disabled={false}

--- a/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -1,8 +1,6 @@
 import { CSSProperties, FocusEvent } from 'react';
-import FormControl from '@mui/material/FormControl';
 import Grid from '@mui/material/Grid';
-import InputLabel from '@mui/material/InputLabel';
-import Input from '@mui/material/OutlinedInput';
+import TextField from '@mui/material/TextField';
 import {
   ADDITIONAL_PROPERTY_FLAG,
   FormContextType,
@@ -62,17 +60,17 @@ export default function WrapIfAdditionalTemplate<
   return (
     <Grid container key={`${id}-key`} alignItems='center' spacing={2} className={classNames} style={style}>
       <Grid item xs>
-        <FormControl fullWidth={true} required={required}>
-          <InputLabel>{keyLabel}</InputLabel>
-          <Input
-            defaultValue={label}
-            disabled={disabled || readonly}
-            id={`${id}-key`}
-            name={`${id}-key`}
-            onBlur={!readonly ? handleBlur : undefined}
-            type='text'
-          />
-        </FormControl>
+        <TextField
+          fullWidth={true}
+          required={required}
+          label={keyLabel}
+          defaultValue={label}
+          disabled={disabled || readonly}
+          id={`${id}-key`}
+          name={`${id}-key`}
+          onBlur={!readonly ? handleBlur : undefined}
+          type='text'
+        />
       </Grid>
       <Grid item={true} xs>
         {children}

--- a/packages/mui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Object.test.tsx.snap
@@ -212,6 +212,23 @@ exports[`object fields additionalProperties 1`] = `
   }
 }
 
+.emotion-5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
 .emotion-6 {
   color: rgba(0, 0, 0, 0.6);
   font-family: "Roboto","Helvetica","Arial",sans-serif;
@@ -270,6 +287,7 @@ exports[`object fields additionalProperties 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  width: 100%;
   position: relative;
   border-radius: 4px;
 }
@@ -433,10 +451,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
   float: unset;
   width: auto;
   overflow: hidden;
+  display: block;
   padding: 0;
-  line-height: 11px;
-  -webkit-transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
-  transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  height: 11px;
+  font-size: 0.75em;
+  visibility: hidden;
+  max-width: 0.01px;
+  -webkit-transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  white-space: nowrap;
+}
+
+.emotion-10>span {
+  padding-left: 5px;
+  padding-right: 5px;
+  display: inline-block;
+  opacity: 0;
+  visibility: visible;
 }
 
 .emotion-13 {
@@ -497,6 +528,56 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
 
 .emotion-14.Mui-error {
   color: #d32f2f;
+}
+
+.emotion-15 {
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  color: rgba(0, 0, 0, 0.87);
+  box-sizing: border-box;
+  position: relative;
+  cursor: text;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border-radius: 4px;
+}
+
+.emotion-15.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+  cursor: default;
+}
+
+.emotion-15:hover .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.87);
+}
+
+@media (hover: none) {
+  .emotion-15:hover .MuiOutlinedInput-notchedOutline {
+    border-color: rgba(0, 0, 0, 0.23);
+  }
+}
+
+.emotion-15.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-color: #1976d2;
+  border-width: 2px;
+}
+
+.emotion-15.Mui-error .MuiOutlinedInput-notchedOutline {
+  border-color: #d32f2f;
+}
+
+.emotion-15.Mui-disabled .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.26);
 }
 
 .emotion-18 {
@@ -888,20 +969,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
             >
               <div
-                className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-5"
               >
                 <label
                   className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined emotion-6"
                   data-shrink={false}
+                  htmlFor="root_foo-key"
+                  id="root_foo-key-label"
                 >
                   foo Key
                 </label>
                 <div
-                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-7"
+                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl emotion-7"
                   onClick={[Function]}
                 >
                   <input
                     aria-invalid={false}
+                    autoFocus={false}
                     className="MuiInputBase-input MuiOutlinedInput-input emotion-8"
                     defaultValue="foo"
                     disabled={false}
@@ -921,10 +1005,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
                     <legend
                       className="emotion-10"
                     >
-                      <span
-                        className="notranslate"
-                      >
-                        ​
+                      <span>
+                        foo Key
                       </span>
                     </legend>
                   </fieldset>
@@ -950,7 +1032,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
                     foo
                   </label>
                   <div
-                    className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-7"
+                    className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-15"
                     onClick={[Function]}
                   >
                     <input
@@ -1998,6 +2080,23 @@ exports[`object fields with title and description additionalProperties 1`] = `
   }
 }
 
+.emotion-9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
 .emotion-10 {
   color: rgba(0, 0, 0, 0.6);
   font-family: "Roboto","Helvetica","Arial",sans-serif;
@@ -2056,6 +2155,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  width: 100%;
   position: relative;
   border-radius: 4px;
 }
@@ -2219,10 +2319,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   float: unset;
   width: auto;
   overflow: hidden;
+  display: block;
   padding: 0;
-  line-height: 11px;
-  -webkit-transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
-  transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  height: 11px;
+  font-size: 0.75em;
+  visibility: hidden;
+  max-width: 0.01px;
+  -webkit-transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  white-space: nowrap;
+}
+
+.emotion-14>span {
+  padding-left: 5px;
+  padding-right: 5px;
+  display: inline-block;
+  opacity: 0;
+  visibility: visible;
 }
 
 .emotion-17 {
@@ -2283,6 +2396,56 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
 
 .emotion-18.Mui-error {
   color: #d32f2f;
+}
+
+.emotion-19 {
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  color: rgba(0, 0, 0, 0.87);
+  box-sizing: border-box;
+  position: relative;
+  cursor: text;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border-radius: 4px;
+}
+
+.emotion-19.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+  cursor: default;
+}
+
+.emotion-19:hover .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.87);
+}
+
+@media (hover: none) {
+  .emotion-19:hover .MuiOutlinedInput-notchedOutline {
+    border-color: rgba(0, 0, 0, 0.23);
+  }
+}
+
+.emotion-19.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-color: #1976d2;
+  border-width: 2px;
+}
+
+.emotion-19.Mui-error .MuiOutlinedInput-notchedOutline {
+  border-color: #d32f2f;
+}
+
+.emotion-19.Mui-disabled .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.26);
 }
 
 .emotion-22 {
@@ -2697,20 +2860,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
             >
               <div
-                className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-9"
               >
                 <label
                   className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined emotion-10"
                   data-shrink={false}
+                  htmlFor="root_foo-key"
+                  id="root_foo-key-label"
                 >
                   foo Key
                 </label>
                 <div
-                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-11"
+                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl emotion-11"
                   onClick={[Function]}
                 >
                   <input
                     aria-invalid={false}
+                    autoFocus={false}
                     className="MuiInputBase-input MuiOutlinedInput-input emotion-12"
                     defaultValue="foo"
                     disabled={false}
@@ -2730,10 +2896,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
                     <legend
                       className="emotion-14"
                     >
-                      <span
-                        className="notranslate"
-                      >
-                        ​
+                      <span>
+                        foo Key
                       </span>
                     </legend>
                   </fieldset>
@@ -2759,7 +2923,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
                     foo
                   </label>
                   <div
-                    className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-11"
+                    className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
                     onClick={[Function]}
                   >
                     <input
@@ -3165,6 +3329,23 @@ exports[`object fields with title and description from both additionalProperties
   }
 }
 
+.emotion-9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
 .emotion-10 {
   color: rgba(0, 0, 0, 0.6);
   font-family: "Roboto","Helvetica","Arial",sans-serif;
@@ -3223,6 +3404,7 @@ exports[`object fields with title and description from both additionalProperties
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  width: 100%;
   position: relative;
   border-radius: 4px;
 }
@@ -3386,10 +3568,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   float: unset;
   width: auto;
   overflow: hidden;
+  display: block;
   padding: 0;
-  line-height: 11px;
-  -webkit-transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
-  transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  height: 11px;
+  font-size: 0.75em;
+  visibility: hidden;
+  max-width: 0.01px;
+  -webkit-transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  white-space: nowrap;
+}
+
+.emotion-14>span {
+  padding-left: 5px;
+  padding-right: 5px;
+  display: inline-block;
+  opacity: 0;
+  visibility: visible;
 }
 
 .emotion-17 {
@@ -3450,6 +3645,56 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
 
 .emotion-18.Mui-error {
   color: #d32f2f;
+}
+
+.emotion-19 {
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  color: rgba(0, 0, 0, 0.87);
+  box-sizing: border-box;
+  position: relative;
+  cursor: text;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border-radius: 4px;
+}
+
+.emotion-19.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+  cursor: default;
+}
+
+.emotion-19:hover .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.87);
+}
+
+@media (hover: none) {
+  .emotion-19:hover .MuiOutlinedInput-notchedOutline {
+    border-color: rgba(0, 0, 0, 0.23);
+  }
+}
+
+.emotion-19.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-color: #1976d2;
+  border-width: 2px;
+}
+
+.emotion-19.Mui-error .MuiOutlinedInput-notchedOutline {
+  border-color: #d32f2f;
+}
+
+.emotion-19.Mui-disabled .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.26);
 }
 
 .emotion-22 {
@@ -3864,20 +4109,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
             >
               <div
-                className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-9"
               >
                 <label
                   className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined emotion-10"
                   data-shrink={false}
+                  htmlFor="root_foo-key"
+                  id="root_foo-key-label"
                 >
                   foo Key
                 </label>
                 <div
-                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-11"
+                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl emotion-11"
                   onClick={[Function]}
                 >
                   <input
                     aria-invalid={false}
+                    autoFocus={false}
                     className="MuiInputBase-input MuiOutlinedInput-input emotion-12"
                     defaultValue="foo"
                     disabled={false}
@@ -3897,10 +4145,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
                     <legend
                       className="emotion-14"
                     >
-                      <span
-                        className="notranslate"
-                      >
-                        ​
+                      <span>
+                        foo Key
                       </span>
                     </legend>
                   </fieldset>
@@ -3926,7 +4172,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
                     foo
                   </label>
                   <div
-                    className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-11"
+                    className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
                     onClick={[Function]}
                   >
                     <input
@@ -5051,6 +5297,23 @@ exports[`object fields with title and description from uiSchema additionalProper
   }
 }
 
+.emotion-9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
 .emotion-10 {
   color: rgba(0, 0, 0, 0.6);
   font-family: "Roboto","Helvetica","Arial",sans-serif;
@@ -5109,6 +5372,7 @@ exports[`object fields with title and description from uiSchema additionalProper
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  width: 100%;
   position: relative;
   border-radius: 4px;
 }
@@ -5272,10 +5536,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   float: unset;
   width: auto;
   overflow: hidden;
+  display: block;
   padding: 0;
-  line-height: 11px;
-  -webkit-transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
-  transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  height: 11px;
+  font-size: 0.75em;
+  visibility: hidden;
+  max-width: 0.01px;
+  -webkit-transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  white-space: nowrap;
+}
+
+.emotion-14>span {
+  padding-left: 5px;
+  padding-right: 5px;
+  display: inline-block;
+  opacity: 0;
+  visibility: visible;
 }
 
 .emotion-17 {
@@ -5336,6 +5613,56 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
 
 .emotion-18.Mui-error {
   color: #d32f2f;
+}
+
+.emotion-19 {
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  color: rgba(0, 0, 0, 0.87);
+  box-sizing: border-box;
+  position: relative;
+  cursor: text;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border-radius: 4px;
+}
+
+.emotion-19.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+  cursor: default;
+}
+
+.emotion-19:hover .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.87);
+}
+
+@media (hover: none) {
+  .emotion-19:hover .MuiOutlinedInput-notchedOutline {
+    border-color: rgba(0, 0, 0, 0.23);
+  }
+}
+
+.emotion-19.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-color: #1976d2;
+  border-width: 2px;
+}
+
+.emotion-19.Mui-error .MuiOutlinedInput-notchedOutline {
+  border-color: #d32f2f;
+}
+
+.emotion-19.Mui-disabled .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.26);
 }
 
 .emotion-22 {
@@ -5750,20 +6077,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
             >
               <div
-                className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-9"
               >
                 <label
                   className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined emotion-10"
                   data-shrink={false}
+                  htmlFor="root_foo-key"
+                  id="root_foo-key-label"
                 >
                   foo Key
                 </label>
                 <div
-                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-11"
+                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl emotion-11"
                   onClick={[Function]}
                 >
                   <input
                     aria-invalid={false}
+                    autoFocus={false}
                     className="MuiInputBase-input MuiOutlinedInput-input emotion-12"
                     defaultValue="foo"
                     disabled={false}
@@ -5783,10 +6113,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
                     <legend
                       className="emotion-14"
                     >
-                      <span
-                        className="notranslate"
-                      >
-                        ​
+                      <span>
+                        foo Key
                       </span>
                     </legend>
                   </fieldset>
@@ -5812,7 +6140,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
                     foo
                   </label>
                   <div
-                    className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-11"
+                    className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-19"
                     onClick={[Function]}
                   >
                     <input
@@ -7622,6 +7950,23 @@ exports[`object fields with title and description with global label off addition
   }
 }
 
+.emotion-5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
 .emotion-6 {
   color: rgba(0, 0, 0, 0.6);
   font-family: "Roboto","Helvetica","Arial",sans-serif;
@@ -7680,6 +8025,7 @@ exports[`object fields with title and description with global label off addition
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  width: 100%;
   position: relative;
   border-radius: 4px;
 }
@@ -7843,10 +8189,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
   float: unset;
   width: auto;
   overflow: hidden;
+  display: block;
   padding: 0;
-  line-height: 11px;
-  -webkit-transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
-  transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  height: 11px;
+  font-size: 0.75em;
+  visibility: hidden;
+  max-width: 0.01px;
+  -webkit-transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  white-space: nowrap;
+}
+
+.emotion-10>span {
+  padding-left: 5px;
+  padding-right: 5px;
+  display: inline-block;
+  opacity: 0;
+  visibility: visible;
 }
 
 .emotion-13 {
@@ -7907,6 +8266,56 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
 
 .emotion-14.Mui-error {
   color: #d32f2f;
+}
+
+.emotion-15 {
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  color: rgba(0, 0, 0, 0.87);
+  box-sizing: border-box;
+  position: relative;
+  cursor: text;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border-radius: 4px;
+}
+
+.emotion-15.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+  cursor: default;
+}
+
+.emotion-15:hover .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.87);
+}
+
+@media (hover: none) {
+  .emotion-15:hover .MuiOutlinedInput-notchedOutline {
+    border-color: rgba(0, 0, 0, 0.23);
+  }
+}
+
+.emotion-15.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-color: #1976d2;
+  border-width: 2px;
+}
+
+.emotion-15.Mui-error .MuiOutlinedInput-notchedOutline {
+  border-color: #d32f2f;
+}
+
+.emotion-15.Mui-disabled .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.26);
 }
 
 .emotion-18 {
@@ -8298,20 +8707,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
             >
               <div
-                className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-5"
               >
                 <label
                   className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined emotion-6"
                   data-shrink={false}
+                  htmlFor="root_foo-key"
+                  id="root_foo-key-label"
                 >
                   foo Key
                 </label>
                 <div
-                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-7"
+                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl emotion-7"
                   onClick={[Function]}
                 >
                   <input
                     aria-invalid={false}
+                    autoFocus={false}
                     className="MuiInputBase-input MuiOutlinedInput-input emotion-8"
                     defaultValue="foo"
                     disabled={false}
@@ -8331,10 +8743,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
                     <legend
                       className="emotion-10"
                     >
-                      <span
-                        className="notranslate"
-                      >
-                        ​
+                      <span>
+                        foo Key
                       </span>
                     </legend>
                   </fieldset>
@@ -8357,7 +8767,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
                     htmlFor="root_foo"
                   />
                   <div
-                    className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-7"
+                    className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-15"
                     onClick={[Function]}
                   >
                     <input

--- a/packages/playground/src/components/Playground.tsx
+++ b/packages/playground/src/components/Playground.tsx
@@ -5,6 +5,7 @@ import {
   ArrayFieldTemplateProps,
   ObjectFieldTemplateProps,
   RJSFSchema,
+  TemplatesType,
   UiSchema,
   ValidatorType,
 } from '@rjsf/utils';
@@ -123,6 +124,14 @@ export default function Playground({ themes, validators }: PlaygroundProps) {
     window.alert('Form submitted');
   }, []);
 
+  const templates: Partial<TemplatesType> = {};
+  if (ArrayFieldTemplate) {
+    templates.ArrayFieldTemplate = ArrayFieldTemplate;
+  }
+  if (ObjectFieldTemplate) {
+    templates.ObjectFieldTemplate = ObjectFieldTemplate;
+  }
+
   return (
     <>
       <Header
@@ -183,7 +192,7 @@ export default function Playground({ themes, validators }: PlaygroundProps) {
             >
               <FormComponent
                 {...liveSettings}
-                templates={{ ArrayFieldTemplate, ObjectFieldTemplate }}
+                templates={templates}
                 extraErrors={extraErrors}
                 schema={schema}
                 uiSchema={uiSchema}


### PR DESCRIPTION
### Reasons for making this change

Fixes #3576 and #3579 by only passing `templates` with non-`undefined` values
Fixes #3578 by using `TextField` to render the label key input value

- Updated `@rjsf/material-ui` and `@rjsf/mui` to use the `TextField` as the input for the label key value rather than attempting to cobble one togther
  - Updated the snapshots accordingly
- Updated the `Playground` component to only pass `templates` with values that aren't undefined to the main `Form`
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
