### PR TITLE
feature: Refactored common utility functions from validators into utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,31 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.6.0
+
+## @rjsf/core
+
+- Switched `Form` to use the new `validatorDataMerge()` function instead of the new deprecated `schemaUtils.mergeValidatorData()`
+
+## @rjsf/utils
+
+- Refactored the `createErrorHandler()`, `toErrorList()`, `toErrorSchema()` and `unwrapErrorHandler()` functions from the `@rjsf/validator-ajv6` and `@rjsf/validator-ajv8` implementations since they were identical
+  - As a result, the `mergeValidationData()` function was deprecated in favor of the new `validationDataMerge()` function that uses the refactored `toErrorList()` function
+  - Refactored the `ROOT_SCHEMA_PREFIX` constant as well
+- Updated `ValidatorType` and `SchemaUtilsType` to deprecate the `toErrorList()` and `mergeValidationData()` functions, respectively
+
+## @rjsf/validator-ajv6
+
+- Removed the refactored functions and constant from the `AJV6Validator` in favor of using the new functions and constant from `@rjsf/utils`
+
+## @rjsf/validator-ajv8
+
+- Removed the refactored functions and constant from the `AJV8Validator` in favor of using the new functions and constant from `@rjsf/utils`
+
+## Dev / docs / playground
+
+- Updated the `utility-functions` documentation to describe the new refactored functions as well as deprecating the `mergeValidationData()` function
+
 # 5.5.2
 
 ## @rjsf/material-ui

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -23,13 +23,14 @@ import {
   RJSF_ADDITONAL_PROPERTIES_FLAG,
   SchemaUtilsType,
   shouldRender,
+  SUBMIT_BTN_OPTIONS_KEY,
   TemplatesType,
   UiSchema,
   UI_GLOBAL_OPTIONS_KEY,
-  ValidationData,
-  ValidatorType,
-  SUBMIT_BTN_OPTIONS_KEY,
   UI_OPTIONS_KEY,
+  ValidationData,
+  validationDataMerge,
+  ValidatorType,
 } from '@rjsf/utils';
 import _get from 'lodash/get';
 import _isEmpty from 'lodash/isEmpty';
@@ -341,7 +342,7 @@ export default class Form<
       errorSchema = currentErrors.errorSchema;
     }
     if (props.extraErrors) {
-      const merged = schemaUtils.mergeValidationData({ errorSchema, errors }, props.extraErrors);
+      const merged = validationDataMerge({ errorSchema, errors }, props.extraErrors);
       errorSchema = merged.errorSchema;
       errors = merged.errors;
     }
@@ -514,7 +515,7 @@ export default class Form<
       const schemaValidationErrors = errors;
       const schemaValidationErrorSchema = errorSchema;
       if (extraErrors) {
-        const merged = schemaUtils.mergeValidationData(schemaValidation, extraErrors);
+        const merged = validationDataMerge(schemaValidation, extraErrors);
         errorSchema = merged.errorSchema;
         errors = merged.errors;
       }
