### PR TITLE
fix: Fixed restoring live settings from links for playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,13 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 5.6.0
 
+## @rjsf/antd
+
+- Treat multiple as a boolean rather than comparing against `undefined` in the `SelectWidget`, fixing [#3595](https://github.com/rjsf-team/react-jsonschema-form/issues/3595)
+
 ## @rjsf/core
 
-- Switched `Form` to use the new `validatorDataMerge()` function instead of the new deprecated `schemaUtils.mergeValidatorData()`
+- Switched `Form` to use the new `validatorDataMerge()` and `toErrorList()` functions instead of the new deprecated `schemaUtils.mergeValidatorData()` and `schemaUtils.getValidator().toErrorList()`
 - Added option to provide a callback function to `focusOnFirstError` ([3590](https://github.com/rjsf-team/react-jsonschema-form/pull/3590))
 - Updated `MultiSchemaField` to handle the OpenAPI `discriminator` extension on `anyOf/oneOf` fields by passing it into `getClosestMatchingOption()` if it exists, fixing [#3512](https://github.com/rjsf-team/react-jsonschema-form/issues/3512)
 - Updated `SchemaField` function to use `getSchemaType` rather than `schema.type` to set the proper class name.
@@ -47,6 +51,8 @@ should change the heading of the (upcoming) version to include a major version b
 ## Dev / docs / playground
 
 - Updated the `utility-functions` documentation to describe the new refactored functions as well as deprecating the `mergeValidationData()` function
+- Updated the `playground` to properly restore `liveSettings` from shared links and added a switch for `noHtml5Validation` in the live settings rather than having it set to `true` always
+  - Also added a new `Blank` example to help users easily paste their code
 
 # 5.5.2
 

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -25,6 +25,7 @@ import {
   shouldRender,
   SUBMIT_BTN_OPTIONS_KEY,
   TemplatesType,
+  toErrorList,
   UiSchema,
   UI_GLOBAL_OPTIONS_KEY,
   UI_OPTIONS_KEY,
@@ -533,7 +534,7 @@ export default class Form<
       state = {
         formData: newFormData,
         errorSchema: errorSchema,
-        errors: schemaUtils.getValidator().toErrorList(errorSchema),
+        errors: toErrorList(errorSchema),
       };
     }
     this.setState(state as FormState<T, S, F>, () => onChange && onChange({ ...this.state, ...state }, id));
@@ -618,7 +619,7 @@ export default class Form<
       // There are no errors generated through schema validation.
       // Check for user provided errors and update state accordingly.
       const errorSchema = extraErrors || {};
-      const errors = extraErrors ? schemaUtils.getValidator().toErrorList(extraErrors) : [];
+      const errors = extraErrors ? toErrorList(extraErrors) : [];
       this.setState(
         {
           formData: newFormData,

--- a/packages/playground/src/components/Header.tsx
+++ b/packages/playground/src/components/Header.tsx
@@ -57,6 +57,7 @@ const liveSettingsSchema: RJSFSchema = {
     omitExtraData: { type: 'boolean', title: 'Omit extra data' },
     liveOmit: { type: 'boolean', title: 'Live omit' },
     noValidate: { type: 'boolean', title: 'Disable validation' },
+    noHtml5Validate: { type: 'boolean', title: 'Disable HTML 5 validation' },
     focusOnFirstError: { type: 'boolean', title: 'Focus on 1st Error' },
     showErrorList: {
       type: 'string',

--- a/packages/playground/src/components/Playground.tsx
+++ b/packages/playground/src/components/Playground.tsx
@@ -5,6 +5,7 @@ import {
   ArrayFieldTemplateProps,
   ObjectFieldTemplateProps,
   RJSFSchema,
+  RJSFValidationError,
   TemplatesType,
   UiSchema,
   ValidatorType,
@@ -17,8 +18,6 @@ import ErrorBoundary from './ErrorBoundary';
 import GeoPosition from './GeoPosition';
 import { ThemesType } from './ThemeSelector';
 import Editors from './Editors';
-
-const log = (type: string) => console.log.bind(console, type);
 
 export interface PlaygroundProps {
   themes: { [themeName: string]: ThemesType };
@@ -40,7 +39,8 @@ export default function Playground({ themes, validators }: PlaygroundProps) {
   const [liveSettings, setLiveSettings] = useState<LiveSettings>({
     showErrorList: 'top',
     validate: false,
-    disable: false,
+    disabled: false,
+    noHtml5Validate: false,
     readonly: false,
     omitExtraData: false,
     liveOmit: false,
@@ -64,7 +64,7 @@ export default function Playground({ themes, validators }: PlaygroundProps) {
   const load = useCallback(
     (data: any) => {
       // Reset the ArrayFieldTemplate whenever you load new data
-      const { ArrayFieldTemplate, ObjectFieldTemplate, extraErrors } = data;
+      const { ArrayFieldTemplate, ObjectFieldTemplate, extraErrors, liveSettings } = data;
       // uiSchema is missing on some examples. Provide a default to
       // clear the field in all cases.
       const { schema, uiSchema = {}, formData, theme: dataTheme = theme } = data;
@@ -80,6 +80,7 @@ export default function Playground({ themes, validators }: PlaygroundProps) {
       setTheme(dataTheme);
       setArrayFieldTemplate(ArrayFieldTemplate);
       setObjectFieldTemplate(ObjectFieldTemplate);
+      setLiveSettings(liveSettings);
       setShowForm(true);
     },
     [theme, onThemeSelected, themes]
@@ -197,14 +198,13 @@ export default function Playground({ themes, validators }: PlaygroundProps) {
                 schema={schema}
                 uiSchema={uiSchema}
                 formData={formData}
-                noHtml5Validate={true}
                 fields={{ geo: GeoPosition }}
                 validator={validators[validator]}
                 onChange={onFormDataChange}
                 onSubmit={onFormDataSubmit}
                 onBlur={(id: string, value: string) => console.log(`Touched ${id} with value ${value}`)}
                 onFocus={(id: string, value: string) => console.log(`Focused ${id} with value ${value}`)}
-                onError={log('errors')}
+                onError={(errorList: RJSFValidationError[]) => console.log('errors', errorList)}
                 ref={playGroundFormRef}
               />
             </DemoFrame>

--- a/packages/playground/src/samples/index.ts
+++ b/packages/playground/src/samples/index.ts
@@ -32,6 +32,7 @@ import options from './options';
 import ifThenElse from './ifThenElse';
 
 export const samples = Object.freeze({
+  Blank: { schema: {}, uiSchema: {}, formData: {} },
   Simple: simple,
   'UI Options': options,
   Nested: nested,


### PR DESCRIPTION
### Reasons for making this change

Fixes the playground so that the live settings are restored for shared links
- In `@rjsf/core`, switched to using the new `toErrorList()` helper function from `utils`
- In the `playground`, fixed an issue where the `liveSettings` from shared links are now restored and exposed setting the `noHtml5Validate` flag on the `Form`
  - Also added a new `Blank` example to help users easily paste their code
- Updated the `CHANGELOG.md` accordingly
  - Added change notification for #3597

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
