### PR TITLE
Implement feature-flagged support for ignoring of optional array fields with `minItems` set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
-# 5.7.0
+# 5.8.0
 
 ## @rjsf/core
 
-- Added new `defaultFormStateBehavior` prop to `Form` to specify alternate behavior when dealing with the rendering of array fields where `minItems` is set but field is not `required` (fixes [3363](https://github.com/rjsf-team/react-jsonschema-form/issues/3363))
+- Added new `experimental_defaultFormStateBehavior` prop to `Form` to specify alternate behavior when dealing with the rendering of array fields where `minItems` is set but field is not `required` (fixes [3363](https://github.com/rjsf-team/react-jsonschema-form/issues/3363)) (PR [3604](https://github.com/rjsf-team/react-jsonschema-form/pull/3604))
 
 ## @rjsf/utils
 
@@ -27,7 +27,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## Dev / docs / playground
 
-- Added **Default Form State Behavior** live setting
+- Added **minItems behavior for array field** live setting
 
 # 5.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.7.0
+
+## @rjsf/core
+
+- Added new `defaultFormStateBehavior` prop to `Form` to specify alternate behavior when dealing with the rendering of array fields where `minItems` is set but field is not `required` (fixes [3363](https://github.com/rjsf-team/react-jsonschema-form/issues/3363))
+
+## @rjsf/utils
+
+- Refactored optional parameters for `computeDefaults()` into destructured props object to reduce clutter when only specifying later of the optional argument
+
+## Dev / docs / playground
+
+- Added **Default Form State Behavior** live setting
 
 # 5.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,19 +15,6 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
-# 5.8.0
-
-## @rjsf/core
-
-- Added new `experimental_defaultFormStateBehavior` prop to `Form` to specify alternate behavior when dealing with the rendering of array fields where `minItems` is set but field is not `required` (fixes [3363](https://github.com/rjsf-team/react-jsonschema-form/issues/3363)) (PR [3604](https://github.com/rjsf-team/react-jsonschema-form/pull/3604))
-
-## @rjsf/utils
-
-- Refactored optional parameters for `computeDefaults()` into destructured props object to reduce clutter when only specifying later of the optional argument
-
-## Dev / docs / playground
-
-- Added **minItems behavior for array field** live setting
 
 # 5.7.0
 
@@ -39,6 +26,8 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Updated the `MultiSchemaField` to use the new `getDiscriminatorFieldFromSchema()` API
 
+- Added new `experimental_defaultFormStateBehavior` prop to `Form` to specify alternate behavior when dealing with the rendering of array fields where `minItems` is set but field is not `required` (fixes [3363](https://github.com/rjsf-team/react-jsonschema-form/issues/3363)) ([3604](https://github.com/rjsf-team/react-jsonschema-form/pull/3604))
+
 ## @rjsf/fluent-ui
 
 - Added support for `additionalProperties` to fluent-ui theme, fixing [#2777](https://github.com/rjsf-team/react-jsonschema-form/issues/2777).
@@ -48,11 +37,13 @@ should change the heading of the (upcoming) version to include a major version b
 - Added two new APIs `getDiscriminatorFieldFromSchema()` (a refactor of code from `MultiSchemaField`) and `hashForSchema()`
   - Updated `getDefaultFormState()` and `toPathSchema()` to use `getDiscriminatorFieldFromSchema()` to provide a discriminator field to `getClosestMatchingOption()` calls.
 - Refactored the `retrieveSchema()` internal API functions to support implementing an internal `schemaParser()` API for use in precompiling schemas, in support of [#3543](https://github.com/rjsf-team/react-jsonschema-form/issues/3543)
+- Refactored optional parameters for `computeDefaults()` into destructured props object to reduce clutter when only specifying later of the optional argument
 - Fixed `toPathSchema()` to handle `properties` in an object along with `anyOf`/`oneOf`, fixing [#3628](https://github.com/rjsf-team/react-jsonschema-form/issues/3628) and [#1628](https://github.com/rjsf-team/react-jsonschema-form/issues/1628)
 
 ## Dev / docs / playground
 
 - Added documentation to `custom-templates` describing how to extend the `BaseInputTemplate`
+- Added **minItems behavior for array field** live setting ([3604](https://github.com/rjsf-team/react-jsonschema-form/pull/3604))
 
 # 5.6.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,8 @@ should change the heading of the (upcoming) version to include a major version b
 - Added two new APIs `getDiscriminatorFieldFromSchema()` (a refactor of code from `MultiSchemaField`) and `hashForSchema()`
   - Updated `getDefaultFormState()` and `toPathSchema()` to use `getDiscriminatorFieldFromSchema()` to provide a discriminator field to `getClosestMatchingOption()` calls.
 - Refactored the `retrieveSchema()` internal API functions to support implementing an internal `schemaParser()` API for use in precompiling schemas, in support of [#3543](https://github.com/rjsf-team/react-jsonschema-form/issues/3543)
-- Refactored optional parameters for `computeDefaults()` into destructured props object to reduce clutter when only specifying later of the optional argument
 - Fixed `toPathSchema()` to handle `properties` in an object along with `anyOf`/`oneOf`, fixing [#3628](https://github.com/rjsf-team/react-jsonschema-form/issues/3628) and [#1628](https://github.com/rjsf-team/react-jsonschema-form/issues/1628)
+- Refactored optional parameters for `computeDefaults()` into destructured props object to reduce clutter when only specifying later of the optional argument ([3604](https://github.com/rjsf-team/react-jsonschema-form/pull/3604))
 
 ## Dev / docs / playground
 

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -182,10 +182,9 @@ export interface FormProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
    * to put the second parameter before the first in its translation.
    */
   translateString?: Registry['translateString'];
-  /** Optional feature flags, if provided, specify different behavior that can be enabled. This enables differing behavior within
-   * the library for differing interpreations of edge cases without breaking existing behavior.
-   */
-  featureFlags?: { defaultFormStateBehavior?: number };
+  /** Optional bit flag, if provided, allows users to override default form state behavior.
+   * Currently only affecting minItems on array fields */
+  defaultFormStateBehavior?: number;
   // Private
   /**
    * _internalFormWrapper is currently used by the semantic-ui theme to provide a custom wrapper around `<Form />`
@@ -311,9 +310,8 @@ export default class Form<
     const mustValidate = edit && !props.noValidate && liveValidate;
     const rootSchema = schema;
     const behaviorBitFlags =
-      ('behaviorBitFlags' in props
-        ? props.featureFlags?.defaultFormStateBehavior
-        : this.props.featureFlags?.defaultFormStateBehavior) || DefaultFormStateBehavior.Legacy_PopulateMinItems;
+      ('behaviorBitFlags' in props ? props.defaultFormStateBehavior : this.props.defaultFormStateBehavior) ||
+      DefaultFormStateBehavior.Legacy_PopulateMinItems;
     let schemaUtils: SchemaUtilsType<T, S, F> = state.schemaUtils;
     if (!schemaUtils || schemaUtils.doesSchemaUtilsDiffer(props.validator, rootSchema, behaviorBitFlags)) {
       schemaUtils = createSchemaUtils<T, S, F>(props.validator, rootSchema, behaviorBitFlags);

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -315,7 +315,7 @@ export default class Form<
         ? props.featureFlags?.defaultFormStateBehavior
         : this.props.featureFlags?.defaultFormStateBehavior) || DefaultFormStateBehavior.Legacy_PopulateMinItems;
     let schemaUtils: SchemaUtilsType<T, S, F> = state.schemaUtils;
-    if (!schemaUtils || schemaUtils.doesSchemaUtilsDiffer(props.validator, rootSchema)) {
+    if (!schemaUtils || schemaUtils.doesSchemaUtilsDiffer(props.validator, rootSchema, behaviorBitFlags)) {
       schemaUtils = createSchemaUtils<T, S, F>(props.validator, rootSchema, behaviorBitFlags);
     }
     const formData: T = schemaUtils.getDefaultFormState(schema, inputFormData) as T;

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -309,12 +309,12 @@ export default class Form<
     const liveValidate = 'liveValidate' in props ? props.liveValidate : this.props.liveValidate;
     const mustValidate = edit && !props.noValidate && liveValidate;
     const rootSchema = schema;
-    const behaviorBitFlags =
-      ('behaviorBitFlags' in props ? props.defaultFormStateBehavior : this.props.defaultFormStateBehavior) ||
+    const defaultFormStateBehavior =
+      ('defaultFormStateBehavior' in props ? props.defaultFormStateBehavior : this.props.defaultFormStateBehavior) ||
       DefaultFormStateBehavior.Legacy_PopulateMinItems;
     let schemaUtils: SchemaUtilsType<T, S, F> = state.schemaUtils;
-    if (!schemaUtils || schemaUtils.doesSchemaUtilsDiffer(props.validator, rootSchema, behaviorBitFlags)) {
-      schemaUtils = createSchemaUtils<T, S, F>(props.validator, rootSchema, behaviorBitFlags);
+    if (!schemaUtils || schemaUtils.doesSchemaUtilsDiffer(props.validator, rootSchema, defaultFormStateBehavior)) {
+      schemaUtils = createSchemaUtils<T, S, F>(props.validator, rootSchema, defaultFormStateBehavior);
     }
     const formData: T = schemaUtils.getDefaultFormState(schema, inputFormData) as T;
     const retrievedSchema = schemaUtils.retrieveSchema(schema, formData);

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -3,7 +3,6 @@ import {
   createSchemaUtils,
   CustomValidator,
   deepEquals,
-  DefaultFormStateBehavior,
   ErrorSchema,
   ErrorTransformer,
   FormContextType,
@@ -33,6 +32,7 @@ import {
   ValidationData,
   validationDataMerge,
   ValidatorType,
+  Experimental_DefaultFormStateBehavior,
 } from '@rjsf/utils';
 import _get from 'lodash/get';
 import _isEmpty from 'lodash/isEmpty';
@@ -182,9 +182,9 @@ export interface FormProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
    * to put the second parameter before the first in its translation.
    */
   translateString?: Registry['translateString'];
-  /** Optional bit flag, if provided, allows users to override default form state behavior.
+  /** Optional configuration object with flags, if provided, allows users to override default form state behavior
    * Currently only affecting minItems on array fields */
-  defaultFormStateBehavior?: number;
+  experimental_defaultFormStateBehavior?: Experimental_DefaultFormStateBehavior;
   // Private
   /**
    * _internalFormWrapper is currently used by the semantic-ui theme to provide a custom wrapper around `<Form />`
@@ -309,12 +309,16 @@ export default class Form<
     const liveValidate = 'liveValidate' in props ? props.liveValidate : this.props.liveValidate;
     const mustValidate = edit && !props.noValidate && liveValidate;
     const rootSchema = schema;
-    const defaultFormStateBehavior =
-      ('defaultFormStateBehavior' in props ? props.defaultFormStateBehavior : this.props.defaultFormStateBehavior) ||
-      DefaultFormStateBehavior.Legacy_PopulateMinItems;
+    const experimental_defaultFormStateBehavior =
+      'experimental_defaultFormStateBehavior' in props
+        ? props.experimental_defaultFormStateBehavior
+        : this.props.experimental_defaultFormStateBehavior;
     let schemaUtils: SchemaUtilsType<T, S, F> = state.schemaUtils;
-    if (!schemaUtils || schemaUtils.doesSchemaUtilsDiffer(props.validator, rootSchema, defaultFormStateBehavior)) {
-      schemaUtils = createSchemaUtils<T, S, F>(props.validator, rootSchema, defaultFormStateBehavior);
+    if (
+      !schemaUtils ||
+      schemaUtils.doesSchemaUtilsDiffer(props.validator, rootSchema, experimental_defaultFormStateBehavior)
+    ) {
+      schemaUtils = createSchemaUtils<T, S, F>(props.validator, rootSchema, experimental_defaultFormStateBehavior);
     }
     const formData: T = schemaUtils.getDefaultFormState(schema, inputFormData) as T;
     const retrievedSchema = schemaUtils.retrieveSchema(schema, formData);

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -3,6 +3,7 @@ import {
   createSchemaUtils,
   CustomValidator,
   deepEquals,
+  DefaultFormStateBehavior,
   ErrorSchema,
   ErrorTransformer,
   FormContextType,
@@ -184,7 +185,7 @@ export interface FormProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
   /** Optional feature flags, if provided, specify different behavior that can be enabled. This enables differing behavior within
    * the library for differing interpreations of edge cases without breaking existing behavior.
    */
-  featureFlags?: { defaultFormStateFeatures?: number; };
+  featureFlags?: { defaultFormStateBehavior?: number };
   // Private
   /**
    * _internalFormWrapper is currently used by the semantic-ui theme to provide a custom wrapper around `<Form />`
@@ -309,9 +310,13 @@ export default class Form<
     const liveValidate = 'liveValidate' in props ? props.liveValidate : this.props.liveValidate;
     const mustValidate = edit && !props.noValidate && liveValidate;
     const rootSchema = schema;
+    const behaviorBitFlags =
+      ('behaviorBitFlags' in props
+        ? props.featureFlags?.defaultFormStateBehavior
+        : this.props.featureFlags?.defaultFormStateBehavior) || DefaultFormStateBehavior.Legacy_PopulateMinItems;
     let schemaUtils: SchemaUtilsType<T, S, F> = state.schemaUtils;
     if (!schemaUtils || schemaUtils.doesSchemaUtilsDiffer(props.validator, rootSchema)) {
-      schemaUtils = createSchemaUtils<T, S, F>(props.validator, rootSchema);
+      schemaUtils = createSchemaUtils<T, S, F>(props.validator, rootSchema, behaviorBitFlags);
     }
     const formData: T = schemaUtils.getDefaultFormState(schema, inputFormData) as T;
     const retrievedSchema = schemaUtils.retrieveSchema(schema, formData);

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -181,6 +181,10 @@ export interface FormProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
    * to put the second parameter before the first in its translation.
    */
   translateString?: Registry['translateString'];
+  /** Optional feature flags, if provided, specify different behavior that can be enabled. This enables differing behavior within
+   * the library for differing interpreations of edge cases without breaking existing behavior.
+   */
+  featureFlags?: { defaultFormStateFeatures?: number; };
   // Private
   /**
    * _internalFormWrapper is currently used by the semantic-ui theme to provide a custom wrapper around `<Form />`

--- a/packages/core/test/Form.test.jsx
+++ b/packages/core/test/Form.test.jsx
@@ -17,7 +17,6 @@ import {
   submitForm,
 } from './test_utils';
 import widgetsSchema from './widgets_schema.json';
-import { DefaultFormStateBehavior } from '@rjsf/utils';
 
 describeRepeated('Form common', (createFormComponent) => {
   let sandbox;
@@ -1417,7 +1416,7 @@ describeRepeated('Form common', (createFormComponent) => {
         formData: {
           albums: ['Until We Have Faces'],
         },
-        defaultFormStateBehavior: DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired,
+        experimental_defaultFormStateBehavior: { arrayMinItems: 'requiredOnly' },
       });
       submitForm(node);
       sinon.assert.calledWithMatch(onError.lastCall, [
@@ -1435,7 +1434,7 @@ describeRepeated('Form common', (createFormComponent) => {
       const { node, onSubmit } = createFormComponent({
         schema,
         formData: {},
-        defaultFormStateBehavior: DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired,
+        experimental_defaultFormStateBehavior: { arrayMinItems: 'requiredOnly' },
       });
       submitForm(node);
       sinon.assert.calledWithMatch(onSubmit.lastCall, { formData: {} });

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -86,9 +86,9 @@ render(
   <Form
     schema={schema}
     validator={validator}
-    experimental_defaultFormStateBehavior={
-      arrayMinItems: 'requiredOnly'
-    }
+    experimental_defaultFormStateBehavior={{
+      arrayMinItems: 'requiredOnly',
+    }}
   />,
   document.getElementById('app')
 );

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -59,17 +59,21 @@ Formerly the `validate` prop.
 The `customValidate` prop requires a function that specifies custom validation rules for the form.
 See [Validation](../usage/validation.md) for more information.
 
-## defaultFormStateBehavior
+## experimental_defaultFormStateBehavior
 
-Allows you to specify different form behavior in regards to handling optional array fields with `minItems` set. This is done via a bit flag with the following values, which are defined in `utils/src/constants.ts` in the `DefaultFormStateBehavior` object:
+Experimental features to specify different form state behavior. Currently, this only affects the handling of optional array fields where `minItems` is set.
 
-| Reference Name                 | Value | Description                                                                                                                        |
-| ------------------------------ | ----- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `Legacy_PopulateMinItems`      | `0`   | Legacy behavior - populate minItems entries with default values initially and include empty array when no values have been defined |
-| `IgnoreMinItemsUnlessRequired` | `1`   | Ignore `minItems` on a field when calculating defaults unless the field is required                                                |
+The following sub-sections represent the different keys in this object, with the tables explaining the values and their meanings.
+
+### `arrayMinItems`
+
+| Flag Value     | Description                                                                                                                        |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `populate`     | Legacy behavior - populate minItems entries with default values initially and include empty array when no values have been defined |
+| `requiredOnly` | Ignore `minItems` on a field when calculating defaults unless the field is required                                                |
 
 ```tsx
-import { RJSFSchema, DefaultFormStateBehavior } from '@rjsf/utils';
+import { RJSFSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 
 const schema: RJSFSchema = {
@@ -82,22 +86,9 @@ render(
   <Form
     schema={schema}
     validator={validator}
-    defaultFormStateBehavior={DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired}
-  />,
-  document.getElementById('app')
-);
-```
-
-OR
-
-```tsx
-...
-
-render(
-  <Form
-    schema={schema}
-    validator={validator}
-    defaultFormStateBehavior={1}
+    experimental_defaultFormStateBehavior={
+      arrayMinItems: 'requiredOnly'
+    }
   />,
   document.getElementById('app')
 );

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -59,6 +59,50 @@ Formerly the `validate` prop.
 The `customValidate` prop requires a function that specifies custom validation rules for the form.
 See [Validation](../usage/validation.md) for more information.
 
+## defaultFormStateBehavior
+
+Allows you to specify different form behavior in regards to handling optional array fields with `minItems` set. This is done via a bit flag with the following values, which are defined in `utils/src/constants.ts` in the `DefaultFormStateBehavior` object:
+
+| Reference Name                 | Value | Description                                                                                                                        |
+| ------------------------------ | ----- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `Legacy_PopulateMinItems`      | `0`   | Legacy behavior - populate minItems entries with default values initially and include empty array when no values have been defined |
+| `IgnoreMinItemsUnlessRequired` | `1`   | Ignore `minItems` on a field when calculating defaults unless the field is required                                                |
+
+```tsx
+import { RJSFSchema, DefaultFormStateBehavior } from '@rjsf/utils';
+import validator from '@rjsf/validator-ajv8';
+
+const schema: RJSFSchema = {
+  type: 'array',
+  items: { type: 'string' },
+  minItems: 3,
+};
+
+render(
+  <Form
+    schema={schema}
+    validator={validator}
+    defaultFormStateBehavior={DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired}
+  />,
+  document.getElementById('app')
+);
+```
+
+OR
+
+```tsx
+...
+
+render(
+  <Form
+    schema={schema}
+    validator={validator}
+    defaultFormStateBehavior={1}
+  />,
+  document.getElementById('app')
+);
+```
+
 ## disabled
 
 It's possible to disable the whole form by setting the `disabled` prop. The `disabled` prop is then forwarded down to each field of the form.

--- a/packages/playground/src/components/Header.tsx
+++ b/packages/playground/src/components/Header.tsx
@@ -65,28 +65,22 @@ const liveSettingsSchema: RJSFSchema = {
       title: 'Show Error List',
       enum: [false, 'top', 'bottom'],
     },
-    featureFlags: {
-      type: 'object',
-      title: 'Feature flags',
-      properties: {
-        defaultFormStateBehavior: {
+    defaultFormStateBehavior: {
+      type: 'number',
+      default: DefaultFormStateBehavior.Legacy_PopulateMinItems,
+      title: 'Default form state behavior',
+      oneOf: [
+        {
           type: 'number',
-          default: DefaultFormStateBehavior.Legacy_PopulateMinItems,
-          title: 'Default form state behavior',
-          oneOf: [
-            {
-              type: 'number',
-              title: 'Populate remaining minItems with default values (legacy behavior)',
-              enum: [DefaultFormStateBehavior.Legacy_PopulateMinItems],
-            },
-            {
-              type: 'number',
-              title: 'Ignore minItems unless field is required',
-              enum: [DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired],
-            },
-          ],
+          title: 'Populate remaining minItems with default values (legacy behavior)',
+          enum: [DefaultFormStateBehavior.Legacy_PopulateMinItems],
         },
-      },
+        {
+          type: 'number',
+          title: 'Ignore minItems unless field is required',
+          enum: [DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired],
+        },
+      ],
     },
   },
 };

--- a/packages/playground/src/components/Header.tsx
+++ b/packages/playground/src/components/Header.tsx
@@ -66,23 +66,35 @@ const liveSettingsSchema: RJSFSchema = {
       enum: [false, 'top', 'bottom'],
     },
     experimental_defaultFormStateBehavior: {
-      title: 'Default form state behavior',
-      arrayMinItems: {
-        type: 'string',
-        title: 'minItems behavior for array field',
-        oneOf: [
-          {
-            type: 'string',
-            title: 'Populate remaining minItems with default values (legacy behavior)',
-            enum: ['populate'],
-          },
-          {
-            type: 'string',
-            title: 'Ignore minItems unless field is required',
-            enum: ['requiredOnly'],
-          },
-        ],
+      title: 'Default Form State Behavior (Experimental)',
+      type: 'object',
+      properties: {
+        arrayMinItems: {
+          type: 'string',
+          title: 'minItems behavior for array field',
+          default: 'populate',
+          oneOf: [
+            {
+              type: 'string',
+              title: 'Populate remaining minItems with default values (legacy behavior)',
+              enum: ['populate'],
+            },
+            {
+              type: 'string',
+              title: 'Ignore minItems unless field is required',
+              enum: ['requiredOnly'],
+            },
+          ],
+        },
       },
+    },
+  },
+};
+
+const liveSettingsUiSchema: UiSchema = {
+  experimental_defaultFormStateBehavior: {
+    'ui:options': {
+      label: false,
     },
   },
 };
@@ -194,6 +206,7 @@ export default function Header({
             formData={liveSettings}
             validator={localValidator}
             onChange={handleSetLiveSettings}
+            uiSchema={liveSettingsUiSchema}
           >
             <div />
           </Form>

--- a/packages/playground/src/components/Header.tsx
+++ b/packages/playground/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import Form, { IChangeEvent } from '@rjsf/core';
-import { RJSFSchema, UiSchema, ValidatorType } from '@rjsf/utils';
+import { DefaultFormStateBehavior, RJSFSchema, UiSchema, ValidatorType } from '@rjsf/utils';
 import localValidator from '@rjsf/validator-ajv8';
 
 import CopyLink from './CopyLink';
@@ -64,6 +64,29 @@ const liveSettingsSchema: RJSFSchema = {
       default: 'top',
       title: 'Show Error List',
       enum: [false, 'top', 'bottom'],
+    },
+    featureFlags: {
+      type: 'object',
+      title: 'Feature flags',
+      properties: {
+        defaultFormStateBehavior: {
+          type: 'number',
+          default: DefaultFormStateBehavior.Legacy_PopulateMinItems,
+          title: 'Default form state behavior',
+          oneOf: [
+            {
+              type: 'number',
+              title: 'Populate remaining minItems with default values (legacy behavior)',
+              enum: [DefaultFormStateBehavior.Legacy_PopulateMinItems],
+            },
+            {
+              type: 'number',
+              title: 'Ignore minItems unless field is required',
+              enum: [DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired],
+            },
+          ],
+        },
+      },
     },
   },
 };

--- a/packages/playground/src/components/Header.tsx
+++ b/packages/playground/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import Form, { IChangeEvent } from '@rjsf/core';
-import { DefaultFormStateBehavior, RJSFSchema, UiSchema, ValidatorType } from '@rjsf/utils';
+import { RJSFSchema, UiSchema, ValidatorType } from '@rjsf/utils';
 import localValidator from '@rjsf/validator-ajv8';
 
 import CopyLink from './CopyLink';
@@ -65,22 +65,24 @@ const liveSettingsSchema: RJSFSchema = {
       title: 'Show Error List',
       enum: [false, 'top', 'bottom'],
     },
-    defaultFormStateBehavior: {
-      type: 'number',
-      default: DefaultFormStateBehavior.Legacy_PopulateMinItems,
+    experimental_defaultFormStateBehavior: {
       title: 'Default form state behavior',
-      oneOf: [
-        {
-          type: 'number',
-          title: 'Populate remaining minItems with default values (legacy behavior)',
-          enum: [DefaultFormStateBehavior.Legacy_PopulateMinItems],
-        },
-        {
-          type: 'number',
-          title: 'Ignore minItems unless field is required',
-          enum: [DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired],
-        },
-      ],
+      arrayMinItems: {
+        type: 'string',
+        title: 'minItems behavior for array field',
+        oneOf: [
+          {
+            type: 'string',
+            title: 'Populate remaining minItems with default values (legacy behavior)',
+            enum: ['populate'],
+          },
+          {
+            type: 'string',
+            title: 'Ignore minItems unless field is required',
+            enum: ['requiredOnly'],
+          },
+        ],
+      },
     },
   },
 };

--- a/packages/playground/src/components/Playground.tsx
+++ b/packages/playground/src/components/Playground.tsx
@@ -9,7 +9,6 @@ import {
   TemplatesType,
   UiSchema,
   ValidatorType,
-  DefaultFormStateBehavior,
 } from '@rjsf/utils';
 
 import { samples } from '../samples';
@@ -45,7 +44,7 @@ export default function Playground({ themes, validators }: PlaygroundProps) {
     readonly: false,
     omitExtraData: false,
     liveOmit: false,
-    defaultFormStateBehavior: DefaultFormStateBehavior.Legacy_PopulateMinItems,
+    experimental_defaultFormStateBehavior: {},
   });
   const [FormComponent, setFormComponent] = useState<ComponentType<FormProps>>(withTheme({}));
   const [ArrayFieldTemplate, setArrayFieldTemplate] = useState<ComponentType<ArrayFieldTemplateProps>>();

--- a/packages/playground/src/components/Playground.tsx
+++ b/packages/playground/src/components/Playground.tsx
@@ -45,9 +45,7 @@ export default function Playground({ themes, validators }: PlaygroundProps) {
     readonly: false,
     omitExtraData: false,
     liveOmit: false,
-    featureFlags: {
-      defaultFormStateBehavior: DefaultFormStateBehavior.Legacy_PopulateMinItems,
-    },
+    defaultFormStateBehavior: DefaultFormStateBehavior.Legacy_PopulateMinItems,
   });
   const [FormComponent, setFormComponent] = useState<ComponentType<FormProps>>(withTheme({}));
   const [ArrayFieldTemplate, setArrayFieldTemplate] = useState<ComponentType<ArrayFieldTemplateProps>>();

--- a/packages/playground/src/components/Playground.tsx
+++ b/packages/playground/src/components/Playground.tsx
@@ -45,7 +45,9 @@ export default function Playground({ themes, validators }: PlaygroundProps) {
     readonly: false,
     omitExtraData: false,
     liveOmit: false,
-    defaultFormStateBehavior: DefaultFormStateBehavior.Legacy_PopulateMinItems,
+    featureFlags: {
+      defaultFormStateBehavior: DefaultFormStateBehavior.Legacy_PopulateMinItems,
+    },
   });
   const [FormComponent, setFormComponent] = useState<ComponentType<FormProps>>(withTheme({}));
   const [ArrayFieldTemplate, setArrayFieldTemplate] = useState<ComponentType<ArrayFieldTemplateProps>>();
@@ -84,6 +86,7 @@ export default function Playground({ themes, validators }: PlaygroundProps) {
       setObjectFieldTemplate(ObjectFieldTemplate);
       setLiveSettings(liveSettings);
       setShowForm(true);
+      setLiveSettings(liveSettings);
     },
     [theme, onThemeSelected, themes]
   );

--- a/packages/playground/src/components/Playground.tsx
+++ b/packages/playground/src/components/Playground.tsx
@@ -9,6 +9,7 @@ import {
   TemplatesType,
   UiSchema,
   ValidatorType,
+  DefaultFormStateBehavior,
 } from '@rjsf/utils';
 
 import { samples } from '../samples';
@@ -44,6 +45,7 @@ export default function Playground({ themes, validators }: PlaygroundProps) {
     readonly: false,
     omitExtraData: false,
     liveOmit: false,
+    defaultFormStateBehavior: DefaultFormStateBehavior.Legacy_PopulateMinItems,
   });
   const [FormComponent, setFormComponent] = useState<ComponentType<FormProps>>(withTheme({}));
   const [ArrayFieldTemplate, setArrayFieldTemplate] = useState<ComponentType<ArrayFieldTemplateProps>>();

--- a/packages/playground/src/components/Playground.tsx
+++ b/packages/playground/src/components/Playground.tsx
@@ -44,7 +44,7 @@ export default function Playground({ themes, validators }: PlaygroundProps) {
     readonly: false,
     omitExtraData: false,
     liveOmit: false,
-    experimental_defaultFormStateBehavior: {},
+    experimental_defaultFormStateBehavior: { arrayMinItems: 'populate' },
   });
   const [FormComponent, setFormComponent] = useState<ComponentType<FormProps>>(withTheme({}));
   const [ArrayFieldTemplate, setArrayFieldTemplate] = useState<ComponentType<ArrayFieldTemplateProps>>();

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -31,6 +31,6 @@ export const UI_GLOBAL_OPTIONS_KEY = 'ui:globalOptions';
 
 export const DefaultFormStateBehavior = {
   Legacy: 0,
-  IgnoreMinItems: 1,
-  RequiredMinItemsPopulated: 2,
+  PopulateMinItems: 0,
+  IgnoreMinItemsUnlessRequired: 1,
 } as const;

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -28,8 +28,3 @@ export const UI_FIELD_KEY = 'ui:field';
 export const UI_WIDGET_KEY = 'ui:widget';
 export const UI_OPTIONS_KEY = 'ui:options';
 export const UI_GLOBAL_OPTIONS_KEY = 'ui:globalOptions';
-
-export const DefaultFormStateBehavior = {
-  Legacy_PopulateMinItems: 0 << 0,
-  IgnoreMinItemsUnlessRequired: 1 << 0,
-} as const;

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -28,3 +28,9 @@ export const UI_FIELD_KEY = 'ui:field';
 export const UI_WIDGET_KEY = 'ui:widget';
 export const UI_OPTIONS_KEY = 'ui:options';
 export const UI_GLOBAL_OPTIONS_KEY = 'ui:globalOptions';
+
+export const DefaultFormStateBehavior = {
+  Legacy: 0,
+  IgnoreMinItems: 1,
+  RequiredMinItemsPopulated: 2,
+} as const;

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -30,7 +30,6 @@ export const UI_OPTIONS_KEY = 'ui:options';
 export const UI_GLOBAL_OPTIONS_KEY = 'ui:globalOptions';
 
 export const DefaultFormStateBehavior = {
-  Legacy: 0,
-  PopulateMinItems: 0,
-  IgnoreMinItemsUnlessRequired: 1,
+  Legacy_PopulateMinItems: 0 << 0,
+  IgnoreMinItemsUnlessRequired: 1 << 0,
 } as const;

--- a/packages/utils/src/createSchemaUtils.ts
+++ b/packages/utils/src/createSchemaUtils.ts
@@ -70,7 +70,11 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
    * @param [defaultFormStateBehavior=0] - Optional bit flag, if provided, allows users to override default form state behavior
    * @returns - True if the `SchemaUtilsType` differs from the given `validator` or `rootSchema`
    */
-  doesSchemaUtilsDiffer(validator: ValidatorType<T, S, F>, rootSchema: S, defaultFormStateBehavior = DefaultFormStateBehavior.Legacy_PopulateMinItems): boolean {
+  doesSchemaUtilsDiffer(
+    validator: ValidatorType<T, S, F>,
+    rootSchema: S,
+    defaultFormStateBehavior = DefaultFormStateBehavior.Legacy_PopulateMinItems
+  ): boolean {
     if (!validator || !rootSchema) {
       return false;
     }

--- a/packages/utils/src/createSchemaUtils.ts
+++ b/packages/utils/src/createSchemaUtils.ts
@@ -67,13 +67,18 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
    *
    * @param validator - An implementation of the `ValidatorType` interface that will be compared against the current one
    * @param rootSchema - The root schema that will be compared against the current one
+   * @param behaviorBitFlags Bitwise flags to set which behavior is chosen for certain edge cases
    * @returns - True if the `SchemaUtilsType` differs from the given `validator` or `rootSchema`
    */
-  doesSchemaUtilsDiffer(validator: ValidatorType<T, S, F>, rootSchema: S): boolean {
+  doesSchemaUtilsDiffer(validator: ValidatorType<T, S, F>, rootSchema: S, behaviorBitFlags: number): boolean {
     if (!validator || !rootSchema) {
       return false;
     }
-    return this.validator !== validator || !deepEquals(this.rootSchema, rootSchema);
+    return (
+      this.validator !== validator ||
+      !deepEquals(this.rootSchema, rootSchema) ||
+      this.behaviorBitFlags !== behaviorBitFlags
+    );
   }
 
   /** Returns the superset of `formData` that includes the given set updated to include any missing fields that have

--- a/packages/utils/src/createSchemaUtils.ts
+++ b/packages/utils/src/createSchemaUtils.ts
@@ -1,6 +1,7 @@
 import deepEquals from './deepEquals';
 import {
   ErrorSchema,
+  Experimental_DefaultFormStateBehavior,
   FormContextType,
   GlobalUISchemaOptions,
   IdSchema,
@@ -27,10 +28,9 @@ import {
   toIdSchema,
   toPathSchema,
 } from './schema';
-import { DefaultFormStateBehavior } from './constants';
 
 /** The `SchemaUtils` class provides a wrapper around the publicly exported APIs in the `utils/schema` directory such
- * that one does not have to explicitly pass the `validator`, `rootSchema`, or `defaultFormStateBehavior` to each method.
+ * that one does not have to explicitly pass the `validator`, `rootSchema`, or `experimental_defaultFormStateBehavior` to each method.
  * Since these generally do not change across a `Form`, this allows for providing a simplified set of APIs to the
  * `@rjsf/core` components and the various themes as well. This class implements the `SchemaUtilsType` interface.
  */
@@ -39,18 +39,22 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
 {
   rootSchema: S;
   validator: ValidatorType<T, S, F>;
-  defaultFormStateBehavior: number;
+  experimental_defaultFormStateBehavior: Experimental_DefaultFormStateBehavior;
 
   /** Constructs the `SchemaUtils` instance with the given `validator` and `rootSchema` stored as instance variables
    *
    * @param validator - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
    * @param rootSchema - The root schema that will be forwarded to all the APIs
-   * @param defaultFormStateBehavior - Bit flag which allows users to override default form state behavior
+   * @param experimental_defaultFormStateBehavior - Configuration flags to allow users to override default form state behavior
    */
-  constructor(validator: ValidatorType<T, S, F>, rootSchema: S, defaultFormStateBehavior: number) {
+  constructor(
+    validator: ValidatorType<T, S, F>,
+    rootSchema: S,
+    experimental_defaultFormStateBehavior: Experimental_DefaultFormStateBehavior
+  ) {
     this.rootSchema = rootSchema;
     this.validator = validator;
-    this.defaultFormStateBehavior = defaultFormStateBehavior;
+    this.experimental_defaultFormStateBehavior = experimental_defaultFormStateBehavior;
   }
 
   /** Returns the `ValidatorType` in the `SchemaUtilsType`
@@ -67,13 +71,13 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
    *
    * @param validator - An implementation of the `ValidatorType` interface that will be compared against the current one
    * @param rootSchema - The root schema that will be compared against the current one
-   * @param [defaultFormStateBehavior=0] - Optional bit flag, if provided, allows users to override default form state behavior
+   * @param [experimental_defaultFormStateBehavior] Optional configuration object, if provided, allows users to override default form state behavior
    * @returns - True if the `SchemaUtilsType` differs from the given `validator` or `rootSchema`
    */
   doesSchemaUtilsDiffer(
     validator: ValidatorType<T, S, F>,
     rootSchema: S,
-    defaultFormStateBehavior = DefaultFormStateBehavior.Legacy_PopulateMinItems
+    experimental_defaultFormStateBehavior = {}
   ): boolean {
     if (!validator || !rootSchema) {
       return false;
@@ -81,7 +85,7 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
     return (
       this.validator !== validator ||
       !deepEquals(this.rootSchema, rootSchema) ||
-      this.defaultFormStateBehavior !== defaultFormStateBehavior
+      !deepEquals(this.experimental_defaultFormStateBehavior, experimental_defaultFormStateBehavior)
     );
   }
 
@@ -106,7 +110,7 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
       formData,
       this.rootSchema,
       includeUndefinedValues,
-      this.defaultFormStateBehavior
+      this.experimental_defaultFormStateBehavior
     );
   }
 
@@ -278,7 +282,7 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
  *
  * @param validator - an implementation of the `ValidatorType` interface that will be forwarded to all the APIs
  * @param rootSchema - The root schema that will be forwarded to all the APIs
- * @param [defaultFormStateBehavior=0] - Optional bit flag, if provided, allows users to override default form state behavior
+ * @param [experimental_defaultFormStateBehavior] Optional configuration object, if provided, allows users to override default form state behavior
  * @returns - An implementation of a `SchemaUtilsType` interface
  */
 export default function createSchemaUtils<
@@ -288,7 +292,7 @@ export default function createSchemaUtils<
 >(
   validator: ValidatorType<T, S, F>,
   rootSchema: S,
-  defaultFormStateBehavior = DefaultFormStateBehavior.Legacy_PopulateMinItems
+  experimental_defaultFormStateBehavior = {}
 ): SchemaUtilsType<T, S, F> {
-  return new SchemaUtils<T, S, F>(validator, rootSchema, defaultFormStateBehavior);
+  return new SchemaUtils<T, S, F>(validator, rootSchema, experimental_defaultFormStateBehavior);
 }

--- a/packages/utils/src/createSchemaUtils.ts
+++ b/packages/utils/src/createSchemaUtils.ts
@@ -80,14 +80,23 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
    * @param [includeUndefinedValues=false] - Optional flag, if true, cause undefined values to be added as defaults.
    *          If "excludeObjectChildren", pass `includeUndefinedValues` as false when computing defaults for any nested
    *          object properties.
+   * @param [behaviorBitFlags=0] Optional bitwise flags to set which behavior is chosen for certain edge cases.
    * @returns - The resulting `formData` with all the defaults provided
    */
   getDefaultFormState(
     schema: S,
     formData?: T,
-    includeUndefinedValues: boolean | 'excludeObjectChildren' = false
+    includeUndefinedValues: boolean | 'excludeObjectChildren' = false,
+    behaviorBitFlags = 0
   ): T | T[] | undefined {
-    return getDefaultFormState<T, S, F>(this.validator, schema, formData, this.rootSchema, includeUndefinedValues);
+    return getDefaultFormState<T, S, F>(
+      this.validator,
+      schema,
+      formData,
+      this.rootSchema,
+      includeUndefinedValues,
+      behaviorBitFlags
+    );
   }
 
   /** Determines whether the combination of `schema` and `uiSchema` properties indicates that the label for the `schema`

--- a/packages/utils/src/createSchemaUtils.ts
+++ b/packages/utils/src/createSchemaUtils.ts
@@ -39,18 +39,18 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
 {
   rootSchema: S;
   validator: ValidatorType<T, S, F>;
-  behaviorBitFlags: number;
+  defaultFormStateBehavior: number;
 
   /** Constructs the `SchemaUtils` instance with the given `validator` and `rootSchema` stored as instance variables
    *
    * @param validator - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
    * @param rootSchema - The root schema that will be forwarded to all the APIs
-   * @param behaviorBitFlags Bitwise flags to set which behavior is chosen for certain edge cases.
+   * @param defaultFormStateBehavior - Bit flag which allows users to override default form state behavior
    */
-  constructor(validator: ValidatorType<T, S, F>, rootSchema: S, behaviorBitFlags: number) {
+  constructor(validator: ValidatorType<T, S, F>, rootSchema: S, defaultFormStateBehavior: number) {
     this.rootSchema = rootSchema;
     this.validator = validator;
-    this.behaviorBitFlags = behaviorBitFlags;
+    this.defaultFormStateBehavior = defaultFormStateBehavior;
   }
 
   /** Returns the `ValidatorType` in the `SchemaUtilsType`
@@ -67,17 +67,17 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
    *
    * @param validator - An implementation of the `ValidatorType` interface that will be compared against the current one
    * @param rootSchema - The root schema that will be compared against the current one
-   * @param behaviorBitFlags Bitwise flags to set which behavior is chosen for certain edge cases
+   * @param [defaultFormStateBehavior=0] - Optional bit flag, if provided, allows users to override default form state behavior
    * @returns - True if the `SchemaUtilsType` differs from the given `validator` or `rootSchema`
    */
-  doesSchemaUtilsDiffer(validator: ValidatorType<T, S, F>, rootSchema: S, behaviorBitFlags: number): boolean {
+  doesSchemaUtilsDiffer(validator: ValidatorType<T, S, F>, rootSchema: S, defaultFormStateBehavior = DefaultFormStateBehavior.Legacy_PopulateMinItems): boolean {
     if (!validator || !rootSchema) {
       return false;
     }
     return (
       this.validator !== validator ||
       !deepEquals(this.rootSchema, rootSchema) ||
-      this.behaviorBitFlags !== behaviorBitFlags
+      this.defaultFormStateBehavior !== defaultFormStateBehavior
     );
   }
 
@@ -102,7 +102,7 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
       formData,
       this.rootSchema,
       includeUndefinedValues,
-      this.behaviorBitFlags
+      this.defaultFormStateBehavior
     );
   }
 
@@ -274,7 +274,7 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
  *
  * @param validator - an implementation of the `ValidatorType` interface that will be forwarded to all the APIs
  * @param rootSchema - The root schema that will be forwarded to all the APIs
- * @param [behaviorBitFlags=0] Optional bitwise flags to set which behavior is chosen for certain edge cases.
+ * @param [defaultFormStateBehavior=0] - Optional bit flag, if provided, allows users to override default form state behavior
  * @returns - An implementation of a `SchemaUtilsType` interface
  */
 export default function createSchemaUtils<
@@ -284,7 +284,7 @@ export default function createSchemaUtils<
 >(
   validator: ValidatorType<T, S, F>,
   rootSchema: S,
-  behaviorBitFlags = DefaultFormStateBehavior.Legacy_PopulateMinItems
+  defaultFormStateBehavior = DefaultFormStateBehavior.Legacy_PopulateMinItems
 ): SchemaUtilsType<T, S, F> {
-  return new SchemaUtils<T, S, F>(validator, rootSchema, behaviorBitFlags);
+  return new SchemaUtils<T, S, F>(validator, rootSchema, defaultFormStateBehavior);
 }

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -318,7 +318,7 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
         // populate the array with the defaults
         const fillerSchema: S = getInnerSchemaForArrayItem<S>(schema, AdditionalItemsHandling.Invert);
         const fillerDefault = fillerSchema.default;
-        if (behaviorBitFlags === DefaultFormStateBehavior.Legacy || (ignoreMinItemsFlag && required)) {
+        if (behaviorBitFlags === DefaultFormStateBehavior.Legacy_PopulateMinItems || (ignoreMinItemsFlag && required)) {
           const fillerEntries: T[] = new Array(schema.minItems - defaultsLength).fill(
             computeDefaults<any, S, F>(
               validator,

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -166,18 +166,14 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
     }
   } else if (DEPENDENCIES_KEY in schema) {
     const resolvedSchema = resolveDependencies<T, S, F>(validator, schema, rootSchema, false, formData);
-    return computeDefaults<T, S, F>(
-      validator, 
-      resolvedSchema[0],
-      {
-        rootSchema,
-        includeUndefinedValues,
-        _recurseList,
-        experimental_defaultFormStateBehavior,
-        parentDefaults: defaults,
-        rawFormData: formData as T,
-      },
-    );
+    return computeDefaults<T, S, F>(validator, resolvedSchema[0], {
+      rootSchema,
+      includeUndefinedValues,
+      _recurseList,
+      experimental_defaultFormStateBehavior,
+      parentDefaults: defaults,
+      rawFormData: formData as T,
+    });
   } else if (isFixedItems(schema)) {
     defaults = (schema.items! as S[]).map((itemSchema: S, idx: number) =>
       computeDefaults<T, S>(validator, itemSchema, {

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -100,7 +100,7 @@ function maybeAddDefaultToObject<T = any>(
   }
 }
 
-interface computeDefaultsProps<T = any, S extends StrictRJSFSchema = RJSFSchema> {
+interface ComputeDefaultsProps<T = any, S extends StrictRJSFSchema = RJSFSchema> {
   parentDefaults?: T;
   rootSchema?: S;
   rawFormData?: T;
@@ -138,7 +138,7 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
     _recurseList = [],
     experimental_defaultFormStateBehavior = undefined,
     required = false,
-  }: computeDefaultsProps<T, S> = {}
+  }: ComputeDefaultsProps<T, S> = {}
 ): T | T[] | undefined {
   const formData: T = (isObject(rawFormData) ? rawFormData : {}) as T;
   let schema: S = isObject(rawSchema) ? rawSchema : ({} as S);

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -302,11 +302,14 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
         }) as T[];
       }
 
-      const ignoreMinItemsFlag = behaviorBitFlags & DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired;
+      const ignoreMinItemsFlagSet =
+        (behaviorBitFlags & DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired) ===
+        DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired;
 
+      console.log('first defaults return', defaults, behaviorBitFlags);
       if (
         !schema.minItems ||
-        (ignoreMinItemsFlag && !required) ||
+        (ignoreMinItemsFlagSet && !required) ||
         isMultiSelect<T, S, F>(validator, schema, rootSchema)
       ) {
         return defaults ? defaults : [];
@@ -318,7 +321,10 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
         // populate the array with the defaults
         const fillerSchema: S = getInnerSchemaForArrayItem<S>(schema, AdditionalItemsHandling.Invert);
         const fillerDefault = fillerSchema.default;
-        if (behaviorBitFlags === DefaultFormStateBehavior.Legacy_PopulateMinItems || (ignoreMinItemsFlag && required)) {
+        if (
+          behaviorBitFlags === DefaultFormStateBehavior.Legacy_PopulateMinItems ||
+          (ignoreMinItemsFlagSet && required)
+        ) {
           const fillerEntries: T[] = new Array(schema.minItems - defaultsLength).fill(
             computeDefaults<any, S, F>(
               validator,

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -1,7 +1,15 @@
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 
-import { ANY_OF_KEY, DEFAULT_KEY, DEPENDENCIES_KEY, PROPERTIES_KEY, ONE_OF_KEY, REF_KEY, DefaultFormStateBehavior } from '../constants';
+import {
+  ANY_OF_KEY,
+  DEFAULT_KEY,
+  DEPENDENCIES_KEY,
+  PROPERTIES_KEY,
+  ONE_OF_KEY,
+  REF_KEY,
+  DefaultFormStateBehavior,
+} from '../constants';
 import findSchemaDefinition from '../findSchemaDefinition';
 import getClosestMatchingOption from './getClosestMatchingOption';
 import getDiscriminatorFieldFromSchema from '../getDiscriminatorFieldFromSchema';
@@ -294,11 +302,8 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
         }) as T[];
       }
 
-      const ignoreMinItemsFlag =
-        behaviorBitFlags &
-        DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired;
+      const ignoreMinItemsFlag = behaviorBitFlags & DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired;
 
-      console.log('defaults test', !schema.minItems, ignoreMinItemsFlag && !required, isMultiSelect<T, S, F>(validator, schema, rootSchema));
       if (
         !schema.minItems ||
         (ignoreMinItemsFlag && !required) ||
@@ -311,19 +316,10 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
       if (schema.minItems > defaultsLength) {
         const defaultEntries: T[] = (defaults || []) as T[];
         // populate the array with the defaults
-        const fillerSchema: S = getInnerSchemaForArrayItem<S>(
-          schema,
-          AdditionalItemsHandling.Invert
-        );
+        const fillerSchema: S = getInnerSchemaForArrayItem<S>(schema, AdditionalItemsHandling.Invert);
         const fillerDefault = fillerSchema.default;
-        console.log('filler', fillerDefault, behaviorBitFlags, required);
-        if (
-          behaviorBitFlags === DefaultFormStateBehavior.Legacy ||
-          (ignoreMinItemsFlag && required)
-        ) {
-          const fillerEntries: T[] = new Array(
-            schema.minItems - defaultsLength
-          ).fill(
+        if (behaviorBitFlags === DefaultFormStateBehavior.Legacy || (ignoreMinItemsFlag && required)) {
+          const fillerEntries: T[] = new Array(schema.minItems - defaultsLength).fill(
             computeDefaults<any, S, F>(
               validator,
               fillerSchema,
@@ -388,10 +384,7 @@ export default function getDefaultFormState<
     undefined,
     behaviorBitFlags
   );
-  if (formData === undefined ||
-    formData === null ||
-    (typeof formData === "number" && isNaN(formData))
-  ) {
+  if (formData === undefined || formData === null || (typeof formData === 'number' && isNaN(formData))) {
     // No form data? Use schema defaults.
     return defaults;
   }

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -306,7 +306,6 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
         (behaviorBitFlags & DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired) ===
         DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired;
 
-      console.log('first defaults return', defaults, behaviorBitFlags);
       if (
         !schema.minItems ||
         (ignoreMinItemsFlagSet && !required) ||

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -290,7 +290,6 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
       // Deeply inject defaults into already existing form data
       if (Array.isArray(rawFormData)) {
         const schemaItem: S = getInnerSchemaForArrayItem<S>(schema);
-        console.log('schemaItem', schemaItem);
         defaults = rawFormData.map((item: T, idx: number) => {
           return computeDefaults<T, S, F>(validator, schemaItem, {
             rootSchema,
@@ -324,12 +323,6 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
       const defaultEntries: T[] = (defaults || []) as T[];
       const fillerSchema: S = getInnerSchemaForArrayItem<S>(schema, AdditionalItemsHandling.Invert);
       const fillerDefault = fillerSchema.default;
-      if (
-        (behaviorBitFlags & DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired) !==
-        DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired
-      ) {
-        return defaultEntries;
-      }
 
       // Calculate filler entries for remaining items (minItems - existing raw data/defaults)
       const fillerEntries: T[] = new Array(schema.minItems - defaultsLength).fill(

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -301,7 +301,7 @@ export interface Registry<T = any, S extends StrictRJSFSchema = RJSFSchema, F ex
 /** The properties that are passed to a Field implementation */
 export interface FieldProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>
   extends GenericObjectType,
-    Pick<HTMLAttributes<HTMLElement>, Exclude<keyof HTMLAttributes<HTMLElement>, 'onBlur' | 'onFocus' | 'onChange'>> {
+  Pick<HTMLAttributes<HTMLElement>, Exclude<keyof HTMLAttributes<HTMLElement>, 'onBlur' | 'onFocus' | 'onChange'>> {
   /** The JSON subschema object for this field */
   schema: S;
   /** The uiSchema for this field */
@@ -644,7 +644,7 @@ export type WrapIfAdditionalTemplateProps<
 /** The properties that are passed to a Widget implementation */
 export interface WidgetProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>
   extends GenericObjectType,
-    Pick<HTMLAttributes<HTMLElement>, Exclude<keyof HTMLAttributes<HTMLElement>, 'onBlur' | 'onFocus'>> {
+  Pick<HTMLAttributes<HTMLElement>, Exclude<keyof HTMLAttributes<HTMLElement>, 'onBlur' | 'onFocus'>> {
   /** The generated id for this widget, used to provide unique `name`s and `id`s for the HTML field elements rendered by
    * widgets
    */
@@ -936,7 +936,7 @@ export interface ValidatorType<T = any, S extends StrictRJSFSchema = RJSFSchema,
    * @param schema - The schema against which to validate the form data
    * @param formData - The form data to validate
    */
-  rawValidation<Result = any>(schema: S, formData?: T): { errors?: Result[]; validationError?: Error };
+  rawValidation<Result = any>(schema: S, formData?: T): { errors?: Result[]; validationError?: Error; };
 }
 
 /** The `SchemaUtilsType` interface provides a wrapper around the publicly exported APIs in the `@rjsf/utils/schema`
@@ -967,12 +967,14 @@ export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchem
    * @param [includeUndefinedValues=false] - Optional flag, if true, cause undefined values to be added as defaults.
    *          If "excludeObjectChildren", cause undefined values for this object and pass `includeUndefinedValues` as
    *          false when computing defaults for any nested object properties.
+   * @param [behaviorBitFlags=0] Optional bitwise flags to set which behavior is chosen for certain edge cases.
    * @returns - The resulting `formData` with all the defaults provided
    */
   getDefaultFormState(
     schema: S,
     formData?: T,
-    includeUndefinedValues?: boolean | 'excludeObjectChildren'
+    includeUndefinedValues?: boolean | 'excludeObjectChildren',
+    behaviorBitFlags?: number
   ): T | T[] | undefined;
   /** Determines whether the combination of `schema` and `uiSchema` properties indicates that the label for the `schema`
    * should be displayed in a UI.

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -956,10 +956,10 @@ export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchem
    *
    * @param validator - An implementation of the `ValidatorType` interface that will be compared against the current one
    * @param rootSchema - The root schema that will be compared against the current one
-   * @param behaviorBitFlags Bitwise flags to set which behavior is chosen for certain edge cases
+   * @param [defaultFormStateBehavior=0] Optional bit flag, if provided, allows users to override default form state behavior
    * @returns - True if the `SchemaUtilsType` differs from the given `validator` or `rootSchema`
    */
-  doesSchemaUtilsDiffer(validator: ValidatorType<T, S, F>, rootSchema: S, behaviorBitFlags: number): boolean;
+  doesSchemaUtilsDiffer(validator: ValidatorType<T, S, F>, rootSchema: S, defaultFormStateBehavior?: number): boolean;
   /** Returns the superset of `formData` that includes the given set updated to include any missing fields that have
    * computed to have defaults provided in the `schema`.
    *

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -968,14 +968,12 @@ export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchem
    * @param [includeUndefinedValues=false] - Optional flag, if true, cause undefined values to be added as defaults.
    *          If "excludeObjectChildren", cause undefined values for this object and pass `includeUndefinedValues` as
    *          false when computing defaults for any nested object properties.
-   * @param [behaviorBitFlags=0] Optional bitwise flags to set which behavior is chosen for certain edge cases.
    * @returns - The resulting `formData` with all the defaults provided
    */
   getDefaultFormState(
     schema: S,
     formData?: T,
-    includeUndefinedValues?: boolean | 'excludeObjectChildren',
-    behaviorBitFlags?: number
+    includeUndefinedValues?: boolean | 'excludeObjectChildren'
   ): T | T[] | undefined;
   /** Determines whether the combination of `schema` and `uiSchema` properties indicates that the label for the `schema`
    * should be displayed in a UI.

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -31,6 +31,9 @@ export type RJSFSchema = StrictRJSFSchema & GenericObjectType;
  */
 export type FormContextType = GenericObjectType;
 
+/** Experimental features to specify different form state behavior. Currently, this only affects the
+ * handling of optional array fields where `minItems` is set.
+ */
 export type Experimental_DefaultFormStateBehavior = {
   arrayMinItems?: 'populate' | 'requiredOnly';
 };

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -301,7 +301,7 @@ export interface Registry<T = any, S extends StrictRJSFSchema = RJSFSchema, F ex
 /** The properties that are passed to a Field implementation */
 export interface FieldProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>
   extends GenericObjectType,
-  Pick<HTMLAttributes<HTMLElement>, Exclude<keyof HTMLAttributes<HTMLElement>, 'onBlur' | 'onFocus' | 'onChange'>> {
+    Pick<HTMLAttributes<HTMLElement>, Exclude<keyof HTMLAttributes<HTMLElement>, 'onBlur' | 'onFocus' | 'onChange'>> {
   /** The JSON subschema object for this field */
   schema: S;
   /** The uiSchema for this field */
@@ -644,7 +644,7 @@ export type WrapIfAdditionalTemplateProps<
 /** The properties that are passed to a Widget implementation */
 export interface WidgetProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>
   extends GenericObjectType,
-  Pick<HTMLAttributes<HTMLElement>, Exclude<keyof HTMLAttributes<HTMLElement>, 'onBlur' | 'onFocus'>> {
+    Pick<HTMLAttributes<HTMLElement>, Exclude<keyof HTMLAttributes<HTMLElement>, 'onBlur' | 'onFocus'>> {
   /** The generated id for this widget, used to provide unique `name`s and `id`s for the HTML field elements rendered by
    * widgets
    */
@@ -936,7 +936,7 @@ export interface ValidatorType<T = any, S extends StrictRJSFSchema = RJSFSchema,
    * @param schema - The schema against which to validate the form data
    * @param formData - The form data to validate
    */
-  rawValidation<Result = any>(schema: S, formData?: T): { errors?: Result[]; validationError?: Error; };
+  rawValidation<Result = any>(schema: S, formData?: T): { errors?: Result[]; validationError?: Error };
 }
 
 /** The `SchemaUtilsType` interface provides a wrapper around the publicly exported APIs in the `@rjsf/utils/schema`
@@ -967,14 +967,12 @@ export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchem
    * @param [includeUndefinedValues=false] - Optional flag, if true, cause undefined values to be added as defaults.
    *          If "excludeObjectChildren", cause undefined values for this object and pass `includeUndefinedValues` as
    *          false when computing defaults for any nested object properties.
-   * @param [behaviorBitFlags=0] Optional bitwise flags to set which behavior is chosen for certain edge cases.
    * @returns - The resulting `formData` with all the defaults provided
    */
   getDefaultFormState(
     schema: S,
     formData?: T,
-    includeUndefinedValues?: boolean | 'excludeObjectChildren',
-    behaviorBitFlags?: number
+    includeUndefinedValues?: boolean | 'excludeObjectChildren'
   ): T | T[] | undefined;
   /** Determines whether the combination of `schema` and `uiSchema` properties indicates that the label for the `schema`
    * should be displayed in a UI.

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -31,6 +31,10 @@ export type RJSFSchema = StrictRJSFSchema & GenericObjectType;
  */
 export type FormContextType = GenericObjectType;
 
+export type Experimental_DefaultFormStateBehavior = {
+  arrayMinItems?: 'populate' | 'requiredOnly';
+};
+
 /** The interface representing a Date object that contains an optional time */
 export interface DateObject {
   /** The year of the Date */
@@ -956,10 +960,14 @@ export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchem
    *
    * @param validator - An implementation of the `ValidatorType` interface that will be compared against the current one
    * @param rootSchema - The root schema that will be compared against the current one
-   * @param [defaultFormStateBehavior=0] Optional bit flag, if provided, allows users to override default form state behavior
+   * @param [experimental_defaultFormStateBehavior] Optional configuration object, if provided, allows users to override default form state behavior
    * @returns - True if the `SchemaUtilsType` differs from the given `validator` or `rootSchema`
    */
-  doesSchemaUtilsDiffer(validator: ValidatorType<T, S, F>, rootSchema: S, defaultFormStateBehavior?: number): boolean;
+  doesSchemaUtilsDiffer(
+    validator: ValidatorType<T, S, F>,
+    rootSchema: S,
+    experimental_defaultFormStateBehavior?: Experimental_DefaultFormStateBehavior
+  ): boolean;
   /** Returns the superset of `formData` that includes the given set updated to include any missing fields that have
    * computed to have defaults provided in the `schema`.
    *

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -967,12 +967,14 @@ export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchem
    * @param [includeUndefinedValues=false] - Optional flag, if true, cause undefined values to be added as defaults.
    *          If "excludeObjectChildren", cause undefined values for this object and pass `includeUndefinedValues` as
    *          false when computing defaults for any nested object properties.
+   * @param [behaviorBitFlags=0] Optional bitwise flags to set which behavior is chosen for certain edge cases.
    * @returns - The resulting `formData` with all the defaults provided
    */
   getDefaultFormState(
     schema: S,
     formData?: T,
-    includeUndefinedValues?: boolean | 'excludeObjectChildren'
+    includeUndefinedValues?: boolean | 'excludeObjectChildren',
+    behaviorBitFlags?: number
   ): T | T[] | undefined;
   /** Determines whether the combination of `schema` and `uiSchema` properties indicates that the label for the `schema`
    * should be displayed in a UI.

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -956,9 +956,10 @@ export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchem
    *
    * @param validator - An implementation of the `ValidatorType` interface that will be compared against the current one
    * @param rootSchema - The root schema that will be compared against the current one
+   * @param behaviorBitFlags Bitwise flags to set which behavior is chosen for certain edge cases
    * @returns - True if the `SchemaUtilsType` differs from the given `validator` or `rootSchema`
    */
-  doesSchemaUtilsDiffer(validator: ValidatorType<T, S, F>, rootSchema: S): boolean;
+  doesSchemaUtilsDiffer(validator: ValidatorType<T, S, F>, rootSchema: S, behaviorBitFlags: number): boolean;
   /** Returns the superset of `formData` that includes the given set updated to include any missing fields that have
    * computed to have defaults provided in the `schema`.
    *

--- a/packages/utils/test/createSchemaUtils.test.ts
+++ b/packages/utils/test/createSchemaUtils.test.ts
@@ -27,12 +27,14 @@ describe('createSchemaUtils()', () => {
         expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema, defaultFormStateBehavior)).toBe(false);
       });
       it('returns false when passing falsy validator', () => {
-        expect(schemaUtils.doesSchemaUtilsDiffer(null as unknown as ValidatorType, {}, defaultFormStateBehavior)).toBe(false);
-      });
-      it('returns false when passing falsy rootSchema', () => {
-        expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, null as unknown as RJSFSchema, defaultFormStateBehavior)).toBe(
+        expect(schemaUtils.doesSchemaUtilsDiffer(null as unknown as ValidatorType, {}, defaultFormStateBehavior)).toBe(
           false
         );
+      });
+      it('returns false when passing falsy rootSchema', () => {
+        expect(
+          schemaUtils.doesSchemaUtilsDiffer(testValidator, null as unknown as RJSFSchema, defaultFormStateBehavior)
+        ).toBe(false);
       });
       it('returns true when passing different validator', () => {
         expect(schemaUtils.doesSchemaUtilsDiffer(getTestValidator({}), {}, defaultFormStateBehavior)).toBe(true);

--- a/packages/utils/test/createSchemaUtils.test.ts
+++ b/packages/utils/test/createSchemaUtils.test.ts
@@ -2,32 +2,35 @@ import { createSchemaUtils, RJSFSchema, SchemaUtilsType, ValidatorType } from '.
 import getTestValidator from './testUtils/getTestValidator';
 
 describe('createSchemaUtils()', () => {
-  let testValidator: ValidatorType;
-  let rootSchema: RJSFSchema;
-  let schemaUtils: SchemaUtilsType;
-  beforeAll(() => {
-    testValidator = getTestValidator({});
-    rootSchema = { type: 'object' };
-    schemaUtils = createSchemaUtils(testValidator, rootSchema);
-  });
+  const testValidator: ValidatorType = getTestValidator({});
+  const rootSchema: RJSFSchema = { type: 'object' };
+  const behaviorBitFlags = 0;
+  const schemaUtils: SchemaUtilsType = createSchemaUtils(testValidator, rootSchema, behaviorBitFlags);
+
   it('getValidator()', () => {
     expect(schemaUtils.getValidator()).toBe(testValidator);
   });
+
   describe('doesSchemaUtilsDiffer()', () => {
-    it('passing falsy validator returns false', () => {
-      expect(schemaUtils.doesSchemaUtilsDiffer(null as unknown as ValidatorType, {})).toBe(false);
+    it('returns false when passing same validator, rootSchema, and behaviorBitFlags', () => {
+      expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema, behaviorBitFlags)).toBe(false);
     });
-    it('passing falsy rootSchema returns false', () => {
-      expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, null as unknown as RJSFSchema)).toBe(false);
+    it('returns false when passing falsy validator', () => {
+      expect(schemaUtils.doesSchemaUtilsDiffer(null as unknown as ValidatorType, {}, behaviorBitFlags)).toBe(false);
     });
-    it('passing different validator returns true', () => {
-      expect(schemaUtils.doesSchemaUtilsDiffer(getTestValidator({}), {})).toBe(true);
+    it('returns false when passing falsy rootSchema', () => {
+      expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, null as unknown as RJSFSchema, behaviorBitFlags)).toBe(
+        false
+      );
     });
-    it('passing different rootSchema returns true', () => {
-      expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, {})).toBe(true);
+    it('returns true when passing different validator', () => {
+      expect(schemaUtils.doesSchemaUtilsDiffer(getTestValidator({}), {}, behaviorBitFlags)).toBe(true);
     });
-    it('passing same validator and rootSchema returns false', () => {
-      expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, { type: 'object' })).toBe(false);
+    it('returns true when passing different rootSchema', () => {
+      expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, {}, behaviorBitFlags)).toBe(true);
+    });
+    it('returns true when passing different behaviorBitFlags', () => {
+      expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema, 1)).toBe(true);
     });
   });
   // NOTE: the rest of the functions are tested in the tests defined in the `schema` directory

--- a/packages/utils/test/createSchemaUtils.test.ts
+++ b/packages/utils/test/createSchemaUtils.test.ts
@@ -4,33 +4,45 @@ import getTestValidator from './testUtils/getTestValidator';
 describe('createSchemaUtils()', () => {
   const testValidator: ValidatorType = getTestValidator({});
   const rootSchema: RJSFSchema = { type: 'object' };
-  const behaviorBitFlags = 0;
-  const schemaUtils: SchemaUtilsType = createSchemaUtils(testValidator, rootSchema, behaviorBitFlags);
+  const defaultFormStateBehavior = 1;
+  const schemaUtils: SchemaUtilsType = createSchemaUtils(testValidator, rootSchema, defaultFormStateBehavior);
 
   it('getValidator()', () => {
     expect(schemaUtils.getValidator()).toBe(testValidator);
   });
 
   describe('doesSchemaUtilsDiffer()', () => {
-    it('returns false when passing same validator, rootSchema, and behaviorBitFlags', () => {
-      expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema, behaviorBitFlags)).toBe(false);
+    describe('constructed without defaultFormStateBehavior', () => {
+      const schemaUtils: SchemaUtilsType = createSchemaUtils(testValidator, rootSchema);
+
+      it('returns false when not passing defaultFormStateBehavior', () => {
+        expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema)).toBe(false);
+      });
+      it('returns true when passing different defaultFormStateBehavior', () => {
+        expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema, 1)).toBe(true);
+      });
     });
-    it('returns false when passing falsy validator', () => {
-      expect(schemaUtils.doesSchemaUtilsDiffer(null as unknown as ValidatorType, {}, behaviorBitFlags)).toBe(false);
-    });
-    it('returns false when passing falsy rootSchema', () => {
-      expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, null as unknown as RJSFSchema, behaviorBitFlags)).toBe(
-        false
-      );
-    });
-    it('returns true when passing different validator', () => {
-      expect(schemaUtils.doesSchemaUtilsDiffer(getTestValidator({}), {}, behaviorBitFlags)).toBe(true);
-    });
-    it('returns true when passing different rootSchema', () => {
-      expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, {}, behaviorBitFlags)).toBe(true);
-    });
-    it('returns true when passing different behaviorBitFlags', () => {
-      expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema, 1)).toBe(true);
+    describe('constructed with defaultFormStateBehavior', () => {
+      it('returns false when passing same validator, rootSchema, and defaultFormStateBehavior', () => {
+        expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema, defaultFormStateBehavior)).toBe(false);
+      });
+      it('returns false when passing falsy validator', () => {
+        expect(schemaUtils.doesSchemaUtilsDiffer(null as unknown as ValidatorType, {}, defaultFormStateBehavior)).toBe(false);
+      });
+      it('returns false when passing falsy rootSchema', () => {
+        expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, null as unknown as RJSFSchema, defaultFormStateBehavior)).toBe(
+          false
+        );
+      });
+      it('returns true when passing different validator', () => {
+        expect(schemaUtils.doesSchemaUtilsDiffer(getTestValidator({}), {}, defaultFormStateBehavior)).toBe(true);
+      });
+      it('returns true when passing different rootSchema', () => {
+        expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, {}, defaultFormStateBehavior)).toBe(true);
+      });
+      it('returns true when passing different defaultFormStateBehavior', () => {
+        expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema, 0)).toBe(true);
+      });
     });
   });
   // NOTE: the rest of the functions are tested in the tests defined in the `schema` directory

--- a/packages/utils/test/createSchemaUtils.test.ts
+++ b/packages/utils/test/createSchemaUtils.test.ts
@@ -1,10 +1,16 @@
-import { createSchemaUtils, RJSFSchema, SchemaUtilsType, ValidatorType } from '../src';
+import {
+  createSchemaUtils,
+  Experimental_DefaultFormStateBehavior,
+  RJSFSchema,
+  SchemaUtilsType,
+  ValidatorType,
+} from '../src';
 import getTestValidator from './testUtils/getTestValidator';
 
 describe('createSchemaUtils()', () => {
   const testValidator: ValidatorType = getTestValidator({});
   const rootSchema: RJSFSchema = { type: 'object' };
-  const defaultFormStateBehavior = 1;
+  const defaultFormStateBehavior: Experimental_DefaultFormStateBehavior = { arrayMinItems: 'requiredOnly' };
   const schemaUtils: SchemaUtilsType = createSchemaUtils(testValidator, rootSchema, defaultFormStateBehavior);
 
   it('getValidator()', () => {
@@ -19,9 +25,12 @@ describe('createSchemaUtils()', () => {
         expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema)).toBe(false);
       });
       it('returns true when passing different defaultFormStateBehavior', () => {
-        expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema, 1)).toBe(true);
+        expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema, { arrayMinItems: 'requiredOnly' })).toBe(
+          true
+        );
       });
     });
+
     describe('constructed with defaultFormStateBehavior', () => {
       it('returns false when passing same validator, rootSchema, and defaultFormStateBehavior', () => {
         expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema, defaultFormStateBehavior)).toBe(false);
@@ -43,7 +52,7 @@ describe('createSchemaUtils()', () => {
         expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, {}, defaultFormStateBehavior)).toBe(true);
       });
       it('returns true when passing different defaultFormStateBehavior', () => {
-        expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema, 0)).toBe(true);
+        expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema, { arrayMinItems: 'populate' })).toBe(true);
       });
     });
   });

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -38,36 +38,6 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           foo: 42,
         });
       });
-      it('test an object with an optional array property with minItems', () => {
-        const schema: RJSFSchema = {
-          type: 'object',
-          properties: {
-            optionalArray: {
-              type: 'array',
-              minItems: 2,
-            },
-          },
-        };
-        expect(
-          computeDefaults(testValidator, schema, undefined, schema)
-        ).toEqual({});
-      });
-      it('test an object with a required array property with minItems', () => {
-        const schema: RJSFSchema = {
-          type: 'object',
-          properties: {
-            requiredArray: {
-              type: 'array',
-              items: { type: 'string' },
-              minItems: 2,
-            },
-          },
-          required: ['requiredArray'],
-        };
-        expect(
-          computeDefaults(testValidator, schema, undefined, schema)
-        ).toEqual({ requiredArray: [undefined, undefined] });
-      });
       it('test an object with an optional property that has a nested required property', () => {
         const schema: RJSFSchema = {
           type: 'object',
@@ -296,21 +266,17 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         ).toEqual(false);
       });
 
-      const noneValues = [null, undefined, NaN];
-      noneValues.forEach((noneValue) => {
-        it('should overwrite existing form data that is equal to a none value', () => {
-          expect(
-            getDefaultFormState(
-              testValidator,
-              {
-                type: 'number',
-                default: 1,
-              },
-              noneValue
-            ),
-            `for noneValue ${noneValue}`
-          ).toEqual(1);
-        });
+      it.each([null, undefined, NaN])('should overwrite existing form data that is equal to a %s', (noneValue) => {
+        expect(
+          getDefaultFormState(
+            testValidator,
+            {
+              type: 'number',
+              default: 1,
+            },
+            noneValue
+          ),
+        ).toEqual(1);
       });
     });
     describe('nested default', () => {

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -234,7 +234,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
       });
     });
     describe('default form state behavior: ignore min items unless required', () => {
-      it('test an object with an optional array property with minItems', () => {
+      it.only('test an object with an optional array property with minItems', () => {
         const schema: RJSFSchema = {
           type: 'object',
           properties: {
@@ -255,7 +255,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
             undefined,
             DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired
           )
-        ).toEqual({ optionalArray: [] });
+        ).toEqual({});
       });
       it('test an object with a required array property with minItems', () => {
         const schema: RJSFSchema = {
@@ -283,8 +283,8 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         ).toEqual({ requiredArray: [undefined, undefined] });
       });
     });
-    describe("root default", () => {
-      it("should map root schema default to form state, if any", () => {
+    describe('root default', () => {
+      it('should map root schema default to form state, if any', () => {
         expect(
           getDefaultFormState(testValidator, {
             type: 'string',
@@ -325,7 +325,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
               default: 1,
             },
             noneValue
-          ),
+          )
         ).toEqual(1);
       });
     });

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -1,4 +1,4 @@
-import { createSchemaUtils, DefaultFormStateBehavior, getDefaultFormState, RJSFSchema } from '../../src';
+import { createSchemaUtils, getDefaultFormState, RJSFSchema } from '../../src';
 import { computeDefaults } from '../../src/schema/getDefaultFormState';
 import { RECURSIVE_REF, RECURSIVE_REF_ALLOF } from '../testUtils/testData';
 import { TestValidatorType } from './types';
@@ -264,7 +264,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         expect(
           computeDefaults(testValidator, schema, {
             rootSchema: schema,
-            defaultFormStateBehavior: DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired,
+            experimental_defaultFormStateBehavior: { arrayMinItems: 'requiredOnly' },
           })
         ).toEqual({});
       });
@@ -282,7 +282,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           computeDefaults(testValidator, schema, {
             rootSchema: schema,
             rawFormData: { optionalArray: [] },
-            defaultFormStateBehavior: DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired,
+            experimental_defaultFormStateBehavior: { arrayMinItems: 'requiredOnly' },
           })
         ).toEqual({ optionalArray: [] });
       });
@@ -301,7 +301,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         expect(
           computeDefaults(testValidator, schema, {
             rootSchema: schema,
-            defaultFormStateBehavior: DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired,
+            experimental_defaultFormStateBehavior: { arrayMinItems: 'requiredOnly' },
           })
         ).toEqual({ requiredArray: [undefined, undefined] });
       });
@@ -321,7 +321,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         expect(
           computeDefaults(testValidator, schema, {
             rootSchema: schema,
-            defaultFormStateBehavior: DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired,
+            experimental_defaultFormStateBehavior: { arrayMinItems: 'requiredOnly' },
           })
         ).toEqual({ requiredArray: ['default0', 'default1'] });
       });
@@ -342,7 +342,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           computeDefaults(testValidator, schema, {
             rootSchema: schema,
             rawFormData: { requiredArray: ['raw0'] },
-            defaultFormStateBehavior: DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired,
+            experimental_defaultFormStateBehavior: { arrayMinItems: 'requiredOnly' },
           })
         ).toEqual({ requiredArray: ['raw0', 'default0'] });
       });

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -1,4 +1,4 @@
-import { createSchemaUtils, getDefaultFormState, RJSFSchema } from '../../src';
+import { createSchemaUtils, DefaultFormStateBehavior, getDefaultFormState, RJSFSchema } from '../../src';
 import { computeDefaults } from '../../src/schema/getDefaultFormState';
 import { RECURSIVE_REF, RECURSIVE_REF_ALLOF } from '../testUtils/testData';
 import { TestValidatorType } from './types';
@@ -233,8 +233,58 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         });
       });
     });
-    describe('root default', () => {
-      it('should map root schema default to form state, if any', () => {
+    describe('default form state behavior: ignore min items unless required', () => {
+      it('test an object with an optional array property with minItems', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            optionalArray: {
+              type: 'array',
+              minItems: 2,
+            },
+          },
+        };
+        expect(
+          computeDefaults(
+            testValidator,
+            schema,
+            undefined,
+            schema,
+            undefined,
+            undefined,
+            undefined,
+            DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired
+          )
+        ).toEqual({ optionalArray: [] });
+      });
+      it('test an object with a required array property with minItems', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            requiredArray: {
+              type: 'array',
+              items: { type: 'string' },
+              minItems: 2,
+            },
+          },
+          required: ['requiredArray'],
+        };
+        expect(
+          computeDefaults(
+            testValidator,
+            schema,
+            undefined,
+            schema,
+            undefined,
+            undefined,
+            undefined,
+            DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired
+          )
+        ).toEqual({ requiredArray: [undefined, undefined] });
+      });
+    });
+    describe("root default", () => {
+      it("should map root schema default to form state, if any", () => {
         expect(
           getDefaultFormState(testValidator, {
             type: 'string',

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -264,6 +264,24 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           })
         ).toEqual({});
       });
+      it('should return empty array when given an empty array as form data for an optional array property with minItems ', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            optionalArray: {
+              type: 'array',
+              minItems: 2,
+            },
+          },
+        };
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            rawFormData: { optionalArray: [] },
+            behaviorBitFlags: DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired,
+          })
+        ).toEqual({ optionalArray: [] });
+      });
       it('should return undefined filled array for a required array property with minItems', () => {
         const schema: RJSFSchema = {
           type: 'object',
@@ -303,7 +321,8 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           })
         ).toEqual({ requiredArray: ['default0', 'default1'] });
       });
-      it('should combine defaults with raw form data for a required array property with minItems', () => {
+      // BUG: https://github.com/rjsf-team/react-jsonschema-form/issues/3602
+      it.skip('should combine defaults with raw form data for a required array property with minItems', () => {
         const schema: RJSFSchema = {
           type: 'object',
           properties: {

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -38,6 +38,36 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           foo: 42,
         });
       });
+      it('test an object with an optional array property with minItems', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            optionalArray: {
+              type: 'array',
+              minItems: 2,
+            },
+          },
+        };
+        expect(
+          computeDefaults(testValidator, schema, undefined, schema)
+        ).toEqual({});
+      });
+      it('test an object with a required array property with minItems', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            requiredArray: {
+              type: 'array',
+              items: { type: 'string' },
+              minItems: 2,
+            },
+          },
+          required: ['requiredArray'],
+        };
+        expect(
+          computeDefaults(testValidator, schema, undefined, schema)
+        ).toEqual({ requiredArray: [undefined, undefined] });
+      });
       it('test an object with an optional property that has a nested required property', () => {
         const schema: RJSFSchema = {
           type: 'object',

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -268,7 +268,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           })
         ).toEqual({});
       });
-      it('should return empty array when given an empty array as form data for an optional array property with minItems ', () => {
+      it('should return empty array when given an empty array as form data for an optional array property with minItems', () => {
         const schema: RJSFSchema = {
           type: 'object',
           properties: {

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -245,6 +245,10 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           value: [undefined],
         });
       });
+      it('test computeDefaults returns undefined with simple schema and no optional args', () => {
+        const schema: RJSFSchema = { type: 'string' };
+        expect(computeDefaults(testValidator, schema)).toBe(undefined);
+      });
     });
     describe('default form state behavior: ignore min items unless required', () => {
       it('should return empty data for an optional array property with minItems', () => {
@@ -260,7 +264,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         expect(
           computeDefaults(testValidator, schema, {
             rootSchema: schema,
-            behaviorBitFlags: DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired,
+            defaultFormStateBehavior: DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired,
           })
         ).toEqual({});
       });
@@ -278,7 +282,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           computeDefaults(testValidator, schema, {
             rootSchema: schema,
             rawFormData: { optionalArray: [] },
-            behaviorBitFlags: DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired,
+            defaultFormStateBehavior: DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired,
           })
         ).toEqual({ optionalArray: [] });
       });
@@ -297,7 +301,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         expect(
           computeDefaults(testValidator, schema, {
             rootSchema: schema,
-            behaviorBitFlags: DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired,
+            defaultFormStateBehavior: DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired,
           })
         ).toEqual({ requiredArray: [undefined, undefined] });
       });
@@ -317,7 +321,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         expect(
           computeDefaults(testValidator, schema, {
             rootSchema: schema,
-            behaviorBitFlags: DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired,
+            defaultFormStateBehavior: DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired,
           })
         ).toEqual({ requiredArray: ['default0', 'default1'] });
       });
@@ -338,7 +342,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           computeDefaults(testValidator, schema, {
             rootSchema: schema,
             rawFormData: { requiredArray: ['raw0'] },
-            behaviorBitFlags: DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired,
+            defaultFormStateBehavior: DefaultFormStateBehavior.IgnoreMinItemsUnlessRequired,
           })
         ).toEqual({ requiredArray: ['raw0', 'default0'] });
       });


### PR DESCRIPTION
### Reasons for making this change

Currently, if `minItems` is set on an optional field that field will show up as an empty array in the form data if no values have been entered by the user. This is an area of ambiguity in the spec and some users want this behavior while others don't. Thus, it should be possible to choose whether you want the field to be populated as an empty array or to be ignored and thus have the key non-existent in the form output if no items have been added.

- fixes #3363
- fixes unreported bug where live settings in the Playground aren't being saved/loaded

### Checklist

- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