@@ -712,7 +713,6 @@ export default class Form<
   validateForm() {
     const { extraErrors, focusOnFirstError, onError } = this.props;
     const { formData } = this.state;
-    const { schemaUtils } = this.state;
     const schemaValidation = this.validate(formData);
     let errors = schemaValidation.errors;
     let errorSchema = schemaValidation.errorSchema;
@@ -720,7 +720,7 @@ export default class Form<
     const schemaValidationErrorSchema = errorSchema;
     if (errors.length > 0) {
       if (extraErrors) {
-        const merged = schemaUtils.mergeValidationData(schemaValidation, extraErrors);
+        const merged = validationDataMerge(schemaValidation, extraErrors);
         errorSchema = merged.errorSchema;
         errors = merged.errors;
       }

--- a/packages/docs/docs/api-reference/utility-functions.md
+++ b/packages/docs/docs/api-reference/utility-functions.md
@@ -11,20 +11,20 @@ There is also a helper [function](#schema-utils-creation-function) used to creat
 The `@rjsf/utils` package exports a set of constants that represent all the keys into various elements of a RJSFSchema or UiSchema that are used by the various utility functions.
 In addition to those keys, there is the special `ADDITIONAL_PROPERTY_FLAG` flag that is added to a schema under certain conditions by the `retrieveSchema()` utility.
 
-These constants can be found on Github [here](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/utils/src/constants.ts).
+These constants can be found on GitHub [here](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/utils/src/constants.ts).
 
 ## Types
 
 Additionally, the Typescript types used by the utility functions represent nearly all the types used by RJSF.
 Those types are exported for use by `@rjsf/core` and all the themes, as well as any customizations you may build.
 
-These types can be found on Github [here](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/utils/src/types.ts).
+These types can be found on GitHub [here](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/utils/src/types.ts).
 
 ## Enums
 
 There are enumerations in `@rjsf/utils` that are exported for use by `@rjsf/core` and all the themes, as well as any customizations you may build.
 
-These enums can be found on Github [here](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/utils/src/enums.ts).
+These enums can be found on GitHub [here](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/utils/src/enums.ts).
 
 ## Non-Validator utility functions
 
@@ -84,6 +84,18 @@ The UI for the field can expand if it has additional properties, is not forced a
 #### Returns
 
 - boolean: True if the schema element has additionalProperties, is expandable, and not at the maxProperties limit
+
+### createErrorHandler<T = any>()
+
+Given a `formData` object, recursively creates a `FormValidation` error handling structure around it
+
+#### Parameters
+
+- formData: T - The form data around which the error handler is created
+
+#### Returns
+
+- FormValidation&lt;T>: A `FormValidation` object based on the `formData` structure
 
 ### dataURItoBlob()
 
@@ -700,6 +712,59 @@ If `time` is false, then the time portion of the string is removed.
 
 - string: The UTC date string
 
+### toErrorList<T = any>()
+
+Converts an `errorSchema` into a list of `RJSFValidationErrors`
+
+#### Parameters
+
+- errorSchema: ErrorSchema&lt;T> - The `ErrorSchema` instance to convert
+- [fieldPath=[]]: string[] | undefined - The current field path, defaults to [] if not specified
+
+#### Returns
+
+- RJSFValidationErrors[]: The list of `RJSFValidationErrors` extracted from the `errorSchema`
+
+### toErrorSchema<T = any>()
+
+Transforms a RJSF validation errors list into an `ErrorSchema`
+
+```ts
+const changesThis = [
+  { property: '.level1.level2[2].level3', message: 'err a' },
+  { property: '.level1.level2[2].level3', message: 'err b' },
+  { property: '.level1.level2[4].level3', message: 'err b' },
+];
+const intoThis = {
+  level1: {
+    level2: {
+      2: { level3: { errors: ['err a', 'err b'] } },
+      4: { level3: { errors: ['err b'] } },
+    },
+  },
+};
+```
+
+#### Parameters
+
+- errors: RJSFValidationError[] - The list of RJSFValidationError objects
+
+#### Returns
+
+- ErrorSchema&lt;T>: The `ErrorSchema` built from the list of `RJSFValidationErrors`
+
+#### unwrapErrorHandler<T = any>()
+
+Unwraps the `errorHandler` structure into the associated `ErrorSchema`, stripping the `addError()` functions from it
+
+#### Parameters
+
+- errorHandler: FormValidation&lt;T> - The `FormValidation` error handling structure
+
+#### Returns
+
+- ErrorSchema&lt;T>: The `ErrorSchema` resulting from the stripping of the `addError()` function
+
 ### utcToLocal()
 
 Converts a UTC date string into a local Date format
@@ -711,6 +776,33 @@ Converts a UTC date string into a local Date format
 #### Returns
 
 - string: An empty string when `jsonDate` is falsey, otherwise a date string in local format
+
+### validationDataMerge<T = any>()
+
+Merges the errors in `additionalErrorSchema` into the existing `validationData` by combining the hierarchies in the two `ErrorSchema`s and then appending the error list from the `additionalErrorSchema` obtained by calling `toErrorList()` on the `errors` in the `validationData`.
+If no `additionalErrorSchema` is passed, then `validationData` is returned.
+
+#### Parameters
+
+- validationData: ValidationData&lt;T> - The current `ValidationData` into which to merge the additional errors
+- [additionalErrorSchema]: ErrorSchema&lt;T> | undefined - The optional additional set of errors in an `ErrorSchema`
+
+#### Returns
+
+- ValidationData&lt;T>: The `validationData` with the additional errors from `additionalErrorSchema` merged into it, if provided.
+
+### withIdRefPrefix&lt;S extends StrictRJSFSchema = RJSFSchema>()
+
+Recursively prefixes all `$ref`s in a schema with the value of the `ROOT_SCHEMA_PREFIX` constant.
+This is used in isValid to make references to the rootSchema
+
+#### Parameters
+
+- schemaNode: S - The object node to which a `ROOT_SCHEMA_PREFIX` is added when a `$ref` is part of it
+
+#### Returns
+
+- S: A copy of the `schemaNode` with updated `$ref`s
 
 ## Validator-based utility functions
 
@@ -844,6 +936,9 @@ Checks to see if the `schema` combination represents a select
 
 Merges the errors in `additionalErrorSchema` into the existing `validationData` by combining the hierarchies in the two `ErrorSchema`s and then appending the error list from the `additionalErrorSchema` obtained by calling `validator.toErrorList()` onto the `errors` in the `validationData`.
 If no `additionalErrorSchema` is passed, then `validationData` is returned.
+
+> NOTE: This is function is deprecated. Use the `validationDataMerge()` function exported from `@rjsf/utils` instead. This function will be
+> removed in the next major release.
 
 #### Parameters
 

--- a/packages/docs/docs/migration-guides/v5.x upgrade guide.md
+++ b/packages/docs/docs/migration-guides/v5.x upgrade guide.md
@@ -74,7 +74,7 @@ Some of the most notable changes are:
 - **BREAKING CHANGE** The `DescriptionField` and `TitleField` props were removed from the `ArrayFieldTemplateProps` and `ObjectFieldTemplateProps` as they can now be derived from the `templates` or `uiSchema` via the new `getTemplate()` utility function.
 - **BREAKING CHANGE** The `fields` prop was removed from the `FieldTemplateProps` as you can simply use `registry.fields` instead.
 - **BREAKING CHANGE** The `showErrorList` prop was changed to accept `false`, `"top"` or `"bottom"`. `true` is no longer a valid value. The default value is `"top"`, which has identical behavior to the default value/`true` in v4.
-  You can view all these [types](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/utils/src/types.ts) on Github.
+  You can view all these [types](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/utils/src/types.ts) on GitHub.
 
 #### Form props
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,7 +18,8 @@
     "cs-format": "prettier \"{src,test}/**/*.ts?(x)\" --write",
     "lint": "eslint src test",
     "precommit": "lint-staged",
-    "test": "dts test"
+    "test": "dts test",
+    "test:debug": "node --inspect-brk node_modules/.bin/dts test"
   },
   "lint-staged": {
     "{src,test}/**/*.ts?(x)": [

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -22,6 +22,7 @@ export const REQUIRED_KEY = 'required';
 export const SUBMIT_BTN_OPTIONS_KEY = 'submitButtonOptions';
 export const REF_KEY = '$ref';
 export const RJSF_ADDITONAL_PROPERTIES_FLAG = '__rjsf_additionalProperties';
+export const ROOT_SCHEMA_PREFIX = '__rjsf_rootSchema';
 export const UI_FIELD_KEY = 'ui:field';
 export const UI_WIDGET_KEY = 'ui:widget';
 export const UI_OPTIONS_KEY = 'ui:options';

--- a/packages/utils/src/createErrorHandler.ts
+++ b/packages/utils/src/createErrorHandler.ts
@@ -1,0 +1,33 @@
+import isPlainObject from 'lodash/isPlainObject';
+
+import { ERRORS_KEY } from './constants';
+import { FieldValidation, FormValidation, GenericObjectType } from './types';
+
+/** Given a `formData` object, recursively creates a `FormValidation` error handling structure around it
+ *
+ * @param formData - The form data around which the error handler is created
+ * @returns - A `FormValidation` object based on the `formData` structure
+ */
+export default function createErrorHandler<T = any>(formData: T): FormValidation<T> {
+  const handler: FieldValidation = {
+    // We store the list of errors for this node in a property named __errors
+    // to avoid name collision with a possible sub schema field named
+    // 'errors' (see `utils.toErrorSchema`).
+    [ERRORS_KEY]: [],
+    addError(message: string) {
+      this[ERRORS_KEY]!.push(message);
+    },
+  };
+  if (Array.isArray(formData)) {
+    return formData.reduce((acc, value, key) => {
+      return { ...acc, [key]: createErrorHandler(value) };
+    }, handler);
+  }
+  if (isPlainObject(formData)) {
+    const formObject: GenericObjectType = formData as GenericObjectType;
+    return Object.keys(formObject).reduce((acc, key) => {
+      return { ...acc, [key]: createErrorHandler(formObject[key]) };
+    }, handler as FormValidation<T>);
+  }
+  return handler as FormValidation<T>;
+}

--- a/packages/utils/src/createSchemaUtils.ts
+++ b/packages/utils/src/createSchemaUtils.ts
@@ -176,6 +176,8 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
    * @param validationData - The current `ValidationData` into which to merge the additional errors
    * @param [additionalErrorSchema] - The additional set of errors
    * @returns - The `validationData` with the additional errors from `additionalErrorSchema` merged into it, if provided.
+   * @deprecated - Use the `validationDataMerge()` function exported from `@rjsf/utils` instead. This function will be
+   *        removed in the next major release.
    */
   mergeValidationData(validationData: ValidationData<T>, additionalErrorSchema?: ErrorSchema<T>): ValidationData<T> {
     return mergeValidationData<T, S, F>(this.validator, validationData, additionalErrorSchema);

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,6 +1,7 @@
 import allowAdditionalItems from './allowAdditionalItems';
 import asNumber from './asNumber';
 import canExpand from './canExpand';
+import createErrorHandler from './createErrorHandler';
 import createSchemaUtils from './createSchemaUtils';
 import dataURItoBlob from './dataURItoBlob';
 import deepEquals from './deepEquals';
@@ -40,7 +41,12 @@ import schemaRequiresTrueValue from './schemaRequiresTrueValue';
 import shouldRender from './shouldRender';
 import toConstant from './toConstant';
 import toDateString from './toDateString';
+import toErrorList from './toErrorList';
+import toErrorSchema from './toErrorSchema';
+import unwrapErrorHandler from './unwrapErrorHandler';
 import utcToLocal from './utcToLocal';
+import validationDataMerge from './validationDataMerge';
+import withIdRefPrefix from './withIdRefPrefix';
 
 export * from './types';
 export * from './enums';
@@ -53,6 +59,7 @@ export {
   ariaDescribedByIds,
   asNumber,
   canExpand,
+  createErrorHandler,
   createSchemaUtils,
   dataURItoBlob,
   deepEquals,
@@ -97,5 +104,10 @@ export {
   titleId,
   toConstant,
   toDateString,
+  toErrorList,
+  toErrorSchema,
+  unwrapErrorHandler,
   utcToLocal,
+  validationDataMerge,
+  withIdRefPrefix,
 };

--- a/packages/utils/src/toErrorList.ts
+++ b/packages/utils/src/toErrorList.ts
@@ -1,0 +1,41 @@
+import isPlainObject from 'lodash/isPlainObject';
+
+import { ERRORS_KEY } from './constants';
+import { ErrorSchema, GenericObjectType, RJSFValidationError } from './types';
+
+/** Converts an `errorSchema` into a list of `RJSFValidationErrors`
+ *
+ * @param errorSchema - The `ErrorSchema` instance to convert
+ * @param [fieldPath=[]] - The current field path, defaults to [] if not specified
+ * @returns - The list of `RJSFValidationErrors` extracted from the `errorSchema`
+ */
+export default function toErrorList<T = any>(
+  errorSchema?: ErrorSchema<T>,
+  fieldPath: string[] = []
+): RJSFValidationError[] {
+  if (!errorSchema) {
+    return [];
+  }
+  let errorList: RJSFValidationError[] = [];
+  if (ERRORS_KEY in errorSchema) {
+    errorList = errorList.concat(
+      errorSchema[ERRORS_KEY]!.map((message: string) => {
+        const property = `.${fieldPath.join('.')}`;
+        return {
+          property,
+          message,
+          stack: `${property} ${message}`,
+        };
+      })
+    );
+  }
+  return Object.keys(errorSchema).reduce((acc, key) => {
+    if (key !== ERRORS_KEY) {
+      const childSchema = (errorSchema as GenericObjectType)[key];
+      if (isPlainObject(childSchema)) {
+        acc = acc.concat(toErrorList(childSchema, [...fieldPath, key]));
+      }
+    }
+    return acc;
+  }, errorList);
+}

--- a/packages/utils/src/toErrorSchema.ts
+++ b/packages/utils/src/toErrorSchema.ts
@@ -1,0 +1,43 @@
+import toPath from 'lodash/toPath';
+
+import { ErrorSchema, RJSFValidationError } from './types';
+import ErrorSchemaBuilder from './ErrorSchemaBuilder';
+
+/** Transforms a rjsf validation errors list:
+ * [
+ *   {property: '.level1.level2[2].level3', message: 'err a'},
+ *   {property: '.level1.level2[2].level3', message: 'err b'},
+ *   {property: '.level1.level2[4].level3', message: 'err b'},
+ * ]
+ * Into an error tree:
+ * {
+ *   level1: {
+ *     level2: {
+ *       2: {level3: {errors: ['err a', 'err b']}},
+ *       4: {level3: {errors: ['err b']}},
+ *     }
+ *   }
+ * };
+ *
+ * @param errors - The list of RJSFValidationError objects
+ * @returns - The `ErrorSchema` built from the list of `RJSFValidationErrors`
+ */
+export default function toErrorSchema<T = any>(errors: RJSFValidationError[]): ErrorSchema<T> {
+  const builder = new ErrorSchemaBuilder<T>();
+  if (errors.length) {
+    errors.forEach((error) => {
+      const { property, message } = error;
+      // When the property is the root element, just use an empty array for the path
+      const path = property === '.' ? [] : toPath(property);
+      // If the property is at the root (.level1) then toPath creates
+      // an empty array element at the first index. Remove it.
+      if (path.length > 0 && path[0] === '') {
+        path.splice(0, 1);
+      }
+      if (message) {
+        builder.addErrors(message, path);
+      }
+    });
+  }
+  return builder.ErrorSchema;
+}

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -917,6 +917,8 @@ export interface ValidatorType<T = any, S extends StrictRJSFSchema = RJSFSchema,
    *
    * @param errorSchema - The `ErrorSchema` instance to convert
    * @param [fieldPath=[]] - The current field path, defaults to [] if not specified
+   * @deprecated - Use the `toErrorList()` function provided by `@rjsf/utils` instead. This function will be removed in
+   *        the next major release.
    */
   toErrorList(errorSchema?: ErrorSchema<T>, fieldPath?: string[]): RJSFValidationError[];
   /** Validates data against a schema, returning true if the data is valid, or
@@ -1046,6 +1048,8 @@ export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchem
    * @param schema - The schema for which retrieving a schema is desired
    * @param [formData] - The current formData, if any, to assist retrieving a schema
    * @returns - The schema having its conditions, additional properties, references and dependencies resolved
+   * @deprecated - Use the `validationDataMerge()` function exported from `@rjsf/utils` instead. This function will be
+   *        removed in the next major release.
    */
   retrieveSchema(schema: S, formData?: T): S;
   /** Sanitize the `data` associated with the `oldSchema` so it is considered appropriate for the `newSchema`. If the

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1031,14 +1031,16 @@ export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchem
    * @returns - True if schema contains a select, otherwise false
    */
   isSelect(schema: S): boolean;
-  /** Merges the errors in `additionalErrorSchema` into the existing `validationData` by combining the hierarchies in the
-   * two `ErrorSchema`s and then appending the error list from the `additionalErrorSchema` obtained by calling
+  /** Merges the errors in `additionalErrorSchema` into the existing `validationData` by combining the hierarchies in
+   * the two `ErrorSchema`s and then appending the error list from the `additionalErrorSchema` obtained by calling
    * `validator.toErrorList()` onto the `errors` in the `validationData`. If no `additionalErrorSchema` is passed, then
    * `validationData` is returned.
    *
    * @param validationData - The current `ValidationData` into which to merge the additional errors
    * @param [additionalErrorSchema] - The additional set of errors
-   * @returns - The `validationData` with the additional errors from `additionalErrorSchema` merged into it, if provided.
+   * @returns - The `validationData` with the additional errors from `additionalErrorSchema` merged into it, if provided
+   * @deprecated - Use the `validationDataMerge()` function exported from `@rjsf/utils` instead. This function will be
+   *        removed in the next major release.
    */
   mergeValidationData(validationData: ValidationData<T>, additionalErrorSchema?: ErrorSchema<T>): ValidationData<T>;
   /** Retrieves an expanded schema that has had all of its conditions, additional properties, references and
@@ -1048,8 +1050,6 @@ export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchem
    * @param schema - The schema for which retrieving a schema is desired
    * @param [formData] - The current formData, if any, to assist retrieving a schema
    * @returns - The schema having its conditions, additional properties, references and dependencies resolved
-   * @deprecated - Use the `validationDataMerge()` function exported from `@rjsf/utils` instead. This function will be
-   *        removed in the next major release.
    */
   retrieveSchema(schema: S, formData?: T): S;
   /** Sanitize the `data` associated with the `oldSchema` so it is considered appropriate for the `newSchema`. If the

--- a/packages/utils/src/unwrapErrorHandler.ts
+++ b/packages/utils/src/unwrapErrorHandler.ts
@@ -1,0 +1,25 @@
+import isPlainObject from 'lodash/isPlainObject';
+
+import { ErrorSchema, FormValidation, GenericObjectType } from './types';
+
+/** Unwraps the `errorHandler` structure into the associated `ErrorSchema`, stripping the `addError()` functions from it
+ *
+ * @param errorHandler - The `FormValidation` error handling structure
+ * @returns - The `ErrorSchema` resulting from the stripping of the `addError()` function
+ */
+export default function unwrapErrorHandler<T = any>(errorHandler: FormValidation<T>): ErrorSchema<T> {
+  return Object.keys(errorHandler).reduce((acc, key) => {
+    if (key === 'addError') {
+      return acc;
+    } else {
+      const childSchema = (errorHandler as GenericObjectType)[key];
+      if (isPlainObject(childSchema)) {
+        return {
+          ...acc,
+          [key]: unwrapErrorHandler(childSchema),
+        };
+      }
+      return { ...acc, [key]: childSchema };
+    }
+  }, {} as ErrorSchema<T>);
+}

--- a/packages/utils/src/validationDataMerge.ts
+++ b/packages/utils/src/validationDataMerge.ts
@@ -1,26 +1,19 @@
 import isEmpty from 'lodash/isEmpty';
 
-import mergeObjects from '../mergeObjects';
-import { ErrorSchema, FormContextType, RJSFSchema, StrictRJSFSchema, ValidationData, ValidatorType } from '../types';
+import mergeObjects from './mergeObjects';
+import toErrorList from './toErrorList';
+import { ErrorSchema, ValidationData } from './types';
 
 /** Merges the errors in `additionalErrorSchema` into the existing `validationData` by combining the hierarchies in the
  * two `ErrorSchema`s and then appending the error list from the `additionalErrorSchema` obtained by calling
- * `validator.toErrorList()` onto the `errors` in the `validationData`. If no `additionalErrorSchema` is passed, then
+ * `toErrorList()` on the `errors` in the `validationData`. If no `additionalErrorSchema` is passed, then
  * `validationData` is returned.
  *
- * @param validator - The validator used to convert an ErrorSchema to a list of errors
  * @param validationData - The current `ValidationData` into which to merge the additional errors
- * @param [additionalErrorSchema] - The additional set of errors in an `ErrorSchema`
+ * @param [additionalErrorSchema] - The optional additional set of errors in an `ErrorSchema`
  * @returns - The `validationData` with the additional errors from `additionalErrorSchema` merged into it, if provided.
- * @deprecated - Use the `validationDataMerge()` function exported from `@rjsf/utils` instead. This function will be
- *        removed in the next major release.
  */
-export default function mergeValidationData<
-  T = any,
-  S extends StrictRJSFSchema = RJSFSchema,
-  F extends FormContextType = any
->(
-  validator: ValidatorType<T, S, F>,
+export default function validationDataMerge<T = any>(
   validationData: ValidationData<T>,
   additionalErrorSchema?: ErrorSchema<T>
 ): ValidationData<T> {
@@ -28,7 +21,7 @@ export default function mergeValidationData<
     return validationData;
   }
   const { errors: oldErrors, errorSchema: oldErrorSchema } = validationData;
-  let errors = validator.toErrorList(additionalErrorSchema);
+  let errors = toErrorList(additionalErrorSchema);
   let errorSchema = additionalErrorSchema;
   if (!isEmpty(oldErrorSchema)) {
     errorSchema = mergeObjects(oldErrorSchema, additionalErrorSchema, true) as ErrorSchema<T>;

--- a/packages/utils/src/withIdRefPrefix.ts
+++ b/packages/utils/src/withIdRefPrefix.ts
@@ -1,0 +1,48 @@
+import { REF_KEY, ROOT_SCHEMA_PREFIX } from './constants';
+import { RJSFSchema, StrictRJSFSchema } from './types';
+
+/** Takes a `node` object and transforms any contained `$ref` node variables with a prefix, recursively calling
+ * `withIdRefPrefix` for any other elements.
+ *
+ * @param node - The object node to which a ROOT_SCHEMA_PREFIX is added when a REF_KEY is part of it
+ */
+function withIdRefPrefixObject<S extends StrictRJSFSchema = RJSFSchema>(node: S): S {
+  for (const key in node) {
+    const realObj: { [k: string]: any } = node;
+    const value = realObj[key];
+    if (key === REF_KEY && typeof value === 'string' && value.startsWith('#')) {
+      realObj[key] = ROOT_SCHEMA_PREFIX + value;
+    } else {
+      realObj[key] = withIdRefPrefix<S>(value);
+    }
+  }
+  return node;
+}
+
+/** Takes a `node` object list and transforms any contained `$ref` node variables with a prefix, recursively calling
+ * `withIdRefPrefix` for any other elements.
+ *
+ * @param node - The list of object nodes to which a ROOT_SCHEMA_PREFIX is added when a REF_KEY is part of it
+ */
+function withIdRefPrefixArray<S extends StrictRJSFSchema = RJSFSchema>(node: S[]): S[] {
+  for (let i = 0; i < node.length; i++) {
+    node[i] = withIdRefPrefix<S>(node[i]) as S;
+  }
+  return node;
+}
+
+/** Recursively prefixes all `$ref`s in a schema with the value of the `ROOT_SCHEMA_PREFIX` constant.
+ * This is used in isValid to make references to the rootSchema
+ *
+ * @param schemaNode - The object node to which a ROOT_SCHEMA_PREFIX is added when a REF_KEY is part of it
+ * @returns - A copy of the `schemaNode` with updated `$ref`s
+ */
+export default function withIdRefPrefix<S extends StrictRJSFSchema = RJSFSchema>(schemaNode: S): S | S[] {
+  if (schemaNode.constructor === Object) {
+    return withIdRefPrefixObject<S>({ ...schemaNode });
+  }
+  if (Array.isArray(schemaNode)) {
+    return withIdRefPrefixArray<S>([...schemaNode]);
+  }
+  return schemaNode;
+}

--- a/packages/utils/test/createErrorHandler.test.ts
+++ b/packages/utils/test/createErrorHandler.test.ts
@@ -1,0 +1,37 @@
+import { createErrorHandler, ERRORS_KEY } from '../src';
+import { TEST_FORM_DATA } from './testUtils/testData';
+
+const SOME_ERROR = 'some error';
+
+describe('createErrorHandler()', () => {
+  it('returns a simple handler for simple type', () => {
+    expect(createErrorHandler('foo')).toEqual({
+      [ERRORS_KEY]: [],
+      addError: expect.any(Function),
+    });
+  });
+  it('expect returned FormValidation.addError() adds error to itself', () => {
+    const formValidation = createErrorHandler(5);
+    formValidation.addError(SOME_ERROR);
+    expect(formValidation[ERRORS_KEY]).toEqual([SOME_ERROR]);
+  });
+  it('returns a handler that maps to the form data with objects and arrays', () => {
+    expect(createErrorHandler(TEST_FORM_DATA)).toEqual({
+      [ERRORS_KEY]: [],
+      addError: expect.any(Function),
+      foo: { [ERRORS_KEY]: [], addError: expect.any(Function) },
+      list: {
+        [ERRORS_KEY]: [],
+        addError: expect.any(Function),
+        '0': { [ERRORS_KEY]: [], addError: expect.any(Function) },
+        '1': { [ERRORS_KEY]: [], addError: expect.any(Function) },
+      },
+      nested: {
+        [ERRORS_KEY]: [],
+        addError: expect.any(Function),
+        baz: { [ERRORS_KEY]: [], addError: expect.any(Function) },
+        blah: { [ERRORS_KEY]: [], addError: expect.any(Function) },
+      },
+    });
+  });
+});

--- a/packages/utils/test/testUtils/testData.ts
+++ b/packages/utils/test/testUtils/testData.ts
@@ -1,4 +1,13 @@
-import { EnumOptionsType, ONE_OF_KEY, RJSFSchema } from '../../src';
+import reduce from 'lodash/reduce';
+
+import {
+  EnumOptionsType,
+  ErrorSchema,
+  ErrorSchemaBuilder,
+  ONE_OF_KEY,
+  RJSFSchema,
+  RJSFValidationError,
+} from '../../src';
 
 export const oneOfData = {
   name: 'second_option',
@@ -337,3 +346,40 @@ export const RECURSIVE_REF: RJSFSchema = {
   },
   $ref: '#/definitions/@enum',
 };
+
+export const ERROR_MAPPER = {
+  '': 'root error',
+  foo: 'foo error',
+  list: 'list error',
+  'list.0': 'list 0 error',
+  'list.1': 'list 1 error',
+  nested: 'nested error',
+  'nested.baz': 'baz error',
+  'nested.blah': 'blah error',
+};
+
+export const TEST_FORM_DATA = {
+  foo: 'bar',
+  list: ['a', 'b'],
+  nested: {
+    baz: 1,
+    blah: false,
+  },
+};
+
+export const TEST_ERROR_SCHEMA: ErrorSchema = reduce(
+  ERROR_MAPPER,
+  (builder: ErrorSchemaBuilder, value, key) => {
+    return builder.addErrors(value, key === '' ? undefined : key);
+  },
+  new ErrorSchemaBuilder()
+).ErrorSchema;
+
+export const TEST_ERROR_LIST: RJSFValidationError[] = reduce(
+  ERROR_MAPPER,
+  (list: RJSFValidationError[], value, key) => {
+    list.push({ property: `.${key}`, message: value, stack: `.${key} ${value}` });
+    return list;
+  },
+  []
+);

--- a/packages/utils/test/toErrorList.test.ts
+++ b/packages/utils/test/toErrorList.test.ts
@@ -1,0 +1,11 @@
+import { toErrorList } from '../src';
+import { TEST_ERROR_LIST, TEST_ERROR_SCHEMA } from './testUtils/testData';
+
+describe('toErrorList()', () => {
+  it('returns empty array when nothing is passed', () => {
+    expect(toErrorList()).toEqual([]);
+  });
+  it('', () => {
+    expect(toErrorList(TEST_ERROR_SCHEMA)).toEqual(TEST_ERROR_LIST);
+  });
+});

--- a/packages/utils/test/toErrorList.test.ts
+++ b/packages/utils/test/toErrorList.test.ts
@@ -5,7 +5,7 @@ describe('toErrorList()', () => {
   it('returns empty array when nothing is passed', () => {
     expect(toErrorList()).toEqual([]);
   });
-  it('', () => {
+  it('Returns the expected list of errors when given an ErrorSchema', () => {
     expect(toErrorList(TEST_ERROR_SCHEMA)).toEqual(TEST_ERROR_LIST);
   });
 });

--- a/packages/utils/test/toErrorSchema.test.ts
+++ b/packages/utils/test/toErrorSchema.test.ts
@@ -1,0 +1,11 @@
+import { toErrorSchema } from '../src';
+import { TEST_ERROR_LIST, TEST_ERROR_SCHEMA } from './testUtils/testData';
+
+describe('toErrorSchema()', () => {
+  it('returns an empty error schema when passed an empty list', () => {
+    expect(toErrorSchema([])).toEqual({});
+  });
+  it('returns the expected ErrorSchema when given a list of errors', () => {
+    expect(toErrorSchema(TEST_ERROR_LIST)).toEqual(TEST_ERROR_SCHEMA);
+  });
+});

--- a/packages/utils/test/unwrapErrorHandler.test.ts
+++ b/packages/utils/test/unwrapErrorHandler.test.ts
@@ -1,0 +1,25 @@
+import get from 'lodash/get';
+import reduce from 'lodash/reduce';
+
+import { createErrorHandler, unwrapErrorHandler, ERRORS_KEY, FormValidation } from '../src';
+import { TEST_FORM_DATA, ERROR_MAPPER, TEST_ERROR_SCHEMA } from './testUtils/testData';
+
+const EMPTY_WRAPPER = createErrorHandler(null);
+const POPULATED_WRAPPER: FormValidation = reduce(
+  ERROR_MAPPER,
+  (validation: FormValidation, value, key) => {
+    const propValidation: FormValidation | undefined = key ? get(validation, key) : validation;
+    propValidation?.addError(value);
+    return validation;
+  },
+  createErrorHandler(TEST_FORM_DATA) as FormValidation
+);
+
+describe('unwrapErrorHandler()', () => {
+  it('an empty FormValidation returns an empty ErrorSchema', () => {
+    expect(unwrapErrorHandler(EMPTY_WRAPPER)).toEqual({ [ERRORS_KEY]: [] });
+  });
+  it('A fully loaded FormValidation returns the associated ErrorSchema', () => {
+    expect(unwrapErrorHandler(POPULATED_WRAPPER)).toEqual(TEST_ERROR_SCHEMA);
+  });
+});

--- a/packages/utils/test/validationDataMerge.test.ts
+++ b/packages/utils/test/validationDataMerge.test.ts
@@ -1,0 +1,40 @@
+import { ERRORS_KEY, ErrorSchema, validationDataMerge, ValidationData } from '../src';
+
+describe('mergeValidationDataTest()', () => {
+  it('Returns validationData when no additionalErrorSchema is passed', () => {
+    const validationData: ValidationData<any> = {
+      errorSchema: {},
+      errors: [],
+    };
+    expect(validationDataMerge(validationData)).toBe(validationData);
+  });
+  it('Returns only additionalErrorSchema when additionalErrorSchema is passed and no validationData', () => {
+    const validationData: ValidationData<any> = {
+      errorSchema: {},
+      errors: [],
+    };
+    const errors = ['custom errors'];
+    const customErrors = [{ property: '.', message: errors[0], stack: `. ${errors[0]}` }];
+    const errorSchema: ErrorSchema = { [ERRORS_KEY]: errors } as ErrorSchema;
+    const expected = {
+      errorSchema,
+      errors: customErrors,
+    };
+    expect(validationDataMerge(validationData, errorSchema)).toEqual(expected);
+  });
+  it('Returns merged data when additionalErrorSchema is passed', () => {
+    const oldError = 'ajv error';
+    const validationData: ValidationData<any> = {
+      errorSchema: { [ERRORS_KEY]: [oldError] } as ErrorSchema,
+      errors: [{ stack: oldError, name: 'foo', schemaPath: '.foo' }],
+    };
+    const errors = ['custom errors'];
+    const customErrors = [{ property: '.', message: errors[0], stack: `. ${errors[0]}` }];
+    const errorSchema: ErrorSchema = { [ERRORS_KEY]: errors } as ErrorSchema;
+    const expected = {
+      errorSchema: { [ERRORS_KEY]: [oldError, ...errors] },
+      errors: [...validationData.errors, ...customErrors],
+    };
+    expect(validationDataMerge(validationData, errorSchema)).toEqual(expected);
+  });
+});

--- a/packages/utils/test/withIdRef.test.ts
+++ b/packages/utils/test/withIdRef.test.ts
@@ -1,0 +1,37 @@
+import { withIdRefPrefix, RJSFSchema } from '../src';
+
+describe('withIdRefPrefix()', () => {
+  it('should recursively add id prefix to all refs', () => {
+    const schema: RJSFSchema = {
+      anyOf: [{ $ref: '#/defs/foo' }],
+    };
+    const expected = {
+      anyOf: [{ $ref: '__rjsf_rootSchema#/defs/foo' }],
+    };
+
+    expect(withIdRefPrefix(schema)).toEqual(expected);
+  });
+  it('shouldn`t mutate the schema', () => {
+    const schema: RJSFSchema = {
+      anyOf: [{ $ref: '#/defs/foo' }],
+    };
+
+    withIdRefPrefix(schema);
+
+    expect(schema).toEqual({
+      anyOf: [{ $ref: '#/defs/foo' }],
+    });
+  });
+  it('should not change a property named `$ref`', () => {
+    const schema: RJSFSchema = {
+      title: 'A registration form',
+      description: 'A simple form example.',
+      type: 'object',
+      properties: {
+        $ref: { type: 'string', title: 'First name', default: 'Chuck' },
+      },
+    };
+
+    expect(withIdRefPrefix(schema)).toEqual(schema);
+  });
+});

--- a/packages/validator-ajv6/src/validator.ts
+++ b/packages/validator-ajv6/src/validator.ts
@@ -1,31 +1,27 @@
 import { Ajv, ErrorObject } from 'ajv';
-import toPath from 'lodash/toPath';
 import {
+  createErrorHandler,
   CustomValidator,
   ErrorSchema,
-  ErrorSchemaBuilder,
   ErrorTransformer,
-  FieldValidation,
   FormContextType,
-  FormValidation,
-  GenericObjectType,
+  getDefaultFormState,
   RJSFSchema,
   RJSFValidationError,
+  ROOT_SCHEMA_PREFIX,
   StrictRJSFSchema,
+  toErrorList,
+  toErrorSchema,
   UiSchema,
+  unwrapErrorHandler,
   ValidationData,
+  validationDataMerge,
   ValidatorType,
-  getDefaultFormState,
-  isObject,
-  mergeValidationData,
-  ERRORS_KEY,
-  REF_KEY,
+  withIdRefPrefix,
 } from '@rjsf/utils';
 
 import { CustomValidatorOptionsType } from './types';
 import createAjvInstance from './createAjvInstance';
-
-const ROOT_SCHEMA_PREFIX = '__rjsf_rootSchema';
 
 /** `ValidatorType` implementation that uses the AJV 6 validation mechanism.
  *
@@ -49,121 +45,13 @@ export default class AJV6Validator<T = any, S extends StrictRJSFSchema = RJSFSch
     this.ajv = createAjvInstance(additionalMetaSchemas, customFormats, ajvOptionsOverrides);
   }
 
-  /** Transforms a ajv validation errors list:
-   * [
-   *   {property: '.level1.level2[2].level3', message: 'err a'},
-   *   {property: '.level1.level2[2].level3', message: 'err b'},
-   *   {property: '.level1.level2[4].level3', message: 'err b'},
-   * ]
-   * Into an error tree:
-   * {
-   *   level1: {
-   *     level2: {
-   *       2: {level3: {errors: ['err a', 'err b']}},
-   *       4: {level3: {errors: ['err b']}},
-   *     }
-   *   }
-   * };
-   *
-   * @param errors - The list of RJSFValidationError objects
-   * @private
-   */
-  private toErrorSchema(errors: RJSFValidationError[]): ErrorSchema<T> {
-    const builder = new ErrorSchemaBuilder<T>();
-    if (errors.length) {
-      errors.forEach((error) => {
-        const { property, message } = error;
-        const path = toPath(property);
-
-        // If the property is at the root (.level1) then toPath creates
-        // an empty array element at the first index. Remove it.
-        if (path.length > 0 && path[0] === '') {
-          path.splice(0, 1);
-        }
-        if (message) {
-          builder.addErrors(message, path);
-        }
-      });
-    }
-    return builder.ErrorSchema;
-  }
-
   /** Converts an `errorSchema` into a list of `RJSFValidationErrors`
    *
    * @param errorSchema - The `ErrorSchema` instance to convert
    * @param [fieldPath=[]] - The current field path, defaults to [] if not specified
    */
   toErrorList(errorSchema?: ErrorSchema<T>, fieldPath: string[] = []) {
-    if (!errorSchema) {
-      return [];
-    }
-    let errorList: RJSFValidationError[] = [];
-    if (ERRORS_KEY in errorSchema) {
-      errorList = errorList.concat(
-        errorSchema.__errors!.map((message: string) => {
-          const property = `.${fieldPath.join('.')}`;
-          return {
-            property,
-            message,
-            stack: `${property} ${message}`,
-          };
-        })
-      );
-    }
-    return Object.keys(errorSchema).reduce((acc, key) => {
-      if (key !== ERRORS_KEY) {
-        acc = acc.concat(this.toErrorList((errorSchema as GenericObjectType)[key], [...fieldPath, key]));
-      }
-      return acc;
-    }, errorList);
-  }
-
-  /** Given a `formData` object, recursively creates a `FormValidation` error handling structure around it
-   *
-   * @param formData - The form data around which the error handler is created
-   * @private
-   */
-  private createErrorHandler(formData: T): FormValidation<T> {
-    const handler: FieldValidation = {
-      // We store the list of errors for this node in a property named __errors
-      // to avoid name collision with a possible sub schema field named
-      // 'errors' (see `utils.toErrorSchema`).
-      __errors: [],
-      addError(message: string) {
-        this.__errors!.push(message);
-      },
-    };
-    if (isObject(formData)) {
-      const formObject: GenericObjectType = formData as GenericObjectType;
-      return Object.keys(formObject).reduce((acc, key) => {
-        return { ...acc, [key]: this.createErrorHandler(formObject[key]) };
-      }, handler as FormValidation<T>);
-    }
-    if (Array.isArray(formData)) {
-      return formData.reduce((acc, value, key) => {
-        return { ...acc, [key]: this.createErrorHandler(value) };
-      }, handler);
-    }
-    return handler as FormValidation<T>;
-  }
-
-  /** Unwraps the `errorHandler` structure into the associated `ErrorSchema`, stripping the `addError` functions from it
-   *
-   * @param errorHandler - The `FormValidation` error handling structure
-   * @private
-   */
-  private unwrapErrorHandler(errorHandler: FormValidation<T>): ErrorSchema<T> {
-    return Object.keys(errorHandler).reduce((acc, key) => {
-      if (key === 'addError') {
-        return acc;
-      } else if (key === ERRORS_KEY) {
-        return { ...acc, [key]: (errorHandler as GenericObjectType)[key] };
-      }
-      return {
-        ...acc,
-        [key]: this.unwrapErrorHandler((errorHandler as GenericObjectType)[key]),
-      };
-    }, {} as ErrorSchema<T>);
+    return toErrorList<T>(errorSchema, fieldPath);
   }
 
   /** Transforming the error output from ajv to format used by @rjsf/utils.
@@ -245,7 +133,7 @@ export default class AJV6Validator<T = any, S extends StrictRJSFSchema = RJSFSch
       errors = transformErrors(errors, uiSchema);
     }
 
-    let errorSchema = this.toErrorSchema(errors);
+    let errorSchema = toErrorSchema<T>(errors);
 
     if (noProperMetaSchema) {
       errorSchema = {
@@ -265,41 +153,9 @@ export default class AJV6Validator<T = any, S extends StrictRJSFSchema = RJSFSch
     // Include form data with undefined values, which is required for custom validation.
     const newFormData = getDefaultFormState<T, S, F>(this, schema, formData, rootSchema, true) as T;
 
-    const errorHandler = customValidate(newFormData, this.createErrorHandler(newFormData), uiSchema);
-    const userErrorSchema = this.unwrapErrorHandler(errorHandler);
-    return mergeValidationData<T, S, F>(this, { errors, errorSchema }, userErrorSchema);
-  }
-
-  /** Takes a `node` object and transforms any contained `$ref` node variables with a prefix, recursively calling
-   * `withIdRefPrefix` for any other elements.
-   *
-   * @param node - The object node to which a ROOT_SCHEMA_PREFIX is added when a REF_KEY is part of it
-   * @private
-   */
-  private withIdRefPrefixObject(node: object) {
-    for (const key in node) {
-      const realObj: { [k: string]: any } = node;
-      const value = realObj[key];
-      if (key === REF_KEY && typeof value === 'string' && value.startsWith('#')) {
-        realObj[key] = ROOT_SCHEMA_PREFIX + value;
-      } else {
-        realObj[key] = this.withIdRefPrefix(value);
-      }
-    }
-    return node;
-  }
-
-  /** Takes a `node` object list and transforms any contained `$ref` node variables with a prefix, recursively calling
-   * `withIdRefPrefix` for any other elements.
-   *
-   * @param node - The list of object nodes to which a ROOT_SCHEMA_PREFIX is added when a REF_KEY is part of it
-   * @private
-   */
-  private withIdRefPrefixArray(node: object[]): RJSFSchema {
-    for (let i = 0; i < node.length; i++) {
-      node[i] = this.withIdRefPrefix(node[i]);
-    }
-    return node as RJSFSchema;
+    const errorHandler = customValidate(newFormData, createErrorHandler<T>(newFormData), uiSchema);
+    const userErrorSchema = unwrapErrorHandler<T>(errorHandler);
+    return validationDataMerge<T>({ errors, errorSchema }, userErrorSchema);
   }
 
   /** Validates data against a schema, returning true if the data is valid, or
@@ -316,9 +172,7 @@ export default class AJV6Validator<T = any, S extends StrictRJSFSchema = RJSFSch
       // then rewrite the schema ref's to point to the rootSchema
       // this accounts for the case where schema have references to models
       // that lives in the rootSchema but not in the schema in question.
-      const result = this.ajv
-        .addSchema(rootSchema, ROOT_SCHEMA_PREFIX)
-        .validate(this.withIdRefPrefix(schema), formData);
+      const result = this.ajv.addSchema(rootSchema, ROOT_SCHEMA_PREFIX).validate(withIdRefPrefix(schema), formData);
       return result as boolean;
     } catch (e) {
       return false;
@@ -326,21 +180,5 @@ export default class AJV6Validator<T = any, S extends StrictRJSFSchema = RJSFSch
       // make sure we remove the rootSchema from the global ajv instance
       this.ajv.removeSchema(ROOT_SCHEMA_PREFIX);
     }
-  }
-
-  /** Recursively prefixes all $ref's in a schema with `ROOT_SCHEMA_PREFIX`
-   * This is used in isValid to make references to the rootSchema
-   *
-   * @param schemaNode - The object node to which a ROOT_SCHEMA_PREFIX is added when a REF_KEY is part of it
-   * @protected
-   */
-  protected withIdRefPrefix(schemaNode: RJSFSchema): RJSFSchema {
-    if (schemaNode.constructor === Object) {
-      return this.withIdRefPrefixObject({ ...schemaNode });
-    }
-    if (Array.isArray(schemaNode)) {
-      return this.withIdRefPrefixArray([...schemaNode]);
-    }
-    return schemaNode;
   }
 }

--- a/packages/validator-ajv6/src/validator.ts
+++ b/packages/validator-ajv6/src/validator.ts
@@ -49,6 +49,8 @@ export default class AJV6Validator<T = any, S extends StrictRJSFSchema = RJSFSch
    *
    * @param errorSchema - The `ErrorSchema` instance to convert
    * @param [fieldPath=[]] - The current field path, defaults to [] if not specified
+   * @deprecated - Use the `toErrorList()` function provided by `@rjsf/utils` instead. This function will be removed in
+   *        the next major release.
    */
   toErrorList(errorSchema?: ErrorSchema<T>, fieldPath: string[] = []) {
     return toErrorList<T>(errorSchema, fieldPath);

--- a/packages/validator-ajv6/test/validator.test.ts
+++ b/packages/validator-ajv6/test/validator.test.ts
@@ -10,12 +10,6 @@ import {
 
 import AJV6Validator from '../src/validator';
 
-class TestValidator extends AJV6Validator {
-  withIdRefPrefix(schemaNode: RJSFSchema): RJSFSchema {
-    return super.withIdRefPrefix(schemaNode);
-  }
-}
-
 const illFormedKey = "bar.`'[]()=+*&^%$#@!";
 const metaSchemaDraft4 = require('ajv/lib/refs/json-schema-draft-04.json');
 const metaSchemaDraft6 = require('ajv/lib/refs/json-schema-draft-06.json');
@@ -29,10 +23,10 @@ describe('AJV6Validator', () => {
     builder.resetAllErrors();
   });
   describe('default options', () => {
-    // Use the TestValidator to access the `withIdRefPrefix` function
-    let validator: TestValidator;
+    // Use the AJV6Validator to access the `withIdRefPrefix` function
+    let validator: AJV6Validator;
     beforeAll(() => {
-      validator = new TestValidator({});
+      validator = new AJV6Validator({});
     });
     describe('validator.isValid()', () => {
       it('should return true if the data is valid against the schema', () => {
@@ -78,41 +72,6 @@ describe('AJV6Validator', () => {
         };
 
         expect(validator.isValid(schema, formData, rootSchema)).toBe(true);
-      });
-    });
-    describe('validator.withIdRefPrefix()', () => {
-      it('should recursively add id prefix to all refs', () => {
-        const schema: RJSFSchema = {
-          anyOf: [{ $ref: '#/defs/foo' }],
-        };
-        const expected = {
-          anyOf: [{ $ref: '__rjsf_rootSchema#/defs/foo' }],
-        };
-
-        expect(validator.withIdRefPrefix(schema)).toEqual(expected);
-      });
-      it('shouldn`t mutate the schema', () => {
-        const schema: RJSFSchema = {
-          anyOf: [{ $ref: '#/defs/foo' }],
-        };
-
-        validator.withIdRefPrefix(schema);
-
-        expect(schema).toEqual({
-          anyOf: [{ $ref: '#/defs/foo' }],
-        });
-      });
-      it('should not change a property named `$ref`', () => {
-        const schema: RJSFSchema = {
-          title: 'A registration form',
-          description: 'A simple form example.',
-          type: 'object',
-          properties: {
-            $ref: { type: 'string', title: 'First name', default: 'Chuck' },
-          },
-        };
-
-        expect(validator.withIdRefPrefix(schema)).toEqual(schema);
       });
     });
     describe('validator.toErrorList()', () => {
@@ -471,10 +430,10 @@ describe('AJV6Validator', () => {
     });
   });
   describe('validator.validateFormData(), custom options', () => {
-    let validator: TestValidator;
+    let validator: AJV6Validator;
     let schema: RJSFSchema;
     beforeAll(() => {
-      validator = new TestValidator({});
+      validator = new AJV6Validator({});
       schema = {
         $ref: '#/definitions/Dataset',
         $schema: 'http://json-schema.org/draft-04/schema#',
@@ -503,7 +462,7 @@ describe('AJV6Validator', () => {
     describe('validating using single custom meta schema', () => {
       let errors: RJSFValidationError[];
       beforeAll(() => {
-        validator = new TestValidator({
+        validator = new AJV6Validator({
           additionalMetaSchemas: [metaSchemaDraft4],
         });
         const result = validator.validateFormData({ datasetId: 'some kind of text' }, schema);
@@ -520,7 +479,7 @@ describe('AJV6Validator', () => {
       let errors: RJSFValidationError[];
 
       beforeAll(() => {
-        validator = new TestValidator({
+        validator = new AJV6Validator({
           additionalMetaSchemas: [metaSchemaDraft4, metaSchemaDraft6],
         });
         const result = validator.validateFormData({ datasetId: 'some kind of text' }, schema);

--- a/packages/validator-ajv8/src/validator.ts
+++ b/packages/validator-ajv8/src/validator.ts
@@ -1,35 +1,30 @@
 import Ajv, { ErrorObject, ValidateFunction } from 'ajv';
-import toPath from 'lodash/toPath';
-import isPlainObject from 'lodash/isPlainObject';
-import clone from 'lodash/clone';
+import get from 'lodash/get';
 import {
+  createErrorHandler,
   CustomValidator,
-  ERRORS_KEY,
   ErrorSchema,
-  ErrorSchemaBuilder,
   ErrorTransformer,
-  FieldValidation,
   FormContextType,
-  FormValidation,
-  GenericObjectType,
   getDefaultFormState,
-  mergeValidationData,
-  REF_KEY,
+  getUiOptions,
+  PROPERTIES_KEY,
   RJSFSchema,
   RJSFValidationError,
+  ROOT_SCHEMA_PREFIX,
   StrictRJSFSchema,
+  toErrorList,
+  toErrorSchema,
   UiSchema,
+  unwrapErrorHandler,
   ValidationData,
+  validationDataMerge,
   ValidatorType,
-  PROPERTIES_KEY,
-  getUiOptions,
+  withIdRefPrefix,
 } from '@rjsf/utils';
-import get from 'lodash/get';
 
 import { CustomValidatorOptionsType, Localizer } from './types';
 import createAjvInstance from './createAjvInstance';
-
-const ROOT_SCHEMA_PREFIX = '__rjsf_rootSchema';
 
 /** `ValidatorType` implementation that uses the AJV 8 validation mechanism.
  */
@@ -59,133 +54,20 @@ export default class AJV8Validator<T = any, S extends StrictRJSFSchema = RJSFSch
     this.localizer = localizer;
   }
 
-  /** Transforms a ajv validation errors list:
-   * [
-   *   {property: '.level1.level2[2].level3', message: 'err a'},
-   *   {property: '.level1.level2[2].level3', message: 'err b'},
-   *   {property: '.level1.level2[4].level3', message: 'err b'},
-   * ]
-   * Into an error tree:
-   * {
-   *   level1: {
-   *     level2: {
-   *       2: {level3: {errors: ['err a', 'err b']}},
-   *       4: {level3: {errors: ['err b']}},
-   *     }
-   *   }
-   * };
-   *
-   * @param errors - The list of RJSFValidationError objects
-   * @private
-   */
-  private toErrorSchema(errors: RJSFValidationError[]): ErrorSchema<T> {
-    const builder = new ErrorSchemaBuilder<T>();
-    if (errors.length) {
-      errors.forEach((error) => {
-        const { property, message } = error;
-        const path = toPath(property);
-
-        // If the property is at the root (.level1) then toPath creates
-        // an empty array element at the first index. Remove it.
-        if (path.length > 0 && path[0] === '') {
-          path.splice(0, 1);
-        }
-        if (message) {
-          builder.addErrors(message, path);
-        }
-      });
-    }
-    return builder.ErrorSchema;
-  }
-
   /** Converts an `errorSchema` into a list of `RJSFValidationErrors`
    *
    * @param errorSchema - The `ErrorSchema` instance to convert
    * @param [fieldPath=[]] - The current field path, defaults to [] if not specified
    */
   toErrorList(errorSchema?: ErrorSchema<T>, fieldPath: string[] = []) {
-    if (!errorSchema) {
-      return [];
-    }
-    let errorList: RJSFValidationError[] = [];
-    if (ERRORS_KEY in errorSchema) {
-      errorList = errorList.concat(
-        errorSchema[ERRORS_KEY]!.map((message: string) => {
-          const property = `.${fieldPath.join('.')}`;
-          return {
-            property,
-            message,
-            stack: `${property} ${message}`,
-          };
-        })
-      );
-    }
-    return Object.keys(errorSchema).reduce((acc, key) => {
-      if (key !== ERRORS_KEY) {
-        const childSchema = (errorSchema as GenericObjectType)[key];
-        if (isPlainObject(childSchema)) {
-          acc = acc.concat(this.toErrorList(childSchema, [...fieldPath, key]));
-        }
-      }
-      return acc;
-    }, errorList);
-  }
-
-  /** Given a `formData` object, recursively creates a `FormValidation` error handling structure around it
-   *
-   * @param formData - The form data around which the error handler is created
-   * @private
-   */
-  private createErrorHandler(formData: T): FormValidation<T> {
-    const handler: FieldValidation = {
-      // We store the list of errors for this node in a property named __errors
-      // to avoid name collision with a possible sub schema field named
-      // 'errors' (see `utils.toErrorSchema`).
-      __errors: [],
-      addError(message: string) {
-        this.__errors!.push(message);
-      },
-    };
-    if (Array.isArray(formData)) {
-      return formData.reduce((acc, value, key) => {
-        return { ...acc, [key]: this.createErrorHandler(value) };
-      }, handler);
-    }
-    if (isPlainObject(formData)) {
-      const formObject: GenericObjectType = formData as GenericObjectType;
-      return Object.keys(formObject).reduce((acc, key) => {
-        return { ...acc, [key]: this.createErrorHandler(formObject[key]) };
-      }, handler as FormValidation<T>);
-    }
-    return handler as FormValidation<T>;
-  }
-
-  /** Unwraps the `errorHandler` structure into the associated `ErrorSchema`, stripping the `addError` functions from it
-   *
-   * @param errorHandler - The `FormValidation` error handling structure
-   * @private
-   */
-  private unwrapErrorHandler(errorHandler: FormValidation<T>): ErrorSchema<T> {
-    return Object.keys(errorHandler).reduce((acc, key) => {
-      if (key === 'addError') {
-        return acc;
-      } else {
-        const childSchema = (errorHandler as GenericObjectType)[key];
-        if (isPlainObject(childSchema)) {
-          return {
-            ...acc,
-            [key]: this.unwrapErrorHandler(childSchema),
-          };
-        }
-        return { ...acc, [key]: childSchema };
-      }
-    }, {} as ErrorSchema<T>);
+    return toErrorList(errorSchema, fieldPath);
   }
 
   /** Transforming the error output from ajv to format used by @rjsf/utils.
    * At some point, components should be updated to support ajv.
    *
    * @param errors - The list of AJV errors to convert to `RJSFValidationErrors`
+   * @param [uiSchema] - An optional uiSchema that is passed to `transformErrors` and `customValidate`
    * @protected
    */
   protected transformRJSFValidationErrors(
@@ -215,7 +97,7 @@ export default class AJV8Validator<T = any, S extends StrictRJSFSchema = RJSFSch
 
         stack = message;
       } else {
-        const uiSchemaTitle = getUiOptions(get(uiSchema, `${property.replace(/^\./, '')}`)).title;
+        const uiSchemaTitle = getUiOptions<T, S, F>(get(uiSchema, `${property.replace(/^\./, '')}`)).title;
 
         if (uiSchemaTitle) {
           stack = `'${uiSchemaTitle}' ${message}`.trim();
@@ -307,7 +189,7 @@ export default class AJV8Validator<T = any, S extends StrictRJSFSchema = RJSFSch
       errors = transformErrors(errors, uiSchema);
     }
 
-    let errorSchema = this.toErrorSchema(errors);
+    let errorSchema = toErrorSchema<T>(errors);
 
     if (invalidSchemaError) {
       errorSchema = {
@@ -325,41 +207,9 @@ export default class AJV8Validator<T = any, S extends StrictRJSFSchema = RJSFSch
     // Include form data with undefined values, which is required for custom validation.
     const newFormData = getDefaultFormState<T, S, F>(this, schema, formData, schema, true) as T;
 
-    const errorHandler = customValidate(newFormData, this.createErrorHandler(newFormData), uiSchema);
-    const userErrorSchema = this.unwrapErrorHandler(errorHandler);
-    return mergeValidationData<T, S, F>(this, { errors, errorSchema }, userErrorSchema);
-  }
-
-  /** Takes a `node` object and transforms any contained `$ref` node variables with a prefix, recursively calling
-   * `withIdRefPrefix` for any other elements.
-   *
-   * @param node - The object node to which a ROOT_SCHEMA_PREFIX is added when a REF_KEY is part of it
-   * @private
-   */
-  private withIdRefPrefixObject(node: S) {
-    for (const key in node) {
-      const realObj: GenericObjectType = node;
-      const value = realObj[key];
-      if (key === REF_KEY && typeof value === 'string' && value.startsWith('#')) {
-        realObj[key] = ROOT_SCHEMA_PREFIX + value;
-      } else {
-        realObj[key] = this.withIdRefPrefix(value);
-      }
-    }
-    return node;
-  }
-
-  /** Takes a `node` object list and transforms any contained `$ref` node variables with a prefix, recursively calling
-   * `withIdRefPrefix` for any other elements.
-   *
-   * @param node - The list of object nodes to which a ROOT_SCHEMA_PREFIX is added when a REF_KEY is part of it
-   * @private
-   */
-  private withIdRefPrefixArray(node: S[]): S[] {
-    for (let i = 0; i < node.length; i++) {
-      node[i] = this.withIdRefPrefix(node[i]) as S;
-    }
-    return node;
+    const errorHandler = customValidate(newFormData, createErrorHandler<T>(newFormData), uiSchema);
+    const userErrorSchema = unwrapErrorHandler<T>(errorHandler);
+    return validationDataMerge<T>({ errors, errorSchema }, userErrorSchema);
   }
 
   /** Validates data against a schema, returning true if the data is valid, or
@@ -380,7 +230,7 @@ export default class AJV8Validator<T = any, S extends StrictRJSFSchema = RJSFSch
       if (this.ajv.getSchema(rootSchemaId) === undefined) {
         this.ajv.addSchema(rootSchema, rootSchemaId);
       }
-      const schemaWithIdRefPrefix = this.withIdRefPrefix(schema) as S;
+      const schemaWithIdRefPrefix = withIdRefPrefix<S>(schema) as S;
       let compiledValidator: ValidateFunction | undefined;
       if (schemaWithIdRefPrefix['$id']) {
         compiledValidator = this.ajv.getSchema(schemaWithIdRefPrefix['$id']);
@@ -398,21 +248,5 @@ export default class AJV8Validator<T = any, S extends StrictRJSFSchema = RJSFSch
       // make sure we remove the rootSchema from the global ajv instance
       this.ajv.removeSchema(rootSchemaId);
     }
-  }
-
-  /** Recursively prefixes all $ref's in a schema with `ROOT_SCHEMA_PREFIX`
-   * This is used in isValid to make references to the rootSchema
-   *
-   * @param schemaNode - The object node to which a ROOT_SCHEMA_PREFIX is added when a REF_KEY is part of it
-   * @protected
-   */
-  protected withIdRefPrefix(schemaNode: S | S[]): S | S[] {
-    if (Array.isArray(schemaNode)) {
-      return this.withIdRefPrefixArray([...schemaNode]);
-    }
-    if (isPlainObject(schemaNode)) {
-      return this.withIdRefPrefixObject(clone<S>(schemaNode));
-    }
-    return schemaNode;
   }
 }

--- a/packages/validator-ajv8/src/validator.ts
+++ b/packages/validator-ajv8/src/validator.ts
@@ -58,6 +58,8 @@ export default class AJV8Validator<T = any, S extends StrictRJSFSchema = RJSFSch
    *
    * @param errorSchema - The `ErrorSchema` instance to convert
    * @param [fieldPath=[]] - The current field path, defaults to [] if not specified
+   * @deprecated - Use the `toErrorList()` function provided by `@rjsf/utils` instead. This function will be removed in
+   *        the next major release.
    */
   toErrorList(errorSchema?: ErrorSchema<T>, fieldPath: string[] = []) {
     return toErrorList(errorSchema, fieldPath);

--- a/packages/validator-ajv8/test/validator.test.ts
+++ b/packages/validator-ajv8/test/validator.test.ts
@@ -15,10 +15,6 @@ import AJV8Validator from '../src/validator';
 import { Localizer } from '../src';
 
 class TestValidator extends AJV8Validator {
-  withIdRefPrefix(schemaNode: RJSFSchema): RJSFSchema {
-    return super.withIdRefPrefix(schemaNode);
-  }
-
   transformRJSFValidationErrors(errors: ErrorObject[] = [], uiSchema?: UiSchema): RJSFValidationError[] {
     return super.transformRJSFValidationErrors(errors, uiSchema);
   }
@@ -113,41 +109,6 @@ describe('AJV8Validator', () => {
         validator.isValid(schema, formData, rootSchema);
 
         expect(compileSpy).toHaveBeenCalledTimes(1);
-      });
-    });
-    describe('validator.withIdRefPrefix()', () => {
-      it('should recursively add id prefix to all refs', () => {
-        const schema: RJSFSchema = {
-          anyOf: [{ $ref: '#/defs/foo' }],
-        };
-        const expected = {
-          anyOf: [{ $ref: '__rjsf_rootSchema#/defs/foo' }],
-        };
-
-        expect(validator.withIdRefPrefix(schema)).toEqual(expected);
-      });
-      it('shouldn`t mutate the schema', () => {
-        const schema: RJSFSchema = {
-          anyOf: [{ $ref: '#/defs/foo' }],
-        };
-
-        validator.withIdRefPrefix(schema);
-
-        expect(schema).toEqual({
-          anyOf: [{ $ref: '#/defs/foo' }],
-        });
-      });
-      it('should not change a property named `$ref`', () => {
-        const schema: RJSFSchema = {
-          title: 'A registration form',
-          description: 'A simple form example.',
-          type: 'object',
-          properties: {
-            $ref: { type: 'string', title: 'First name', default: 'Chuck' },
-          },
-        };
-
-        expect(validator.withIdRefPrefix(schema)).toEqual(schema);
       });
     });
     describe('validator.toErrorList()', () => {
@@ -604,41 +565,6 @@ describe('AJV8Validator', () => {
         expect(compileSpy).toHaveBeenCalledTimes(1);
       });
     });
-    describe('validator.withIdRefPrefix()', () => {
-      it('should recursively add id prefix to all refs', () => {
-        const schema: RJSFSchema = {
-          anyOf: [{ $ref: '#/defs/foo' }],
-        };
-        const expected = {
-          anyOf: [{ $ref: '__rjsf_rootSchema#/defs/foo' }],
-        };
-
-        expect(validator.withIdRefPrefix(schema)).toEqual(expected);
-      });
-      it('shouldn`t mutate the schema', () => {
-        const schema: RJSFSchema = {
-          anyOf: [{ $ref: '#/defs/foo' }],
-        };
-
-        validator.withIdRefPrefix(schema);
-
-        expect(schema).toEqual({
-          anyOf: [{ $ref: '#/defs/foo' }],
-        });
-      });
-      it('should not change a property named `$ref`', () => {
-        const schema: RJSFSchema = {
-          title: 'A registration form',
-          description: 'A simple form example.',
-          type: 'object',
-          properties: {
-            $ref: { type: 'string', title: 'First name', default: 'Chuck' },
-          },
-        };
-
-        expect(validator.withIdRefPrefix(schema)).toEqual(schema);
-      });
-    });
     describe('validator.toErrorList()', () => {
       it('should return empty list for unspecified errorSchema', () => {
         expect(validator.toErrorList()).toEqual([]);
@@ -1092,41 +1018,6 @@ describe('AJV8Validator', () => {
         validator.isValid(schema, formData, rootSchema);
 
         expect(compileSpy).toHaveBeenCalledTimes(1);
-      });
-    });
-    describe('validator.withIdRefPrefix()', () => {
-      it('should recursively add id prefix to all refs', () => {
-        const schema: RJSFSchema = {
-          anyOf: [{ $ref: '#/defs/foo' }],
-        };
-        const expected = {
-          anyOf: [{ $ref: '__rjsf_rootSchema#/defs/foo' }],
-        };
-
-        expect(validator.withIdRefPrefix(schema)).toEqual(expected);
-      });
-      it('shouldn`t mutate the schema', () => {
-        const schema: RJSFSchema = {
-          anyOf: [{ $ref: '#/defs/foo' }],
-        };
-
-        validator.withIdRefPrefix(schema);
-
-        expect(schema).toEqual({
-          anyOf: [{ $ref: '#/defs/foo' }],
-        });
-      });
-      it('should not change a property named `$ref`', () => {
-        const schema: RJSFSchema = {
-          title: 'A registration form',
-          description: 'A simple form example.',
-          type: 'object',
-          properties: {
-            $ref: { type: 'string', title: 'First name', default: 'Chuck' },
-          },
-        };
-
-        expect(validator.withIdRefPrefix(schema)).toEqual(schema);
       });
     });
     describe('validator.toErrorList()', () => {


### PR DESCRIPTION
### Reasons for making this change

There were a bunch of utility functions in the two validator implementations that were duplicated
- In `@rjsf/utils`, refactored the common functions as follows:
  - Refactored the `createErrorHandler()`, `toErrorList()`, `toErrorSchema()` and `unwrapErrorHandler()` functions from the `@rjsf/validator-ajv6` and `@rjsf/validator-ajv8` implementations since they were identical - As a result, the `mergeValidationData()` function was deprecated in favor of the new `validationDataMerge()` function that uses the refactored `toErrorList()` function - Refactored the `ROOT_SCHEMA_PREFIX` constant as well
  - Updated `ValidatorType` and `SchemaUtilsType` to deprecate the `toErrorList()` and `mergeValidationData()` functions, respectively
- In `@rjsf/validator-ajv6` and `@rjsf/validator-ajv8`, updated the validator implementations to use the new refactored functions
- In `@rjsf/core` updated `Form` to use the `validationDataMerge()` function instead of the `schemaUtils.mergeValidationData()` function
- In the `utility-functions` documentation, described the new refactored functions and deprecated `mergeValidationData()`
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
