### PR TITLE
Add option to provide a callback function to focusOnFirstError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 
 - Switched `Form` to use the new `validatorDataMerge()` function instead of the new deprecated `schemaUtils.mergeValidatorData()`
+- Added option to provide a callback function to `focusOnFirstError`
 
 ## @rjsf/utils
 
@@ -59,13 +60,13 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/core
 
-- Updated `Form` to include the top `disabled` property in the `ui:submitButtonOptions` so the submit button will be disabled when the whole form is disabled. Fixes [#3264](https://github.com/rjsf-team/react-jsonschema-form/issues/3264). 
+- Updated `Form` to include the top `disabled` property in the `ui:submitButtonOptions` so the submit button will be disabled when the whole form is disabled. Fixes [#3264](https://github.com/rjsf-team/react-jsonschema-form/issues/3264).
 
 ## @rjsf/utils
 
 - Added protections against infinite recursion of `$ref`s for the `toIdSchema()`, `toPathSchema()` and `getDefaultFormState()` functions, fixing [#3560](https://github.com/rjsf-team/react-jsonschema-form/issues/3560)
 - Updated `getDefaultFormState()` to handle object-based `additionalProperties` with defaults using `formData` in addition to values contained in a `default` object, fixing [#2593](https://github.com/rjsf-team/react-jsonschema-form/issues/2593)
-- Updated internal helper `withExactlyOneSubschema()` inside of `retrieveSchema()` to use the `isValid()` function rather than `validateFormData()` when determining the one-of branch 
+- Updated internal helper `withExactlyOneSubschema()` inside of `retrieveSchema()` to use the `isValid()` function rather than `validateFormData()` when determining the one-of branch
 
 ## Dev / docs / playground
 
@@ -119,6 +120,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Converted the `playground` to use Typescript, including some refactoring of code to make that job easier
 - Updated the `custom-templates` documentation to add `errorSchema` to the props for `ObjectFieldTemplate`
+
 # 5.4.0
 
 ## @rjsf/antd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 
 - Switched `Form` to use the new `validatorDataMerge()` function instead of the new deprecated `schemaUtils.mergeValidatorData()`
-- Added option to provide a callback function to `focusOnFirstError`
+- Added option to provide a callback function to `focusOnFirstError` ([3590](https://github.com/rjsf-team/react-jsonschema-form/pull/3590))
 
 ## @rjsf/utils
 

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -173,7 +173,7 @@ export interface FormProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
   transformErrors?: ErrorTransformer<T, S, F>;
   /** If set to true, then the first field with an error will receive the focus when the form is submitted with errors
    */
-  focusOnFirstError?: boolean;
+  focusOnFirstError?: boolean | ((error: RJSFValidationError) => void);
   /** Optional string translation function, if provided, allows users to change the translation of the RJSF internal
    * strings. Some strings contain replaceable parameter values as indicated by `%1`, `%2`, etc. The number after the
    * `%` indicates the order of the parameter. The ordering of parameters is important because some languages may choose
@@ -725,7 +725,11 @@ export default class Form<
         errors = merged.errors;
       }
       if (focusOnFirstError) {
-        this.focusOnError(schemaValidation.errors[0]);
+        if (typeof focusOnFirstError === 'function') {
+          focusOnFirstError(schemaValidation.errors[0]);
+        } else {
+          this.focusOnError(schemaValidation.errors[0]);
+        }
       }
       this.setState(
         {

--- a/packages/core/test/Form.test.jsx
+++ b/packages/core/test/Form.test.jsx
@@ -1964,6 +1964,43 @@ describeRepeated('Form common', (createFormComponent) => {
         sinon.assert.calledOnce(focusSpy);
       });
 
+      it('should call the onError handler and call the provided focusOnFirstError callback function', () => {
+        const onError = sandbox.spy();
+
+        const focusCallback = () => {
+          console.log('focusCallback called');
+        };
+
+        const focusOnFirstError = sandbox.spy(focusCallback);
+        const { node } = createFormComponent({
+          schema,
+          onError,
+          focusOnFirstError,
+          uiSchema: {
+            'ui:disabled': true,
+          },
+        });
+
+        const input = node.querySelector('input[type=text]');
+        const focusSpy = sinon.spy();
+        // Since programmatically triggering focus does not call onFocus, change the focus method to a spy
+        input.focus = focusSpy;
+
+        Simulate.change(input, {
+          target: { value: 'short' },
+        });
+        Simulate.submit(node);
+
+        sinon.assert.calledWithMatch(
+          onError,
+          sinon.match((value) => {
+            return value.length === 1 && value[0].message === 'must NOT have fewer than 8 characters';
+          })
+        );
+        sinon.assert.notCalled(focusSpy);
+        sinon.assert.calledOnce(focusOnFirstError);
+      });
+
       it('should reset errors and errorSchema state to initial state after correction and resubmission', () => {
         const { node, onError, onSubmit } = createFormComponent({
           schema,

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -113,6 +113,22 @@ Dictionary of registered fields in the form. See [Custom Widgets and Fields](../
 
 If set to true, then the first field with an error will receive the focus when the form is submitted with errors.
 
+You can also provide a custom callback function to handle what happens when this function is called.
+
+```tsx
+import { RJSFSchema, RJSFValidationError } from '@rjsf/utils';
+
+const schema: RJSFSchema = {
+  type: 'string',
+};
+
+const focusOnError = (error: RJSFValidationError) => {
+  console.log('I need to handle focusing this error');
+};
+
+render(<Form schema={schema} focusOnFirstError={focusOnError} />, document.getElementById('app'));
+```
+
 ## formContext
 
 You can provide a `formContext` object to the Form, which is passed down to all fields and widgets. Useful for implementing context aware fields and widgets.


### PR DESCRIPTION
### Reasons for making this change
fixes #3580 

Focusing the first error using `focusOnFirstError` requires an actual element to be focusable. This is not always possible, you might have disabled fields that are filled by some type of action that the user has missed.

This change provides the option to add a custom callback function to `focusOnFirstError`, the function recieves a `RJSFValidationError` in which you can handle what happens then `focusOnFirstError` is called.

Example:
```tsx
import { RJSFSchema, RJSFValidationError } from '@rjsf/utils';

const schema: RJSFSchema = {
  type: 'string',
};

const focusOnError = (error: RJSFValidationError) => {
  console.log('I need to handle focusing this error');
};

render(<Form schema={schema} focusOnFirstError={focusOnError} />, document.getElementById('app'));
```

### Checklist

- [X] **I'm updating documentation**
  - [X] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [X] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature