### PR TITLE
fix: make post-versioning script also update tags on github

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.6.2
+
+## Dev / docs / playground
+
+- Fixed issues with `post-versioning` that caused the 5.6.1 branch to not be publishable
+
 # 5.6.1
 
 ## Dev / docs / playground

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/react-dom": "^17.0.19",
         "@typescript-eslint/eslint-plugin": "^5.58.0",
         "@typescript-eslint/parser": "^5.58.0",
+        "cross-env": "^7.0.3",
         "dts-cli": "^1.6.3",
         "eslint": "^8.38.0",
         "eslint-plugin-import": "^2.27.5",
@@ -7610,6 +7611,24 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -27034,6 +27053,15 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "bump-packages": "npm update --save --lockfile-version 2",
     "bump-peer-deps": "node scripts/bump-peer-deps.js",
     "refresh-node-modules": "rimraf packages/*/node_modules && rimraf node_modules && npm install",
-    "post-versioning": "echo 'This will take a while...' && npm run bump-peer-deps && npm run refresh-node-modules && git add package-lock.json packages/*/package*.json && CI=skipPrecommit git commit -m 'updated package*.json after versioning' && git push"
+    "commit-package-changes": "git add package-lock.json packages/*/package*.json && cross-env CI=skipPrecommit git commit -m 'updated package*.json after versioning' && git push",
+    "post-versioning": "echo 'This will take a while...' && npm run bump-peer-deps && npm run refresh-node-modules && npm run commit-package-changes && npm run update-version-tags",
+    "update-version-tags": "git tag -f $(node scripts/get-version-tag.js) && git push -f origin $(node scripts/get-version-tag.js)"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/rjsf-team/react-jsonschema-form",
@@ -38,6 +40,7 @@
     "@types/react-dom": "^17.0.19",
     "@typescript-eslint/eslint-plugin": "^5.58.0",
     "@typescript-eslint/parser": "^5.58.0",
+    "cross-env": "^7.0.3",
     "dts-cli": "^1.6.3",
     "eslint": "^8.38.0",
     "eslint-plugin-import": "^2.27.5",

--- a/scripts/bump-peer-deps.js
+++ b/scripts/bump-peer-deps.js
@@ -10,7 +10,7 @@ const MAJOR_MINOR_REGEX = /^\^(\d+.\d+).\d+$/;
 
 // Since this file is in the `scripts` directory, the root dir of the repo is up one level
 const rootDir = path.resolve(__dirname, '../');
-// Read all of the packages directory names
+// Read all the packages directory names
 const dirs = fs.readdirSync(path.resolve(rootDir, 'packages'));
 dirs.forEach((dir) => {
   // Get the name of each of the package.json files from the directory

--- a/scripts/get-version-tag.js
+++ b/scripts/get-version-tag.js
@@ -4,10 +4,11 @@ const path = require('path');
 // Since this file is in the `scripts` directory, the root dir of the repo is up one level
 const utilsPackage = path.resolve(__dirname, '../packages/utils/package.json');
 
-// Read the file and parse it into a json object and find the dev and peer dependencies
+// Read the file and parse it into a json object and find the version tag
 const packageJson = fs.readFileSync(utilsPackage);
 const packageObject = JSON.parse(packageJson);
 
 const { version } = packageObject;
 
+// Write the version, prefixed by the `v` used by lerna to the standard out so it can be used externally
 process.stdout.write(`v${version}`);

--- a/scripts/get-version-tag.js
+++ b/scripts/get-version-tag.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+// Since this file is in the `scripts` directory, the root dir of the repo is up one level
+const utilsPackage = path.resolve(__dirname, '../packages/utils/package.json');
+
+// Read the file and parse it into a json object and find the dev and peer dependencies
+const packageJson = fs.readFileSync(utilsPackage);
+const packageObject = JSON.parse(packageJson);
+
+const { version } = packageObject;
+
+process.stdout.write(`v${version}`);


### PR DESCRIPTION
### Reasons for making this change

The 5.6.1 release failed to publish because the `post-versioning` script did not update the tags made by `npx lerna version`
- Added a new `scripts/get-version-tag.js` file that returns the current version tag by reading the version from the `@rjsf/utils` package
- Added new `commit-package-changes` as a separate script to shorten the `post-versioning` script
- Added new `update-version-tags` script that uses the `get-version-tags.js` script to force update the local and remote tags to the current head
- Updated `package*.json` to add `cross-env` so that the setting of the CI variable in `commit-package-changes` works on all environments
- Updated the `CHANGELOG.md` file accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
