### PR TITLE
Add additionalProperties support to fluent-ui theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Fix [#3608](https://github.com/rjsf-team/react-jsonschema-form/issues/3608) by ensuring the root field is always wrapped in Form.Item
 
+## @rjsf/fluent-ui
+
+- Added support for `additionalProperties` to fluent-ui theme, fixing [#2777](https://github.com/rjsf-team/react-jsonschema-form/issues/2777).
+
 # 5.6.2
 
 ## Dev / docs / playground

--- a/packages/fluent-ui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/fluent-ui/src/FieldTemplate/FieldTemplate.tsx
@@ -13,24 +13,22 @@ export default function FieldTemplate<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any
 >(props: FieldTemplateProps<T, S, F>) {
-  const { id, children, errors, help, displayLabel, rawDescription, hidden, uiSchema, registry } = props;
+  const { children, errors, help, displayLabel, rawDescription, hidden, uiSchema, registry } = props;
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
   const WrapIfAdditionalTemplate = getTemplate<'WrapIfAdditionalTemplate', T, S, F>(
     'WrapIfAdditionalTemplate',
     registry,
     uiOptions
   );
-  // TODO: do this better by not returning the form-group class from master.
-  let { classNames = '' } = props;
-  classNames = 'ms-Grid-col ms-sm12 ' + classNames.replace('form-group', '');
+  if (hidden) {
+    return <div style={{ display: 'none' }}>{children}</div>;
+  }
   return (
     <WrapIfAdditionalTemplate {...props}>
-      <div id={id} className={classNames} style={{ marginBottom: 15, display: hidden ? 'none' : undefined }}>
-        {children}
-        {displayLabel && rawDescription && <Text>{rawDescription}</Text>}
-        {errors}
-        {help}
-      </div>
+      {children}
+      {displayLabel && rawDescription && <Text>{rawDescription}</Text>}
+      {errors}
+      {help}
     </WrapIfAdditionalTemplate>
   );
 }

--- a/packages/fluent-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/fluent-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -1,4 +1,6 @@
+import { CSSProperties } from 'react';
 import {
+  canExpand,
   descriptionId,
   FormContextType,
   getTemplate,
@@ -9,6 +11,10 @@ import {
   titleId,
 } from '@rjsf/utils';
 
+const rightJustify = {
+  float: 'right',
+} as CSSProperties;
+
 export default function ObjectFieldTemplate<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
@@ -18,9 +24,13 @@ export default function ObjectFieldTemplate<
   title,
   properties,
   required,
+  disabled,
+  readonly,
   schema,
   uiSchema,
   idSchema,
+  formData,
+  onAddClick,
   registry,
 }: ObjectFieldTemplateProps<T, S, F>) {
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
@@ -30,6 +40,10 @@ export default function ObjectFieldTemplate<
     registry,
     uiOptions
   );
+  // Button templates are not overridden in the uiSchema
+  const {
+    ButtonTemplates: { AddButton },
+  } = registry.templates;
   return (
     <>
       {title && (
@@ -53,6 +67,17 @@ export default function ObjectFieldTemplate<
       )}
       <div className='ms-Grid' dir='ltr'>
         <div className='ms-Grid-row'>{properties.map((element) => element.content)}</div>
+        {canExpand<T, S, F>(schema, uiSchema, formData) && (
+          <span style={rightJustify}>
+            <AddButton
+              className='object-property-expand'
+              onClick={onAddClick(schema)}
+              disabled={disabled || readonly}
+              uiSchema={uiSchema}
+              registry={registry}
+            />
+          </span>
+        )}
       </div>
     </>
   );

--- a/packages/fluent-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/fluent-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -41,7 +41,7 @@ export default function WrapIfAdditionalTemplate<
 
   if (!additional) {
     return (
-      <div id={id} className={classNames} style={{ ...style, marginBottom: 15 }}>
+      <div className={classNames} style={{ ...style, marginBottom: 15 }}>
         {children}
       </div>
     );

--- a/packages/fluent-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/fluent-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -1,11 +1,75 @@
-import { FormContextType, RJSFSchema, StrictRJSFSchema, WrapIfAdditionalTemplateProps } from '@rjsf/utils';
+import { FocusEvent } from 'react';
+import { TextField } from '@fluentui/react';
+import {
+  ADDITIONAL_PROPERTY_FLAG,
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  TranslatableString,
+  WrapIfAdditionalTemplateProps,
+} from '@rjsf/utils';
 
 export default function WrapIfAdditionalTemplate<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any
 >(props: WrapIfAdditionalTemplateProps<T, S, F>) {
-  const { children } = props;
-  // TODO Implement WrapIfAdditionalTemplate features in FluentUI (#2777)
-  return <>{children}</>;
+  const {
+    children,
+    classNames,
+    disabled,
+    id,
+    label,
+    onDropPropertyClick,
+    onKeyChange,
+    readonly,
+    registry,
+    required,
+    schema,
+    style,
+    uiSchema,
+  } = props;
+  const { templates, translateString } = registry;
+  // Button templates are not overridden in the uiSchema
+  const { RemoveButton } = templates.ButtonTemplates;
+  const keyLabel = translateString(TranslatableString.KeyLabel, [label]);
+  const additional = ADDITIONAL_PROPERTY_FLAG in schema;
+
+  if (!additional) {
+    return (
+      <div className={classNames} style={style}>
+        {children}
+      </div>
+    );
+  }
+
+  const handleBlur = ({ target }: FocusEvent<HTMLInputElement>) => onKeyChange(target.value);
+
+  return (
+    <div className={`ms-Grid ${classNames}`} style={style} dir='ltr'>
+      <div className='ms-Grid-row'>
+        <div key={`${id}-key`} className='ms-Grid-col ms-sm4 ms-md4 ms-lg5'>
+          <TextField
+            required={required}
+            label={keyLabel}
+            defaultValue={label}
+            disabled={disabled || readonly}
+            id={`${id}-key`}
+            name={`${id}-key`}
+            onBlur={!readonly ? handleBlur : undefined}
+            type='text'
+          />
+        </div>
+        <div className='ms-Grid-col ms-sm4 ms-md4 ms-lg5'>{children}</div>
+        <div className='ms-Grid-col ms-sm4 ms-md4 ms-lg2' style={{ textAlign: 'right' }}>
+          <RemoveButton
+            disabled={disabled || readonly}
+            onClick={onDropPropertyClick(label)}
+            uiSchema={uiSchema}
+            registry={registry}
+          />
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/packages/fluent-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/fluent-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -16,7 +16,6 @@ export default function WrapIfAdditionalTemplate<
 >(props: WrapIfAdditionalTemplateProps<T, S, F>) {
   const {
     children,
-    classNames,
     disabled,
     id,
     label,
@@ -30,6 +29,11 @@ export default function WrapIfAdditionalTemplate<
     uiSchema,
   } = props;
   const { templates, translateString } = registry;
+
+  // TODO: do this better by not returning the form-group class from master.
+  let { classNames = '' } = props;
+  classNames = 'ms-Grid-col ms-sm12 ' + classNames.replace('form-group', '');
+
   // Button templates are not overridden in the uiSchema
   const { RemoveButton } = templates.ButtonTemplates;
   const keyLabel = translateString(TranslatableString.KeyLabel, [label]);
@@ -37,7 +41,7 @@ export default function WrapIfAdditionalTemplate<
 
   if (!additional) {
     return (
-      <div className={classNames} style={style}>
+      <div id={id} className={classNames} style={{ ...style, marginBottom: 15 }}>
         {children}
       </div>
     );
@@ -46,9 +50,9 @@ export default function WrapIfAdditionalTemplate<
   const handleBlur = ({ target }: FocusEvent<HTMLInputElement>) => onKeyChange(target.value);
 
   return (
-    <div className={`ms-Grid ${classNames}`} style={style} dir='ltr'>
-      <div className='ms-Grid-row'>
-        <div key={`${id}-key`} className='ms-Grid-col ms-sm4 ms-md4 ms-lg5'>
+    <div className={classNames} style={{ ...style, marginBottom: 15 }} dir='ltr'>
+      <div key={`${id}-key`} className='ms-Grid-row'>
+        <div className='ms-Grid-col ms-sm4 ms-md4 ms-lg5'>
           <TextField
             required={required}
             label={keyLabel}

--- a/packages/fluent-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Array.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`array fields array 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -113,7 +112,6 @@ exports[`array fields array icons 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -135,7 +133,6 @@ exports[`array fields array icons 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
               style={
                 Object {
                   "marginBottom": 15,
@@ -320,7 +317,6 @@ exports[`array fields array icons 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-string"
-              id="root_1"
               style={
                 Object {
                   "marginBottom": 15,
@@ -588,7 +584,6 @@ exports[`array fields checkboxes 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -681,7 +676,6 @@ exports[`array fields empty errors array 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -698,7 +692,6 @@ exports[`array fields empty errors array 1`] = `
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string"
-          id="root_name"
           style={
             Object {
               "marginBottom": 15,
@@ -793,7 +786,6 @@ exports[`array fields fixed array 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -815,7 +807,6 @@ exports[`array fields fixed array 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
               style={
                 Object {
                   "marginBottom": 15,
@@ -873,7 +864,6 @@ exports[`array fields fixed array 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-number"
-              id="root_1"
               style={
                 Object {
                   "marginBottom": 15,
@@ -993,7 +983,6 @@ exports[`array fields has errors 1`] = `
   </div>
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1010,7 +999,6 @@ exports[`array fields has errors 1`] = `
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string field-error has-error has-danger"
-          id="root_name"
           style={
             Object {
               "marginBottom": 15,
@@ -1137,7 +1125,6 @@ exports[`array fields no errors 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1154,7 +1141,6 @@ exports[`array fields no errors 1`] = `
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string"
-          id="root_name"
           style={
             Object {
               "marginBottom": 15,
@@ -1249,7 +1235,6 @@ exports[`with title and description array 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1366,7 +1351,6 @@ exports[`with title and description array icons 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1400,7 +1384,6 @@ exports[`with title and description array icons 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
               style={
                 Object {
                   "marginBottom": 15,
@@ -1597,7 +1580,6 @@ exports[`with title and description array icons 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-string"
-              id="root_1"
               style={
                 Object {
                   "marginBottom": 15,
@@ -1877,7 +1859,6 @@ exports[`with title and description checkboxes 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1981,7 +1962,6 @@ exports[`with title and description fixed array 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2015,7 +1995,6 @@ exports[`with title and description fixed array 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
               style={
                 Object {
                   "marginBottom": 15,
@@ -2085,7 +2064,6 @@ exports[`with title and description fixed array 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-number"
-              id="root_1"
               style={
                 Object {
                   "marginBottom": 15,
@@ -2187,7 +2165,6 @@ exports[`with title and description from both array 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2304,7 +2281,6 @@ exports[`with title and description from both array icons 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2338,7 +2314,6 @@ exports[`with title and description from both array icons 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
               style={
                 Object {
                   "marginBottom": 15,
@@ -2535,7 +2510,6 @@ exports[`with title and description from both array icons 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-string"
-              id="root_1"
               style={
                 Object {
                   "marginBottom": 15,
@@ -2815,7 +2789,6 @@ exports[`with title and description from both checkboxes 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2919,7 +2892,6 @@ exports[`with title and description from both fixed array 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2953,7 +2925,6 @@ exports[`with title and description from both fixed array 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
               style={
                 Object {
                   "marginBottom": 15,
@@ -3023,7 +2994,6 @@ exports[`with title and description from both fixed array 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-number"
-              id="root_1"
               style={
                 Object {
                   "marginBottom": 15,
@@ -3125,7 +3095,6 @@ exports[`with title and description from uiSchema array 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -3242,7 +3211,6 @@ exports[`with title and description from uiSchema array icons 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -3276,7 +3244,6 @@ exports[`with title and description from uiSchema array icons 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
               style={
                 Object {
                   "marginBottom": 15,
@@ -3473,7 +3440,6 @@ exports[`with title and description from uiSchema array icons 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-string"
-              id="root_1"
               style={
                 Object {
                   "marginBottom": 15,
@@ -3753,7 +3719,6 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -3857,7 +3822,6 @@ exports[`with title and description from uiSchema fixed array 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -3891,7 +3855,6 @@ exports[`with title and description from uiSchema fixed array 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
               style={
                 Object {
                   "marginBottom": 15,
@@ -3961,7 +3924,6 @@ exports[`with title and description from uiSchema fixed array 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-number"
-              id="root_1"
               style={
                 Object {
                   "marginBottom": 15,
@@ -4063,7 +4025,6 @@ exports[`with title and description with global label off array 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -4168,7 +4129,6 @@ exports[`with title and description with global label off array icons 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -4190,7 +4150,6 @@ exports[`with title and description with global label off array icons 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
               style={
                 Object {
                   "marginBottom": 15,
@@ -4374,7 +4333,6 @@ exports[`with title and description with global label off array icons 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-string"
-              id="root_1"
               style={
                 Object {
                   "marginBottom": 15,
@@ -4641,7 +4599,6 @@ exports[`with title and description with global label off checkboxes 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -4745,7 +4702,6 @@ exports[`with title and description with global label off fixed array 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -4767,7 +4723,6 @@ exports[`with title and description with global label off fixed array 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
               style={
                 Object {
                   "marginBottom": 15,
@@ -4824,7 +4779,6 @@ exports[`with title and description with global label off fixed array 1`] = `
           >
             <div
               className="ms-Grid-col ms-sm12  field field-number"
-              id="root_1"
               style={
                 Object {
                   "marginBottom": 15,

--- a/packages/fluent-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Array.test.tsx.snap
@@ -7,71 +7,66 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
-    <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
+    <span
       style={
         Object {
-          "display": undefined,
-          "marginBottom": 15,
+          "float": "right",
         }
       }
     >
-      <span
+      <button
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
         style={
           Object {
-            "float": "right",
+            "height": "32px",
           }
         }
+        type="button"
       >
-        <button
-          className="ms-Button ms-Button--commandBar array-item-add root-53"
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          style={
-            Object {
-              "height": "32px",
-            }
-          }
-          type="button"
+        <span
+          className="ms-Button-flexContainer flexContainer-54"
+          data-automationid="splitbuttonprimary"
         >
-          <span
-            className="ms-Button-flexContainer flexContainer-54"
-            data-automationid="splitbuttonprimary"
-          >
-            <i
-              aria-hidden={true}
-              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-              data-icon-name="Add"
-              style={
-                Object {
-                  "fontFamily": "\\"FabricMDL2Icons\\"",
-                }
+          <i
+            aria-hidden={true}
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+            data-icon-name="Add"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
               }
-            >
-              
-            </i>
+            }
+          >
+            
+          </i>
+          <span
+            className="ms-Button-textContainer textContainer-55"
+          >
             <span
-              className="ms-Button-textContainer textContainer-55"
+              className="ms-Button-label label-57"
+              id="id__0"
             >
-              <span
-                className="ms-Button-label label-57"
-                id="id__0"
-              >
-                Add Item
-              </span>
+              Add Item
             </span>
           </span>
-        </button>
-      </span>
-    </div>
+        </span>
+      </button>
+    </span>
   </div>
   <div>
     <br />
@@ -117,451 +112,436 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-Grid"
+      dir="ltr"
     >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
         >
           <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+            className="ms-Grid-row"
           >
             <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="form-group field field-string"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_0"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField is-required root-67"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-68"
-                      >
-                        <input
-                          aria-describedby="root_0__error root_0__description root_0__help"
-                          aria-invalid={false}
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_0"
-                          name="root_0"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          type="text"
-                          value="a"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-            style={
-              Object {
-                "textAlign": "right",
-              }
-            }
-          >
-            <button
-              aria-disabled={true}
-              className="ms-Button ms-Button--icon is-disabled root-95"
-              data-is-focusable={false}
-              disabled={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                  data-icon-name="Up"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                  data-icon-name="Down"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                  data-icon-name="Copy"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                  data-icon-name="Delete"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-          </div>
-        </div>
-      </div>
-      <div
-        className="ms-Grid"
-        dir="ltr"
-      >
-        <div
-          className="ms-Grid-row"
-        >
-          <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
-          >
-            <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="form-group field field-string"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_1"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField is-required root-67"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-68"
-                      >
-                        <input
-                          aria-describedby="root_1__error root_1__description root_1__help"
-                          aria-invalid={false}
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_1"
-                          name="root_1"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          type="text"
-                          value="b"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-            style={
-              Object {
-                "textAlign": "right",
-              }
-            }
-          >
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                  data-icon-name="Up"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              aria-disabled={true}
-              className="ms-Button ms-Button--icon is-disabled root-95"
-              data-is-focusable={false}
-              disabled={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                  data-icon-name="Down"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                  data-icon-name="Copy"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                  data-icon-name="Delete"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-          </div>
-        </div>
-      </div>
-      <span
-        style={
-          Object {
-            "float": "right",
-          }
-        }
-      >
-        <button
-          className="ms-Button ms-Button--commandBar array-item-add root-53"
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          style={
-            Object {
-              "height": "32px",
-            }
-          }
-          type="button"
-        >
-          <span
-            className="ms-Button-flexContainer flexContainer-54"
-            data-automationid="splitbuttonprimary"
-          >
-            <i
-              aria-hidden={true}
-              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-              data-icon-name="Add"
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_0"
               style={
                 Object {
-                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                  "marginBottom": 15,
                 }
               }
             >
-              
-            </i>
-            <span
-              className="ms-Button-textContainer textContainer-55"
-            >
-              <span
-                className="ms-Button-label label-57"
-                id="id__48"
+              <div
+                className="ms-TextField is-required root-67"
               >
-                Add Item
-              </span>
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-68"
+                  >
+                    <input
+                      aria-describedby="root_0__error root_0__description root_0__help"
+                      aria-invalid={false}
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_0"
+                      name="root_0"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      type="text"
+                      value="a"
+                    />
+                  </div>
+                </div>
+              </div>
+              
+            </div>
+          </div>
+        </div>
+        <div
+          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
+          style={
+            Object {
+              "textAlign": "right",
+            }
+          }
+        >
+          <button
+            aria-disabled={true}
+            className="ms-Button ms-Button--icon is-disabled root-95"
+            data-is-focusable={false}
+            disabled={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                data-icon-name="Up"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                data-icon-name="Down"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                data-icon-name="Copy"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                data-icon-name="Delete"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
+      <div
+        className="ms-Grid-row"
+      >
+        <div
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+        >
+          <div
+            className="ms-Grid-row"
+          >
+            <div
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_1"
+              style={
+                Object {
+                  "marginBottom": 15,
+                }
+              }
+            >
+              <div
+                className="ms-TextField is-required root-67"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-68"
+                  >
+                    <input
+                      aria-describedby="root_1__error root_1__description root_1__help"
+                      aria-invalid={false}
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_1"
+                      name="root_1"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      type="text"
+                      value="b"
+                    />
+                  </div>
+                </div>
+              </div>
+              
+            </div>
+          </div>
+        </div>
+        <div
+          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
+          style={
+            Object {
+              "textAlign": "right",
+            }
+          }
+        >
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                data-icon-name="Up"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            aria-disabled={true}
+            className="ms-Button ms-Button--icon is-disabled root-95"
+            data-is-focusable={false}
+            disabled={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                data-icon-name="Down"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                data-icon-name="Copy"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                data-icon-name="Delete"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <span
+      style={
+        Object {
+          "float": "right",
+        }
+      }
+    >
+      <button
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        style={
+          Object {
+            "height": "32px",
+          }
+        }
+        type="button"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-54"
+          data-automationid="splitbuttonprimary"
+        >
+          <i
+            aria-hidden={true}
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+            data-icon-name="Add"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
+          >
+            
+          </i>
+          <span
+            className="ms-Button-textContainer textContainer-55"
+          >
+            <span
+              className="ms-Button-label label-57"
+              id="id__48"
+            >
+              Add Item
             </span>
           </span>
-        </button>
-      </span>
-    </div>
+        </span>
+      </button>
+    </span>
   </div>
   <div>
     <br />
@@ -607,59 +587,54 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-Dropdown-container"
     >
       <div
-        className="ms-Dropdown-container"
+        aria-describedby="root__error root__description root__help"
+        aria-disabled={false}
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-required={false}
+        className="ms-Dropdown dropdown-78"
+        data-is-focusable={true}
+        id="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        role="combobox"
+        tabIndex={0}
       >
-        <div
-          aria-describedby="root__error root__description root__help"
-          aria-disabled={false}
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-required={false}
-          className="ms-Dropdown dropdown-78"
-          data-is-focusable={true}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          role="combobox"
-          tabIndex={0}
+        <span
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
+          id="root-option"
+        />
+        <span
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
         >
-          <span
-            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
-            id="root-option"
-          />
-          <span
-            className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
+          <i
+            aria-hidden={true}
+            className="ms-Dropdown-caretDown caretDown-94"
+            data-icon-name="ChevronDown"
           >
-            <i
-              aria-hidden={true}
-              className="ms-Dropdown-caretDown caretDown-94"
-              data-icon-name="ChevronDown"
-            >
-              
-            </i>
-          </span>
-        </div>
+            
+          </i>
+        </span>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -705,80 +680,70 @@ exports[`array fields empty errors array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    
+    <div
+      className="ms-Grid"
+      dir="ltr"
     >
-      
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm12  field field-string"
+          id="root_name"
+          style={
+            Object {
+              "marginBottom": 15,
+            }
+          }
         >
           <div
-            className="form-group field field-string"
+            className="ms-TextField root-67"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_name"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-TextField-wrapper"
             >
-              <div
-                className="ms-TextField root-67"
+              <label
+                className="ms-Label root-114"
+                htmlFor="root_name"
+                id="TextFieldLabel69"
               >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-114"
-                    htmlFor="root_name"
-                    id="TextFieldLabel69"
-                  >
-                    name
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-115"
-                  >
-                    <input
-                      aria-describedby="root_name__error root_name__description root_name__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel69"
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_name"
-                      name="root_name"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={false}
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
+                name
+              </label>
+              <div
+                className="ms-TextField-fieldGroup fieldGroup-115"
+              >
+                <input
+                  aria-describedby="root_name__error root_name__description root_name__help"
+                  aria-invalid={false}
+                  aria-labelledby="TextFieldLabel69"
+                  autoFocus={false}
+                  className="ms-TextField-field field-69"
+                  disabled={false}
+                  id="root_name"
+                  name="root_name"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
               </div>
-              
             </div>
           </div>
+          
         </div>
       </div>
     </div>
@@ -827,141 +792,126 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-Grid"
+      dir="ltr"
     >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
         >
           <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+            className="ms-Grid-row"
           >
             <div
-              className="ms-Grid-row"
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_0"
+              style={
+                Object {
+                  "marginBottom": 15,
+                }
+              }
             >
               <div
-                className="form-group field field-string"
+                className="ms-TextField is-required root-67"
               >
                 <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_0"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
+                  className="ms-TextField-wrapper"
                 >
                   <div
-                    className="ms-TextField is-required root-67"
+                    className="ms-TextField-fieldGroup fieldGroup-68"
                   >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-68"
-                      >
-                        <input
-                          aria-describedby="root_0__error root_0__description root_0__help"
-                          aria-invalid={false}
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_0"
-                          name="root_0"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                    </div>
+                    <input
+                      aria-describedby="root_0__error root_0__description root_0__help"
+                      aria-invalid={false}
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_0"
+                      name="root_0"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      type="text"
+                      value=""
+                    />
                   </div>
-                  
                 </div>
               </div>
+              
             </div>
           </div>
         </div>
       </div>
+    </div>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
         >
           <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+            className="ms-Grid-row"
           >
             <div
-              className="ms-Grid-row"
+              className="ms-Grid-col ms-sm12  field field-number"
+              id="root_1"
+              style={
+                Object {
+                  "marginBottom": 15,
+                }
+              }
             >
               <div
-                className="form-group field field-number"
+                className="ms-TextField is-required root-67"
               >
                 <div
-                  className="ms-Grid-col ms-sm12  field field-number"
-                  id="root_1"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
+                  className="ms-TextField-wrapper"
                 >
                   <div
-                    className="ms-TextField is-required root-67"
+                    className="ms-TextField-fieldGroup fieldGroup-68"
                   >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-68"
-                      >
-                        <input
-                          aria-describedby="root_1__error root_1__description root_1__help"
-                          aria-invalid={false}
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_1"
-                          name="root_1"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          step="any"
-                          type="number"
-                          value=""
-                        />
-                      </div>
-                    </div>
+                    <input
+                      aria-describedby="root_1__error root_1__description root_1__help"
+                      aria-invalid={false}
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_1"
+                      name="root_1"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      step="any"
+                      type="number"
+                      value=""
+                    />
                   </div>
-                  
                 </div>
               </div>
+              
             </div>
           </div>
         </div>
@@ -1042,108 +992,98 @@ exports[`array fields has errors 1`] = `
     </div>
   </div>
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    
+    <div
+      className="ms-Grid"
+      dir="ltr"
     >
-      
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm12  field field-string field-error has-error has-danger"
+          id="root_name"
+          style={
+            Object {
+              "marginBottom": 15,
+            }
+          }
         >
           <div
-            className="form-group field field-string field-error has-error has-danger"
+            className="ms-TextField root-67"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-string field-error has-error has-danger"
-              id="root_name"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-TextField-wrapper"
+            >
+              <label
+                className="ms-Label root-114"
+                htmlFor="root_name"
+                id="TextFieldLabel57"
+              >
+                name
+              </label>
+              <div
+                className="ms-TextField-fieldGroup fieldGroup-113"
+              >
+                <input
+                  aria-describedby="TextFieldDescription56"
+                  aria-invalid={true}
+                  aria-labelledby="TextFieldLabel57"
+                  autoFocus={false}
+                  className="ms-TextField-field field-69"
+                  disabled={false}
+                  id="root_name"
+                  name="root_name"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+            <span
+              id="TextFieldDescription56"
             >
               <div
-                className="ms-TextField root-67"
-              >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-114"
-                    htmlFor="root_name"
-                    id="TextFieldLabel57"
-                  >
-                    name
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-113"
-                  >
-                    <input
-                      aria-describedby="TextFieldDescription56"
-                      aria-invalid={true}
-                      aria-labelledby="TextFieldLabel57"
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_name"
-                      name="root_name"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={false}
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
-                <span
-                  id="TextFieldDescription56"
-                >
-                  <div
-                    role="alert"
-                  />
-                </span>
-              </div>
-              
+                role="alert"
+              />
+            </span>
+          </div>
+          
+          <div
+            className="ms-List"
+            id="root_name__error"
+            role="list"
+          >
+            <div
+              className="ms-List-surface"
+              role="presentation"
+            >
               <div
-                className="ms-List"
-                id="root_name__error"
-                role="list"
+                className="ms-List-page"
+                role="presentation"
+                style={Object {}}
               >
                 <div
-                  className="ms-List-surface"
-                  role="presentation"
+                  className="ms-List-cell"
+                  data-automationid="ListCell"
+                  data-list-index={0}
+                  role="listitem"
                 >
-                  <div
-                    className="ms-List-page"
-                    role="presentation"
-                    style={Object {}}
-                  >
-                    <div
-                      className="ms-List-cell"
-                      data-automationid="ListCell"
-                      data-list-index={0}
-                      role="listitem"
-                    >
-                      
-                    </div>
-                  </div>
+                  
                 </div>
               </div>
             </div>
@@ -1196,80 +1136,70 @@ exports[`array fields no errors 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    
+    <div
+      className="ms-Grid"
+      dir="ltr"
     >
-      
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm12  field field-string"
+          id="root_name"
+          style={
+            Object {
+              "marginBottom": 15,
+            }
+          }
         >
           <div
-            className="form-group field field-string"
+            className="ms-TextField root-67"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_name"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-TextField-wrapper"
             >
-              <div
-                className="ms-TextField root-67"
+              <label
+                className="ms-Label root-114"
+                htmlFor="root_name"
+                id="TextFieldLabel63"
               >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-114"
-                    htmlFor="root_name"
-                    id="TextFieldLabel63"
-                  >
-                    name
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-115"
-                  >
-                    <input
-                      aria-describedby="root_name__error root_name__description root_name__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel63"
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_name"
-                      name="root_name"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={false}
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
+                name
+              </label>
+              <div
+                className="ms-TextField-fieldGroup fieldGroup-115"
+              >
+                <input
+                  aria-describedby="root_name__error root_name__description root_name__help"
+                  aria-invalid={false}
+                  aria-labelledby="TextFieldLabel63"
+                  autoFocus={false}
+                  className="ms-TextField-field field-69"
+                  disabled={false}
+                  id="root_name"
+                  name="root_name"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
               </div>
-              
             </div>
           </div>
+          
         </div>
       </div>
     </div>
@@ -1318,83 +1248,78 @@ exports[`with title and description array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
-    <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
+    <label
+      className="ms-Label root-116"
+      id="root__title"
+    >
+      Test field
+    </label>
+    <span
+      className="css-117"
+      id="root__description"
+    >
+      a test description
+    </span>
+    <span
       style={
         Object {
-          "display": undefined,
-          "marginBottom": 15,
+          "float": "right",
         }
       }
     >
-      <label
-        className="ms-Label root-116"
-        id="root__title"
-      >
-        Test field
-      </label>
-      <span
-        className="css-117"
-        id="root__description"
-      >
-        a test description
-      </span>
-      <span
+      <button
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
         style={
           Object {
-            "float": "right",
+            "height": "32px",
           }
         }
+        type="button"
       >
-        <button
-          className="ms-Button ms-Button--commandBar array-item-add root-53"
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          style={
-            Object {
-              "height": "32px",
-            }
-          }
-          type="button"
+        <span
+          className="ms-Button-flexContainer flexContainer-54"
+          data-automationid="splitbuttonprimary"
         >
-          <span
-            className="ms-Button-flexContainer flexContainer-54"
-            data-automationid="splitbuttonprimary"
-          >
-            <i
-              aria-hidden={true}
-              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-              data-icon-name="Add"
-              style={
-                Object {
-                  "fontFamily": "\\"FabricMDL2Icons\\"",
-                }
+          <i
+            aria-hidden={true}
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+            data-icon-name="Add"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
               }
-            >
-              
-            </i>
+            }
+          >
+            
+          </i>
+          <span
+            className="ms-Button-textContainer textContainer-55"
+          >
             <span
-              className="ms-Button-textContainer textContainer-55"
+              className="ms-Button-label label-57"
+              id="id__73"
             >
-              <span
-                className="ms-Button-label label-57"
-                id="id__73"
-              >
-                Add Item
-              </span>
+              Add Item
             </span>
           </span>
-        </button>
-      </span>
-    </div>
+        </span>
+      </button>
+    </span>
   </div>
   <div>
     <br />
@@ -1440,487 +1365,472 @@ exports[`with title and description array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    <label
+      className="ms-Label root-116"
+      id="root__title"
     >
-      <label
-        className="ms-Label root-116"
-        id="root__title"
-      >
-        Test field
-      </label>
-      <span
-        className="css-117"
-        id="root__description"
-      >
-        a test description
-      </span>
+      Test field
+    </label>
+    <span
+      className="css-117"
+      id="root__description"
+    >
+      a test description
+    </span>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
         >
           <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+            className="ms-Grid-row"
           >
             <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="form-group field field-string"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_0"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField is-required root-67"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-118"
-                        htmlFor="root_0"
-                        id="TextFieldLabel93"
-                      >
-                        Test item
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-115"
-                      >
-                        <input
-                          aria-describedby="root_0__error root_0__description root_0__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel93"
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_0"
-                          name="root_0"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          type="text"
-                          value="a"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <span
-                    className="css-117"
-                  >
-                    a test item description
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-            style={
-              Object {
-                "textAlign": "right",
-              }
-            }
-          >
-            <button
-              aria-disabled={true}
-              className="ms-Button ms-Button--icon is-disabled root-95"
-              data-is-focusable={false}
-              disabled={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                  data-icon-name="Up"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                  data-icon-name="Down"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                  data-icon-name="Copy"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                  data-icon-name="Delete"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-          </div>
-        </div>
-      </div>
-      <div
-        className="ms-Grid"
-        dir="ltr"
-      >
-        <div
-          className="ms-Grid-row"
-        >
-          <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
-          >
-            <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="form-group field field-string"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_1"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField is-required root-67"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-118"
-                        htmlFor="root_1"
-                        id="TextFieldLabel108"
-                      >
-                        Test item
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-115"
-                      >
-                        <input
-                          aria-describedby="root_1__error root_1__description root_1__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel108"
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_1"
-                          name="root_1"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          type="text"
-                          value="b"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <span
-                    className="css-117"
-                  >
-                    a test item description
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-            style={
-              Object {
-                "textAlign": "right",
-              }
-            }
-          >
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                  data-icon-name="Up"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              aria-disabled={true}
-              className="ms-Button ms-Button--icon is-disabled root-95"
-              data-is-focusable={false}
-              disabled={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                  data-icon-name="Down"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                  data-icon-name="Copy"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                  data-icon-name="Delete"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-          </div>
-        </div>
-      </div>
-      <span
-        style={
-          Object {
-            "float": "right",
-          }
-        }
-      >
-        <button
-          className="ms-Button ms-Button--commandBar array-item-add root-53"
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          style={
-            Object {
-              "height": "32px",
-            }
-          }
-          type="button"
-        >
-          <span
-            className="ms-Button-flexContainer flexContainer-54"
-            data-automationid="splitbuttonprimary"
-          >
-            <i
-              aria-hidden={true}
-              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-              data-icon-name="Add"
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_0"
               style={
                 Object {
-                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                  "marginBottom": 15,
                 }
               }
             >
-              
-            </i>
-            <span
-              className="ms-Button-textContainer textContainer-55"
-            >
-              <span
-                className="ms-Button-label label-57"
-                id="id__121"
+              <div
+                className="ms-TextField is-required root-67"
               >
-                Add Item
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-118"
+                    htmlFor="root_0"
+                    id="TextFieldLabel93"
+                  >
+                    Test item
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-115"
+                  >
+                    <input
+                      aria-describedby="root_0__error root_0__description root_0__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel93"
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_0"
+                      name="root_0"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      type="text"
+                      value="a"
+                    />
+                  </div>
+                </div>
+              </div>
+              <span
+                className="css-117"
+              >
+                a test item description
               </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
+          style={
+            Object {
+              "textAlign": "right",
+            }
+          }
+        >
+          <button
+            aria-disabled={true}
+            className="ms-Button ms-Button--icon is-disabled root-95"
+            data-is-focusable={false}
+            disabled={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                data-icon-name="Up"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                data-icon-name="Down"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                data-icon-name="Copy"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                data-icon-name="Delete"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
+      <div
+        className="ms-Grid-row"
+      >
+        <div
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+        >
+          <div
+            className="ms-Grid-row"
+          >
+            <div
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_1"
+              style={
+                Object {
+                  "marginBottom": 15,
+                }
+              }
+            >
+              <div
+                className="ms-TextField is-required root-67"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-118"
+                    htmlFor="root_1"
+                    id="TextFieldLabel108"
+                  >
+                    Test item
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-115"
+                  >
+                    <input
+                      aria-describedby="root_1__error root_1__description root_1__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel108"
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_1"
+                      name="root_1"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      type="text"
+                      value="b"
+                    />
+                  </div>
+                </div>
+              </div>
+              <span
+                className="css-117"
+              >
+                a test item description
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
+          style={
+            Object {
+              "textAlign": "right",
+            }
+          }
+        >
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                data-icon-name="Up"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            aria-disabled={true}
+            className="ms-Button ms-Button--icon is-disabled root-95"
+            data-is-focusable={false}
+            disabled={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                data-icon-name="Down"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                data-icon-name="Copy"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                data-icon-name="Delete"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <span
+      style={
+        Object {
+          "float": "right",
+        }
+      }
+    >
+      <button
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        style={
+          Object {
+            "height": "32px",
+          }
+        }
+        type="button"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-54"
+          data-automationid="splitbuttonprimary"
+        >
+          <i
+            aria-hidden={true}
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+            data-icon-name="Add"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
+          >
+            
+          </i>
+          <span
+            className="ms-Button-textContainer textContainer-55"
+          >
+            <span
+              className="ms-Button-label label-57"
+              id="id__121"
+            >
+              Add Item
             </span>
           </span>
-        </button>
-      </span>
-    </div>
+        </span>
+      </button>
+    </span>
   </div>
   <div>
     <br />
@@ -1966,70 +1876,65 @@ exports[`with title and description checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-Dropdown-container"
     >
+      <label
+        className="ms-Label ms-Dropdown-label root-119"
+        id="root-label"
+      >
+        Test field
+      </label>
       <div
-        className="ms-Dropdown-container"
+        aria-describedby="root__error root__description root__help"
+        aria-disabled={false}
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="root-label root-option"
+        aria-required={false}
+        className="ms-Dropdown dropdown-78"
+        data-is-focusable={true}
+        id="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        role="combobox"
+        tabIndex={0}
       >
-        <label
-          className="ms-Label ms-Dropdown-label root-119"
-          id="root-label"
+        <span
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
+          id="root-option"
+        />
+        <span
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
         >
-          Test field
-        </label>
-        <div
-          aria-describedby="root__error root__description root__help"
-          aria-disabled={false}
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-labelledby="root-label root-option"
-          aria-required={false}
-          className="ms-Dropdown dropdown-78"
-          data-is-focusable={true}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          role="combobox"
-          tabIndex={0}
-        >
-          <span
-            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
-            id="root-option"
-          />
-          <span
-            className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
+          <i
+            aria-hidden={true}
+            className="ms-Dropdown-caretDown caretDown-94"
+            data-icon-name="ChevronDown"
           >
-            <i
-              aria-hidden={true}
-              className="ms-Dropdown-caretDown caretDown-94"
-              data-icon-name="ChevronDown"
-            >
-              
-            </i>
-          </span>
-        </div>
+            
+          </i>
+        </span>
       </div>
-      <span
-        className="css-117"
-      >
-        a test description
-      </span>
     </div>
+    <span
+      className="css-117"
+    >
+      a test description
+    </span>
   </div>
   <div>
     <br />
@@ -2075,177 +1980,162 @@ exports[`with title and description fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    <label
+      className="ms-Label root-116"
+      id="root__title"
     >
-      <label
-        className="ms-Label root-116"
-        id="root__title"
-      >
-        Test field
-      </label>
-      <span
-        className="css-117"
-        id="root__description"
-      >
-        a test description
-      </span>
+      Test field
+    </label>
+    <span
+      className="css-117"
+      id="root__description"
+    >
+      a test description
+    </span>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
         >
           <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+            className="ms-Grid-row"
           >
             <div
-              className="ms-Grid-row"
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_0"
+              style={
+                Object {
+                  "marginBottom": 15,
+                }
+              }
             >
               <div
-                className="form-group field field-string"
+                className="ms-TextField is-required root-67"
               >
                 <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_0"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
+                  className="ms-TextField-wrapper"
                 >
+                  <label
+                    className="ms-Label root-118"
+                    htmlFor="root_0"
+                    id="TextFieldLabel81"
+                  >
+                    Test item
+                  </label>
                   <div
-                    className="ms-TextField is-required root-67"
+                    className="ms-TextField-fieldGroup fieldGroup-115"
                   >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-118"
-                        htmlFor="root_0"
-                        id="TextFieldLabel81"
-                      >
-                        Test item
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-115"
-                      >
-                        <input
-                          aria-describedby="root_0__error root_0__description root_0__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel81"
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_0"
-                          name="root_0"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                    </div>
+                    <input
+                      aria-describedby="root_0__error root_0__description root_0__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel81"
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_0"
+                      name="root_0"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      type="text"
+                      value=""
+                    />
                   </div>
-                  <span
-                    className="css-117"
-                  >
-                    a test item description
-                  </span>
                 </div>
               </div>
+              <span
+                className="css-117"
+              >
+                a test item description
+              </span>
             </div>
           </div>
         </div>
       </div>
+    </div>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
         >
           <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+            className="ms-Grid-row"
           >
             <div
-              className="ms-Grid-row"
+              className="ms-Grid-col ms-sm12  field field-number"
+              id="root_1"
+              style={
+                Object {
+                  "marginBottom": 15,
+                }
+              }
             >
               <div
-                className="form-group field field-number"
+                className="ms-TextField is-required root-67"
               >
                 <div
-                  className="ms-Grid-col ms-sm12  field field-number"
-                  id="root_1"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
+                  className="ms-TextField-wrapper"
                 >
+                  <label
+                    className="ms-Label root-118"
+                    htmlFor="root_1"
+                    id="TextFieldLabel84"
+                  >
+                    Test item
+                  </label>
                   <div
-                    className="ms-TextField is-required root-67"
+                    className="ms-TextField-fieldGroup fieldGroup-115"
                   >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-118"
-                        htmlFor="root_1"
-                        id="TextFieldLabel84"
-                      >
-                        Test item
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-115"
-                      >
-                        <input
-                          aria-describedby="root_1__error root_1__description root_1__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel84"
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_1"
-                          name="root_1"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          step="any"
-                          type="number"
-                          value=""
-                        />
-                      </div>
-                    </div>
+                    <input
+                      aria-describedby="root_1__error root_1__description root_1__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel84"
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_1"
+                      name="root_1"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      step="any"
+                      type="number"
+                      value=""
+                    />
                   </div>
-                  <span
-                    className="css-117"
-                  >
-                    a test item description
-                  </span>
                 </div>
               </div>
+              <span
+                className="css-117"
+              >
+                a test item description
+              </span>
             </div>
           </div>
         </div>
@@ -2296,83 +2186,78 @@ exports[`with title and description from both array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
-    <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
+    <label
+      className="ms-Label root-116"
+      id="root__title"
+    >
+      My Field
+    </label>
+    <span
+      className="css-117"
+      id="root__description"
+    >
+      a fancier description
+    </span>
+    <span
       style={
         Object {
-          "display": undefined,
-          "marginBottom": 15,
+          "float": "right",
         }
       }
     >
-      <label
-        className="ms-Label root-116"
-        id="root__title"
-      >
-        My Field
-      </label>
-      <span
-        className="css-117"
-        id="root__description"
-      >
-        a fancier description
-      </span>
-      <span
+      <button
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
         style={
           Object {
-            "float": "right",
+            "height": "32px",
           }
         }
+        type="button"
       >
-        <button
-          className="ms-Button ms-Button--commandBar array-item-add root-53"
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          style={
-            Object {
-              "height": "32px",
-            }
-          }
-          type="button"
+        <span
+          className="ms-Button-flexContainer flexContainer-54"
+          data-automationid="splitbuttonprimary"
         >
-          <span
-            className="ms-Button-flexContainer flexContainer-54"
-            data-automationid="splitbuttonprimary"
-          >
-            <i
-              aria-hidden={true}
-              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-              data-icon-name="Add"
-              style={
-                Object {
-                  "fontFamily": "\\"FabricMDL2Icons\\"",
-                }
+          <i
+            aria-hidden={true}
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+            data-icon-name="Add"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
               }
-            >
-              
-            </i>
+            }
+          >
+            
+          </i>
+          <span
+            className="ms-Button-textContainer textContainer-55"
+          >
             <span
-              className="ms-Button-textContainer textContainer-55"
+              className="ms-Button-label label-57"
+              id="id__181"
             >
-              <span
-                className="ms-Button-label label-57"
-                id="id__181"
-              >
-                Add Item
-              </span>
+              Add Item
             </span>
           </span>
-        </button>
-      </span>
-    </div>
+        </span>
+      </button>
+    </span>
   </div>
   <div>
     <br />
@@ -2418,487 +2303,472 @@ exports[`with title and description from both array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    <label
+      className="ms-Label root-116"
+      id="root__title"
     >
-      <label
-        className="ms-Label root-116"
-        id="root__title"
-      >
-        My Field
-      </label>
-      <span
-        className="css-117"
-        id="root__description"
-      >
-        a fancier description
-      </span>
+      My Field
+    </label>
+    <span
+      className="css-117"
+      id="root__description"
+    >
+      a fancier description
+    </span>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
         >
           <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+            className="ms-Grid-row"
           >
             <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="form-group field field-string"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_0"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField is-required root-67"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-118"
-                        htmlFor="root_0"
-                        id="TextFieldLabel201"
-                      >
-                        My Item
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-115"
-                      >
-                        <input
-                          aria-describedby="root_0__error root_0__description root_0__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel201"
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_0"
-                          name="root_0"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          type="text"
-                          value="a"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <span
-                    className="css-117"
-                  >
-                    a fancier item description
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-            style={
-              Object {
-                "textAlign": "right",
-              }
-            }
-          >
-            <button
-              aria-disabled={true}
-              className="ms-Button ms-Button--icon is-disabled root-95"
-              data-is-focusable={false}
-              disabled={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                  data-icon-name="Up"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                  data-icon-name="Down"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                  data-icon-name="Copy"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                  data-icon-name="Delete"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-          </div>
-        </div>
-      </div>
-      <div
-        className="ms-Grid"
-        dir="ltr"
-      >
-        <div
-          className="ms-Grid-row"
-        >
-          <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
-          >
-            <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="form-group field field-string"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_1"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField is-required root-67"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-118"
-                        htmlFor="root_1"
-                        id="TextFieldLabel216"
-                      >
-                        My Item
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-115"
-                      >
-                        <input
-                          aria-describedby="root_1__error root_1__description root_1__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel216"
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_1"
-                          name="root_1"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          type="text"
-                          value="b"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <span
-                    className="css-117"
-                  >
-                    a fancier item description
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-            style={
-              Object {
-                "textAlign": "right",
-              }
-            }
-          >
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                  data-icon-name="Up"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              aria-disabled={true}
-              className="ms-Button ms-Button--icon is-disabled root-95"
-              data-is-focusable={false}
-              disabled={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                  data-icon-name="Down"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                  data-icon-name="Copy"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                  data-icon-name="Delete"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-          </div>
-        </div>
-      </div>
-      <span
-        style={
-          Object {
-            "float": "right",
-          }
-        }
-      >
-        <button
-          className="ms-Button ms-Button--commandBar array-item-add root-53"
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          style={
-            Object {
-              "height": "32px",
-            }
-          }
-          type="button"
-        >
-          <span
-            className="ms-Button-flexContainer flexContainer-54"
-            data-automationid="splitbuttonprimary"
-          >
-            <i
-              aria-hidden={true}
-              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-              data-icon-name="Add"
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_0"
               style={
                 Object {
-                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                  "marginBottom": 15,
                 }
               }
             >
-              
-            </i>
-            <span
-              className="ms-Button-textContainer textContainer-55"
-            >
-              <span
-                className="ms-Button-label label-57"
-                id="id__229"
+              <div
+                className="ms-TextField is-required root-67"
               >
-                Add Item
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-118"
+                    htmlFor="root_0"
+                    id="TextFieldLabel201"
+                  >
+                    My Item
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-115"
+                  >
+                    <input
+                      aria-describedby="root_0__error root_0__description root_0__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel201"
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_0"
+                      name="root_0"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      type="text"
+                      value="a"
+                    />
+                  </div>
+                </div>
+              </div>
+              <span
+                className="css-117"
+              >
+                a fancier item description
               </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
+          style={
+            Object {
+              "textAlign": "right",
+            }
+          }
+        >
+          <button
+            aria-disabled={true}
+            className="ms-Button ms-Button--icon is-disabled root-95"
+            data-is-focusable={false}
+            disabled={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                data-icon-name="Up"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                data-icon-name="Down"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                data-icon-name="Copy"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                data-icon-name="Delete"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
+      <div
+        className="ms-Grid-row"
+      >
+        <div
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+        >
+          <div
+            className="ms-Grid-row"
+          >
+            <div
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_1"
+              style={
+                Object {
+                  "marginBottom": 15,
+                }
+              }
+            >
+              <div
+                className="ms-TextField is-required root-67"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-118"
+                    htmlFor="root_1"
+                    id="TextFieldLabel216"
+                  >
+                    My Item
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-115"
+                  >
+                    <input
+                      aria-describedby="root_1__error root_1__description root_1__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel216"
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_1"
+                      name="root_1"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      type="text"
+                      value="b"
+                    />
+                  </div>
+                </div>
+              </div>
+              <span
+                className="css-117"
+              >
+                a fancier item description
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
+          style={
+            Object {
+              "textAlign": "right",
+            }
+          }
+        >
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                data-icon-name="Up"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            aria-disabled={true}
+            className="ms-Button ms-Button--icon is-disabled root-95"
+            data-is-focusable={false}
+            disabled={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                data-icon-name="Down"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                data-icon-name="Copy"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                data-icon-name="Delete"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <span
+      style={
+        Object {
+          "float": "right",
+        }
+      }
+    >
+      <button
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        style={
+          Object {
+            "height": "32px",
+          }
+        }
+        type="button"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-54"
+          data-automationid="splitbuttonprimary"
+        >
+          <i
+            aria-hidden={true}
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+            data-icon-name="Add"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
+          >
+            
+          </i>
+          <span
+            className="ms-Button-textContainer textContainer-55"
+          >
+            <span
+              className="ms-Button-label label-57"
+              id="id__229"
+            >
+              Add Item
             </span>
           </span>
-        </button>
-      </span>
-    </div>
+        </span>
+      </button>
+    </span>
   </div>
   <div>
     <br />
@@ -2944,70 +2814,65 @@ exports[`with title and description from both checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-Dropdown-container"
     >
+      <label
+        className="ms-Label ms-Dropdown-label root-119"
+        id="root-label"
+      >
+        My Field
+      </label>
       <div
-        className="ms-Dropdown-container"
+        aria-describedby="root__error root__description root__help"
+        aria-disabled={false}
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="root-label root-option"
+        aria-required={false}
+        className="ms-Dropdown dropdown-78"
+        data-is-focusable={true}
+        id="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        role="combobox"
+        tabIndex={0}
       >
-        <label
-          className="ms-Label ms-Dropdown-label root-119"
-          id="root-label"
+        <span
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
+          id="root-option"
+        />
+        <span
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
         >
-          My Field
-        </label>
-        <div
-          aria-describedby="root__error root__description root__help"
-          aria-disabled={false}
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-labelledby="root-label root-option"
-          aria-required={false}
-          className="ms-Dropdown dropdown-78"
-          data-is-focusable={true}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          role="combobox"
-          tabIndex={0}
-        >
-          <span
-            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
-            id="root-option"
-          />
-          <span
-            className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
+          <i
+            aria-hidden={true}
+            className="ms-Dropdown-caretDown caretDown-94"
+            data-icon-name="ChevronDown"
           >
-            <i
-              aria-hidden={true}
-              className="ms-Dropdown-caretDown caretDown-94"
-              data-icon-name="ChevronDown"
-            >
-              
-            </i>
-          </span>
-        </div>
+            
+          </i>
+        </span>
       </div>
-      <span
-        className="css-117"
-      >
-        a fancier description
-      </span>
     </div>
+    <span
+      className="css-117"
+    >
+      a fancier description
+    </span>
   </div>
   <div>
     <br />
@@ -3053,177 +2918,162 @@ exports[`with title and description from both fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    <label
+      className="ms-Label root-116"
+      id="root__title"
     >
-      <label
-        className="ms-Label root-116"
-        id="root__title"
-      >
-        My Field
-      </label>
-      <span
-        className="css-117"
-        id="root__description"
-      >
-        a fancier description
-      </span>
+      My Field
+    </label>
+    <span
+      className="css-117"
+      id="root__description"
+    >
+      a fancier description
+    </span>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
         >
           <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+            className="ms-Grid-row"
           >
             <div
-              className="ms-Grid-row"
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_0"
+              style={
+                Object {
+                  "marginBottom": 15,
+                }
+              }
             >
               <div
-                className="form-group field field-string"
+                className="ms-TextField is-required root-67"
               >
                 <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_0"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
+                  className="ms-TextField-wrapper"
                 >
+                  <label
+                    className="ms-Label root-118"
+                    htmlFor="root_0"
+                    id="TextFieldLabel189"
+                  >
+                    My Item
+                  </label>
                   <div
-                    className="ms-TextField is-required root-67"
+                    className="ms-TextField-fieldGroup fieldGroup-115"
                   >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-118"
-                        htmlFor="root_0"
-                        id="TextFieldLabel189"
-                      >
-                        My Item
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-115"
-                      >
-                        <input
-                          aria-describedby="root_0__error root_0__description root_0__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel189"
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_0"
-                          name="root_0"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                    </div>
+                    <input
+                      aria-describedby="root_0__error root_0__description root_0__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel189"
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_0"
+                      name="root_0"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      type="text"
+                      value=""
+                    />
                   </div>
-                  <span
-                    className="css-117"
-                  >
-                    a fancier item description
-                  </span>
                 </div>
               </div>
+              <span
+                className="css-117"
+              >
+                a fancier item description
+              </span>
             </div>
           </div>
         </div>
       </div>
+    </div>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
         >
           <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+            className="ms-Grid-row"
           >
             <div
-              className="ms-Grid-row"
+              className="ms-Grid-col ms-sm12  field field-number"
+              id="root_1"
+              style={
+                Object {
+                  "marginBottom": 15,
+                }
+              }
             >
               <div
-                className="form-group field field-number"
+                className="ms-TextField is-required root-67"
               >
                 <div
-                  className="ms-Grid-col ms-sm12  field field-number"
-                  id="root_1"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
+                  className="ms-TextField-wrapper"
                 >
+                  <label
+                    className="ms-Label root-118"
+                    htmlFor="root_1"
+                    id="TextFieldLabel192"
+                  >
+                    My Item
+                  </label>
                   <div
-                    className="ms-TextField is-required root-67"
+                    className="ms-TextField-fieldGroup fieldGroup-115"
                   >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-118"
-                        htmlFor="root_1"
-                        id="TextFieldLabel192"
-                      >
-                        My Item
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-115"
-                      >
-                        <input
-                          aria-describedby="root_1__error root_1__description root_1__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel192"
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_1"
-                          name="root_1"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          step="any"
-                          type="number"
-                          value=""
-                        />
-                      </div>
-                    </div>
+                    <input
+                      aria-describedby="root_1__error root_1__description root_1__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel192"
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_1"
+                      name="root_1"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      step="any"
+                      type="number"
+                      value=""
+                    />
                   </div>
-                  <span
-                    className="css-117"
-                  >
-                    a fancier item description
-                  </span>
                 </div>
               </div>
+              <span
+                className="css-117"
+              >
+                a fancier item description
+              </span>
             </div>
           </div>
         </div>
@@ -3274,83 +3124,78 @@ exports[`with title and description from uiSchema array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
-    <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
+    <label
+      className="ms-Label root-116"
+      id="root__title"
+    >
+      My Field
+    </label>
+    <span
+      className="css-117"
+      id="root__description"
+    >
+      a fancier description
+    </span>
+    <span
       style={
         Object {
-          "display": undefined,
-          "marginBottom": 15,
+          "float": "right",
         }
       }
     >
-      <label
-        className="ms-Label root-116"
-        id="root__title"
-      >
-        My Field
-      </label>
-      <span
-        className="css-117"
-        id="root__description"
-      >
-        a fancier description
-      </span>
-      <span
+      <button
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
         style={
           Object {
-            "float": "right",
+            "height": "32px",
           }
         }
+        type="button"
       >
-        <button
-          className="ms-Button ms-Button--commandBar array-item-add root-53"
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          style={
-            Object {
-              "height": "32px",
-            }
-          }
-          type="button"
+        <span
+          className="ms-Button-flexContainer flexContainer-54"
+          data-automationid="splitbuttonprimary"
         >
-          <span
-            className="ms-Button-flexContainer flexContainer-54"
-            data-automationid="splitbuttonprimary"
-          >
-            <i
-              aria-hidden={true}
-              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-              data-icon-name="Add"
-              style={
-                Object {
-                  "fontFamily": "\\"FabricMDL2Icons\\"",
-                }
+          <i
+            aria-hidden={true}
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+            data-icon-name="Add"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
               }
-            >
-              
-            </i>
+            }
+          >
+            
+          </i>
+          <span
+            className="ms-Button-textContainer textContainer-55"
+          >
             <span
-              className="ms-Button-textContainer textContainer-55"
+              className="ms-Button-label label-57"
+              id="id__127"
             >
-              <span
-                className="ms-Button-label label-57"
-                id="id__127"
-              >
-                Add Item
-              </span>
+              Add Item
             </span>
           </span>
-        </button>
-      </span>
-    </div>
+        </span>
+      </button>
+    </span>
   </div>
   <div>
     <br />
@@ -3396,487 +3241,472 @@ exports[`with title and description from uiSchema array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    <label
+      className="ms-Label root-116"
+      id="root__title"
     >
-      <label
-        className="ms-Label root-116"
-        id="root__title"
-      >
-        My Field
-      </label>
-      <span
-        className="css-117"
-        id="root__description"
-      >
-        a fancier description
-      </span>
+      My Field
+    </label>
+    <span
+      className="css-117"
+      id="root__description"
+    >
+      a fancier description
+    </span>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
         >
           <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+            className="ms-Grid-row"
           >
             <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="form-group field field-string"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_0"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField is-required root-67"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-118"
-                        htmlFor="root_0"
-                        id="TextFieldLabel147"
-                      >
-                        My Item
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-115"
-                      >
-                        <input
-                          aria-describedby="root_0__error root_0__description root_0__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel147"
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_0"
-                          name="root_0"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          type="text"
-                          value="a"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <span
-                    className="css-117"
-                  >
-                    a fancier item description
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-            style={
-              Object {
-                "textAlign": "right",
-              }
-            }
-          >
-            <button
-              aria-disabled={true}
-              className="ms-Button ms-Button--icon is-disabled root-95"
-              data-is-focusable={false}
-              disabled={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                  data-icon-name="Up"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                  data-icon-name="Down"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                  data-icon-name="Copy"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                  data-icon-name="Delete"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-          </div>
-        </div>
-      </div>
-      <div
-        className="ms-Grid"
-        dir="ltr"
-      >
-        <div
-          className="ms-Grid-row"
-        >
-          <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
-          >
-            <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="form-group field field-string"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_1"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField is-required root-67"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-118"
-                        htmlFor="root_1"
-                        id="TextFieldLabel162"
-                      >
-                        My Item
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-115"
-                      >
-                        <input
-                          aria-describedby="root_1__error root_1__description root_1__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel162"
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_1"
-                          name="root_1"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          type="text"
-                          value="b"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <span
-                    className="css-117"
-                  >
-                    a fancier item description
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-            style={
-              Object {
-                "textAlign": "right",
-              }
-            }
-          >
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                  data-icon-name="Up"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              aria-disabled={true}
-              className="ms-Button ms-Button--icon is-disabled root-95"
-              data-is-focusable={false}
-              disabled={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                  data-icon-name="Down"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                  data-icon-name="Copy"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                  data-icon-name="Delete"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-          </div>
-        </div>
-      </div>
-      <span
-        style={
-          Object {
-            "float": "right",
-          }
-        }
-      >
-        <button
-          className="ms-Button ms-Button--commandBar array-item-add root-53"
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          style={
-            Object {
-              "height": "32px",
-            }
-          }
-          type="button"
-        >
-          <span
-            className="ms-Button-flexContainer flexContainer-54"
-            data-automationid="splitbuttonprimary"
-          >
-            <i
-              aria-hidden={true}
-              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-              data-icon-name="Add"
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_0"
               style={
                 Object {
-                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                  "marginBottom": 15,
                 }
               }
             >
-              
-            </i>
-            <span
-              className="ms-Button-textContainer textContainer-55"
-            >
-              <span
-                className="ms-Button-label label-57"
-                id="id__175"
+              <div
+                className="ms-TextField is-required root-67"
               >
-                Add Item
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-118"
+                    htmlFor="root_0"
+                    id="TextFieldLabel147"
+                  >
+                    My Item
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-115"
+                  >
+                    <input
+                      aria-describedby="root_0__error root_0__description root_0__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel147"
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_0"
+                      name="root_0"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      type="text"
+                      value="a"
+                    />
+                  </div>
+                </div>
+              </div>
+              <span
+                className="css-117"
+              >
+                a fancier item description
               </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
+          style={
+            Object {
+              "textAlign": "right",
+            }
+          }
+        >
+          <button
+            aria-disabled={true}
+            className="ms-Button ms-Button--icon is-disabled root-95"
+            data-is-focusable={false}
+            disabled={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                data-icon-name="Up"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                data-icon-name="Down"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                data-icon-name="Copy"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                data-icon-name="Delete"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
+      <div
+        className="ms-Grid-row"
+      >
+        <div
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+        >
+          <div
+            className="ms-Grid-row"
+          >
+            <div
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_1"
+              style={
+                Object {
+                  "marginBottom": 15,
+                }
+              }
+            >
+              <div
+                className="ms-TextField is-required root-67"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-118"
+                    htmlFor="root_1"
+                    id="TextFieldLabel162"
+                  >
+                    My Item
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-115"
+                  >
+                    <input
+                      aria-describedby="root_1__error root_1__description root_1__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel162"
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_1"
+                      name="root_1"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      type="text"
+                      value="b"
+                    />
+                  </div>
+                </div>
+              </div>
+              <span
+                className="css-117"
+              >
+                a fancier item description
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
+          style={
+            Object {
+              "textAlign": "right",
+            }
+          }
+        >
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                data-icon-name="Up"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            aria-disabled={true}
+            className="ms-Button ms-Button--icon is-disabled root-95"
+            data-is-focusable={false}
+            disabled={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                data-icon-name="Down"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                data-icon-name="Copy"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                data-icon-name="Delete"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <span
+      style={
+        Object {
+          "float": "right",
+        }
+      }
+    >
+      <button
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        style={
+          Object {
+            "height": "32px",
+          }
+        }
+        type="button"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-54"
+          data-automationid="splitbuttonprimary"
+        >
+          <i
+            aria-hidden={true}
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+            data-icon-name="Add"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
+          >
+            
+          </i>
+          <span
+            className="ms-Button-textContainer textContainer-55"
+          >
+            <span
+              className="ms-Button-label label-57"
+              id="id__175"
+            >
+              Add Item
             </span>
           </span>
-        </button>
-      </span>
-    </div>
+        </span>
+      </button>
+    </span>
   </div>
   <div>
     <br />
@@ -3922,70 +3752,65 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-Dropdown-container"
     >
+      <label
+        className="ms-Label ms-Dropdown-label root-119"
+        id="root-label"
+      >
+        My Field
+      </label>
       <div
-        className="ms-Dropdown-container"
+        aria-describedby="root__error root__description root__help"
+        aria-disabled={false}
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="root-label root-option"
+        aria-required={false}
+        className="ms-Dropdown dropdown-78"
+        data-is-focusable={true}
+        id="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        role="combobox"
+        tabIndex={0}
       >
-        <label
-          className="ms-Label ms-Dropdown-label root-119"
-          id="root-label"
+        <span
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
+          id="root-option"
+        />
+        <span
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
         >
-          My Field
-        </label>
-        <div
-          aria-describedby="root__error root__description root__help"
-          aria-disabled={false}
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-labelledby="root-label root-option"
-          aria-required={false}
-          className="ms-Dropdown dropdown-78"
-          data-is-focusable={true}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          role="combobox"
-          tabIndex={0}
-        >
-          <span
-            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
-            id="root-option"
-          />
-          <span
-            className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
+          <i
+            aria-hidden={true}
+            className="ms-Dropdown-caretDown caretDown-94"
+            data-icon-name="ChevronDown"
           >
-            <i
-              aria-hidden={true}
-              className="ms-Dropdown-caretDown caretDown-94"
-              data-icon-name="ChevronDown"
-            >
-              
-            </i>
-          </span>
-        </div>
+            
+          </i>
+        </span>
       </div>
-      <span
-        className="css-117"
-      >
-        a fancier description
-      </span>
     </div>
+    <span
+      className="css-117"
+    >
+      a fancier description
+    </span>
   </div>
   <div>
     <br />
@@ -4031,177 +3856,162 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    <label
+      className="ms-Label root-116"
+      id="root__title"
     >
-      <label
-        className="ms-Label root-116"
-        id="root__title"
-      >
-        My Field
-      </label>
-      <span
-        className="css-117"
-        id="root__description"
-      >
-        a fancier description
-      </span>
+      My Field
+    </label>
+    <span
+      className="css-117"
+      id="root__description"
+    >
+      a fancier description
+    </span>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
         >
           <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+            className="ms-Grid-row"
           >
             <div
-              className="ms-Grid-row"
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_0"
+              style={
+                Object {
+                  "marginBottom": 15,
+                }
+              }
             >
               <div
-                className="form-group field field-string"
+                className="ms-TextField is-required root-67"
               >
                 <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_0"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
+                  className="ms-TextField-wrapper"
                 >
+                  <label
+                    className="ms-Label root-118"
+                    htmlFor="root_0"
+                    id="TextFieldLabel135"
+                  >
+                    My Item
+                  </label>
                   <div
-                    className="ms-TextField is-required root-67"
+                    className="ms-TextField-fieldGroup fieldGroup-115"
                   >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-118"
-                        htmlFor="root_0"
-                        id="TextFieldLabel135"
-                      >
-                        My Item
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-115"
-                      >
-                        <input
-                          aria-describedby="root_0__error root_0__description root_0__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel135"
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_0"
-                          name="root_0"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                    </div>
+                    <input
+                      aria-describedby="root_0__error root_0__description root_0__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel135"
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_0"
+                      name="root_0"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      type="text"
+                      value=""
+                    />
                   </div>
-                  <span
-                    className="css-117"
-                  >
-                    a fancier item description
-                  </span>
                 </div>
               </div>
+              <span
+                className="css-117"
+              >
+                a fancier item description
+              </span>
             </div>
           </div>
         </div>
       </div>
+    </div>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
         >
           <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+            className="ms-Grid-row"
           >
             <div
-              className="ms-Grid-row"
+              className="ms-Grid-col ms-sm12  field field-number"
+              id="root_1"
+              style={
+                Object {
+                  "marginBottom": 15,
+                }
+              }
             >
               <div
-                className="form-group field field-number"
+                className="ms-TextField is-required root-67"
               >
                 <div
-                  className="ms-Grid-col ms-sm12  field field-number"
-                  id="root_1"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
+                  className="ms-TextField-wrapper"
                 >
+                  <label
+                    className="ms-Label root-118"
+                    htmlFor="root_1"
+                    id="TextFieldLabel138"
+                  >
+                    My Item
+                  </label>
                   <div
-                    className="ms-TextField is-required root-67"
+                    className="ms-TextField-fieldGroup fieldGroup-115"
                   >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-118"
-                        htmlFor="root_1"
-                        id="TextFieldLabel138"
-                      >
-                        My Item
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-115"
-                      >
-                        <input
-                          aria-describedby="root_1__error root_1__description root_1__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel138"
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_1"
-                          name="root_1"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          step="any"
-                          type="number"
-                          value=""
-                        />
-                      </div>
-                    </div>
+                    <input
+                      aria-describedby="root_1__error root_1__description root_1__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel138"
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_1"
+                      name="root_1"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      step="any"
+                      type="number"
+                      value=""
+                    />
                   </div>
-                  <span
-                    className="css-117"
-                  >
-                    a fancier item description
-                  </span>
                 </div>
               </div>
+              <span
+                className="css-117"
+              >
+                a fancier item description
+              </span>
             </div>
           </div>
         </div>
@@ -4252,71 +4062,66 @@ exports[`with title and description with global label off array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
-    <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
+    <span
       style={
         Object {
-          "display": undefined,
-          "marginBottom": 15,
+          "float": "right",
         }
       }
     >
-      <span
+      <button
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
         style={
           Object {
-            "float": "right",
+            "height": "32px",
           }
         }
+        type="button"
       >
-        <button
-          className="ms-Button ms-Button--commandBar array-item-add root-53"
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          style={
-            Object {
-              "height": "32px",
-            }
-          }
-          type="button"
+        <span
+          className="ms-Button-flexContainer flexContainer-54"
+          data-automationid="splitbuttonprimary"
         >
-          <span
-            className="ms-Button-flexContainer flexContainer-54"
-            data-automationid="splitbuttonprimary"
-          >
-            <i
-              aria-hidden={true}
-              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-              data-icon-name="Add"
-              style={
-                Object {
-                  "fontFamily": "\\"FabricMDL2Icons\\"",
-                }
+          <i
+            aria-hidden={true}
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+            data-icon-name="Add"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
               }
-            >
-              
-            </i>
+            }
+          >
+            
+          </i>
+          <span
+            className="ms-Button-textContainer textContainer-55"
+          >
             <span
-              className="ms-Button-textContainer textContainer-55"
+              className="ms-Button-label label-57"
+              id="id__235"
             >
-              <span
-                className="ms-Button-label label-57"
-                id="id__235"
-              >
-                Add Item
-              </span>
+              Add Item
             </span>
           </span>
-        </button>
-      </span>
-    </div>
+        </span>
+      </button>
+    </span>
   </div>
   <div>
     <br />
@@ -4362,449 +4167,434 @@ exports[`with title and description with global label off array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-Grid"
+      dir="ltr"
     >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
         >
           <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+            className="ms-Grid-row"
           >
             <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="form-group field field-string"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_0"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField is-required root-67"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-68"
-                      >
-                        <input
-                          aria-describedby="root_0__error root_0__description root_0__help"
-                          aria-invalid={false}
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_0"
-                          name="root_0"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          type="text"
-                          value="a"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-            style={
-              Object {
-                "textAlign": "right",
-              }
-            }
-          >
-            <button
-              aria-disabled={true}
-              className="ms-Button ms-Button--icon is-disabled root-95"
-              data-is-focusable={false}
-              disabled={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                  data-icon-name="Up"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                  data-icon-name="Down"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                  data-icon-name="Copy"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                  data-icon-name="Delete"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-          </div>
-        </div>
-      </div>
-      <div
-        className="ms-Grid"
-        dir="ltr"
-      >
-        <div
-          className="ms-Grid-row"
-        >
-          <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
-          >
-            <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="form-group field field-string"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_1"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField is-required root-67"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-68"
-                      >
-                        <input
-                          aria-describedby="root_1__error root_1__description root_1__help"
-                          aria-invalid={false}
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_1"
-                          name="root_1"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          type="text"
-                          value="b"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-            style={
-              Object {
-                "textAlign": "right",
-              }
-            }
-          >
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                  data-icon-name="Up"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              aria-disabled={true}
-              className="ms-Button ms-Button--icon is-disabled root-95"
-              data-is-focusable={false}
-              disabled={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                  data-icon-name="Down"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                  data-icon-name="Copy"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              className="ms-Button ms-Button--icon root-100"
-              data-is-focusable={true}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-54"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                  data-icon-name="Delete"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-          </div>
-        </div>
-      </div>
-      <span
-        style={
-          Object {
-            "float": "right",
-          }
-        }
-      >
-        <button
-          className="ms-Button ms-Button--commandBar array-item-add root-53"
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          style={
-            Object {
-              "height": "32px",
-            }
-          }
-          type="button"
-        >
-          <span
-            className="ms-Button-flexContainer flexContainer-54"
-            data-automationid="splitbuttonprimary"
-          >
-            <i
-              aria-hidden={true}
-              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-              data-icon-name="Add"
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_0"
               style={
                 Object {
-                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                  "marginBottom": 15,
                 }
               }
             >
-              
-            </i>
-            <span
-              className="ms-Button-textContainer textContainer-55"
-            >
-              <span
-                className="ms-Button-label label-57"
-                id="id__283"
+              <div
+                className="ms-TextField is-required root-67"
               >
-                Add Item
-              </span>
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-68"
+                  >
+                    <input
+                      aria-describedby="root_0__error root_0__description root_0__help"
+                      aria-invalid={false}
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_0"
+                      name="root_0"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      type="text"
+                      value="a"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
+          style={
+            Object {
+              "textAlign": "right",
+            }
+          }
+        >
+          <button
+            aria-disabled={true}
+            className="ms-Button ms-Button--icon is-disabled root-95"
+            data-is-focusable={false}
+            disabled={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                data-icon-name="Up"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                data-icon-name="Down"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                data-icon-name="Copy"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                data-icon-name="Delete"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
+      <div
+        className="ms-Grid-row"
+      >
+        <div
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+        >
+          <div
+            className="ms-Grid-row"
+          >
+            <div
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_1"
+              style={
+                Object {
+                  "marginBottom": 15,
+                }
+              }
+            >
+              <div
+                className="ms-TextField is-required root-67"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-68"
+                  >
+                    <input
+                      aria-describedby="root_1__error root_1__description root_1__help"
+                      aria-invalid={false}
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_1"
+                      name="root_1"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      type="text"
+                      value="b"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
+          style={
+            Object {
+              "textAlign": "right",
+            }
+          }
+        >
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                data-icon-name="Up"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            aria-disabled={true}
+            className="ms-Button ms-Button--icon is-disabled root-95"
+            data-is-focusable={false}
+            disabled={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                data-icon-name="Down"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                data-icon-name="Copy"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            className="ms-Button ms-Button--icon root-100"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-54"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                data-icon-name="Delete"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <span
+      style={
+        Object {
+          "float": "right",
+        }
+      }
+    >
+      <button
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        style={
+          Object {
+            "height": "32px",
+          }
+        }
+        type="button"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-54"
+          data-automationid="splitbuttonprimary"
+        >
+          <i
+            aria-hidden={true}
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+            data-icon-name="Add"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
+          >
+            
+          </i>
+          <span
+            className="ms-Button-textContainer textContainer-55"
+          >
+            <span
+              className="ms-Button-label label-57"
+              id="id__283"
+            >
+              Add Item
             </span>
           </span>
-        </button>
-      </span>
-    </div>
+        </span>
+      </button>
+    </span>
   </div>
   <div>
     <br />
@@ -4850,70 +4640,65 @@ exports[`with title and description with global label off checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-Dropdown-container"
     >
+      <label
+        className="ms-Label ms-Dropdown-label root-119"
+        id="root-label"
+      >
+        Test field
+      </label>
       <div
-        className="ms-Dropdown-container"
+        aria-describedby="root__error root__description root__help"
+        aria-disabled={false}
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="root-label root-option"
+        aria-required={false}
+        className="ms-Dropdown dropdown-78"
+        data-is-focusable={true}
+        id="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        role="combobox"
+        tabIndex={0}
       >
-        <label
-          className="ms-Label ms-Dropdown-label root-119"
-          id="root-label"
+        <span
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
+          id="root-option"
+        />
+        <span
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
         >
-          Test field
-        </label>
-        <div
-          aria-describedby="root__error root__description root__help"
-          aria-disabled={false}
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-labelledby="root-label root-option"
-          aria-required={false}
-          className="ms-Dropdown dropdown-78"
-          data-is-focusable={true}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          role="combobox"
-          tabIndex={0}
-        >
-          <span
-            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
-            id="root-option"
-          />
-          <span
-            className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
+          <i
+            aria-hidden={true}
+            className="ms-Dropdown-caretDown caretDown-94"
+            data-icon-name="ChevronDown"
           >
-            <i
-              aria-hidden={true}
-              className="ms-Dropdown-caretDown caretDown-94"
-              data-icon-name="ChevronDown"
-            >
-              
-            </i>
-          </span>
-        </div>
+            
+          </i>
+        </span>
       </div>
-      <span
-        className="css-117"
-      >
-        a test description
-      </span>
     </div>
+    <span
+      className="css-117"
+    >
+      a test description
+    </span>
   </div>
   <div>
     <br />
@@ -4959,73 +4744,63 @@ exports[`with title and description with global label off fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-Grid"
+      dir="ltr"
     >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
         >
           <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+            className="ms-Grid-row"
           >
             <div
-              className="ms-Grid-row"
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_0"
+              style={
+                Object {
+                  "marginBottom": 15,
+                }
+              }
             >
               <div
-                className="form-group field field-string"
+                className="ms-TextField is-required root-67"
               >
                 <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_0"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
+                  className="ms-TextField-wrapper"
                 >
                   <div
-                    className="ms-TextField is-required root-67"
+                    className="ms-TextField-fieldGroup fieldGroup-68"
                   >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-68"
-                      >
-                        <input
-                          aria-describedby="root_0__error root_0__description root_0__help"
-                          aria-invalid={false}
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_0"
-                          name="root_0"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          type="text"
-                          value=""
-                        />
-                      </div>
-                    </div>
+                    <input
+                      aria-describedby="root_0__error root_0__description root_0__help"
+                      aria-invalid={false}
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_0"
+                      name="root_0"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      type="text"
+                      value=""
+                    />
                   </div>
                 </div>
               </div>
@@ -5033,62 +4808,57 @@ exports[`with title and description with global label off fixed array 1`] = `
           </div>
         </div>
       </div>
+    </div>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
         >
           <div
-            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+            className="ms-Grid-row"
           >
             <div
-              className="ms-Grid-row"
+              className="ms-Grid-col ms-sm12  field field-number"
+              id="root_1"
+              style={
+                Object {
+                  "marginBottom": 15,
+                }
+              }
             >
               <div
-                className="form-group field field-number"
+                className="ms-TextField is-required root-67"
               >
                 <div
-                  className="ms-Grid-col ms-sm12  field field-number"
-                  id="root_1"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
+                  className="ms-TextField-wrapper"
                 >
                   <div
-                    className="ms-TextField is-required root-67"
+                    className="ms-TextField-fieldGroup fieldGroup-68"
                   >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-68"
-                      >
-                        <input
-                          aria-describedby="root_1__error root_1__description root_1__help"
-                          aria-invalid={false}
-                          autoFocus={false}
-                          className="ms-TextField-field field-69"
-                          disabled={false}
-                          id="root_1"
-                          name="root_1"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={true}
-                          step="any"
-                          type="number"
-                          value=""
-                        />
-                      </div>
-                    </div>
+                    <input
+                      aria-describedby="root_1__error root_1__description root_1__help"
+                      aria-invalid={false}
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_1"
+                      name="root_1"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={true}
+                      step="any"
+                      type="number"
+                      value=""
+                    />
                   </div>
                 </div>
               </div>

--- a/packages/fluent-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Array.test.tsx.snap
@@ -7,67 +7,71 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
-    <span
+    <div
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
       style={
         Object {
-          "float": "right",
+          "display": undefined,
+          "marginBottom": 15,
         }
       }
     >
-      <button
-        className="ms-Button ms-Button--commandBar array-item-add root-53"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
+      <span
         style={
           Object {
-            "height": "32px",
+            "float": "right",
           }
         }
-        type="button"
       >
-        <span
-          className="ms-Button-flexContainer flexContainer-54"
-          data-automationid="splitbuttonprimary"
-        >
-          <i
-            aria-hidden={true}
-            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-            data-icon-name="Add"
-            style={
-              Object {
-                "fontFamily": "\\"FabricMDL2Icons\\"",
-              }
+        <button
+          className="ms-Button ms-Button--commandBar array-item-add root-53"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
             }
-          >
-            
-          </i>
+          }
+          type="button"
+        >
           <span
-            className="ms-Button-textContainer textContainer-55"
+            className="ms-Button-flexContainer flexContainer-54"
+            data-automationid="splitbuttonprimary"
           >
-            <span
-              className="ms-Button-label label-57"
-              id="id__0"
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
             >
-              Add Item
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-55"
+            >
+              <span
+                className="ms-Button-label label-57"
+                id="id__0"
+              >
+                Add Item
+              </span>
             </span>
           </span>
-        </span>
-      </button>
-    </span>
+        </button>
+      </span>
+    </div>
   </div>
   <div>
     <br />
@@ -113,439 +117,451 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
     <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
-        >
-          <div
-            className="ms-Grid-row"
-          >
-            <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
-            >
-              <div
-                className="ms-TextField is-required root-67"
-              >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-68"
-                  >
-                    <input
-                      aria-describedby="root_0__error root_0__description root_0__help"
-                      aria-invalid={false}
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_0"
-                      name="root_0"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      type="text"
-                      value="a"
-                    />
-                  </div>
-                </div>
-              </div>
-              
-            </div>
-          </div>
-        </div>
-        <div
-          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-          style={
-            Object {
-              "textAlign": "right",
-            }
-          }
-        >
-          <button
-            aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-95"
-            data-is-focusable={false}
-            disabled={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                data-icon-name="Up"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                data-icon-name="Down"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                data-icon-name="Copy"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                data-icon-name="Delete"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-        </div>
-      </div>
-    </div>
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
-        >
-          <div
-            className="ms-Grid-row"
-          >
-            <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_1"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
-            >
-              <div
-                className="ms-TextField is-required root-67"
-              >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-68"
-                  >
-                    <input
-                      aria-describedby="root_1__error root_1__description root_1__help"
-                      aria-invalid={false}
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_1"
-                      name="root_1"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      type="text"
-                      value="b"
-                    />
-                  </div>
-                </div>
-              </div>
-              
-            </div>
-          </div>
-        </div>
-        <div
-          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-          style={
-            Object {
-              "textAlign": "right",
-            }
-          }
-        >
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                data-icon-name="Up"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-95"
-            data-is-focusable={false}
-            disabled={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                data-icon-name="Down"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                data-icon-name="Copy"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                data-icon-name="Delete"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-        </div>
-      </div>
-    </div>
-    <span
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
       style={
         Object {
-          "float": "right",
+          "display": undefined,
+          "marginBottom": 15,
         }
       }
     >
-      <button
-        className="ms-Button ms-Button--commandBar array-item-add root-53"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        style={
-          Object {
-            "height": "32px",
-          }
-        }
-        type="button"
+      <div
+        className="ms-Grid"
+        dir="ltr"
       >
-        <span
-          className="ms-Button-flexContainer flexContainer-54"
-          data-automationid="splitbuttonprimary"
+        <div
+          className="ms-Grid-row"
         >
-          <i
-            aria-hidden={true}
-            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-            data-icon-name="Add"
+          <div
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          >
+            <div
+              className="ms-Grid-row"
+            >
+              <div
+                className="form-group field field-string"
+              >
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_0"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField is-required root-67"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-68"
+                      >
+                        <input
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          aria-invalid={false}
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_0"
+                          name="root_0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          type="text"
+                          value="a"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
             style={
               Object {
-                "fontFamily": "\\"FabricMDL2Icons\\"",
+                "textAlign": "right",
               }
             }
           >
-            
-          </i>
-          <span
-            className="ms-Button-textContainer textContainer-55"
-          >
-            <span
-              className="ms-Button-label label-57"
-              id="id__48"
+            <button
+              aria-disabled={true}
+              className="ms-Button ms-Button--icon is-disabled root-95"
+              data-is-focusable={false}
+              disabled={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
             >
-              Add Item
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                  data-icon-name="Up"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                  data-icon-name="Down"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                  data-icon-name="Copy"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                  data-icon-name="Delete"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ms-Grid"
+        dir="ltr"
+      >
+        <div
+          className="ms-Grid-row"
+        >
+          <div
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          >
+            <div
+              className="ms-Grid-row"
+            >
+              <div
+                className="form-group field field-string"
+              >
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_1"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField is-required root-67"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-68"
+                      >
+                        <input
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          aria-invalid={false}
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_1"
+                          name="root_1"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          type="text"
+                          value="b"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
+            style={
+              Object {
+                "textAlign": "right",
+              }
+            }
+          >
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                  data-icon-name="Up"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              aria-disabled={true}
+              className="ms-Button ms-Button--icon is-disabled root-95"
+              data-is-focusable={false}
+              disabled={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                  data-icon-name="Down"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                  data-icon-name="Copy"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                  data-icon-name="Delete"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <span
+        style={
+          Object {
+            "float": "right",
+          }
+        }
+      >
+        <button
+          className="ms-Button ms-Button--commandBar array-item-add root-53"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
+            }
+          }
+          type="button"
+        >
+          <span
+            className="ms-Button-flexContainer flexContainer-54"
+            data-automationid="splitbuttonprimary"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
+            >
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-55"
+            >
+              <span
+                className="ms-Button-label label-57"
+                id="id__48"
+              >
+                Add Item
+              </span>
             </span>
           </span>
-        </span>
-      </button>
-    </span>
+        </button>
+      </span>
+    </div>
   </div>
   <div>
     <br />
@@ -591,55 +607,59 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
     <div
-      className="ms-Dropdown-container"
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        aria-describedby="root__error root__description root__help"
-        aria-disabled={false}
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-required={false}
-        className="ms-Dropdown dropdown-78"
-        data-is-focusable={true}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        role="combobox"
-        tabIndex={0}
+        className="ms-Dropdown-container"
       >
-        <span
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
-          id="root-option"
-        />
-        <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
+        <div
+          aria-describedby="root__error root__description root__help"
+          aria-disabled={false}
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-required={false}
+          className="ms-Dropdown dropdown-78"
+          data-is-focusable={true}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          role="combobox"
+          tabIndex={0}
         >
-          <i
-            aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-94"
-            data-icon-name="ChevronDown"
+          <span
+            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
+            id="root-option"
+          />
+          <span
+            className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
           >
-            
-          </i>
-        </span>
+            <i
+              aria-hidden={true}
+              className="ms-Dropdown-caretDown caretDown-94"
+              data-icon-name="ChevronDown"
+            >
+              
+            </i>
+          </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -685,72 +705,80 @@ exports[`array fields empty errors array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-object"
   >
-    
     <div
-      className="ms-Grid"
-      dir="ltr"
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
+      
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_name"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
+          className="ms-Grid-row"
         >
           <div
-            className="ms-TextField root-67"
+            className="form-group field field-string"
           >
             <div
-              className="ms-TextField-wrapper"
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_name"
+              style={
+                Object {
+                  "display": undefined,
+                  "marginBottom": 15,
+                }
+              }
             >
-              <label
-                className="ms-Label root-114"
-                htmlFor="root_name"
-                id="TextFieldLabel69"
-              >
-                name
-              </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-115"
+                className="ms-TextField root-67"
               >
-                <input
-                  aria-describedby="root_name__error root_name__description root_name__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel69"
-                  autoFocus={false}
-                  className="ms-TextField-field field-69"
-                  disabled={false}
-                  id="root_name"
-                  name="root_name"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value=""
-                />
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-114"
+                    htmlFor="root_name"
+                    id="TextFieldLabel69"
+                  >
+                    name
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-115"
+                  >
+                    <input
+                      aria-describedby="root_name__error root_name__description root_name__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel69"
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_name"
+                      name="root_name"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
               </div>
+              
             </div>
           </div>
-          
         </div>
       </div>
     </div>
@@ -799,129 +827,141 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
     <div
-      className="ms-Grid"
-      dir="ltr"
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          className="ms-Grid-row"
         >
           <div
-            className="ms-Grid-row"
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-Grid-row"
             >
               <div
-                className="ms-TextField is-required root-67"
+                className="form-group field field-string"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_0"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
                 >
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-68"
+                    className="ms-TextField is-required root-67"
                   >
-                    <input
-                      aria-describedby="root_0__error root_0__description root_0__help"
-                      aria-invalid={false}
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_0"
-                      name="root_0"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      type="text"
-                      value=""
-                    />
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-68"
+                      >
+                        <input
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          aria-invalid={false}
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_0"
+                          name="root_0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
                   </div>
+                  
                 </div>
               </div>
-              
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          className="ms-Grid-row"
         >
           <div
-            className="ms-Grid-row"
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-number"
-              id="root_1"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-Grid-row"
             >
               <div
-                className="ms-TextField is-required root-67"
+                className="form-group field field-number"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className="ms-Grid-col ms-sm12  field field-number"
+                  id="root_1"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
                 >
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-68"
+                    className="ms-TextField is-required root-67"
                   >
-                    <input
-                      aria-describedby="root_1__error root_1__description root_1__help"
-                      aria-invalid={false}
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_1"
-                      name="root_1"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      step="any"
-                      type="number"
-                      value=""
-                    />
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-68"
+                      >
+                        <input
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          aria-invalid={false}
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_1"
+                          name="root_1"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          step="any"
+                          type="number"
+                          value=""
+                        />
+                      </div>
+                    </div>
                   </div>
+                  
                 </div>
               </div>
-              
             </div>
           </div>
         </div>
@@ -1002,100 +1042,108 @@ exports[`array fields has errors 1`] = `
     </div>
   </div>
   <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-object"
   >
-    
     <div
-      className="ms-Grid"
-      dir="ltr"
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
+      
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm12  field field-string field-error has-error has-danger"
-          id="root_name"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
+          className="ms-Grid-row"
         >
           <div
-            className="ms-TextField root-67"
+            className="form-group field field-string field-error has-error has-danger"
           >
             <div
-              className="ms-TextField-wrapper"
-            >
-              <label
-                className="ms-Label root-114"
-                htmlFor="root_name"
-                id="TextFieldLabel57"
-              >
-                name
-              </label>
-              <div
-                className="ms-TextField-fieldGroup fieldGroup-113"
-              >
-                <input
-                  aria-describedby="TextFieldDescription56"
-                  aria-invalid={true}
-                  aria-labelledby="TextFieldLabel57"
-                  autoFocus={false}
-                  className="ms-TextField-field field-69"
-                  disabled={false}
-                  id="root_name"
-                  name="root_name"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value=""
-                />
-              </div>
-            </div>
-            <span
-              id="TextFieldDescription56"
+              className="ms-Grid-col ms-sm12  field field-string field-error has-error has-danger"
+              id="root_name"
+              style={
+                Object {
+                  "display": undefined,
+                  "marginBottom": 15,
+                }
+              }
             >
               <div
-                role="alert"
-              />
-            </span>
-          </div>
-          
-          <div
-            className="ms-List"
-            id="root_name__error"
-            role="list"
-          >
-            <div
-              className="ms-List-surface"
-              role="presentation"
-            >
-              <div
-                className="ms-List-page"
-                role="presentation"
-                style={Object {}}
+                className="ms-TextField root-67"
               >
                 <div
-                  className="ms-List-cell"
-                  data-automationid="ListCell"
-                  data-list-index={0}
-                  role="listitem"
+                  className="ms-TextField-wrapper"
                 >
-                  
+                  <label
+                    className="ms-Label root-114"
+                    htmlFor="root_name"
+                    id="TextFieldLabel57"
+                  >
+                    name
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-113"
+                  >
+                    <input
+                      aria-describedby="TextFieldDescription56"
+                      aria-invalid={true}
+                      aria-labelledby="TextFieldLabel57"
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_name"
+                      name="root_name"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+                <span
+                  id="TextFieldDescription56"
+                >
+                  <div
+                    role="alert"
+                  />
+                </span>
+              </div>
+              
+              <div
+                className="ms-List"
+                id="root_name__error"
+                role="list"
+              >
+                <div
+                  className="ms-List-surface"
+                  role="presentation"
+                >
+                  <div
+                    className="ms-List-page"
+                    role="presentation"
+                    style={Object {}}
+                  >
+                    <div
+                      className="ms-List-cell"
+                      data-automationid="ListCell"
+                      data-list-index={0}
+                      role="listitem"
+                    >
+                      
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
@@ -1148,72 +1196,80 @@ exports[`array fields no errors 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-object"
   >
-    
     <div
-      className="ms-Grid"
-      dir="ltr"
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
+      
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_name"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
+          className="ms-Grid-row"
         >
           <div
-            className="ms-TextField root-67"
+            className="form-group field field-string"
           >
             <div
-              className="ms-TextField-wrapper"
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_name"
+              style={
+                Object {
+                  "display": undefined,
+                  "marginBottom": 15,
+                }
+              }
             >
-              <label
-                className="ms-Label root-114"
-                htmlFor="root_name"
-                id="TextFieldLabel63"
-              >
-                name
-              </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-115"
+                className="ms-TextField root-67"
               >
-                <input
-                  aria-describedby="root_name__error root_name__description root_name__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel63"
-                  autoFocus={false}
-                  className="ms-TextField-field field-69"
-                  disabled={false}
-                  id="root_name"
-                  name="root_name"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value=""
-                />
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-114"
+                    htmlFor="root_name"
+                    id="TextFieldLabel63"
+                  >
+                    name
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-115"
+                  >
+                    <input
+                      aria-describedby="root_name__error root_name__description root_name__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel63"
+                      autoFocus={false}
+                      className="ms-TextField-field field-69"
+                      disabled={false}
+                      id="root_name"
+                      name="root_name"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
               </div>
+              
             </div>
           </div>
-          
         </div>
       </div>
     </div>
@@ -1262,79 +1318,83 @@ exports[`with title and description array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
-    <label
-      className="ms-Label root-116"
-      id="root__title"
-    >
-      Test field
-    </label>
-    <span
-      className="css-117"
-      id="root__description"
-    >
-      a test description
-    </span>
-    <span
+    <div
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
       style={
         Object {
-          "float": "right",
+          "display": undefined,
+          "marginBottom": 15,
         }
       }
     >
-      <button
-        className="ms-Button ms-Button--commandBar array-item-add root-53"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
+      <label
+        className="ms-Label root-116"
+        id="root__title"
+      >
+        Test field
+      </label>
+      <span
+        className="css-117"
+        id="root__description"
+      >
+        a test description
+      </span>
+      <span
         style={
           Object {
-            "height": "32px",
+            "float": "right",
           }
         }
-        type="button"
       >
-        <span
-          className="ms-Button-flexContainer flexContainer-54"
-          data-automationid="splitbuttonprimary"
-        >
-          <i
-            aria-hidden={true}
-            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-            data-icon-name="Add"
-            style={
-              Object {
-                "fontFamily": "\\"FabricMDL2Icons\\"",
-              }
+        <button
+          className="ms-Button ms-Button--commandBar array-item-add root-53"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
             }
-          >
-            
-          </i>
+          }
+          type="button"
+        >
           <span
-            className="ms-Button-textContainer textContainer-55"
+            className="ms-Button-flexContainer flexContainer-54"
+            data-automationid="splitbuttonprimary"
           >
-            <span
-              className="ms-Button-label label-57"
-              id="id__73"
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
             >
-              Add Item
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-55"
+            >
+              <span
+                className="ms-Button-label label-57"
+                id="id__73"
+              >
+                Add Item
+              </span>
             </span>
           </span>
-        </span>
-      </button>
-    </span>
+        </button>
+      </span>
+    </div>
   </div>
   <div>
     <br />
@@ -1380,475 +1440,487 @@ exports[`with title and description array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
-    <label
-      className="ms-Label root-116"
-      id="root__title"
-    >
-      Test field
-    </label>
-    <span
-      className="css-117"
-      id="root__description"
-    >
-      a test description
-    </span>
     <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
-        >
-          <div
-            className="ms-Grid-row"
-          >
-            <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
-            >
-              <div
-                className="ms-TextField is-required root-67"
-              >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-118"
-                    htmlFor="root_0"
-                    id="TextFieldLabel93"
-                  >
-                    Test item
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-115"
-                  >
-                    <input
-                      aria-describedby="root_0__error root_0__description root_0__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel93"
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_0"
-                      name="root_0"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      type="text"
-                      value="a"
-                    />
-                  </div>
-                </div>
-              </div>
-              <span
-                className="css-117"
-              >
-                a test item description
-              </span>
-            </div>
-          </div>
-        </div>
-        <div
-          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-          style={
-            Object {
-              "textAlign": "right",
-            }
-          }
-        >
-          <button
-            aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-95"
-            data-is-focusable={false}
-            disabled={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                data-icon-name="Up"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                data-icon-name="Down"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                data-icon-name="Copy"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                data-icon-name="Delete"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-        </div>
-      </div>
-    </div>
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
-        >
-          <div
-            className="ms-Grid-row"
-          >
-            <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_1"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
-            >
-              <div
-                className="ms-TextField is-required root-67"
-              >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-118"
-                    htmlFor="root_1"
-                    id="TextFieldLabel108"
-                  >
-                    Test item
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-115"
-                  >
-                    <input
-                      aria-describedby="root_1__error root_1__description root_1__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel108"
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_1"
-                      name="root_1"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      type="text"
-                      value="b"
-                    />
-                  </div>
-                </div>
-              </div>
-              <span
-                className="css-117"
-              >
-                a test item description
-              </span>
-            </div>
-          </div>
-        </div>
-        <div
-          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-          style={
-            Object {
-              "textAlign": "right",
-            }
-          }
-        >
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                data-icon-name="Up"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-95"
-            data-is-focusable={false}
-            disabled={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                data-icon-name="Down"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                data-icon-name="Copy"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                data-icon-name="Delete"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-        </div>
-      </div>
-    </div>
-    <span
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
       style={
         Object {
-          "float": "right",
+          "display": undefined,
+          "marginBottom": 15,
         }
       }
     >
-      <button
-        className="ms-Button ms-Button--commandBar array-item-add root-53"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        style={
-          Object {
-            "height": "32px",
-          }
-        }
-        type="button"
+      <label
+        className="ms-Label root-116"
+        id="root__title"
       >
-        <span
-          className="ms-Button-flexContainer flexContainer-54"
-          data-automationid="splitbuttonprimary"
+        Test field
+      </label>
+      <span
+        className="css-117"
+        id="root__description"
+      >
+        a test description
+      </span>
+      <div
+        className="ms-Grid"
+        dir="ltr"
+      >
+        <div
+          className="ms-Grid-row"
         >
-          <i
-            aria-hidden={true}
-            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-            data-icon-name="Add"
+          <div
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          >
+            <div
+              className="ms-Grid-row"
+            >
+              <div
+                className="form-group field field-string"
+              >
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_0"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField is-required root-67"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-118"
+                        htmlFor="root_0"
+                        id="TextFieldLabel93"
+                      >
+                        Test item
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-115"
+                      >
+                        <input
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel93"
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_0"
+                          name="root_0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          type="text"
+                          value="a"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <span
+                    className="css-117"
+                  >
+                    a test item description
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
             style={
               Object {
-                "fontFamily": "\\"FabricMDL2Icons\\"",
+                "textAlign": "right",
               }
             }
           >
-            
-          </i>
-          <span
-            className="ms-Button-textContainer textContainer-55"
-          >
-            <span
-              className="ms-Button-label label-57"
-              id="id__121"
+            <button
+              aria-disabled={true}
+              className="ms-Button ms-Button--icon is-disabled root-95"
+              data-is-focusable={false}
+              disabled={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
             >
-              Add Item
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                  data-icon-name="Up"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                  data-icon-name="Down"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                  data-icon-name="Copy"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                  data-icon-name="Delete"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ms-Grid"
+        dir="ltr"
+      >
+        <div
+          className="ms-Grid-row"
+        >
+          <div
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          >
+            <div
+              className="ms-Grid-row"
+            >
+              <div
+                className="form-group field field-string"
+              >
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_1"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField is-required root-67"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-118"
+                        htmlFor="root_1"
+                        id="TextFieldLabel108"
+                      >
+                        Test item
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-115"
+                      >
+                        <input
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel108"
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_1"
+                          name="root_1"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          type="text"
+                          value="b"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <span
+                    className="css-117"
+                  >
+                    a test item description
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
+            style={
+              Object {
+                "textAlign": "right",
+              }
+            }
+          >
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                  data-icon-name="Up"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              aria-disabled={true}
+              className="ms-Button ms-Button--icon is-disabled root-95"
+              data-is-focusable={false}
+              disabled={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                  data-icon-name="Down"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                  data-icon-name="Copy"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                  data-icon-name="Delete"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <span
+        style={
+          Object {
+            "float": "right",
+          }
+        }
+      >
+        <button
+          className="ms-Button ms-Button--commandBar array-item-add root-53"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
+            }
+          }
+          type="button"
+        >
+          <span
+            className="ms-Button-flexContainer flexContainer-54"
+            data-automationid="splitbuttonprimary"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
+            >
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-55"
+            >
+              <span
+                className="ms-Button-label label-57"
+                id="id__121"
+              >
+                Add Item
+              </span>
             </span>
           </span>
-        </span>
-      </button>
-    </span>
+        </button>
+      </span>
+    </div>
   </div>
   <div>
     <br />
@@ -1894,66 +1966,70 @@ exports[`with title and description checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
     <div
-      className="ms-Dropdown-container"
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
-      <label
-        className="ms-Label ms-Dropdown-label root-119"
-        id="root-label"
-      >
-        Test field
-      </label>
       <div
-        aria-describedby="root__error root__description root__help"
-        aria-disabled={false}
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby="root-label root-option"
-        aria-required={false}
-        className="ms-Dropdown dropdown-78"
-        data-is-focusable={true}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        role="combobox"
-        tabIndex={0}
+        className="ms-Dropdown-container"
       >
-        <span
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
-          id="root-option"
-        />
-        <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
+        <label
+          className="ms-Label ms-Dropdown-label root-119"
+          id="root-label"
         >
-          <i
-            aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-94"
-            data-icon-name="ChevronDown"
+          Test field
+        </label>
+        <div
+          aria-describedby="root__error root__description root__help"
+          aria-disabled={false}
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-labelledby="root-label root-option"
+          aria-required={false}
+          className="ms-Dropdown dropdown-78"
+          data-is-focusable={true}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          role="combobox"
+          tabIndex={0}
+        >
+          <span
+            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
+            id="root-option"
+          />
+          <span
+            className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
           >
-            
-          </i>
-        </span>
+            <i
+              aria-hidden={true}
+              className="ms-Dropdown-caretDown caretDown-94"
+              data-icon-name="ChevronDown"
+            >
+              
+            </i>
+          </span>
+        </div>
       </div>
+      <span
+        className="css-117"
+      >
+        a test description
+      </span>
     </div>
-    <span
-      className="css-117"
-    >
-      a test description
-    </span>
   </div>
   <div>
     <br />
@@ -1999,165 +2075,177 @@ exports[`with title and description fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
-    <label
-      className="ms-Label root-116"
-      id="root__title"
-    >
-      Test field
-    </label>
-    <span
-      className="css-117"
-      id="root__description"
-    >
-      a test description
-    </span>
     <div
-      className="ms-Grid"
-      dir="ltr"
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
+      <label
+        className="ms-Label root-116"
+        id="root__title"
+      >
+        Test field
+      </label>
+      <span
+        className="css-117"
+        id="root__description"
+      >
+        a test description
+      </span>
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          className="ms-Grid-row"
         >
           <div
-            className="ms-Grid-row"
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-Grid-row"
             >
               <div
-                className="ms-TextField is-required root-67"
+                className="form-group field field-string"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_0"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
                 >
-                  <label
-                    className="ms-Label root-118"
-                    htmlFor="root_0"
-                    id="TextFieldLabel81"
-                  >
-                    Test item
-                  </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-115"
+                    className="ms-TextField is-required root-67"
                   >
-                    <input
-                      aria-describedby="root_0__error root_0__description root_0__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel81"
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_0"
-                      name="root_0"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      type="text"
-                      value=""
-                    />
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-118"
+                        htmlFor="root_0"
+                        id="TextFieldLabel81"
+                      >
+                        Test item
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-115"
+                      >
+                        <input
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel81"
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_0"
+                          name="root_0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
                   </div>
+                  <span
+                    className="css-117"
+                  >
+                    a test item description
+                  </span>
                 </div>
               </div>
-              <span
-                className="css-117"
-              >
-                a test item description
-              </span>
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          className="ms-Grid-row"
         >
           <div
-            className="ms-Grid-row"
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-number"
-              id="root_1"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-Grid-row"
             >
               <div
-                className="ms-TextField is-required root-67"
+                className="form-group field field-number"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className="ms-Grid-col ms-sm12  field field-number"
+                  id="root_1"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
                 >
-                  <label
-                    className="ms-Label root-118"
-                    htmlFor="root_1"
-                    id="TextFieldLabel84"
-                  >
-                    Test item
-                  </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-115"
+                    className="ms-TextField is-required root-67"
                   >
-                    <input
-                      aria-describedby="root_1__error root_1__description root_1__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel84"
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_1"
-                      name="root_1"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      step="any"
-                      type="number"
-                      value=""
-                    />
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-118"
+                        htmlFor="root_1"
+                        id="TextFieldLabel84"
+                      >
+                        Test item
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-115"
+                      >
+                        <input
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel84"
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_1"
+                          name="root_1"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          step="any"
+                          type="number"
+                          value=""
+                        />
+                      </div>
+                    </div>
                   </div>
+                  <span
+                    className="css-117"
+                  >
+                    a test item description
+                  </span>
                 </div>
               </div>
-              <span
-                className="css-117"
-              >
-                a test item description
-              </span>
             </div>
           </div>
         </div>
@@ -2208,79 +2296,83 @@ exports[`with title and description from both array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
-    <label
-      className="ms-Label root-116"
-      id="root__title"
-    >
-      My Field
-    </label>
-    <span
-      className="css-117"
-      id="root__description"
-    >
-      a fancier description
-    </span>
-    <span
+    <div
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
       style={
         Object {
-          "float": "right",
+          "display": undefined,
+          "marginBottom": 15,
         }
       }
     >
-      <button
-        className="ms-Button ms-Button--commandBar array-item-add root-53"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
+      <label
+        className="ms-Label root-116"
+        id="root__title"
+      >
+        My Field
+      </label>
+      <span
+        className="css-117"
+        id="root__description"
+      >
+        a fancier description
+      </span>
+      <span
         style={
           Object {
-            "height": "32px",
+            "float": "right",
           }
         }
-        type="button"
       >
-        <span
-          className="ms-Button-flexContainer flexContainer-54"
-          data-automationid="splitbuttonprimary"
-        >
-          <i
-            aria-hidden={true}
-            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-            data-icon-name="Add"
-            style={
-              Object {
-                "fontFamily": "\\"FabricMDL2Icons\\"",
-              }
+        <button
+          className="ms-Button ms-Button--commandBar array-item-add root-53"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
             }
-          >
-            
-          </i>
+          }
+          type="button"
+        >
           <span
-            className="ms-Button-textContainer textContainer-55"
+            className="ms-Button-flexContainer flexContainer-54"
+            data-automationid="splitbuttonprimary"
           >
-            <span
-              className="ms-Button-label label-57"
-              id="id__181"
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
             >
-              Add Item
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-55"
+            >
+              <span
+                className="ms-Button-label label-57"
+                id="id__181"
+              >
+                Add Item
+              </span>
             </span>
           </span>
-        </span>
-      </button>
-    </span>
+        </button>
+      </span>
+    </div>
   </div>
   <div>
     <br />
@@ -2326,475 +2418,487 @@ exports[`with title and description from both array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
-    <label
-      className="ms-Label root-116"
-      id="root__title"
-    >
-      My Field
-    </label>
-    <span
-      className="css-117"
-      id="root__description"
-    >
-      a fancier description
-    </span>
     <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
-        >
-          <div
-            className="ms-Grid-row"
-          >
-            <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
-            >
-              <div
-                className="ms-TextField is-required root-67"
-              >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-118"
-                    htmlFor="root_0"
-                    id="TextFieldLabel201"
-                  >
-                    My Item
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-115"
-                  >
-                    <input
-                      aria-describedby="root_0__error root_0__description root_0__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel201"
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_0"
-                      name="root_0"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      type="text"
-                      value="a"
-                    />
-                  </div>
-                </div>
-              </div>
-              <span
-                className="css-117"
-              >
-                a fancier item description
-              </span>
-            </div>
-          </div>
-        </div>
-        <div
-          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-          style={
-            Object {
-              "textAlign": "right",
-            }
-          }
-        >
-          <button
-            aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-95"
-            data-is-focusable={false}
-            disabled={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                data-icon-name="Up"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                data-icon-name="Down"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                data-icon-name="Copy"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                data-icon-name="Delete"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-        </div>
-      </div>
-    </div>
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
-        >
-          <div
-            className="ms-Grid-row"
-          >
-            <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_1"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
-            >
-              <div
-                className="ms-TextField is-required root-67"
-              >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-118"
-                    htmlFor="root_1"
-                    id="TextFieldLabel216"
-                  >
-                    My Item
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-115"
-                  >
-                    <input
-                      aria-describedby="root_1__error root_1__description root_1__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel216"
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_1"
-                      name="root_1"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      type="text"
-                      value="b"
-                    />
-                  </div>
-                </div>
-              </div>
-              <span
-                className="css-117"
-              >
-                a fancier item description
-              </span>
-            </div>
-          </div>
-        </div>
-        <div
-          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-          style={
-            Object {
-              "textAlign": "right",
-            }
-          }
-        >
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                data-icon-name="Up"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-95"
-            data-is-focusable={false}
-            disabled={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                data-icon-name="Down"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                data-icon-name="Copy"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                data-icon-name="Delete"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-        </div>
-      </div>
-    </div>
-    <span
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
       style={
         Object {
-          "float": "right",
+          "display": undefined,
+          "marginBottom": 15,
         }
       }
     >
-      <button
-        className="ms-Button ms-Button--commandBar array-item-add root-53"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        style={
-          Object {
-            "height": "32px",
-          }
-        }
-        type="button"
+      <label
+        className="ms-Label root-116"
+        id="root__title"
       >
-        <span
-          className="ms-Button-flexContainer flexContainer-54"
-          data-automationid="splitbuttonprimary"
+        My Field
+      </label>
+      <span
+        className="css-117"
+        id="root__description"
+      >
+        a fancier description
+      </span>
+      <div
+        className="ms-Grid"
+        dir="ltr"
+      >
+        <div
+          className="ms-Grid-row"
         >
-          <i
-            aria-hidden={true}
-            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-            data-icon-name="Add"
+          <div
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          >
+            <div
+              className="ms-Grid-row"
+            >
+              <div
+                className="form-group field field-string"
+              >
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_0"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField is-required root-67"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-118"
+                        htmlFor="root_0"
+                        id="TextFieldLabel201"
+                      >
+                        My Item
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-115"
+                      >
+                        <input
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel201"
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_0"
+                          name="root_0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          type="text"
+                          value="a"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <span
+                    className="css-117"
+                  >
+                    a fancier item description
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
             style={
               Object {
-                "fontFamily": "\\"FabricMDL2Icons\\"",
+                "textAlign": "right",
               }
             }
           >
-            
-          </i>
-          <span
-            className="ms-Button-textContainer textContainer-55"
-          >
-            <span
-              className="ms-Button-label label-57"
-              id="id__229"
+            <button
+              aria-disabled={true}
+              className="ms-Button ms-Button--icon is-disabled root-95"
+              data-is-focusable={false}
+              disabled={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
             >
-              Add Item
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                  data-icon-name="Up"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                  data-icon-name="Down"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                  data-icon-name="Copy"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                  data-icon-name="Delete"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ms-Grid"
+        dir="ltr"
+      >
+        <div
+          className="ms-Grid-row"
+        >
+          <div
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          >
+            <div
+              className="ms-Grid-row"
+            >
+              <div
+                className="form-group field field-string"
+              >
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_1"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField is-required root-67"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-118"
+                        htmlFor="root_1"
+                        id="TextFieldLabel216"
+                      >
+                        My Item
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-115"
+                      >
+                        <input
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel216"
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_1"
+                          name="root_1"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          type="text"
+                          value="b"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <span
+                    className="css-117"
+                  >
+                    a fancier item description
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
+            style={
+              Object {
+                "textAlign": "right",
+              }
+            }
+          >
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                  data-icon-name="Up"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              aria-disabled={true}
+              className="ms-Button ms-Button--icon is-disabled root-95"
+              data-is-focusable={false}
+              disabled={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                  data-icon-name="Down"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                  data-icon-name="Copy"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                  data-icon-name="Delete"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <span
+        style={
+          Object {
+            "float": "right",
+          }
+        }
+      >
+        <button
+          className="ms-Button ms-Button--commandBar array-item-add root-53"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
+            }
+          }
+          type="button"
+        >
+          <span
+            className="ms-Button-flexContainer flexContainer-54"
+            data-automationid="splitbuttonprimary"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
+            >
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-55"
+            >
+              <span
+                className="ms-Button-label label-57"
+                id="id__229"
+              >
+                Add Item
+              </span>
             </span>
           </span>
-        </span>
-      </button>
-    </span>
+        </button>
+      </span>
+    </div>
   </div>
   <div>
     <br />
@@ -2840,66 +2944,70 @@ exports[`with title and description from both checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
     <div
-      className="ms-Dropdown-container"
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
-      <label
-        className="ms-Label ms-Dropdown-label root-119"
-        id="root-label"
-      >
-        My Field
-      </label>
       <div
-        aria-describedby="root__error root__description root__help"
-        aria-disabled={false}
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby="root-label root-option"
-        aria-required={false}
-        className="ms-Dropdown dropdown-78"
-        data-is-focusable={true}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        role="combobox"
-        tabIndex={0}
+        className="ms-Dropdown-container"
       >
-        <span
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
-          id="root-option"
-        />
-        <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
+        <label
+          className="ms-Label ms-Dropdown-label root-119"
+          id="root-label"
         >
-          <i
-            aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-94"
-            data-icon-name="ChevronDown"
+          My Field
+        </label>
+        <div
+          aria-describedby="root__error root__description root__help"
+          aria-disabled={false}
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-labelledby="root-label root-option"
+          aria-required={false}
+          className="ms-Dropdown dropdown-78"
+          data-is-focusable={true}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          role="combobox"
+          tabIndex={0}
+        >
+          <span
+            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
+            id="root-option"
+          />
+          <span
+            className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
           >
-            
-          </i>
-        </span>
+            <i
+              aria-hidden={true}
+              className="ms-Dropdown-caretDown caretDown-94"
+              data-icon-name="ChevronDown"
+            >
+              
+            </i>
+          </span>
+        </div>
       </div>
+      <span
+        className="css-117"
+      >
+        a fancier description
+      </span>
     </div>
-    <span
-      className="css-117"
-    >
-      a fancier description
-    </span>
   </div>
   <div>
     <br />
@@ -2945,165 +3053,177 @@ exports[`with title and description from both fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
-    <label
-      className="ms-Label root-116"
-      id="root__title"
-    >
-      My Field
-    </label>
-    <span
-      className="css-117"
-      id="root__description"
-    >
-      a fancier description
-    </span>
     <div
-      className="ms-Grid"
-      dir="ltr"
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
+      <label
+        className="ms-Label root-116"
+        id="root__title"
+      >
+        My Field
+      </label>
+      <span
+        className="css-117"
+        id="root__description"
+      >
+        a fancier description
+      </span>
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          className="ms-Grid-row"
         >
           <div
-            className="ms-Grid-row"
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-Grid-row"
             >
               <div
-                className="ms-TextField is-required root-67"
+                className="form-group field field-string"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_0"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
                 >
-                  <label
-                    className="ms-Label root-118"
-                    htmlFor="root_0"
-                    id="TextFieldLabel189"
-                  >
-                    My Item
-                  </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-115"
+                    className="ms-TextField is-required root-67"
                   >
-                    <input
-                      aria-describedby="root_0__error root_0__description root_0__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel189"
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_0"
-                      name="root_0"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      type="text"
-                      value=""
-                    />
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-118"
+                        htmlFor="root_0"
+                        id="TextFieldLabel189"
+                      >
+                        My Item
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-115"
+                      >
+                        <input
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel189"
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_0"
+                          name="root_0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
                   </div>
+                  <span
+                    className="css-117"
+                  >
+                    a fancier item description
+                  </span>
                 </div>
               </div>
-              <span
-                className="css-117"
-              >
-                a fancier item description
-              </span>
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          className="ms-Grid-row"
         >
           <div
-            className="ms-Grid-row"
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-number"
-              id="root_1"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-Grid-row"
             >
               <div
-                className="ms-TextField is-required root-67"
+                className="form-group field field-number"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className="ms-Grid-col ms-sm12  field field-number"
+                  id="root_1"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
                 >
-                  <label
-                    className="ms-Label root-118"
-                    htmlFor="root_1"
-                    id="TextFieldLabel192"
-                  >
-                    My Item
-                  </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-115"
+                    className="ms-TextField is-required root-67"
                   >
-                    <input
-                      aria-describedby="root_1__error root_1__description root_1__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel192"
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_1"
-                      name="root_1"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      step="any"
-                      type="number"
-                      value=""
-                    />
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-118"
+                        htmlFor="root_1"
+                        id="TextFieldLabel192"
+                      >
+                        My Item
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-115"
+                      >
+                        <input
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel192"
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_1"
+                          name="root_1"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          step="any"
+                          type="number"
+                          value=""
+                        />
+                      </div>
+                    </div>
                   </div>
+                  <span
+                    className="css-117"
+                  >
+                    a fancier item description
+                  </span>
                 </div>
               </div>
-              <span
-                className="css-117"
-              >
-                a fancier item description
-              </span>
             </div>
           </div>
         </div>
@@ -3154,79 +3274,83 @@ exports[`with title and description from uiSchema array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
-    <label
-      className="ms-Label root-116"
-      id="root__title"
-    >
-      My Field
-    </label>
-    <span
-      className="css-117"
-      id="root__description"
-    >
-      a fancier description
-    </span>
-    <span
+    <div
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
       style={
         Object {
-          "float": "right",
+          "display": undefined,
+          "marginBottom": 15,
         }
       }
     >
-      <button
-        className="ms-Button ms-Button--commandBar array-item-add root-53"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
+      <label
+        className="ms-Label root-116"
+        id="root__title"
+      >
+        My Field
+      </label>
+      <span
+        className="css-117"
+        id="root__description"
+      >
+        a fancier description
+      </span>
+      <span
         style={
           Object {
-            "height": "32px",
+            "float": "right",
           }
         }
-        type="button"
       >
-        <span
-          className="ms-Button-flexContainer flexContainer-54"
-          data-automationid="splitbuttonprimary"
-        >
-          <i
-            aria-hidden={true}
-            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-            data-icon-name="Add"
-            style={
-              Object {
-                "fontFamily": "\\"FabricMDL2Icons\\"",
-              }
+        <button
+          className="ms-Button ms-Button--commandBar array-item-add root-53"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
             }
-          >
-            
-          </i>
+          }
+          type="button"
+        >
           <span
-            className="ms-Button-textContainer textContainer-55"
+            className="ms-Button-flexContainer flexContainer-54"
+            data-automationid="splitbuttonprimary"
           >
-            <span
-              className="ms-Button-label label-57"
-              id="id__127"
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
             >
-              Add Item
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-55"
+            >
+              <span
+                className="ms-Button-label label-57"
+                id="id__127"
+              >
+                Add Item
+              </span>
             </span>
           </span>
-        </span>
-      </button>
-    </span>
+        </button>
+      </span>
+    </div>
   </div>
   <div>
     <br />
@@ -3272,475 +3396,487 @@ exports[`with title and description from uiSchema array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
-    <label
-      className="ms-Label root-116"
-      id="root__title"
-    >
-      My Field
-    </label>
-    <span
-      className="css-117"
-      id="root__description"
-    >
-      a fancier description
-    </span>
     <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
-        >
-          <div
-            className="ms-Grid-row"
-          >
-            <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
-            >
-              <div
-                className="ms-TextField is-required root-67"
-              >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-118"
-                    htmlFor="root_0"
-                    id="TextFieldLabel147"
-                  >
-                    My Item
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-115"
-                  >
-                    <input
-                      aria-describedby="root_0__error root_0__description root_0__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel147"
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_0"
-                      name="root_0"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      type="text"
-                      value="a"
-                    />
-                  </div>
-                </div>
-              </div>
-              <span
-                className="css-117"
-              >
-                a fancier item description
-              </span>
-            </div>
-          </div>
-        </div>
-        <div
-          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-          style={
-            Object {
-              "textAlign": "right",
-            }
-          }
-        >
-          <button
-            aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-95"
-            data-is-focusable={false}
-            disabled={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                data-icon-name="Up"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                data-icon-name="Down"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                data-icon-name="Copy"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                data-icon-name="Delete"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-        </div>
-      </div>
-    </div>
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
-        >
-          <div
-            className="ms-Grid-row"
-          >
-            <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_1"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
-            >
-              <div
-                className="ms-TextField is-required root-67"
-              >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-118"
-                    htmlFor="root_1"
-                    id="TextFieldLabel162"
-                  >
-                    My Item
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-115"
-                  >
-                    <input
-                      aria-describedby="root_1__error root_1__description root_1__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel162"
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_1"
-                      name="root_1"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      type="text"
-                      value="b"
-                    />
-                  </div>
-                </div>
-              </div>
-              <span
-                className="css-117"
-              >
-                a fancier item description
-              </span>
-            </div>
-          </div>
-        </div>
-        <div
-          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-          style={
-            Object {
-              "textAlign": "right",
-            }
-          }
-        >
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                data-icon-name="Up"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-95"
-            data-is-focusable={false}
-            disabled={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                data-icon-name="Down"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                data-icon-name="Copy"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                data-icon-name="Delete"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-        </div>
-      </div>
-    </div>
-    <span
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
       style={
         Object {
-          "float": "right",
+          "display": undefined,
+          "marginBottom": 15,
         }
       }
     >
-      <button
-        className="ms-Button ms-Button--commandBar array-item-add root-53"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        style={
-          Object {
-            "height": "32px",
-          }
-        }
-        type="button"
+      <label
+        className="ms-Label root-116"
+        id="root__title"
       >
-        <span
-          className="ms-Button-flexContainer flexContainer-54"
-          data-automationid="splitbuttonprimary"
+        My Field
+      </label>
+      <span
+        className="css-117"
+        id="root__description"
+      >
+        a fancier description
+      </span>
+      <div
+        className="ms-Grid"
+        dir="ltr"
+      >
+        <div
+          className="ms-Grid-row"
         >
-          <i
-            aria-hidden={true}
-            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-            data-icon-name="Add"
+          <div
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          >
+            <div
+              className="ms-Grid-row"
+            >
+              <div
+                className="form-group field field-string"
+              >
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_0"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField is-required root-67"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-118"
+                        htmlFor="root_0"
+                        id="TextFieldLabel147"
+                      >
+                        My Item
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-115"
+                      >
+                        <input
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel147"
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_0"
+                          name="root_0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          type="text"
+                          value="a"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <span
+                    className="css-117"
+                  >
+                    a fancier item description
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
             style={
               Object {
-                "fontFamily": "\\"FabricMDL2Icons\\"",
+                "textAlign": "right",
               }
             }
           >
-            
-          </i>
-          <span
-            className="ms-Button-textContainer textContainer-55"
-          >
-            <span
-              className="ms-Button-label label-57"
-              id="id__175"
+            <button
+              aria-disabled={true}
+              className="ms-Button ms-Button--icon is-disabled root-95"
+              data-is-focusable={false}
+              disabled={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
             >
-              Add Item
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                  data-icon-name="Up"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                  data-icon-name="Down"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                  data-icon-name="Copy"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                  data-icon-name="Delete"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ms-Grid"
+        dir="ltr"
+      >
+        <div
+          className="ms-Grid-row"
+        >
+          <div
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          >
+            <div
+              className="ms-Grid-row"
+            >
+              <div
+                className="form-group field field-string"
+              >
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_1"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField is-required root-67"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-118"
+                        htmlFor="root_1"
+                        id="TextFieldLabel162"
+                      >
+                        My Item
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-115"
+                      >
+                        <input
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel162"
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_1"
+                          name="root_1"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          type="text"
+                          value="b"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  <span
+                    className="css-117"
+                  >
+                    a fancier item description
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
+            style={
+              Object {
+                "textAlign": "right",
+              }
+            }
+          >
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                  data-icon-name="Up"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              aria-disabled={true}
+              className="ms-Button ms-Button--icon is-disabled root-95"
+              data-is-focusable={false}
+              disabled={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                  data-icon-name="Down"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                  data-icon-name="Copy"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                  data-icon-name="Delete"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <span
+        style={
+          Object {
+            "float": "right",
+          }
+        }
+      >
+        <button
+          className="ms-Button ms-Button--commandBar array-item-add root-53"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
+            }
+          }
+          type="button"
+        >
+          <span
+            className="ms-Button-flexContainer flexContainer-54"
+            data-automationid="splitbuttonprimary"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
+            >
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-55"
+            >
+              <span
+                className="ms-Button-label label-57"
+                id="id__175"
+              >
+                Add Item
+              </span>
             </span>
           </span>
-        </span>
-      </button>
-    </span>
+        </button>
+      </span>
+    </div>
   </div>
   <div>
     <br />
@@ -3786,66 +3922,70 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
     <div
-      className="ms-Dropdown-container"
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
-      <label
-        className="ms-Label ms-Dropdown-label root-119"
-        id="root-label"
-      >
-        My Field
-      </label>
       <div
-        aria-describedby="root__error root__description root__help"
-        aria-disabled={false}
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby="root-label root-option"
-        aria-required={false}
-        className="ms-Dropdown dropdown-78"
-        data-is-focusable={true}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        role="combobox"
-        tabIndex={0}
+        className="ms-Dropdown-container"
       >
-        <span
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
-          id="root-option"
-        />
-        <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
+        <label
+          className="ms-Label ms-Dropdown-label root-119"
+          id="root-label"
         >
-          <i
-            aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-94"
-            data-icon-name="ChevronDown"
+          My Field
+        </label>
+        <div
+          aria-describedby="root__error root__description root__help"
+          aria-disabled={false}
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-labelledby="root-label root-option"
+          aria-required={false}
+          className="ms-Dropdown dropdown-78"
+          data-is-focusable={true}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          role="combobox"
+          tabIndex={0}
+        >
+          <span
+            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
+            id="root-option"
+          />
+          <span
+            className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
           >
-            
-          </i>
-        </span>
+            <i
+              aria-hidden={true}
+              className="ms-Dropdown-caretDown caretDown-94"
+              data-icon-name="ChevronDown"
+            >
+              
+            </i>
+          </span>
+        </div>
       </div>
+      <span
+        className="css-117"
+      >
+        a fancier description
+      </span>
     </div>
-    <span
-      className="css-117"
-    >
-      a fancier description
-    </span>
   </div>
   <div>
     <br />
@@ -3891,165 +4031,177 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
-    <label
-      className="ms-Label root-116"
-      id="root__title"
-    >
-      My Field
-    </label>
-    <span
-      className="css-117"
-      id="root__description"
-    >
-      a fancier description
-    </span>
     <div
-      className="ms-Grid"
-      dir="ltr"
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
+      <label
+        className="ms-Label root-116"
+        id="root__title"
+      >
+        My Field
+      </label>
+      <span
+        className="css-117"
+        id="root__description"
+      >
+        a fancier description
+      </span>
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          className="ms-Grid-row"
         >
           <div
-            className="ms-Grid-row"
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-Grid-row"
             >
               <div
-                className="ms-TextField is-required root-67"
+                className="form-group field field-string"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_0"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
                 >
-                  <label
-                    className="ms-Label root-118"
-                    htmlFor="root_0"
-                    id="TextFieldLabel135"
-                  >
-                    My Item
-                  </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-115"
+                    className="ms-TextField is-required root-67"
                   >
-                    <input
-                      aria-describedby="root_0__error root_0__description root_0__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel135"
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_0"
-                      name="root_0"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      type="text"
-                      value=""
-                    />
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-118"
+                        htmlFor="root_0"
+                        id="TextFieldLabel135"
+                      >
+                        My Item
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-115"
+                      >
+                        <input
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel135"
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_0"
+                          name="root_0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
                   </div>
+                  <span
+                    className="css-117"
+                  >
+                    a fancier item description
+                  </span>
                 </div>
               </div>
-              <span
-                className="css-117"
-              >
-                a fancier item description
-              </span>
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          className="ms-Grid-row"
         >
           <div
-            className="ms-Grid-row"
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-number"
-              id="root_1"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-Grid-row"
             >
               <div
-                className="ms-TextField is-required root-67"
+                className="form-group field field-number"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className="ms-Grid-col ms-sm12  field field-number"
+                  id="root_1"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
                 >
-                  <label
-                    className="ms-Label root-118"
-                    htmlFor="root_1"
-                    id="TextFieldLabel138"
-                  >
-                    My Item
-                  </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-115"
+                    className="ms-TextField is-required root-67"
                   >
-                    <input
-                      aria-describedby="root_1__error root_1__description root_1__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel138"
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_1"
-                      name="root_1"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      step="any"
-                      type="number"
-                      value=""
-                    />
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-118"
+                        htmlFor="root_1"
+                        id="TextFieldLabel138"
+                      >
+                        My Item
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-115"
+                      >
+                        <input
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel138"
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_1"
+                          name="root_1"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          step="any"
+                          type="number"
+                          value=""
+                        />
+                      </div>
+                    </div>
                   </div>
+                  <span
+                    className="css-117"
+                  >
+                    a fancier item description
+                  </span>
                 </div>
               </div>
-              <span
-                className="css-117"
-              >
-                a fancier item description
-              </span>
             </div>
           </div>
         </div>
@@ -4100,67 +4252,71 @@ exports[`with title and description with global label off array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
-    <span
+    <div
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
       style={
         Object {
-          "float": "right",
+          "display": undefined,
+          "marginBottom": 15,
         }
       }
     >
-      <button
-        className="ms-Button ms-Button--commandBar array-item-add root-53"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
+      <span
         style={
           Object {
-            "height": "32px",
+            "float": "right",
           }
         }
-        type="button"
       >
-        <span
-          className="ms-Button-flexContainer flexContainer-54"
-          data-automationid="splitbuttonprimary"
-        >
-          <i
-            aria-hidden={true}
-            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-            data-icon-name="Add"
-            style={
-              Object {
-                "fontFamily": "\\"FabricMDL2Icons\\"",
-              }
+        <button
+          className="ms-Button ms-Button--commandBar array-item-add root-53"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
             }
-          >
-            
-          </i>
+          }
+          type="button"
+        >
           <span
-            className="ms-Button-textContainer textContainer-55"
+            className="ms-Button-flexContainer flexContainer-54"
+            data-automationid="splitbuttonprimary"
           >
-            <span
-              className="ms-Button-label label-57"
-              id="id__235"
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
             >
-              Add Item
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-55"
+            >
+              <span
+                className="ms-Button-label label-57"
+                id="id__235"
+              >
+                Add Item
+              </span>
             </span>
           </span>
-        </span>
-      </button>
-    </span>
+        </button>
+      </span>
+    </div>
   </div>
   <div>
     <br />
@@ -4206,437 +4362,449 @@ exports[`with title and description with global label off array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
     <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
-        >
-          <div
-            className="ms-Grid-row"
-          >
-            <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
-            >
-              <div
-                className="ms-TextField is-required root-67"
-              >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-68"
-                  >
-                    <input
-                      aria-describedby="root_0__error root_0__description root_0__help"
-                      aria-invalid={false}
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_0"
-                      name="root_0"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      type="text"
-                      value="a"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-          style={
-            Object {
-              "textAlign": "right",
-            }
-          }
-        >
-          <button
-            aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-95"
-            data-is-focusable={false}
-            disabled={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                data-icon-name="Up"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                data-icon-name="Down"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                data-icon-name="Copy"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                data-icon-name="Delete"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-        </div>
-      </div>
-    </div>
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
-        >
-          <div
-            className="ms-Grid-row"
-          >
-            <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_1"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
-            >
-              <div
-                className="ms-TextField is-required root-67"
-              >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-68"
-                  >
-                    <input
-                      aria-describedby="root_1__error root_1__description root_1__help"
-                      aria-invalid={false}
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_1"
-                      name="root_1"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      type="text"
-                      value="b"
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
-          style={
-            Object {
-              "textAlign": "right",
-            }
-          }
-        >
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
-                data-icon-name="Up"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-95"
-            data-is-focusable={false}
-            disabled={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
-                data-icon-name="Down"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-0\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
-                data-icon-name="Copy"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            className="ms-Button ms-Button--icon root-100"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-54"
-              data-automationid="splitbuttonprimary"
-            >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
-                data-icon-name="Delete"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
-              >
-                
-              </i>
-            </span>
-          </button>
-        </div>
-      </div>
-    </div>
-    <span
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
       style={
         Object {
-          "float": "right",
+          "display": undefined,
+          "marginBottom": 15,
         }
       }
     >
-      <button
-        className="ms-Button ms-Button--commandBar array-item-add root-53"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        style={
-          Object {
-            "height": "32px",
-          }
-        }
-        type="button"
+      <div
+        className="ms-Grid"
+        dir="ltr"
       >
-        <span
-          className="ms-Button-flexContainer flexContainer-54"
-          data-automationid="splitbuttonprimary"
+        <div
+          className="ms-Grid-row"
         >
-          <i
-            aria-hidden={true}
-            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
-            data-icon-name="Add"
+          <div
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          >
+            <div
+              className="ms-Grid-row"
+            >
+              <div
+                className="form-group field field-string"
+              >
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_0"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField is-required root-67"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-68"
+                      >
+                        <input
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          aria-invalid={false}
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_0"
+                          name="root_0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          type="text"
+                          value="a"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
             style={
               Object {
-                "fontFamily": "\\"FabricMDL2Icons\\"",
+                "textAlign": "right",
               }
             }
           >
-            
-          </i>
-          <span
-            className="ms-Button-textContainer textContainer-55"
-          >
-            <span
-              className="ms-Button-label label-57"
-              id="id__283"
+            <button
+              aria-disabled={true}
+              className="ms-Button ms-Button--icon is-disabled root-95"
+              data-is-focusable={false}
+              disabled={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
             >
-              Add Item
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                  data-icon-name="Up"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                  data-icon-name="Down"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                  data-icon-name="Copy"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                  data-icon-name="Delete"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        className="ms-Grid"
+        dir="ltr"
+      >
+        <div
+          className="ms-Grid-row"
+        >
+          <div
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          >
+            <div
+              className="ms-Grid-row"
+            >
+              <div
+                className="form-group field field-string"
+              >
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_1"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField is-required root-67"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-68"
+                      >
+                        <input
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          aria-invalid={false}
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_1"
+                          name="root_1"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          type="text"
+                          value="b"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="ms-Grid-col ms-sm6 ms-md4 ms-lg3"
+            style={
+              Object {
+                "textAlign": "right",
+              }
+            }
+          >
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
+                  data-icon-name="Up"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              aria-disabled={true}
+              className="ms-Button ms-Button--icon is-disabled root-95"
+              data-is-focusable={false}
+              disabled={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
+                  data-icon-name="Down"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-0\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
+                  data-icon-name="Copy"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              className="ms-Button ms-Button--icon root-100"
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className="ms-Button-flexContainer flexContainer-54"
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
+                  data-icon-name="Delete"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <span
+        style={
+          Object {
+            "float": "right",
+          }
+        }
+      >
+        <button
+          className="ms-Button ms-Button--commandBar array-item-add root-53"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
+            }
+          }
+          type="button"
+        >
+          <span
+            className="ms-Button-flexContainer flexContainer-54"
+            data-automationid="splitbuttonprimary"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
+            >
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-55"
+            >
+              <span
+                className="ms-Button-label label-57"
+                id="id__283"
+              >
+                Add Item
+              </span>
             </span>
           </span>
-        </span>
-      </button>
-    </span>
+        </button>
+      </span>
+    </div>
   </div>
   <div>
     <br />
@@ -4682,66 +4850,70 @@ exports[`with title and description with global label off checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
     <div
-      className="ms-Dropdown-container"
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
-      <label
-        className="ms-Label ms-Dropdown-label root-119"
-        id="root-label"
-      >
-        Test field
-      </label>
       <div
-        aria-describedby="root__error root__description root__help"
-        aria-disabled={false}
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby="root-label root-option"
-        aria-required={false}
-        className="ms-Dropdown dropdown-78"
-        data-is-focusable={true}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        role="combobox"
-        tabIndex={0}
+        className="ms-Dropdown-container"
       >
-        <span
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
-          id="root-option"
-        />
-        <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
+        <label
+          className="ms-Label ms-Dropdown-label root-119"
+          id="root-label"
         >
-          <i
-            aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-94"
-            data-icon-name="ChevronDown"
+          Test field
+        </label>
+        <div
+          aria-describedby="root__error root__description root__help"
+          aria-disabled={false}
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-labelledby="root-label root-option"
+          aria-required={false}
+          className="ms-Dropdown dropdown-78"
+          data-is-focusable={true}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          role="combobox"
+          tabIndex={0}
+        >
+          <span
+            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
+            id="root-option"
+          />
+          <span
+            className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
           >
-            
-          </i>
-        </span>
+            <i
+              aria-hidden={true}
+              className="ms-Dropdown-caretDown caretDown-94"
+              data-icon-name="ChevronDown"
+            >
+              
+            </i>
+          </span>
+        </div>
       </div>
+      <span
+        className="css-117"
+      >
+        a test description
+      </span>
     </div>
-    <span
-      className="css-117"
-    >
-      a test description
-    </span>
   </div>
   <div>
     <br />
@@ -4787,65 +4959,73 @@ exports[`with title and description with global label off fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
     <div
-      className="ms-Grid"
-      dir="ltr"
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          className="ms-Grid-row"
         >
           <div
-            className="ms-Grid-row"
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_0"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-Grid-row"
             >
               <div
-                className="ms-TextField is-required root-67"
+                className="form-group field field-string"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_0"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
                 >
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-68"
+                    className="ms-TextField is-required root-67"
                   >
-                    <input
-                      aria-describedby="root_0__error root_0__description root_0__help"
-                      aria-invalid={false}
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_0"
-                      name="root_0"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      type="text"
-                      value=""
-                    />
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-68"
+                      >
+                        <input
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          aria-invalid={false}
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_0"
+                          name="root_0"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          type="text"
+                          value=""
+                        />
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -4853,58 +5033,62 @@ exports[`with title and description with global label off fixed array 1`] = `
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
+          className="ms-Grid-row"
         >
           <div
-            className="ms-Grid-row"
+            className="ms-Grid-col ms-sm6 ms-md8 ms-lg9"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-number"
-              id="root_1"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-Grid-row"
             >
               <div
-                className="ms-TextField is-required root-67"
+                className="form-group field field-number"
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className="ms-Grid-col ms-sm12  field field-number"
+                  id="root_1"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
                 >
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-68"
+                    className="ms-TextField is-required root-67"
                   >
-                    <input
-                      aria-describedby="root_1__error root_1__description root_1__help"
-                      aria-invalid={false}
-                      autoFocus={false}
-                      className="ms-TextField-field field-69"
-                      disabled={false}
-                      id="root_1"
-                      name="root_1"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={true}
-                      step="any"
-                      type="number"
-                      value=""
-                    />
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-68"
+                      >
+                        <input
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          aria-invalid={false}
+                          autoFocus={false}
+                          className="ms-TextField-field field-69"
+                          disabled={false}
+                          id="root_1"
+                          name="root_1"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={true}
+                          step="any"
+                          type="number"
+                          value=""
+                        />
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`single fields checkbox field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-boolean"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -94,7 +93,6 @@ exports[`single fields checkbox field with label 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-boolean"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -187,7 +185,6 @@ exports[`single fields checkboxes field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -416,7 +413,6 @@ exports[`single fields field with description 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -433,7 +429,6 @@ exports[`single fields field with description 1`] = `
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string"
-          id="root_my-field"
           style={
             Object {
               "marginBottom": 15,
@@ -532,7 +527,6 @@ exports[`single fields field with description in uiSchema 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -549,7 +543,6 @@ exports[`single fields field with description in uiSchema 1`] = `
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string"
-          id="root_my-field"
           style={
             Object {
               "marginBottom": 15,
@@ -648,7 +641,6 @@ exports[`single fields format color 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1010,7 +1002,6 @@ exports[`single fields format date 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1117,7 +1108,6 @@ exports[`single fields format datetime 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1200,7 +1190,6 @@ exports[`single fields format time 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1313,7 +1302,6 @@ exports[`single fields help and error display 1`] = `
   </div>
   <div
     className="ms-Grid-col ms-sm12  field field-string field-error has-error has-danger"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1434,7 +1422,6 @@ exports[`single fields hidden field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1511,7 +1498,6 @@ exports[`single fields hidden label 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1593,7 +1579,6 @@ exports[`single fields null field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-null"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1647,7 +1632,6 @@ exports[`single fields number field 0 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-number"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1731,7 +1715,6 @@ exports[`single fields number field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-number"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1815,7 +1798,6 @@ exports[`single fields password field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1898,7 +1880,6 @@ exports[`single fields radio field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-boolean"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2031,7 +2012,6 @@ exports[`single fields schema examples 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2134,7 +2114,6 @@ exports[`single fields select field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2226,7 +2205,6 @@ exports[`single fields select field multiple choice 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2319,7 +2297,6 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2412,7 +2389,6 @@ exports[`single fields select field multiple choice formData 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2507,7 +2483,6 @@ exports[`single fields select field multiple choice with labels 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2600,7 +2575,6 @@ exports[`single fields select field single choice enumDisabled 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2692,7 +2666,6 @@ exports[`single fields select field single choice formData 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2786,7 +2759,6 @@ exports[`single fields slider field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-integer"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2901,7 +2873,6 @@ exports[`single fields string field format data-url 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2986,7 +2957,6 @@ exports[`single fields string field format email 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -3069,7 +3039,6 @@ exports[`single fields string field format uri 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -3152,7 +3121,6 @@ exports[`single fields string field regular 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -3235,7 +3203,6 @@ exports[`single fields string field with placeholder 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -3318,7 +3285,6 @@ exports[`single fields textarea field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -3401,7 +3367,6 @@ exports[`single fields title field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -3423,7 +3388,6 @@ exports[`single fields title field 1`] = `
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string"
-          id="root_title"
           style={
             Object {
               "marginBottom": 15,
@@ -3518,7 +3482,6 @@ exports[`single fields unsupported field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-undefined"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -3592,7 +3555,6 @@ exports[`single fields up/down field 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-number"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -3751,7 +3713,6 @@ exports[`single fields using custom tagName 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
     style={
       Object {
         "marginBottom": 15,

--- a/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
@@ -7,51 +7,46 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="ms-Grid-col ms-sm12  field field-boolean"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-boolean"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-Checkbox is-enabled root-139"
     >
-      <div
-        className="ms-Checkbox is-enabled root-139"
+      <input
+        aria-checked="false"
+        aria-disabled={false}
+        checked={false}
+        className="input-140"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        type="checkbox"
+      />
+      <label
+        className="ms-Checkbox-label label-141"
+        htmlFor="root"
       >
-        <input
-          aria-checked="false"
-          aria-disabled={false}
-          checked={false}
-          className="input-140"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          type="checkbox"
-        />
-        <label
-          className="ms-Checkbox-label label-141"
-          htmlFor="root"
+        <div
+          className="ms-Checkbox-checkbox checkbox-142"
         >
-          <div
-            className="ms-Checkbox-checkbox checkbox-142"
+          <i
+            aria-hidden={true}
+            className="ms-Checkbox-checkmark checkmark-145"
+            data-icon-name="CheckMark"
           >
-            <i
-              aria-hidden={true}
-              className="ms-Checkbox-checkmark checkmark-145"
-              data-icon-name="CheckMark"
-            >
-              
-            </i>
-          </div>
-        </label>
-      </div>
+            
+          </i>
+        </div>
+      </label>
     </div>
   </div>
   <div>
@@ -98,58 +93,53 @@ exports[`single fields checkbox field with label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="ms-Grid-col ms-sm12  field field-boolean"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-boolean"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-Checkbox is-enabled root-139"
     >
-      <div
-        className="ms-Checkbox is-enabled root-139"
+      <input
+        aria-checked="false"
+        aria-disabled={false}
+        aria-label="test"
+        checked={false}
+        className="input-140"
+        disabled={false}
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        type="checkbox"
+      />
+      <label
+        className="ms-Checkbox-label label-141"
+        htmlFor="root"
       >
-        <input
-          aria-checked="false"
-          aria-disabled={false}
-          aria-label="test"
-          checked={false}
-          className="input-140"
-          disabled={false}
-          id="root"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          type="checkbox"
-        />
-        <label
-          className="ms-Checkbox-label label-141"
-          htmlFor="root"
+        <div
+          className="ms-Checkbox-checkbox checkbox-142"
         >
-          <div
-            className="ms-Checkbox-checkbox checkbox-142"
+          <i
+            aria-hidden={true}
+            className="ms-Checkbox-checkmark checkmark-145"
+            data-icon-name="CheckMark"
           >
-            <i
-              aria-hidden={true}
-              className="ms-Checkbox-checkmark checkmark-145"
-              data-icon-name="CheckMark"
-            >
-              
-            </i>
-          </div>
-          <span
-            aria-hidden="true"
-            className="ms-Checkbox-text text-144"
-          >
-            test
-          </span>
-        </label>
-      </div>
+            
+          </i>
+        </div>
+        <span
+          aria-hidden="true"
+          className="ms-Checkbox-text text-144"
+        >
+          test
+        </span>
+      </label>
     </div>
   </div>
   <div>
@@ -196,195 +186,190 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
+    <label
+      className="ms-Label root-73"
+    />
     <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
+      className="ms-Checkbox is-enabled root-139"
+    >
+      <input
+        aria-checked="false"
+        aria-disabled={false}
+        aria-label="foo"
+        checked={false}
+        className="input-140"
+        disabled={false}
+        id="root-0"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        type="checkbox"
+      />
+      <label
+        className="ms-Checkbox-label label-141"
+        htmlFor="root-0"
+      >
+        <div
+          className="ms-Checkbox-checkbox checkbox-142"
+        >
+          <i
+            aria-hidden={true}
+            className="ms-Checkbox-checkmark checkmark-145"
+            data-icon-name="CheckMark"
+          >
+            
+          </i>
+        </div>
+        <span
+          aria-hidden="true"
+          className="ms-Checkbox-text text-144"
+        >
+          foo
+        </span>
+      </label>
+    </div>
+    <div
+      className="ms-Checkbox is-enabled root-139"
+    >
+      <input
+        aria-checked="false"
+        aria-disabled={false}
+        aria-label="bar"
+        checked={false}
+        className="input-140"
+        disabled={false}
+        id="root-1"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        type="checkbox"
+      />
+      <label
+        className="ms-Checkbox-label label-141"
+        htmlFor="root-1"
+      >
+        <div
+          className="ms-Checkbox-checkbox checkbox-142"
+        >
+          <i
+            aria-hidden={true}
+            className="ms-Checkbox-checkmark checkmark-145"
+            data-icon-name="CheckMark"
+          >
+            
+          </i>
+        </div>
+        <span
+          aria-hidden="true"
+          className="ms-Checkbox-text text-144"
+        >
+          bar
+        </span>
+      </label>
+    </div>
+    <div
+      className="ms-Checkbox is-enabled root-139"
+    >
+      <input
+        aria-checked="false"
+        aria-disabled={false}
+        aria-label="fuzz"
+        checked={false}
+        className="input-140"
+        disabled={false}
+        id="root-2"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        type="checkbox"
+      />
+      <label
+        className="ms-Checkbox-label label-141"
+        htmlFor="root-2"
+      >
+        <div
+          className="ms-Checkbox-checkbox checkbox-142"
+        >
+          <i
+            aria-hidden={true}
+            className="ms-Checkbox-checkmark checkmark-145"
+            data-icon-name="CheckMark"
+          >
+            
+          </i>
+        </div>
+        <span
+          aria-hidden="true"
+          className="ms-Checkbox-text text-144"
+        >
+          fuzz
+        </span>
+      </label>
+    </div>
+    <div
+      className="ms-Checkbox is-enabled root-139"
+    >
+      <input
+        aria-checked="false"
+        aria-disabled={false}
+        aria-label="qux"
+        checked={false}
+        className="input-140"
+        disabled={false}
+        id="root-3"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        type="checkbox"
+      />
+      <label
+        className="ms-Checkbox-label label-141"
+        htmlFor="root-3"
+      >
+        <div
+          className="ms-Checkbox-checkbox checkbox-142"
+        >
+          <i
+            aria-hidden={true}
+            className="ms-Checkbox-checkmark checkmark-145"
+            data-icon-name="CheckMark"
+          >
+            
+          </i>
+        </div>
+        <span
+          aria-hidden="true"
+          className="ms-Checkbox-text text-144"
+        >
+          qux
+        </span>
+      </label>
+    </div>
+    <span
       style={
         Object {
-          "display": undefined,
-          "marginBottom": 15,
+          "color": "rgb(164, 38, 44)",
+          "fontFamily": "\\"Segoe UI\\", \\"Segoe UI Web (West European)\\", \\"Segoe UI\\", -apple-system, BlinkMacSystemFont, Roboto, \\"Helvetica Neue\\", sans-serif",
+          "fontSize": 12,
+          "fontWeight": "normal",
         }
       }
     >
-      <label
-        className="ms-Label root-73"
-      />
-      <div
-        className="ms-Checkbox is-enabled root-139"
-      >
-        <input
-          aria-checked="false"
-          aria-disabled={false}
-          aria-label="foo"
-          checked={false}
-          className="input-140"
-          disabled={false}
-          id="root-0"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          type="checkbox"
-        />
-        <label
-          className="ms-Checkbox-label label-141"
-          htmlFor="root-0"
-        >
-          <div
-            className="ms-Checkbox-checkbox checkbox-142"
-          >
-            <i
-              aria-hidden={true}
-              className="ms-Checkbox-checkmark checkmark-145"
-              data-icon-name="CheckMark"
-            >
-              
-            </i>
-          </div>
-          <span
-            aria-hidden="true"
-            className="ms-Checkbox-text text-144"
-          >
-            foo
-          </span>
-        </label>
-      </div>
-      <div
-        className="ms-Checkbox is-enabled root-139"
-      >
-        <input
-          aria-checked="false"
-          aria-disabled={false}
-          aria-label="bar"
-          checked={false}
-          className="input-140"
-          disabled={false}
-          id="root-1"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          type="checkbox"
-        />
-        <label
-          className="ms-Checkbox-label label-141"
-          htmlFor="root-1"
-        >
-          <div
-            className="ms-Checkbox-checkbox checkbox-142"
-          >
-            <i
-              aria-hidden={true}
-              className="ms-Checkbox-checkmark checkmark-145"
-              data-icon-name="CheckMark"
-            >
-              
-            </i>
-          </div>
-          <span
-            aria-hidden="true"
-            className="ms-Checkbox-text text-144"
-          >
-            bar
-          </span>
-        </label>
-      </div>
-      <div
-        className="ms-Checkbox is-enabled root-139"
-      >
-        <input
-          aria-checked="false"
-          aria-disabled={false}
-          aria-label="fuzz"
-          checked={false}
-          className="input-140"
-          disabled={false}
-          id="root-2"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          type="checkbox"
-        />
-        <label
-          className="ms-Checkbox-label label-141"
-          htmlFor="root-2"
-        >
-          <div
-            className="ms-Checkbox-checkbox checkbox-142"
-          >
-            <i
-              aria-hidden={true}
-              className="ms-Checkbox-checkmark checkmark-145"
-              data-icon-name="CheckMark"
-            >
-              
-            </i>
-          </div>
-          <span
-            aria-hidden="true"
-            className="ms-Checkbox-text text-144"
-          >
-            fuzz
-          </span>
-        </label>
-      </div>
-      <div
-        className="ms-Checkbox is-enabled root-139"
-      >
-        <input
-          aria-checked="false"
-          aria-disabled={false}
-          aria-label="qux"
-          checked={false}
-          className="input-140"
-          disabled={false}
-          id="root-3"
-          name="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          type="checkbox"
-        />
-        <label
-          className="ms-Checkbox-label label-141"
-          htmlFor="root-3"
-        >
-          <div
-            className="ms-Checkbox-checkbox checkbox-142"
-          >
-            <i
-              aria-hidden={true}
-              className="ms-Checkbox-checkmark checkmark-145"
-              data-icon-name="CheckMark"
-            >
-              
-            </i>
-          </div>
-          <span
-            aria-hidden="true"
-            className="ms-Checkbox-text text-144"
-          >
-            qux
-          </span>
-        </label>
-      </div>
-      <span
-        style={
-          Object {
-            "color": "rgb(164, 38, 44)",
-            "fontFamily": "\\"Segoe UI\\", \\"Segoe UI Web (West European)\\", \\"Segoe UI\\", -apple-system, BlinkMacSystemFont, Roboto, \\"Helvetica Neue\\", sans-serif",
-            "fontSize": 12,
-            "fontWeight": "normal",
-          }
-        }
-      >
-        
-      </span>
       
-    </div>
+    </span>
+    
   </div>
   <div>
     <br />
@@ -430,84 +415,74 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    
+    <div
+      className="ms-Grid"
+      dir="ltr"
     >
-      
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm12  field field-string"
+          id="root_my-field"
+          style={
+            Object {
+              "marginBottom": 15,
+            }
+          }
         >
           <div
-            className="form-group field field-string"
+            className="ms-TextField root-54"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_my-field"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-TextField-wrapper"
             >
+              <label
+                className="ms-Label root-73"
+                htmlFor="root_my-field"
+                id="TextFieldLabel153"
+              >
+                my-field
+              </label>
               <div
-                className="ms-TextField root-54"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-73"
-                    htmlFor="root_my-field"
-                    id="TextFieldLabel153"
-                  >
-                    my-field
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-55"
-                  >
-                    <input
-                      aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel153"
-                      autoFocus={false}
-                      className="ms-TextField-field field-56"
-                      disabled={false}
-                      id="root_my-field"
-                      name="root_my-field"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={false}
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
+                <input
+                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                  aria-invalid={false}
+                  aria-labelledby="TextFieldLabel153"
+                  autoFocus={false}
+                  className="ms-TextField-field field-56"
+                  disabled={false}
+                  id="root_my-field"
+                  name="root_my-field"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
               </div>
-              <span
-                className="css-166"
-              >
-                some description
-              </span>
             </div>
           </div>
+          <span
+            className="css-166"
+          >
+            some description
+          </span>
         </div>
       </div>
     </div>
@@ -556,84 +531,74 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    
+    <div
+      className="ms-Grid"
+      dir="ltr"
     >
-      
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm12  field field-string"
+          id="root_my-field"
+          style={
+            Object {
+              "marginBottom": 15,
+            }
+          }
         >
           <div
-            className="form-group field field-string"
+            className="ms-TextField root-54"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_my-field"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-TextField-wrapper"
             >
+              <label
+                className="ms-Label root-73"
+                htmlFor="root_my-field"
+                id="TextFieldLabel159"
+              >
+                my-field
+              </label>
               <div
-                className="ms-TextField root-54"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-73"
-                    htmlFor="root_my-field"
-                    id="TextFieldLabel159"
-                  >
-                    my-field
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-55"
-                  >
-                    <input
-                      aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel159"
-                      autoFocus={false}
-                      className="ms-TextField-field field-56"
-                      disabled={false}
-                      id="root_my-field"
-                      name="root_my-field"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={false}
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
+                <input
+                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                  aria-invalid={false}
+                  aria-labelledby="TextFieldLabel159"
+                  autoFocus={false}
+                  className="ms-TextField-field field-56"
+                  disabled={false}
+                  id="root_my-field"
+                  name="root_my-field"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
               </div>
-              <span
-                className="css-166"
-              >
-                some other description
-              </span>
             </div>
           </div>
+          <span
+            className="css-166"
+          >
+            some other description
+          </span>
         </div>
       </div>
     </div>
@@ -682,328 +647,323 @@ exports[`single fields format color 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-string"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    <label
+      className="ms-Label root-73"
+      htmlFor="root"
+    />
+    <div
+      aria-label="Color picker, Red 255 Green 255 Blue 255 Alpha 100% selected."
+      className="ms-ColorPicker root-74"
+      role="group"
     >
-      <label
-        className="ms-Label root-73"
-        htmlFor="root"
-      />
       <div
-        aria-label="Color picker, Red 255 Green 255 Blue 255 Alpha 100% selected."
-        className="ms-ColorPicker root-74"
-        role="group"
+        className="ms-ColorPicker-panel panel-75"
       >
         <div
-          className="ms-ColorPicker-panel panel-75"
+          aria-describedby="ColorRectangle-description48"
+          aria-label="Saturation and brightness"
+          aria-valuemax={100}
+          aria-valuemin={0}
+          aria-valuenow={0}
+          aria-valuetext="Saturation 0 brightness 100"
+          className="ms-ColorPicker-colorRect root-84"
+          data-is-focusable={true}
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          role="slider"
+          style={
+            Object {
+              "backgroundColor": "#ff0000",
+            }
+          }
+          tabIndex={0}
         >
           <div
-            aria-describedby="ColorRectangle-description48"
-            aria-label="Saturation and brightness"
-            aria-valuemax={100}
-            aria-valuemin={0}
-            aria-valuenow={0}
-            aria-valuetext="Saturation 0 brightness 100"
-            className="ms-ColorPicker-colorRect root-84"
-            data-is-focusable={true}
-            onKeyDown={[Function]}
-            onMouseDown={[Function]}
-            role="slider"
-            style={
-              Object {
-                "backgroundColor": "#ff0000",
-              }
-            }
-            tabIndex={0}
+            className="description-88"
+            id="ColorRectangle-description48"
           >
-            <div
-              className="description-88"
-              id="ColorRectangle-description48"
-            >
-              Use left and right arrow keys to set saturation. Use up and down arrow keys to set brightness.
-            </div>
-            <div
-              className="ms-ColorPicker-light light-85"
-            />
-            <div
-              className="ms-ColorPicker-dark dark-86"
-            />
-            <div
-              className="ms-ColorPicker-thumb thumb-87"
-              style={
-                Object {
-                  "backgroundColor": "#ffffff",
-                  "left": "0%",
-                  "top": "0%",
-                }
-              }
-            />
+            Use left and right arrow keys to set saturation. Use up and down arrow keys to set brightness.
           </div>
           <div
-            className="flexContainer-80"
+            className="ms-ColorPicker-light light-85"
+          />
+          <div
+            className="ms-ColorPicker-dark dark-86"
+          />
+          <div
+            className="ms-ColorPicker-thumb thumb-87"
+            style={
+              Object {
+                "backgroundColor": "#ffffff",
+                "left": "0%",
+                "top": "0%",
+              }
+            }
+          />
+        </div>
+        <div
+          className="flexContainer-80"
+        >
+          <div
+            className="flexSlider-81"
           >
             <div
-              className="flexSlider-81"
+              aria-label="Hue"
+              aria-valuemax={359}
+              aria-valuemin={0}
+              aria-valuenow={0}
+              aria-valuetext="0"
+              className="ms-ColorPicker-slider is-hue root-89"
+              data-is-focusable={true}
+              onKeyDown={[Function]}
+              onMouseDown={[Function]}
+              role="slider"
+              tabIndex={0}
             >
               <div
-                aria-label="Hue"
-                aria-valuemax={359}
-                aria-valuemin={0}
-                aria-valuenow={0}
-                aria-valuetext="0"
-                className="ms-ColorPicker-slider is-hue root-89"
-                data-is-focusable={true}
-                onKeyDown={[Function]}
-                onMouseDown={[Function]}
-                role="slider"
-                tabIndex={0}
-              >
-                <div
-                  className="ms-ColorPicker-thumb is-slider sliderThumb-91"
-                  style={
-                    Object {
-                      "left": "0%",
-                    }
-                  }
-                />
-              </div>
-              <div
-                aria-label="Alpha"
-                aria-valuemax={100}
-                aria-valuemin={0}
-                aria-valuenow={100}
-                aria-valuetext="100"
-                className="ms-ColorPicker-slider is-alpha root-92"
-                data-is-focusable={true}
-                onKeyDown={[Function]}
-                onMouseDown={[Function]}
-                role="slider"
-                tabIndex={0}
-              >
-                <div
-                  className="ms-ColorPicker-sliderOverlay sliderOverlay-90"
-                  style={
-                    Object {
-                      "background": "linear-gradient(to right, transparent, #ffffff)",
-                    }
-                  }
-                />
-                <div
-                  className="ms-ColorPicker-thumb is-slider sliderThumb-91"
-                  style={
-                    Object {
-                      "left": "100%",
-                    }
-                  }
-                />
-              </div>
-            </div>
-            <div
-              className="flexPreviewBox-82"
-            >
-              <div
-                className="ms-ColorPicker-colorSquare colorSquare-79 is-preview"
+                className="ms-ColorPicker-thumb is-slider sliderThumb-91"
                 style={
                   Object {
-                    "backgroundColor": "#ffffff",
+                    "left": "0%",
+                  }
+                }
+              />
+            </div>
+            <div
+              aria-label="Alpha"
+              aria-valuemax={100}
+              aria-valuemin={0}
+              aria-valuenow={100}
+              aria-valuetext="100"
+              className="ms-ColorPicker-slider is-alpha root-92"
+              data-is-focusable={true}
+              onKeyDown={[Function]}
+              onMouseDown={[Function]}
+              role="slider"
+              tabIndex={0}
+            >
+              <div
+                className="ms-ColorPicker-sliderOverlay sliderOverlay-90"
+                style={
+                  Object {
+                    "background": "linear-gradient(to right, transparent, #ffffff)",
+                  }
+                }
+              />
+              <div
+                className="ms-ColorPicker-thumb is-slider sliderThumb-91"
+                style={
+                  Object {
+                    "left": "100%",
                   }
                 }
               />
             </div>
           </div>
-          <table
-            cellPadding="0"
-            cellSpacing="0"
-            className="ms-ColorPicker-table table-76"
-            role="group"
+          <div
+            className="flexPreviewBox-82"
           >
-            <thead>
-              <tr
-                className="tableHeader-77"
-              >
-                <td
-                  className="tableHexCell-78"
-                >
-                  Hex
-                </td>
-                <td>
-                  Red
-                </td>
-                <td>
-                  Green
-                </td>
-                <td>
-                  Blue
-                </td>
-                <td
-                  className=""
-                >
-                  Alpha
-                </td>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>
-                  <div
-                    className="ms-TextField ms-ColorPicker-input input-93"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-55"
-                      >
-                        <input
-                          aria-invalid={false}
-                          aria-label="Hex"
-                          autoComplete="off"
-                          className="ms-TextField-field field-56"
-                          id="TextField49"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          spellCheck={false}
-                          type="text"
-                          value="ffffff"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                </td>
-                <td>
-                  <div
-                    className="ms-TextField ms-ColorPicker-input input-93"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-55"
-                      >
-                        <input
-                          aria-invalid={false}
-                          aria-label="Red"
-                          aria-live="assertive"
-                          autoComplete="off"
-                          className="ms-TextField-field field-56"
-                          id="TextField52"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          spellCheck={false}
-                          type="text"
-                          value="255"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                </td>
-                <td>
-                  <div
-                    className="ms-TextField ms-ColorPicker-input input-93"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-55"
-                      >
-                        <input
-                          aria-invalid={false}
-                          aria-label="Green"
-                          aria-live="assertive"
-                          autoComplete="off"
-                          className="ms-TextField-field field-56"
-                          id="TextField55"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          spellCheck={false}
-                          type="text"
-                          value="255"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                </td>
-                <td>
-                  <div
-                    className="ms-TextField ms-ColorPicker-input input-93"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-55"
-                      >
-                        <input
-                          aria-invalid={false}
-                          aria-label="Blue"
-                          aria-live="assertive"
-                          autoComplete="off"
-                          className="ms-TextField-field field-56"
-                          id="TextField58"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          spellCheck={false}
-                          type="text"
-                          value="255"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                </td>
-                <td>
-                  <div
-                    className="ms-TextField ms-ColorPicker-input input-93"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-55"
-                      >
-                        <input
-                          aria-invalid={false}
-                          aria-label="Alpha"
-                          aria-live="assertive"
-                          autoComplete="off"
-                          className="ms-TextField-field field-56"
-                          id="TextField61"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          spellCheck={false}
-                          type="text"
-                          value="100"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+            <div
+              className="ms-ColorPicker-colorSquare colorSquare-79 is-preview"
+              style={
+                Object {
+                  "backgroundColor": "#ffffff",
+                }
+              }
+            />
+          </div>
         </div>
+        <table
+          cellPadding="0"
+          cellSpacing="0"
+          className="ms-ColorPicker-table table-76"
+          role="group"
+        >
+          <thead>
+            <tr
+              className="tableHeader-77"
+            >
+              <td
+                className="tableHexCell-78"
+              >
+                Hex
+              </td>
+              <td>
+                Red
+              </td>
+              <td>
+                Green
+              </td>
+              <td>
+                Blue
+              </td>
+              <td
+                className=""
+              >
+                Alpha
+              </td>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <div
+                  className="ms-TextField ms-ColorPicker-input input-93"
+                >
+                  <div
+                    className="ms-TextField-wrapper"
+                  >
+                    <div
+                      className="ms-TextField-fieldGroup fieldGroup-55"
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-label="Hex"
+                        autoComplete="off"
+                        className="ms-TextField-field field-56"
+                        id="TextField49"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        spellCheck={false}
+                        type="text"
+                        value="ffffff"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </td>
+              <td>
+                <div
+                  className="ms-TextField ms-ColorPicker-input input-93"
+                >
+                  <div
+                    className="ms-TextField-wrapper"
+                  >
+                    <div
+                      className="ms-TextField-fieldGroup fieldGroup-55"
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-label="Red"
+                        aria-live="assertive"
+                        autoComplete="off"
+                        className="ms-TextField-field field-56"
+                        id="TextField52"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        spellCheck={false}
+                        type="text"
+                        value="255"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </td>
+              <td>
+                <div
+                  className="ms-TextField ms-ColorPicker-input input-93"
+                >
+                  <div
+                    className="ms-TextField-wrapper"
+                  >
+                    <div
+                      className="ms-TextField-fieldGroup fieldGroup-55"
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-label="Green"
+                        aria-live="assertive"
+                        autoComplete="off"
+                        className="ms-TextField-field field-56"
+                        id="TextField55"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        spellCheck={false}
+                        type="text"
+                        value="255"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </td>
+              <td>
+                <div
+                  className="ms-TextField ms-ColorPicker-input input-93"
+                >
+                  <div
+                    className="ms-TextField-wrapper"
+                  >
+                    <div
+                      className="ms-TextField-fieldGroup fieldGroup-55"
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-label="Blue"
+                        aria-live="assertive"
+                        autoComplete="off"
+                        className="ms-TextField-field field-56"
+                        id="TextField58"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        spellCheck={false}
+                        type="text"
+                        value="255"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </td>
+              <td>
+                <div
+                  className="ms-TextField ms-ColorPicker-input input-93"
+                >
+                  <div
+                    className="ms-TextField-wrapper"
+                  >
+                    <div
+                      className="ms-TextField-fieldGroup fieldGroup-55"
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-label="Alpha"
+                        aria-live="assertive"
+                        autoComplete="off"
+                        className="ms-TextField-field field-56"
+                        id="TextField61"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        spellCheck={false}
+                        type="text"
+                        value="100"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -1049,73 +1009,68 @@ exports[`single fields format date 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-string"
+      aria-describedby="root__error root__description root__help"
+      className="ms-DatePicker control-94"
       id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      onBlur={[Function]}
+      onFocus={[Function]}
     >
       <div
-        aria-describedby="root__error root__description root__help"
-        className="ms-DatePicker control-94"
-        id="root"
-        onBlur={[Function]}
-        onFocus={[Function]}
+        aria-haspopup="true"
       >
         <div
-          aria-haspopup="true"
+          className="ms-TextField textField-100"
         >
           <div
-            className="ms-TextField textField-100"
+            className="ms-TextField-wrapper"
           >
             <div
-              className="ms-TextField-wrapper"
+              className="ms-TextField-fieldGroup fieldGroup-55"
             >
               <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
+                aria-expanded={false}
+                aria-invalid={false}
+                aria-label="Select a date"
+                className="ms-TextField-field field-101 readOnlyTextField-98"
+                id="root-label"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                onKeyDown={[Function]}
+                role="combobox"
+                tabIndex={0}
               >
-                <div
-                  aria-expanded={false}
-                  aria-invalid={false}
-                  aria-label="Select a date"
-                  className="ms-TextField-field field-101 readOnlyTextField-98"
-                  id="root-label"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  onKeyDown={[Function]}
-                  role="combobox"
-                  tabIndex={0}
+                <span
+                  className="readOnlyPlaceholder-99"
                 >
-                  <span
-                    className="readOnlyPlaceholder-99"
-                  >
-                    
-                  </span>
-                </div>
-                <i
-                  aria-hidden={true}
-                  className="ms-DatePicker-event--without-label msDatePickerDisabled icon-105"
-                  data-icon-name="Calendar"
-                  onClick={[Function]}
-                >
-                  
-                </i>
+                  
+                </span>
               </div>
+              <i
+                aria-hidden={true}
+                className="ms-DatePicker-event--without-label msDatePickerDisabled icon-105"
+                data-icon-name="Calendar"
+                onClick={[Function]}
+              >
+                
+              </i>
             </div>
           </div>
         </div>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -1161,49 +1116,44 @@ exports[`single fields format datetime 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-string"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-TextField root-54"
     >
       <div
-        className="ms-TextField root-54"
+        className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-wrapper"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
-          <div
-            className="ms-TextField-fieldGroup fieldGroup-55"
-          >
-            <input
-              aria-describedby="root__error root__description root__help"
-              aria-invalid={false}
-              autoFocus={false}
-              className="ms-TextField-field field-56"
-              disabled={false}
-              id="root"
-              name="root"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onInput={[Function]}
-              placeholder=""
-              readOnly={false}
-              type="datetime-local"
-              value=""
-            />
-          </div>
+          <input
+            aria-describedby="root__error root__description root__help"
+            aria-invalid={false}
+            autoFocus={false}
+            className="ms-TextField-field field-56"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            placeholder=""
+            readOnly={false}
+            type="datetime-local"
+            value=""
+          />
         </div>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -1249,49 +1199,44 @@ exports[`single fields format time 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-string"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-TextField root-54"
     >
       <div
-        className="ms-TextField root-54"
+        className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-wrapper"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
-          <div
-            className="ms-TextField-fieldGroup fieldGroup-55"
-          >
-            <input
-              aria-describedby="root__error root__description root__help"
-              aria-invalid={false}
-              autoFocus={false}
-              className="ms-TextField-field field-56"
-              disabled={false}
-              id="root"
-              name="root"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onInput={[Function]}
-              placeholder=""
-              readOnly={false}
-              type="time"
-              value=""
-            />
-          </div>
+          <input
+            aria-describedby="root__error root__description root__help"
+            aria-invalid={false}
+            autoFocus={false}
+            className="ms-TextField-field field-56"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            placeholder=""
+            readOnly={false}
+            type="time"
+            value=""
+          />
         </div>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -1367,87 +1312,82 @@ exports[`single fields help and error display 1`] = `
     </div>
   </div>
   <div
-    className="form-group field field-string field-error has-error has-danger"
+    className="ms-Grid-col ms-sm12  field field-string field-error has-error has-danger"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-string field-error has-error has-danger"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-TextField root-54"
     >
       <div
-        className="ms-TextField root-54"
+        className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-wrapper"
+          className="ms-TextField-fieldGroup fieldGroup-178"
         >
-          <div
-            className="ms-TextField-fieldGroup fieldGroup-178"
-          >
-            <input
-              aria-describedby="TextFieldDescription189"
-              aria-invalid={true}
-              autoFocus={false}
-              className="ms-TextField-field field-56"
-              disabled={false}
-              id="root"
-              name="root"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onInput={[Function]}
-              placeholder=""
-              readOnly={false}
-              type="text"
-              value=""
-            />
-          </div>
-        </div>
-        <span
-          id="TextFieldDescription189"
-        >
-          <div
-            role="alert"
+          <input
+            aria-describedby="TextFieldDescription189"
+            aria-invalid={true}
+            autoFocus={false}
+            className="ms-TextField-field field-56"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            placeholder=""
+            readOnly={false}
+            type="text"
+            value=""
           />
-        </span>
-      </div>
-      
-      <div
-        className="ms-List"
-        id="root__error"
-        role="list"
-      >
-        <div
-          className="ms-List-surface"
-          role="presentation"
-        >
-          <div
-            className="ms-List-page"
-            role="presentation"
-            style={Object {}}
-          >
-            <div
-              className="ms-List-cell"
-              data-automationid="ListCell"
-              data-list-index={0}
-              role="listitem"
-            >
-              
-            </div>
-          </div>
         </div>
       </div>
       <span
-        className="css-166"
-        id="root__help"
+        id="TextFieldDescription189"
       >
-        help me!
+        <div
+          role="alert"
+        />
       </span>
     </div>
+    
+    <div
+      className="ms-List"
+      id="root__error"
+      role="list"
+    >
+      <div
+        className="ms-List-surface"
+        role="presentation"
+      >
+        <div
+          className="ms-List-page"
+          role="presentation"
+          style={Object {}}
+        >
+          <div
+            className="ms-List-cell"
+            data-automationid="ListCell"
+            data-list-index={0}
+            role="listitem"
+          >
+            
+          </div>
+        </div>
+      </div>
+    </div>
+    <span
+      className="css-166"
+      id="root__help"
+    >
+      help me!
+    </span>
   </div>
   <div>
     <br />
@@ -1493,48 +1433,35 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    
+    <div
+      className="ms-Grid"
+      dir="ltr"
     >
-      
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          style={
+            Object {
+              "display": "none",
+            }
+          }
         >
-          <div
-            className="form-group field field-string"
-          >
-            <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_my-field"
-              style={
-                Object {
-                  "display": "none",
-                  "marginBottom": 15,
-                }
-              }
-            >
-              <input
-                id="root_my-field"
-                name="root_my-field"
-                type="hidden"
-                value=""
-              />
-              
-            </div>
-          </div>
+          <input
+            id="root_my-field"
+            name="root_my-field"
+            type="hidden"
+            value=""
+          />
         </div>
       </div>
     </div>
@@ -1583,45 +1510,40 @@ exports[`single fields hidden label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-string"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-TextField root-54"
     >
       <div
-        className="ms-TextField root-54"
+        className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-wrapper"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
-          <div
-            className="ms-TextField-fieldGroup fieldGroup-55"
-          >
-            <input
-              aria-describedby="root__error root__description root__help"
-              aria-invalid={false}
-              autoFocus={false}
-              className="ms-TextField-field field-56"
-              disabled={false}
-              id="root"
-              name="root"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onInput={[Function]}
-              placeholder=""
-              readOnly={false}
-              type="text"
-              value=""
-            />
-          </div>
+          <input
+            aria-describedby="root__error root__description root__help"
+            aria-invalid={false}
+            autoFocus={false}
+            className="ms-TextField-field field-56"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            placeholder=""
+            readOnly={false}
+            type="text"
+            value=""
+          />
         </div>
       </div>
     </div>
@@ -1670,20 +1592,15 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-null"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-null"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-null"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
-    >
-      
-    </div>
+    }
+  >
+    
   </div>
   <div>
     <br />
@@ -1729,50 +1646,45 @@ exports[`single fields number field 0 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="ms-Grid-col ms-sm12  field field-number"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-number"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-TextField root-54"
     >
       <div
-        className="ms-TextField root-54"
+        className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-wrapper"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
-          <div
-            className="ms-TextField-fieldGroup fieldGroup-55"
-          >
-            <input
-              aria-describedby="root__error root__description root__help"
-              aria-invalid={false}
-              autoFocus={false}
-              className="ms-TextField-field field-56"
-              disabled={false}
-              id="root"
-              name="root"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onInput={[Function]}
-              placeholder=""
-              readOnly={false}
-              step="any"
-              type="number"
-              value="0"
-            />
-          </div>
+          <input
+            aria-describedby="root__error root__description root__help"
+            aria-invalid={false}
+            autoFocus={false}
+            className="ms-TextField-field field-56"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            placeholder=""
+            readOnly={false}
+            step="any"
+            type="number"
+            value="0"
+          />
         </div>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -1818,50 +1730,45 @@ exports[`single fields number field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="ms-Grid-col ms-sm12  field field-number"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-number"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-TextField root-54"
     >
       <div
-        className="ms-TextField root-54"
+        className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-wrapper"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
-          <div
-            className="ms-TextField-fieldGroup fieldGroup-55"
-          >
-            <input
-              aria-describedby="root__error root__description root__help"
-              aria-invalid={false}
-              autoFocus={false}
-              className="ms-TextField-field field-56"
-              disabled={false}
-              id="root"
-              name="root"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onInput={[Function]}
-              placeholder=""
-              readOnly={false}
-              step="any"
-              type="number"
-              value=""
-            />
-          </div>
+          <input
+            aria-describedby="root__error root__description root__help"
+            aria-invalid={false}
+            autoFocus={false}
+            className="ms-TextField-field field-56"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            placeholder=""
+            readOnly={false}
+            step="any"
+            type="number"
+            value=""
+          />
         </div>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -1907,49 +1814,44 @@ exports[`single fields password field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-string"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-TextField root-54"
     >
       <div
-        className="ms-TextField root-54"
+        className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-wrapper"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
-          <div
-            className="ms-TextField-fieldGroup fieldGroup-55"
-          >
-            <input
-              aria-describedby="root__error root__description root__help"
-              aria-invalid={false}
-              autoFocus={false}
-              className="ms-TextField-field field-56"
-              disabled={false}
-              id="root"
-              name="root"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onInput={[Function]}
-              placeholder=""
-              readOnly={false}
-              type="password"
-              value=""
-            />
-          </div>
+          <input
+            aria-describedby="root__error root__description root__help"
+            aria-invalid={false}
+            autoFocus={false}
+            className="ms-TextField-field field-56"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            placeholder=""
+            readOnly={false}
+            type="password"
+            value=""
+          />
         </div>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -1995,99 +1897,94 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="ms-Grid-col ms-sm12  field field-boolean"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-boolean"
+      className=""
       id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      name="root"
+      onBlur={[Function]}
+      onFocus={[Function]}
     >
       <div
-        className=""
-        id="root"
-        name="root"
-        onBlur={[Function]}
-        onFocus={[Function]}
+        className="ms-ChoiceFieldGroup root-146"
+        role="radiogroup"
       >
         <div
-          className="ms-ChoiceFieldGroup root-146"
-          role="radiogroup"
+          className="ms-ChoiceFieldGroup-flexContainer"
         >
           <div
-            className="ms-ChoiceFieldGroup-flexContainer"
+            className="ms-ChoiceField root-147"
           >
             <div
-              className="ms-ChoiceField root-147"
+              className="ms-ChoiceField-wrapper"
             >
-              <div
-                className="ms-ChoiceField-wrapper"
+              <input
+                aria-describedby="root__error root__description root__help"
+                checked={false}
+                className="ms-ChoiceField-input input-148"
+                disabled={false}
+                id="root-0"
+                name="root"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                type="radio"
+              />
+              <label
+                className="ms-ChoiceField-field field-149"
+                htmlFor="root-0"
               >
-                <input
-                  aria-describedby="root__error root__description root__help"
-                  checked={false}
-                  className="ms-ChoiceField-input input-148"
-                  disabled={false}
-                  id="root-0"
-                  name="root"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  type="radio"
-                />
-                <label
-                  className="ms-ChoiceField-field field-149"
-                  htmlFor="root-0"
+                <span
+                  className="ms-ChoiceFieldLabel"
+                  id="ChoiceGroupLabel140-0"
                 >
-                  <span
-                    className="ms-ChoiceFieldLabel"
-                    id="ChoiceGroupLabel140-0"
-                  >
-                    Yes
-                  </span>
-                </label>
-              </div>
+                  Yes
+                </span>
+              </label>
             </div>
+          </div>
+          <div
+            className="ms-ChoiceField root-147"
+          >
             <div
-              className="ms-ChoiceField root-147"
+              className="ms-ChoiceField-wrapper"
             >
-              <div
-                className="ms-ChoiceField-wrapper"
+              <input
+                aria-describedby="root__error root__description root__help"
+                checked={false}
+                className="ms-ChoiceField-input input-148"
+                disabled={false}
+                id="root-1"
+                name="root"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                type="radio"
+              />
+              <label
+                className="ms-ChoiceField-field field-149"
+                htmlFor="root-1"
               >
-                <input
-                  aria-describedby="root__error root__description root__help"
-                  checked={false}
-                  className="ms-ChoiceField-input input-148"
-                  disabled={false}
-                  id="root-1"
-                  name="root"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  type="radio"
-                />
-                <label
-                  className="ms-ChoiceField-field field-149"
-                  htmlFor="root-1"
+                <span
+                  className="ms-ChoiceFieldLabel"
+                  id="ChoiceGroupLabel140-1"
                 >
-                  <span
-                    className="ms-ChoiceFieldLabel"
-                    id="ChoiceGroupLabel140-1"
-                  >
-                    No
-                  </span>
-                </label>
-              </div>
+                  No
+                </span>
+              </label>
             </div>
           </div>
         </div>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -2133,69 +2030,64 @@ exports[`single fields schema examples 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-string"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-TextField root-54"
     >
       <div
-        className="ms-TextField root-54"
+        className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-wrapper"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
-          <div
-            className="ms-TextField-fieldGroup fieldGroup-55"
-          >
-            <input
-              aria-describedby="root__error root__description root__help root__examples"
-              aria-invalid={false}
-              autoFocus={false}
-              className="ms-TextField-field field-56"
-              disabled={false}
-              id="root"
-              list="root__examples"
-              name="root"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onInput={[Function]}
-              placeholder=""
-              readOnly={false}
-              type="text"
-              value=""
-            />
-          </div>
+          <input
+            aria-describedby="root__error root__description root__help root__examples"
+            aria-invalid={false}
+            autoFocus={false}
+            className="ms-TextField-field field-56"
+            disabled={false}
+            id="root"
+            list="root__examples"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            placeholder=""
+            readOnly={false}
+            type="text"
+            value=""
+          />
         </div>
       </div>
-      <datalist
-        id="root__examples"
-      >
-        <option
-          value="Firefox"
-        />
-        <option
-          value="Chrome"
-        />
-        <option
-          value="Opera"
-        />
-        <option
-          value="Vivaldi"
-        />
-        <option
-          value="Safari"
-        />
-      </datalist>
-      
     </div>
+    <datalist
+      id="root__examples"
+    >
+      <option
+        value="Firefox"
+      />
+      <option
+        value="Chrome"
+      />
+      <option
+        value="Opera"
+      />
+      <option
+        value="Vivaldi"
+      />
+      <option
+        value="Safari"
+      />
+    </datalist>
+    
   </div>
   <div>
     <br />
@@ -2241,58 +2133,53 @@ exports[`single fields select field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-string"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-Dropdown-container"
     >
       <div
-        className="ms-Dropdown-container"
+        aria-describedby="root__error root__description root__help"
+        aria-disabled={false}
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        className="ms-Dropdown dropdown-121"
+        data-is-focusable={true}
+        id="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        role="combobox"
+        tabIndex={0}
       >
-        <div
-          aria-describedby="root__error root__description root__help"
-          aria-disabled={false}
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          className="ms-Dropdown dropdown-121"
-          data-is-focusable={true}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          role="combobox"
-          tabIndex={0}
+        <span
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
+          id="root-option"
+        />
+        <span
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
         >
-          <span
-            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
-            id="root-option"
-          />
-          <span
-            className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
+          <i
+            aria-hidden={true}
+            className="ms-Dropdown-caretDown caretDown-137"
+            data-icon-name="ChevronDown"
           >
-            <i
-              aria-hidden={true}
-              className="ms-Dropdown-caretDown caretDown-137"
-              data-icon-name="ChevronDown"
-            >
-              
-            </i>
-          </span>
-        </div>
+            
+          </i>
+        </span>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -2338,59 +2225,54 @@ exports[`single fields select field multiple choice 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-Dropdown-container"
     >
       <div
-        className="ms-Dropdown-container"
+        aria-describedby="root__error root__description root__help"
+        aria-disabled={false}
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-required={false}
+        className="ms-Dropdown dropdown-121"
+        data-is-focusable={true}
+        id="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        role="combobox"
+        tabIndex={0}
       >
-        <div
-          aria-describedby="root__error root__description root__help"
-          aria-disabled={false}
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-required={false}
-          className="ms-Dropdown dropdown-121"
-          data-is-focusable={true}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          role="combobox"
-          tabIndex={0}
+        <span
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
+          id="root-option"
+        />
+        <span
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
         >
-          <span
-            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
-            id="root-option"
-          />
-          <span
-            className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
+          <i
+            aria-hidden={true}
+            className="ms-Dropdown-caretDown caretDown-137"
+            data-icon-name="ChevronDown"
           >
-            <i
-              aria-hidden={true}
-              className="ms-Dropdown-caretDown caretDown-137"
-              data-icon-name="ChevronDown"
-            >
-              
-            </i>
-          </span>
-        </div>
+            
+          </i>
+        </span>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -2436,59 +2318,54 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-Dropdown-container"
     >
       <div
-        className="ms-Dropdown-container"
+        aria-describedby="root__error root__description root__help"
+        aria-disabled={false}
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-required={false}
+        className="ms-Dropdown dropdown-121"
+        data-is-focusable={true}
+        id="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        role="combobox"
+        tabIndex={0}
       >
-        <div
-          aria-describedby="root__error root__description root__help"
-          aria-disabled={false}
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-required={false}
-          className="ms-Dropdown dropdown-121"
-          data-is-focusable={true}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          role="combobox"
-          tabIndex={0}
+        <span
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
+          id="root-option"
+        />
+        <span
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
         >
-          <span
-            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
-            id="root-option"
-          />
-          <span
-            className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
+          <i
+            aria-hidden={true}
+            className="ms-Dropdown-caretDown caretDown-137"
+            data-icon-name="ChevronDown"
           >
-            <i
-              aria-hidden={true}
-              className="ms-Dropdown-caretDown caretDown-137"
-              data-icon-name="ChevronDown"
-            >
-              
-            </i>
-          </span>
-        </div>
+            
+          </i>
+        </span>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -2534,61 +2411,56 @@ exports[`single fields select field multiple choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-Dropdown-container"
     >
       <div
-        className="ms-Dropdown-container"
+        aria-describedby="root__error root__description root__help"
+        aria-disabled={false}
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-required={false}
+        className="ms-Dropdown dropdown-121"
+        data-is-focusable={true}
+        id="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        role="combobox"
+        tabIndex={0}
       >
-        <div
-          aria-describedby="root__error root__description root__help"
-          aria-disabled={false}
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-required={false}
-          className="ms-Dropdown dropdown-121"
-          data-is-focusable={true}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          role="combobox"
-          tabIndex={0}
+        <span
+          className="ms-Dropdown-title title-138"
+          id="root-option"
         >
-          <span
-            className="ms-Dropdown-title title-138"
-            id="root-option"
+          foo, bar
+        </span>
+        <span
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
+        >
+          <i
+            aria-hidden={true}
+            className="ms-Dropdown-caretDown caretDown-137"
+            data-icon-name="ChevronDown"
           >
-            foo, bar
-          </span>
-          <span
-            className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
-          >
-            <i
-              aria-hidden={true}
-              className="ms-Dropdown-caretDown caretDown-137"
-              data-icon-name="ChevronDown"
-            >
-              
-            </i>
-          </span>
-        </div>
+            
+          </i>
+        </span>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -2634,59 +2506,54 @@ exports[`single fields select field multiple choice with labels 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="ms-Grid-col ms-sm12  field field-array"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-array"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-Dropdown-container"
     >
       <div
-        className="ms-Dropdown-container"
+        aria-describedby="root__error root__description root__help"
+        aria-disabled={false}
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-required={false}
+        className="ms-Dropdown dropdown-121"
+        data-is-focusable={true}
+        id="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        role="combobox"
+        tabIndex={0}
       >
-        <div
-          aria-describedby="root__error root__description root__help"
-          aria-disabled={false}
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          aria-required={false}
-          className="ms-Dropdown dropdown-121"
-          data-is-focusable={true}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          role="combobox"
-          tabIndex={0}
+        <span
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
+          id="root-option"
+        />
+        <span
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
         >
-          <span
-            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
-            id="root-option"
-          />
-          <span
-            className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
+          <i
+            aria-hidden={true}
+            className="ms-Dropdown-caretDown caretDown-137"
+            data-icon-name="ChevronDown"
           >
-            <i
-              aria-hidden={true}
-              className="ms-Dropdown-caretDown caretDown-137"
-              data-icon-name="ChevronDown"
-            >
-              
-            </i>
-          </span>
-        </div>
+            
+          </i>
+        </span>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -2732,58 +2599,53 @@ exports[`single fields select field single choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-string"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-Dropdown-container"
     >
       <div
-        className="ms-Dropdown-container"
+        aria-describedby="root__error root__description root__help"
+        aria-disabled={false}
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        className="ms-Dropdown dropdown-121"
+        data-is-focusable={true}
+        id="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        role="combobox"
+        tabIndex={0}
       >
-        <div
-          aria-describedby="root__error root__description root__help"
-          aria-disabled={false}
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          className="ms-Dropdown dropdown-121"
-          data-is-focusable={true}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          role="combobox"
-          tabIndex={0}
+        <span
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
+          id="root-option"
+        />
+        <span
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
         >
-          <span
-            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
-            id="root-option"
-          />
-          <span
-            className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
+          <i
+            aria-hidden={true}
+            className="ms-Dropdown-caretDown caretDown-137"
+            data-icon-name="ChevronDown"
           >
-            <i
-              aria-hidden={true}
-              className="ms-Dropdown-caretDown caretDown-137"
-              data-icon-name="ChevronDown"
-            >
-              
-            </i>
-          </span>
-        </div>
+            
+          </i>
+        </span>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -2829,60 +2691,55 @@ exports[`single fields select field single choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-string"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-Dropdown-container"
     >
       <div
-        className="ms-Dropdown-container"
+        aria-describedby="root__error root__description root__help"
+        aria-disabled={false}
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        className="ms-Dropdown dropdown-121"
+        data-is-focusable={true}
+        id="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        role="combobox"
+        tabIndex={0}
       >
-        <div
-          aria-describedby="root__error root__description root__help"
-          aria-disabled={false}
-          aria-expanded="false"
-          aria-haspopup="listbox"
-          className="ms-Dropdown dropdown-121"
-          data-is-focusable={true}
-          id="root"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onClick={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          role="combobox"
-          tabIndex={0}
+        <span
+          className="ms-Dropdown-title title-138"
+          id="root-option"
         >
-          <span
-            className="ms-Dropdown-title title-138"
-            id="root-option"
+          bar
+        </span>
+        <span
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
+        >
+          <i
+            aria-hidden={true}
+            className="ms-Dropdown-caretDown caretDown-137"
+            data-icon-name="ChevronDown"
           >
-            bar
-          </span>
-          <span
-            className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
-          >
-            <i
-              aria-hidden={true}
-              className="ms-Dropdown-caretDown caretDown-137"
-              data-icon-name="ChevronDown"
-            >
-              
-            </i>
-          </span>
-        </div>
+            
+          </i>
+        </span>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -2928,81 +2785,76 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-integer"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-integer"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-integer"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    <label
+      className="ms-Label root-73"
+      htmlFor="root"
+    />
+    <div
+      className="ms-Slider ms-Slider-enabled ms-Slider-row root-154"
     >
-      <label
-        className="ms-Label root-73"
-        htmlFor="root"
-      />
       <div
-        className="ms-Slider ms-Slider-enabled ms-Slider-row root-154"
+        className="ms-Slider-container container-156"
       >
         <div
-          className="ms-Slider-container container-156"
+          aria-disabled={false}
+          aria-valuemax={100}
+          aria-valuemin={42}
+          aria-valuenow={42}
+          aria-valuetext="42"
+          className="ms-Slider-slideBox ms-Slider-showValue ms-Slider-showTransitions slideBox-157"
+          data-is-focusable={true}
+          id="Slider144"
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+          role="slider"
+          tabIndex={0}
         >
           <div
-            aria-disabled={false}
-            aria-valuemax={100}
-            aria-valuemin={42}
-            aria-valuenow={42}
-            aria-valuetext="42"
-            className="ms-Slider-slideBox ms-Slider-showValue ms-Slider-showTransitions slideBox-157"
-            data-is-focusable={true}
-            id="Slider144"
-            onKeyDown={[Function]}
-            onMouseDown={[Function]}
-            onTouchStart={[Function]}
-            role="slider"
-            tabIndex={0}
+            className="ms-Slider-line line-159"
           >
-            <div
-              className="ms-Slider-line line-159"
-            >
-              <span
-                className="ms-Slider-thumb thumb-158"
-                style={
-                  Object {
-                    "left": "0%",
-                  }
+            <span
+              className="ms-Slider-thumb thumb-158"
+              style={
+                Object {
+                  "left": "0%",
                 }
-              />
-              <span
-                className="lineContainer-160 ms-Slider-active activeSection-161"
-                style={
-                  Object {
-                    "width": "0%",
-                  }
+              }
+            />
+            <span
+              className="lineContainer-160 ms-Slider-active activeSection-161"
+              style={
+                Object {
+                  "width": "0%",
                 }
-              />
-              <span
-                className="lineContainer-160 ms-Slider-inactive inactiveSection-162"
-                style={
-                  Object {
-                    "width": "100%",
-                  }
+              }
+            />
+            <span
+              className="lineContainer-160 ms-Slider-inactive inactiveSection-162"
+              style={
+                Object {
+                  "width": "100%",
                 }
-              />
-            </div>
+              }
+            />
           </div>
-          <label
-            className="ms-Label ms-Slider-value valueLabel-165"
-          >
-            42
-          </label>
         </div>
+        <label
+          className="ms-Label ms-Slider-value valueLabel-165"
+        >
+          42
+        </label>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -3048,51 +2900,46 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-string"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
-    >
-      <div>
+    }
+  >
+    <div>
+      <div
+        className="ms-TextField root-54"
+      >
         <div
-          className="ms-TextField root-54"
+          className="ms-TextField-wrapper"
         >
           <div
-            className="ms-TextField-wrapper"
+            className="ms-TextField-fieldGroup fieldGroup-55"
           >
-            <div
-              className="ms-TextField-fieldGroup fieldGroup-55"
-            >
-              <input
-                aria-describedby="root__error root__description root__help"
-                aria-invalid={false}
-                autoFocus={false}
-                className="ms-TextField-field field-56"
-                disabled={false}
-                id="root"
-                name="root"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                onInput={[Function]}
-                placeholder=""
-                readOnly={false}
-                type="file"
-                value=""
-              />
-            </div>
+            <input
+              aria-describedby="root__error root__description root__help"
+              aria-invalid={false}
+              autoFocus={false}
+              className="ms-TextField-field field-56"
+              disabled={false}
+              id="root"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              placeholder=""
+              readOnly={false}
+              type="file"
+              value=""
+            />
           </div>
         </div>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -3138,49 +2985,44 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-string"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-TextField root-54"
     >
       <div
-        className="ms-TextField root-54"
+        className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-wrapper"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
-          <div
-            className="ms-TextField-fieldGroup fieldGroup-55"
-          >
-            <input
-              aria-describedby="root__error root__description root__help"
-              aria-invalid={false}
-              autoFocus={false}
-              className="ms-TextField-field field-56"
-              disabled={false}
-              id="root"
-              name="root"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onInput={[Function]}
-              placeholder=""
-              readOnly={false}
-              type="email"
-              value=""
-            />
-          </div>
+          <input
+            aria-describedby="root__error root__description root__help"
+            aria-invalid={false}
+            autoFocus={false}
+            className="ms-TextField-field field-56"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            placeholder=""
+            readOnly={false}
+            type="email"
+            value=""
+          />
         </div>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -3226,49 +3068,44 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-string"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-TextField root-54"
     >
       <div
-        className="ms-TextField root-54"
+        className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-wrapper"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
-          <div
-            className="ms-TextField-fieldGroup fieldGroup-55"
-          >
-            <input
-              aria-describedby="root__error root__description root__help"
-              aria-invalid={false}
-              autoFocus={false}
-              className="ms-TextField-field field-56"
-              disabled={false}
-              id="root"
-              name="root"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onInput={[Function]}
-              placeholder=""
-              readOnly={false}
-              type="url"
-              value=""
-            />
-          </div>
+          <input
+            aria-describedby="root__error root__description root__help"
+            aria-invalid={false}
+            autoFocus={false}
+            className="ms-TextField-field field-56"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            placeholder=""
+            readOnly={false}
+            type="url"
+            value=""
+          />
         </div>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -3314,49 +3151,44 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-string"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-TextField root-54"
     >
       <div
-        className="ms-TextField root-54"
+        className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-wrapper"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
-          <div
-            className="ms-TextField-fieldGroup fieldGroup-55"
-          >
-            <input
-              aria-describedby="root__error root__description root__help"
-              aria-invalid={false}
-              autoFocus={false}
-              className="ms-TextField-field field-56"
-              disabled={false}
-              id="root"
-              name="root"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onInput={[Function]}
-              placeholder=""
-              readOnly={false}
-              type="text"
-              value=""
-            />
-          </div>
+          <input
+            aria-describedby="root__error root__description root__help"
+            aria-invalid={false}
+            autoFocus={false}
+            className="ms-TextField-field field-56"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            placeholder=""
+            readOnly={false}
+            type="text"
+            value=""
+          />
         </div>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -3402,49 +3234,44 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-string"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-TextField root-54"
     >
       <div
-        className="ms-TextField root-54"
+        className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-wrapper"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
-          <div
-            className="ms-TextField-fieldGroup fieldGroup-55"
-          >
-            <input
-              aria-describedby="root__error root__description root__help"
-              aria-invalid={false}
-              autoFocus={false}
-              className="ms-TextField-field field-56"
-              disabled={false}
-              id="root"
-              name="root"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onInput={[Function]}
-              placeholder="placeholder"
-              readOnly={false}
-              type="text"
-              value=""
-            />
-          </div>
+          <input
+            aria-describedby="root__error root__description root__help"
+            aria-invalid={false}
+            autoFocus={false}
+            className="ms-TextField-field field-56"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            placeholder="placeholder"
+            readOnly={false}
+            type="text"
+            value=""
+          />
         </div>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -3490,49 +3317,44 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-string"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-TextField ms-TextField--multiline root-54"
     >
       <div
-        className="ms-TextField ms-TextField--multiline root-54"
+        className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-wrapper"
+          className="ms-TextField-fieldGroup fieldGroup-118"
         >
-          <div
-            className="ms-TextField-fieldGroup fieldGroup-118"
-          >
-            <textarea
-              aria-describedby="root__error root__description root__help"
-              aria-invalid={false}
-              autoFocus={false}
-              className="ms-TextField-field field-119"
-              disabled={false}
-              id="root"
-              name="root"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onInput={[Function]}
-              placeholder=""
-              readOnly={false}
-              type="text"
-              value=""
-            />
-          </div>
+          <textarea
+            aria-describedby="root__error root__description root__help"
+            aria-invalid={false}
+            autoFocus={false}
+            className="ms-TextField-field field-119"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            placeholder=""
+            readOnly={false}
+            type="text"
+            value=""
+          />
         </div>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />
@@ -3578,85 +3400,75 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    <label
+      className="ms-Label root-167"
+      id="root__title"
     >
-      <label
-        className="ms-Label root-167"
-        id="root__title"
-      >
-        Titre 1
-      </label>
+      Titre 1
+    </label>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm12  field field-string"
+          id="root_title"
+          style={
+            Object {
+              "marginBottom": 15,
+            }
+          }
         >
           <div
-            className="form-group field field-string"
+            className="ms-TextField root-54"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_title"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-TextField-wrapper"
             >
-              <div
-                className="ms-TextField root-54"
+              <label
+                className="ms-Label root-73"
+                htmlFor="root_title"
+                id="TextFieldLabel165"
               >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-73"
-                    htmlFor="root_title"
-                    id="TextFieldLabel165"
-                  >
-                    Titre 2
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-55"
-                  >
-                    <input
-                      aria-describedby="root_title__error root_title__description root_title__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel165"
-                      autoFocus={false}
-                      className="ms-TextField-field field-56"
-                      disabled={false}
-                      id="root_title"
-                      name="root_title"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={false}
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
+                Titre 2
+              </label>
+              <div
+                className="ms-TextField-fieldGroup fieldGroup-55"
+              >
+                <input
+                  aria-describedby="root_title__error root_title__description root_title__help"
+                  aria-invalid={false}
+                  aria-labelledby="TextFieldLabel165"
+                  autoFocus={false}
+                  className="ms-TextField-field field-56"
+                  disabled={false}
+                  id="root_title"
+                  name="root_title"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
               </div>
-              
             </div>
           </div>
+          
         </div>
       </div>
     </div>
@@ -3705,40 +3517,35 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-undefined"
+    className="ms-Grid-col ms-sm12  field field-undefined"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-undefined"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="unsupported-field"
     >
-      <div
-        className="unsupported-field"
-      >
-        <p>
-          <span>
-            Unsupported field schema for field 
-            <code>
-              root
-            </code>
-            : 
-            <em>
-              Unknown field type undefined
-            </em>
-            .
-          </span>
-        </p>
-        <pre>
-          {}
-        </pre>
-      </div>
-      
+      <p>
+        <span>
+          Unsupported field schema for field 
+          <code>
+            root
+          </code>
+          : 
+          <em>
+            Unknown field type undefined
+          </em>
+          .
+        </span>
+      </p>
+      <pre>
+        {}
+      </pre>
     </div>
+    
   </div>
   <div>
     <br />
@@ -3784,125 +3591,120 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-number"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-number"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    <label
+      className="ms-Label root-73"
+      htmlFor="root"
+    />
+    <div
+      className="css-106"
     >
-      <label
-        className="ms-Label root-73"
-        htmlFor="root"
-      />
-      <div
-        className="css-106"
-      >
-        
-        <div
-          aria-describedby="root__error root__description root__help"
-          className="css-110"
-          id="root"
-          onChange={[Function]}
-        >
-          <input
-            aria-disabled={false}
-            aria-labelledby=""
-            aria-valuemax={Infinity}
-            aria-valuemin={-Infinity}
-            aria-valuetext=""
-            autoComplete="off"
-            className="ms-spinButton-input css-111"
-            data-lpignore={true}
-            disabled={false}
-            id="input93"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            role="spinbutton"
-            type="text"
-            value=""
-          />
-          <span
-            className="css-112"
-          >
-            <button
-              aria-label="Increase value by 1"
-              className="ms-Button ms-Button--icon ms-UpButton root-113"
-              data-is-focusable={false}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              tabIndex={-1}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-66"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-116 ms-Button-icon icon-114"
-                  data-icon-name="ChevronUpSmall"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-            <button
-              aria-label="Decrease value by 1"
-              className="ms-Button ms-Button--icon ms-DownButton root-113"
-              data-is-focusable={false}
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              tabIndex={-1}
-              type="button"
-            >
-              <span
-                className="ms-Button-flexContainer flexContainer-66"
-                data-automationid="splitbuttonprimary"
-              >
-                <i
-                  aria-hidden={true}
-                  className="ms-Icon root-37 css-117 ms-Button-icon icon-114"
-                  data-icon-name="ChevronDownSmall"
-                  style={
-                    Object {
-                      "fontFamily": "\\"FabricMDL2Icons-3\\"",
-                    }
-                  }
-                >
-                  
-                </i>
-              </span>
-            </button>
-          </span>
-        </div>
-      </div>
       
+      <div
+        aria-describedby="root__error root__description root__help"
+        className="css-110"
+        id="root"
+        onChange={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-labelledby=""
+          aria-valuemax={Infinity}
+          aria-valuemin={-Infinity}
+          aria-valuetext=""
+          autoComplete="off"
+          className="ms-spinButton-input css-111"
+          data-lpignore={true}
+          disabled={false}
+          id="input93"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onInput={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          role="spinbutton"
+          type="text"
+          value=""
+        />
+        <span
+          className="css-112"
+        >
+          <button
+            aria-label="Increase value by 1"
+            className="ms-Button ms-Button--icon ms-UpButton root-113"
+            data-is-focusable={false}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            tabIndex={-1}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-66"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-116 ms-Button-icon icon-114"
+                data-icon-name="ChevronUpSmall"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+          <button
+            aria-label="Decrease value by 1"
+            className="ms-Button ms-Button--icon ms-DownButton root-113"
+            data-is-focusable={false}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            tabIndex={-1}
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-66"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-117 ms-Button-icon icon-114"
+                data-icon-name="ChevronDownSmall"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-3\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+        </span>
+      </div>
     </div>
+    
   </div>
   <div>
     <br />
@@ -3948,49 +3750,44 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="ms-Grid-col ms-sm12  field field-string"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
+      }
+    }
   >
     <div
-      className="ms-Grid-col ms-sm12  field field-string"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
-      }
+      className="ms-TextField root-54"
     >
       <div
-        className="ms-TextField root-54"
+        className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-wrapper"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
-          <div
-            className="ms-TextField-fieldGroup fieldGroup-55"
-          >
-            <input
-              aria-describedby="root__error root__description root__help"
-              aria-invalid={false}
-              autoFocus={false}
-              className="ms-TextField-field field-56"
-              disabled={false}
-              id="root"
-              name="root"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onInput={[Function]}
-              placeholder=""
-              readOnly={false}
-              type="text"
-              value=""
-            />
-          </div>
+          <input
+            aria-describedby="root__error root__description root__help"
+            aria-invalid={false}
+            autoFocus={false}
+            className="ms-TextField-field field-56"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            placeholder=""
+            readOnly={false}
+            type="text"
+            value=""
+          />
         </div>
       </div>
-      
     </div>
+    
   </div>
   <div>
     <br />

--- a/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
@@ -7,47 +7,51 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-boolean"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-boolean"
   >
     <div
-      className="ms-Checkbox is-enabled root-139"
+      className="ms-Grid-col ms-sm12  field field-boolean"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
-      <input
-        aria-checked="false"
-        aria-disabled={false}
-        checked={false}
-        className="input-140"
-        disabled={false}
-        id="root"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        type="checkbox"
-      />
-      <label
-        className="ms-Checkbox-label label-141"
-        htmlFor="root"
+      <div
+        className="ms-Checkbox is-enabled root-139"
       >
-        <div
-          className="ms-Checkbox-checkbox checkbox-142"
+        <input
+          aria-checked="false"
+          aria-disabled={false}
+          checked={false}
+          className="input-140"
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          type="checkbox"
+        />
+        <label
+          className="ms-Checkbox-label label-141"
+          htmlFor="root"
         >
-          <i
-            aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-145"
-            data-icon-name="CheckMark"
+          <div
+            className="ms-Checkbox-checkbox checkbox-142"
           >
-            
-          </i>
-        </div>
-      </label>
+            <i
+              aria-hidden={true}
+              className="ms-Checkbox-checkmark checkmark-145"
+              data-icon-name="CheckMark"
+            >
+              
+            </i>
+          </div>
+        </label>
+      </div>
     </div>
   </div>
   <div>
@@ -94,54 +98,58 @@ exports[`single fields checkbox field with label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-boolean"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-boolean"
   >
     <div
-      className="ms-Checkbox is-enabled root-139"
+      className="ms-Grid-col ms-sm12  field field-boolean"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
-      <input
-        aria-checked="false"
-        aria-disabled={false}
-        aria-label="test"
-        checked={false}
-        className="input-140"
-        disabled={false}
-        id="root"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        type="checkbox"
-      />
-      <label
-        className="ms-Checkbox-label label-141"
-        htmlFor="root"
+      <div
+        className="ms-Checkbox is-enabled root-139"
       >
-        <div
-          className="ms-Checkbox-checkbox checkbox-142"
+        <input
+          aria-checked="false"
+          aria-disabled={false}
+          aria-label="test"
+          checked={false}
+          className="input-140"
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          type="checkbox"
+        />
+        <label
+          className="ms-Checkbox-label label-141"
+          htmlFor="root"
         >
-          <i
-            aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-145"
-            data-icon-name="CheckMark"
+          <div
+            className="ms-Checkbox-checkbox checkbox-142"
           >
-            
-          </i>
-        </div>
-        <span
-          aria-hidden="true"
-          className="ms-Checkbox-text text-144"
-        >
-          test
-        </span>
-      </label>
+            <i
+              aria-hidden={true}
+              className="ms-Checkbox-checkmark checkmark-145"
+              data-icon-name="CheckMark"
+            >
+              
+            </i>
+          </div>
+          <span
+            aria-hidden="true"
+            className="ms-Checkbox-text text-144"
+          >
+            test
+          </span>
+        </label>
+      </div>
     </div>
   </div>
   <div>
@@ -188,191 +196,195 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
-    <label
-      className="ms-Label root-73"
-    />
     <div
-      className="ms-Checkbox is-enabled root-139"
-    >
-      <input
-        aria-checked="false"
-        aria-disabled={false}
-        aria-label="foo"
-        checked={false}
-        className="input-140"
-        disabled={false}
-        id="root-0"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        type="checkbox"
-      />
-      <label
-        className="ms-Checkbox-label label-141"
-        htmlFor="root-0"
-      >
-        <div
-          className="ms-Checkbox-checkbox checkbox-142"
-        >
-          <i
-            aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-145"
-            data-icon-name="CheckMark"
-          >
-            
-          </i>
-        </div>
-        <span
-          aria-hidden="true"
-          className="ms-Checkbox-text text-144"
-        >
-          foo
-        </span>
-      </label>
-    </div>
-    <div
-      className="ms-Checkbox is-enabled root-139"
-    >
-      <input
-        aria-checked="false"
-        aria-disabled={false}
-        aria-label="bar"
-        checked={false}
-        className="input-140"
-        disabled={false}
-        id="root-1"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        type="checkbox"
-      />
-      <label
-        className="ms-Checkbox-label label-141"
-        htmlFor="root-1"
-      >
-        <div
-          className="ms-Checkbox-checkbox checkbox-142"
-        >
-          <i
-            aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-145"
-            data-icon-name="CheckMark"
-          >
-            
-          </i>
-        </div>
-        <span
-          aria-hidden="true"
-          className="ms-Checkbox-text text-144"
-        >
-          bar
-        </span>
-      </label>
-    </div>
-    <div
-      className="ms-Checkbox is-enabled root-139"
-    >
-      <input
-        aria-checked="false"
-        aria-disabled={false}
-        aria-label="fuzz"
-        checked={false}
-        className="input-140"
-        disabled={false}
-        id="root-2"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        type="checkbox"
-      />
-      <label
-        className="ms-Checkbox-label label-141"
-        htmlFor="root-2"
-      >
-        <div
-          className="ms-Checkbox-checkbox checkbox-142"
-        >
-          <i
-            aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-145"
-            data-icon-name="CheckMark"
-          >
-            
-          </i>
-        </div>
-        <span
-          aria-hidden="true"
-          className="ms-Checkbox-text text-144"
-        >
-          fuzz
-        </span>
-      </label>
-    </div>
-    <div
-      className="ms-Checkbox is-enabled root-139"
-    >
-      <input
-        aria-checked="false"
-        aria-disabled={false}
-        aria-label="qux"
-        checked={false}
-        className="input-140"
-        disabled={false}
-        id="root-3"
-        name="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        type="checkbox"
-      />
-      <label
-        className="ms-Checkbox-label label-141"
-        htmlFor="root-3"
-      >
-        <div
-          className="ms-Checkbox-checkbox checkbox-142"
-        >
-          <i
-            aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-145"
-            data-icon-name="CheckMark"
-          >
-            
-          </i>
-        </div>
-        <span
-          aria-hidden="true"
-          className="ms-Checkbox-text text-144"
-        >
-          qux
-        </span>
-      </label>
-    </div>
-    <span
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
       style={
         Object {
-          "color": "rgb(164, 38, 44)",
-          "fontFamily": "\\"Segoe UI\\", \\"Segoe UI Web (West European)\\", \\"Segoe UI\\", -apple-system, BlinkMacSystemFont, Roboto, \\"Helvetica Neue\\", sans-serif",
-          "fontSize": 12,
-          "fontWeight": "normal",
+          "display": undefined,
+          "marginBottom": 15,
         }
       }
     >
+      <label
+        className="ms-Label root-73"
+      />
+      <div
+        className="ms-Checkbox is-enabled root-139"
+      >
+        <input
+          aria-checked="false"
+          aria-disabled={false}
+          aria-label="foo"
+          checked={false}
+          className="input-140"
+          disabled={false}
+          id="root-0"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          type="checkbox"
+        />
+        <label
+          className="ms-Checkbox-label label-141"
+          htmlFor="root-0"
+        >
+          <div
+            className="ms-Checkbox-checkbox checkbox-142"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Checkbox-checkmark checkmark-145"
+              data-icon-name="CheckMark"
+            >
+              
+            </i>
+          </div>
+          <span
+            aria-hidden="true"
+            className="ms-Checkbox-text text-144"
+          >
+            foo
+          </span>
+        </label>
+      </div>
+      <div
+        className="ms-Checkbox is-enabled root-139"
+      >
+        <input
+          aria-checked="false"
+          aria-disabled={false}
+          aria-label="bar"
+          checked={false}
+          className="input-140"
+          disabled={false}
+          id="root-1"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          type="checkbox"
+        />
+        <label
+          className="ms-Checkbox-label label-141"
+          htmlFor="root-1"
+        >
+          <div
+            className="ms-Checkbox-checkbox checkbox-142"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Checkbox-checkmark checkmark-145"
+              data-icon-name="CheckMark"
+            >
+              
+            </i>
+          </div>
+          <span
+            aria-hidden="true"
+            className="ms-Checkbox-text text-144"
+          >
+            bar
+          </span>
+        </label>
+      </div>
+      <div
+        className="ms-Checkbox is-enabled root-139"
+      >
+        <input
+          aria-checked="false"
+          aria-disabled={false}
+          aria-label="fuzz"
+          checked={false}
+          className="input-140"
+          disabled={false}
+          id="root-2"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          type="checkbox"
+        />
+        <label
+          className="ms-Checkbox-label label-141"
+          htmlFor="root-2"
+        >
+          <div
+            className="ms-Checkbox-checkbox checkbox-142"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Checkbox-checkmark checkmark-145"
+              data-icon-name="CheckMark"
+            >
+              
+            </i>
+          </div>
+          <span
+            aria-hidden="true"
+            className="ms-Checkbox-text text-144"
+          >
+            fuzz
+          </span>
+        </label>
+      </div>
+      <div
+        className="ms-Checkbox is-enabled root-139"
+      >
+        <input
+          aria-checked="false"
+          aria-disabled={false}
+          aria-label="qux"
+          checked={false}
+          className="input-140"
+          disabled={false}
+          id="root-3"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          type="checkbox"
+        />
+        <label
+          className="ms-Checkbox-label label-141"
+          htmlFor="root-3"
+        >
+          <div
+            className="ms-Checkbox-checkbox checkbox-142"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Checkbox-checkmark checkmark-145"
+              data-icon-name="CheckMark"
+            >
+              
+            </i>
+          </div>
+          <span
+            aria-hidden="true"
+            className="ms-Checkbox-text text-144"
+          >
+            qux
+          </span>
+        </label>
+      </div>
+      <span
+        style={
+          Object {
+            "color": "rgb(164, 38, 44)",
+            "fontFamily": "\\"Segoe UI\\", \\"Segoe UI Web (West European)\\", \\"Segoe UI\\", -apple-system, BlinkMacSystemFont, Roboto, \\"Helvetica Neue\\", sans-serif",
+            "fontSize": 12,
+            "fontWeight": "normal",
+          }
+        }
+      >
+        
+      </span>
       
-    </span>
-    
+    </div>
   </div>
   <div>
     <br />
@@ -418,76 +430,84 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-object"
   >
-    
     <div
-      className="ms-Grid"
-      dir="ltr"
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
+      
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_my-field"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
+          className="ms-Grid-row"
         >
           <div
-            className="ms-TextField root-54"
+            className="form-group field field-string"
           >
             <div
-              className="ms-TextField-wrapper"
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_my-field"
+              style={
+                Object {
+                  "display": undefined,
+                  "marginBottom": 15,
+                }
+              }
             >
-              <label
-                className="ms-Label root-73"
-                htmlFor="root_my-field"
-                id="TextFieldLabel153"
-              >
-                my-field
-              </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
+                className="ms-TextField root-54"
               >
-                <input
-                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel153"
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
-                  id="root_my-field"
-                  name="root_my-field"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value=""
-                />
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-73"
+                    htmlFor="root_my-field"
+                    id="TextFieldLabel153"
+                  >
+                    my-field
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel153"
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_my-field"
+                      name="root_my-field"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
               </div>
+              <span
+                className="css-166"
+              >
+                some description
+              </span>
             </div>
           </div>
-          <span
-            className="css-166"
-          >
-            some description
-          </span>
         </div>
       </div>
     </div>
@@ -536,76 +556,84 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-object"
   >
-    
     <div
-      className="ms-Grid"
-      dir="ltr"
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
+      
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_my-field"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
+          className="ms-Grid-row"
         >
           <div
-            className="ms-TextField root-54"
+            className="form-group field field-string"
           >
             <div
-              className="ms-TextField-wrapper"
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_my-field"
+              style={
+                Object {
+                  "display": undefined,
+                  "marginBottom": 15,
+                }
+              }
             >
-              <label
-                className="ms-Label root-73"
-                htmlFor="root_my-field"
-                id="TextFieldLabel159"
-              >
-                my-field
-              </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
+                className="ms-TextField root-54"
               >
-                <input
-                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel159"
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
-                  id="root_my-field"
-                  name="root_my-field"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value=""
-                />
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-73"
+                    htmlFor="root_my-field"
+                    id="TextFieldLabel159"
+                  >
+                    my-field
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel159"
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_my-field"
+                      name="root_my-field"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
               </div>
+              <span
+                className="css-166"
+              >
+                some other description
+              </span>
             </div>
           </div>
-          <span
-            className="css-166"
-          >
-            some other description
-          </span>
         </div>
       </div>
     </div>
@@ -654,324 +682,328 @@ exports[`single fields format color 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-string"
   >
-    <label
-      className="ms-Label root-73"
-      htmlFor="root"
-    />
     <div
-      aria-label="Color picker, Red 255 Green 255 Blue 255 Alpha 100% selected."
-      className="ms-ColorPicker root-74"
-      role="group"
+      className="ms-Grid-col ms-sm12  field field-string"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
+      <label
+        className="ms-Label root-73"
+        htmlFor="root"
+      />
       <div
-        className="ms-ColorPicker-panel panel-75"
+        aria-label="Color picker, Red 255 Green 255 Blue 255 Alpha 100% selected."
+        className="ms-ColorPicker root-74"
+        role="group"
       >
         <div
-          aria-describedby="ColorRectangle-description48"
-          aria-label="Saturation and brightness"
-          aria-valuemax={100}
-          aria-valuemin={0}
-          aria-valuenow={0}
-          aria-valuetext="Saturation 0 brightness 100"
-          className="ms-ColorPicker-colorRect root-84"
-          data-is-focusable={true}
-          onKeyDown={[Function]}
-          onMouseDown={[Function]}
-          role="slider"
-          style={
-            Object {
-              "backgroundColor": "#ff0000",
-            }
-          }
-          tabIndex={0}
+          className="ms-ColorPicker-panel panel-75"
         >
           <div
-            className="description-88"
-            id="ColorRectangle-description48"
-          >
-            Use left and right arrow keys to set saturation. Use up and down arrow keys to set brightness.
-          </div>
-          <div
-            className="ms-ColorPicker-light light-85"
-          />
-          <div
-            className="ms-ColorPicker-dark dark-86"
-          />
-          <div
-            className="ms-ColorPicker-thumb thumb-87"
+            aria-describedby="ColorRectangle-description48"
+            aria-label="Saturation and brightness"
+            aria-valuemax={100}
+            aria-valuemin={0}
+            aria-valuenow={0}
+            aria-valuetext="Saturation 0 brightness 100"
+            className="ms-ColorPicker-colorRect root-84"
+            data-is-focusable={true}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            role="slider"
             style={
               Object {
-                "backgroundColor": "#ffffff",
-                "left": "0%",
-                "top": "0%",
+                "backgroundColor": "#ff0000",
               }
             }
-          />
-        </div>
-        <div
-          className="flexContainer-80"
-        >
-          <div
-            className="flexSlider-81"
+            tabIndex={0}
           >
             <div
-              aria-label="Hue"
-              aria-valuemax={359}
-              aria-valuemin={0}
-              aria-valuenow={0}
-              aria-valuetext="0"
-              className="ms-ColorPicker-slider is-hue root-89"
-              data-is-focusable={true}
-              onKeyDown={[Function]}
-              onMouseDown={[Function]}
-              role="slider"
-              tabIndex={0}
+              className="description-88"
+              id="ColorRectangle-description48"
             >
-              <div
-                className="ms-ColorPicker-thumb is-slider sliderThumb-91"
-                style={
-                  Object {
-                    "left": "0%",
-                  }
-                }
-              />
+              Use left and right arrow keys to set saturation. Use up and down arrow keys to set brightness.
             </div>
             <div
-              aria-label="Alpha"
-              aria-valuemax={100}
-              aria-valuemin={0}
-              aria-valuenow={100}
-              aria-valuetext="100"
-              className="ms-ColorPicker-slider is-alpha root-92"
-              data-is-focusable={true}
-              onKeyDown={[Function]}
-              onMouseDown={[Function]}
-              role="slider"
-              tabIndex={0}
-            >
-              <div
-                className="ms-ColorPicker-sliderOverlay sliderOverlay-90"
-                style={
-                  Object {
-                    "background": "linear-gradient(to right, transparent, #ffffff)",
-                  }
-                }
-              />
-              <div
-                className="ms-ColorPicker-thumb is-slider sliderThumb-91"
-                style={
-                  Object {
-                    "left": "100%",
-                  }
-                }
-              />
-            </div>
-          </div>
-          <div
-            className="flexPreviewBox-82"
-          >
+              className="ms-ColorPicker-light light-85"
+            />
             <div
-              className="ms-ColorPicker-colorSquare colorSquare-79 is-preview"
+              className="ms-ColorPicker-dark dark-86"
+            />
+            <div
+              className="ms-ColorPicker-thumb thumb-87"
               style={
                 Object {
                   "backgroundColor": "#ffffff",
+                  "left": "0%",
+                  "top": "0%",
                 }
               }
             />
           </div>
-        </div>
-        <table
-          cellPadding="0"
-          cellSpacing="0"
-          className="ms-ColorPicker-table table-76"
-          role="group"
-        >
-          <thead>
-            <tr
-              className="tableHeader-77"
+          <div
+            className="flexContainer-80"
+          >
+            <div
+              className="flexSlider-81"
             >
-              <td
-                className="tableHexCell-78"
+              <div
+                aria-label="Hue"
+                aria-valuemax={359}
+                aria-valuemin={0}
+                aria-valuenow={0}
+                aria-valuetext="0"
+                className="ms-ColorPicker-slider is-hue root-89"
+                data-is-focusable={true}
+                onKeyDown={[Function]}
+                onMouseDown={[Function]}
+                role="slider"
+                tabIndex={0}
               >
-                Hex
-              </td>
-              <td>
-                Red
-              </td>
-              <td>
-                Green
-              </td>
-              <td>
-                Blue
-              </td>
-              <td
-                className=""
+                <div
+                  className="ms-ColorPicker-thumb is-slider sliderThumb-91"
+                  style={
+                    Object {
+                      "left": "0%",
+                    }
+                  }
+                />
+              </div>
+              <div
+                aria-label="Alpha"
+                aria-valuemax={100}
+                aria-valuemin={0}
+                aria-valuenow={100}
+                aria-valuetext="100"
+                className="ms-ColorPicker-slider is-alpha root-92"
+                data-is-focusable={true}
+                onKeyDown={[Function]}
+                onMouseDown={[Function]}
+                role="slider"
+                tabIndex={0}
               >
-                Alpha
-              </td>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>
                 <div
-                  className="ms-TextField ms-ColorPicker-input input-93"
+                  className="ms-ColorPicker-sliderOverlay sliderOverlay-90"
+                  style={
+                    Object {
+                      "background": "linear-gradient(to right, transparent, #ffffff)",
+                    }
+                  }
+                />
+                <div
+                  className="ms-ColorPicker-thumb is-slider sliderThumb-91"
+                  style={
+                    Object {
+                      "left": "100%",
+                    }
+                  }
+                />
+              </div>
+            </div>
+            <div
+              className="flexPreviewBox-82"
+            >
+              <div
+                className="ms-ColorPicker-colorSquare colorSquare-79 is-preview"
+                style={
+                  Object {
+                    "backgroundColor": "#ffffff",
+                  }
+                }
+              />
+            </div>
+          </div>
+          <table
+            cellPadding="0"
+            cellSpacing="0"
+            className="ms-ColorPicker-table table-76"
+            role="group"
+          >
+            <thead>
+              <tr
+                className="tableHeader-77"
+              >
+                <td
+                  className="tableHexCell-78"
                 >
+                  Hex
+                </td>
+                <td>
+                  Red
+                </td>
+                <td>
+                  Green
+                </td>
+                <td>
+                  Blue
+                </td>
+                <td
+                  className=""
+                >
+                  Alpha
+                </td>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
                   <div
-                    className="ms-TextField-wrapper"
+                    className="ms-TextField ms-ColorPicker-input input-93"
                   >
                     <div
-                      className="ms-TextField-fieldGroup fieldGroup-55"
+                      className="ms-TextField-wrapper"
                     >
-                      <input
-                        aria-invalid={false}
-                        aria-label="Hex"
-                        autoComplete="off"
-                        className="ms-TextField-field field-56"
-                        id="TextField49"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        onInput={[Function]}
-                        spellCheck={false}
-                        type="text"
-                        value="ffffff"
-                      />
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-55"
+                      >
+                        <input
+                          aria-invalid={false}
+                          aria-label="Hex"
+                          autoComplete="off"
+                          className="ms-TextField-field field-56"
+                          id="TextField49"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          spellCheck={false}
+                          type="text"
+                          value="ffffff"
+                        />
+                      </div>
                     </div>
                   </div>
-                </div>
-              </td>
-              <td>
-                <div
-                  className="ms-TextField ms-ColorPicker-input input-93"
-                >
+                </td>
+                <td>
                   <div
-                    className="ms-TextField-wrapper"
+                    className="ms-TextField ms-ColorPicker-input input-93"
                   >
                     <div
-                      className="ms-TextField-fieldGroup fieldGroup-55"
+                      className="ms-TextField-wrapper"
                     >
-                      <input
-                        aria-invalid={false}
-                        aria-label="Red"
-                        aria-live="assertive"
-                        autoComplete="off"
-                        className="ms-TextField-field field-56"
-                        id="TextField52"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        onInput={[Function]}
-                        spellCheck={false}
-                        type="text"
-                        value="255"
-                      />
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-55"
+                      >
+                        <input
+                          aria-invalid={false}
+                          aria-label="Red"
+                          aria-live="assertive"
+                          autoComplete="off"
+                          className="ms-TextField-field field-56"
+                          id="TextField52"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          spellCheck={false}
+                          type="text"
+                          value="255"
+                        />
+                      </div>
                     </div>
                   </div>
-                </div>
-              </td>
-              <td>
-                <div
-                  className="ms-TextField ms-ColorPicker-input input-93"
-                >
+                </td>
+                <td>
                   <div
-                    className="ms-TextField-wrapper"
+                    className="ms-TextField ms-ColorPicker-input input-93"
                   >
                     <div
-                      className="ms-TextField-fieldGroup fieldGroup-55"
+                      className="ms-TextField-wrapper"
                     >
-                      <input
-                        aria-invalid={false}
-                        aria-label="Green"
-                        aria-live="assertive"
-                        autoComplete="off"
-                        className="ms-TextField-field field-56"
-                        id="TextField55"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        onInput={[Function]}
-                        spellCheck={false}
-                        type="text"
-                        value="255"
-                      />
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-55"
+                      >
+                        <input
+                          aria-invalid={false}
+                          aria-label="Green"
+                          aria-live="assertive"
+                          autoComplete="off"
+                          className="ms-TextField-field field-56"
+                          id="TextField55"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          spellCheck={false}
+                          type="text"
+                          value="255"
+                        />
+                      </div>
                     </div>
                   </div>
-                </div>
-              </td>
-              <td>
-                <div
-                  className="ms-TextField ms-ColorPicker-input input-93"
-                >
+                </td>
+                <td>
                   <div
-                    className="ms-TextField-wrapper"
+                    className="ms-TextField ms-ColorPicker-input input-93"
                   >
                     <div
-                      className="ms-TextField-fieldGroup fieldGroup-55"
+                      className="ms-TextField-wrapper"
                     >
-                      <input
-                        aria-invalid={false}
-                        aria-label="Blue"
-                        aria-live="assertive"
-                        autoComplete="off"
-                        className="ms-TextField-field field-56"
-                        id="TextField58"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        onInput={[Function]}
-                        spellCheck={false}
-                        type="text"
-                        value="255"
-                      />
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-55"
+                      >
+                        <input
+                          aria-invalid={false}
+                          aria-label="Blue"
+                          aria-live="assertive"
+                          autoComplete="off"
+                          className="ms-TextField-field field-56"
+                          id="TextField58"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          spellCheck={false}
+                          type="text"
+                          value="255"
+                        />
+                      </div>
                     </div>
                   </div>
-                </div>
-              </td>
-              <td>
-                <div
-                  className="ms-TextField ms-ColorPicker-input input-93"
-                >
+                </td>
+                <td>
                   <div
-                    className="ms-TextField-wrapper"
+                    className="ms-TextField ms-ColorPicker-input input-93"
                   >
                     <div
-                      className="ms-TextField-fieldGroup fieldGroup-55"
+                      className="ms-TextField-wrapper"
                     >
-                      <input
-                        aria-invalid={false}
-                        aria-label="Alpha"
-                        aria-live="assertive"
-                        autoComplete="off"
-                        className="ms-TextField-field field-56"
-                        id="TextField61"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        onInput={[Function]}
-                        spellCheck={false}
-                        type="text"
-                        value="100"
-                      />
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-55"
+                      >
+                        <input
+                          aria-invalid={false}
+                          aria-label="Alpha"
+                          aria-live="assertive"
+                          autoComplete="off"
+                          className="ms-TextField-field field-56"
+                          id="TextField61"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          spellCheck={false}
+                          type="text"
+                          value="100"
+                        />
+                      </div>
                     </div>
                   </div>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -1017,69 +1049,73 @@ exports[`single fields format date 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-string"
   >
     <div
-      aria-describedby="root__error root__description root__help"
-      className="ms-DatePicker control-94"
+      className="ms-Grid-col ms-sm12  field field-string"
       id="root"
-      onBlur={[Function]}
-      onFocus={[Function]}
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        aria-haspopup="true"
+        aria-describedby="root__error root__description root__help"
+        className="ms-DatePicker control-94"
+        id="root"
+        onBlur={[Function]}
+        onFocus={[Function]}
       >
         <div
-          className="ms-TextField textField-100"
+          aria-haspopup="true"
         >
           <div
-            className="ms-TextField-wrapper"
+            className="ms-TextField textField-100"
           >
             <div
-              className="ms-TextField-fieldGroup fieldGroup-55"
+              className="ms-TextField-wrapper"
             >
               <div
-                aria-expanded={false}
-                aria-invalid={false}
-                aria-label="Select a date"
-                className="ms-TextField-field field-101 readOnlyTextField-98"
-                id="root-label"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onClick={[Function]}
-                onFocus={[Function]}
-                onInput={[Function]}
-                onKeyDown={[Function]}
-                role="combobox"
-                tabIndex={0}
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
-                <span
-                  className="readOnlyPlaceholder-99"
+                <div
+                  aria-expanded={false}
+                  aria-invalid={false}
+                  aria-label="Select a date"
+                  className="ms-TextField-field field-101 readOnlyTextField-98"
+                  id="root-label"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  onKeyDown={[Function]}
+                  role="combobox"
+                  tabIndex={0}
                 >
-                  
-                </span>
+                  <span
+                    className="readOnlyPlaceholder-99"
+                  >
+                    
+                  </span>
+                </div>
+                <i
+                  aria-hidden={true}
+                  className="ms-DatePicker-event--without-label msDatePickerDisabled icon-105"
+                  data-icon-name="Calendar"
+                  onClick={[Function]}
+                >
+                  
+                </i>
               </div>
-              <i
-                aria-hidden={true}
-                className="ms-DatePicker-event--without-label msDatePickerDisabled icon-105"
-                data-icon-name="Calendar"
-                onClick={[Function]}
-              >
-                
-              </i>
             </div>
           </div>
         </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -1125,45 +1161,49 @@ exports[`single fields format datetime 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-string"
   >
     <div
-      className="ms-TextField root-54"
+      className="ms-Grid-col ms-sm12  field field-string"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        className="ms-TextField-wrapper"
+        className="ms-TextField root-54"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-55"
+          className="ms-TextField-wrapper"
         >
-          <input
-            aria-describedby="root__error root__description root__help"
-            aria-invalid={false}
-            autoFocus={false}
-            className="ms-TextField-field field-56"
-            disabled={false}
-            id="root"
-            name="root"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            placeholder=""
-            readOnly={false}
-            type="datetime-local"
-            value=""
-          />
+          <div
+            className="ms-TextField-fieldGroup fieldGroup-55"
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              aria-invalid={false}
+              autoFocus={false}
+              className="ms-TextField-field field-56"
+              disabled={false}
+              id="root"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              placeholder=""
+              readOnly={false}
+              type="datetime-local"
+              value=""
+            />
+          </div>
         </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -1209,45 +1249,49 @@ exports[`single fields format time 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-string"
   >
     <div
-      className="ms-TextField root-54"
+      className="ms-Grid-col ms-sm12  field field-string"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        className="ms-TextField-wrapper"
+        className="ms-TextField root-54"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-55"
+          className="ms-TextField-wrapper"
         >
-          <input
-            aria-describedby="root__error root__description root__help"
-            aria-invalid={false}
-            autoFocus={false}
-            className="ms-TextField-field field-56"
-            disabled={false}
-            id="root"
-            name="root"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            placeholder=""
-            readOnly={false}
-            type="time"
-            value=""
-          />
+          <div
+            className="ms-TextField-fieldGroup fieldGroup-55"
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              aria-invalid={false}
+              autoFocus={false}
+              className="ms-TextField-field field-56"
+              disabled={false}
+              id="root"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              placeholder=""
+              readOnly={false}
+              type="time"
+              value=""
+            />
+          </div>
         </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -1323,83 +1367,87 @@ exports[`single fields help and error display 1`] = `
     </div>
   </div>
   <div
-    className="ms-Grid-col ms-sm12  field field-string field-error has-error has-danger"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-string field-error has-error has-danger"
   >
     <div
-      className="ms-TextField root-54"
+      className="ms-Grid-col ms-sm12  field field-string field-error has-error has-danger"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        className="ms-TextField-wrapper"
+        className="ms-TextField root-54"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-178"
-        >
-          <input
-            aria-describedby="TextFieldDescription189"
-            aria-invalid={true}
-            autoFocus={false}
-            className="ms-TextField-field field-56"
-            disabled={false}
-            id="root"
-            name="root"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            placeholder=""
-            readOnly={false}
-            type="text"
-            value=""
-          />
-        </div>
-      </div>
-      <span
-        id="TextFieldDescription189"
-      >
-        <div
-          role="alert"
-        />
-      </span>
-    </div>
-    
-    <div
-      className="ms-List"
-      id="root__error"
-      role="list"
-    >
-      <div
-        className="ms-List-surface"
-        role="presentation"
-      >
-        <div
-          className="ms-List-page"
-          role="presentation"
-          style={Object {}}
+          className="ms-TextField-wrapper"
         >
           <div
-            className="ms-List-cell"
-            data-automationid="ListCell"
-            data-list-index={0}
-            role="listitem"
+            className="ms-TextField-fieldGroup fieldGroup-178"
           >
-            
+            <input
+              aria-describedby="TextFieldDescription189"
+              aria-invalid={true}
+              autoFocus={false}
+              className="ms-TextField-field field-56"
+              disabled={false}
+              id="root"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              placeholder=""
+              readOnly={false}
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <span
+          id="TextFieldDescription189"
+        >
+          <div
+            role="alert"
+          />
+        </span>
+      </div>
+      
+      <div
+        className="ms-List"
+        id="root__error"
+        role="list"
+      >
+        <div
+          className="ms-List-surface"
+          role="presentation"
+        >
+          <div
+            className="ms-List-page"
+            role="presentation"
+            style={Object {}}
+          >
+            <div
+              className="ms-List-cell"
+              data-automationid="ListCell"
+              data-list-index={0}
+              role="listitem"
+            >
+              
+            </div>
           </div>
         </div>
       </div>
+      <span
+        className="css-166"
+        id="root__help"
+      >
+        help me!
+      </span>
     </div>
-    <span
-      className="css-166"
-      id="root__help"
-    >
-      help me!
-    </span>
   </div>
   <div>
     <br />
@@ -1445,40 +1493,48 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-object"
   >
-    
     <div
-      className="ms-Grid"
-      dir="ltr"
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
+      
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_my-field"
-          style={
-            Object {
-              "display": "none",
-              "marginBottom": 15,
-            }
-          }
+          className="ms-Grid-row"
         >
-          <input
-            id="root_my-field"
-            name="root_my-field"
-            type="hidden"
-            value=""
-          />
-          
+          <div
+            className="form-group field field-string"
+          >
+            <div
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_my-field"
+              style={
+                Object {
+                  "display": "none",
+                  "marginBottom": 15,
+                }
+              }
+            >
+              <input
+                id="root_my-field"
+                name="root_my-field"
+                type="hidden"
+                value=""
+              />
+              
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -1527,41 +1583,45 @@ exports[`single fields hidden label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-string"
   >
     <div
-      className="ms-TextField root-54"
+      className="ms-Grid-col ms-sm12  field field-string"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        className="ms-TextField-wrapper"
+        className="ms-TextField root-54"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-55"
+          className="ms-TextField-wrapper"
         >
-          <input
-            aria-describedby="root__error root__description root__help"
-            aria-invalid={false}
-            autoFocus={false}
-            className="ms-TextField-field field-56"
-            disabled={false}
-            id="root"
-            name="root"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            placeholder=""
-            readOnly={false}
-            type="text"
-            value=""
-          />
+          <div
+            className="ms-TextField-fieldGroup fieldGroup-55"
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              aria-invalid={false}
+              autoFocus={false}
+              className="ms-TextField-field field-56"
+              disabled={false}
+              id="root"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              placeholder=""
+              readOnly={false}
+              type="text"
+              value=""
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -1610,16 +1670,20 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-null"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-null"
   >
-    
+    <div
+      className="ms-Grid-col ms-sm12  field field-null"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
+    >
+      
+    </div>
   </div>
   <div>
     <br />
@@ -1665,46 +1729,50 @@ exports[`single fields number field 0 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-number"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-number"
   >
     <div
-      className="ms-TextField root-54"
+      className="ms-Grid-col ms-sm12  field field-number"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        className="ms-TextField-wrapper"
+        className="ms-TextField root-54"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-55"
+          className="ms-TextField-wrapper"
         >
-          <input
-            aria-describedby="root__error root__description root__help"
-            aria-invalid={false}
-            autoFocus={false}
-            className="ms-TextField-field field-56"
-            disabled={false}
-            id="root"
-            name="root"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            placeholder=""
-            readOnly={false}
-            step="any"
-            type="number"
-            value="0"
-          />
+          <div
+            className="ms-TextField-fieldGroup fieldGroup-55"
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              aria-invalid={false}
+              autoFocus={false}
+              className="ms-TextField-field field-56"
+              disabled={false}
+              id="root"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              placeholder=""
+              readOnly={false}
+              step="any"
+              type="number"
+              value="0"
+            />
+          </div>
         </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -1750,46 +1818,50 @@ exports[`single fields number field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-number"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-number"
   >
     <div
-      className="ms-TextField root-54"
+      className="ms-Grid-col ms-sm12  field field-number"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        className="ms-TextField-wrapper"
+        className="ms-TextField root-54"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-55"
+          className="ms-TextField-wrapper"
         >
-          <input
-            aria-describedby="root__error root__description root__help"
-            aria-invalid={false}
-            autoFocus={false}
-            className="ms-TextField-field field-56"
-            disabled={false}
-            id="root"
-            name="root"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            placeholder=""
-            readOnly={false}
-            step="any"
-            type="number"
-            value=""
-          />
+          <div
+            className="ms-TextField-fieldGroup fieldGroup-55"
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              aria-invalid={false}
+              autoFocus={false}
+              className="ms-TextField-field field-56"
+              disabled={false}
+              id="root"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              placeholder=""
+              readOnly={false}
+              step="any"
+              type="number"
+              value=""
+            />
+          </div>
         </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -1835,45 +1907,49 @@ exports[`single fields password field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-string"
   >
     <div
-      className="ms-TextField root-54"
+      className="ms-Grid-col ms-sm12  field field-string"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        className="ms-TextField-wrapper"
+        className="ms-TextField root-54"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-55"
+          className="ms-TextField-wrapper"
         >
-          <input
-            aria-describedby="root__error root__description root__help"
-            aria-invalid={false}
-            autoFocus={false}
-            className="ms-TextField-field field-56"
-            disabled={false}
-            id="root"
-            name="root"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            placeholder=""
-            readOnly={false}
-            type="password"
-            value=""
-          />
+          <div
+            className="ms-TextField-fieldGroup fieldGroup-55"
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              aria-invalid={false}
+              autoFocus={false}
+              className="ms-TextField-field field-56"
+              disabled={false}
+              id="root"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              placeholder=""
+              readOnly={false}
+              type="password"
+              value=""
+            />
+          </div>
         </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -1919,95 +1995,99 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-boolean"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-boolean"
   >
     <div
-      className=""
+      className="ms-Grid-col ms-sm12  field field-boolean"
       id="root"
-      name="root"
-      onBlur={[Function]}
-      onFocus={[Function]}
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        className="ms-ChoiceFieldGroup root-146"
-        role="radiogroup"
+        className=""
+        id="root"
+        name="root"
+        onBlur={[Function]}
+        onFocus={[Function]}
       >
         <div
-          className="ms-ChoiceFieldGroup-flexContainer"
+          className="ms-ChoiceFieldGroup root-146"
+          role="radiogroup"
         >
           <div
-            className="ms-ChoiceField root-147"
+            className="ms-ChoiceFieldGroup-flexContainer"
           >
             <div
-              className="ms-ChoiceField-wrapper"
+              className="ms-ChoiceField root-147"
             >
-              <input
-                aria-describedby="root__error root__description root__help"
-                checked={false}
-                className="ms-ChoiceField-input input-148"
-                disabled={false}
-                id="root-0"
-                name="root"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                type="radio"
-              />
-              <label
-                className="ms-ChoiceField-field field-149"
-                htmlFor="root-0"
+              <div
+                className="ms-ChoiceField-wrapper"
               >
-                <span
-                  className="ms-ChoiceFieldLabel"
-                  id="ChoiceGroupLabel140-0"
+                <input
+                  aria-describedby="root__error root__description root__help"
+                  checked={false}
+                  className="ms-ChoiceField-input input-148"
+                  disabled={false}
+                  id="root-0"
+                  name="root"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  type="radio"
+                />
+                <label
+                  className="ms-ChoiceField-field field-149"
+                  htmlFor="root-0"
                 >
-                  Yes
-                </span>
-              </label>
+                  <span
+                    className="ms-ChoiceFieldLabel"
+                    id="ChoiceGroupLabel140-0"
+                  >
+                    Yes
+                  </span>
+                </label>
+              </div>
             </div>
-          </div>
-          <div
-            className="ms-ChoiceField root-147"
-          >
             <div
-              className="ms-ChoiceField-wrapper"
+              className="ms-ChoiceField root-147"
             >
-              <input
-                aria-describedby="root__error root__description root__help"
-                checked={false}
-                className="ms-ChoiceField-input input-148"
-                disabled={false}
-                id="root-1"
-                name="root"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                type="radio"
-              />
-              <label
-                className="ms-ChoiceField-field field-149"
-                htmlFor="root-1"
+              <div
+                className="ms-ChoiceField-wrapper"
               >
-                <span
-                  className="ms-ChoiceFieldLabel"
-                  id="ChoiceGroupLabel140-1"
+                <input
+                  aria-describedby="root__error root__description root__help"
+                  checked={false}
+                  className="ms-ChoiceField-input input-148"
+                  disabled={false}
+                  id="root-1"
+                  name="root"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  type="radio"
+                />
+                <label
+                  className="ms-ChoiceField-field field-149"
+                  htmlFor="root-1"
                 >
-                  No
-                </span>
-              </label>
+                  <span
+                    className="ms-ChoiceFieldLabel"
+                    id="ChoiceGroupLabel140-1"
+                  >
+                    No
+                  </span>
+                </label>
+              </div>
             </div>
           </div>
         </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -2053,65 +2133,69 @@ exports[`single fields schema examples 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-string"
   >
     <div
-      className="ms-TextField root-54"
+      className="ms-Grid-col ms-sm12  field field-string"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        className="ms-TextField-wrapper"
+        className="ms-TextField root-54"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-55"
+          className="ms-TextField-wrapper"
         >
-          <input
-            aria-describedby="root__error root__description root__help root__examples"
-            aria-invalid={false}
-            autoFocus={false}
-            className="ms-TextField-field field-56"
-            disabled={false}
-            id="root"
-            list="root__examples"
-            name="root"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            placeholder=""
-            readOnly={false}
-            type="text"
-            value=""
-          />
+          <div
+            className="ms-TextField-fieldGroup fieldGroup-55"
+          >
+            <input
+              aria-describedby="root__error root__description root__help root__examples"
+              aria-invalid={false}
+              autoFocus={false}
+              className="ms-TextField-field field-56"
+              disabled={false}
+              id="root"
+              list="root__examples"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              placeholder=""
+              readOnly={false}
+              type="text"
+              value=""
+            />
+          </div>
         </div>
       </div>
+      <datalist
+        id="root__examples"
+      >
+        <option
+          value="Firefox"
+        />
+        <option
+          value="Chrome"
+        />
+        <option
+          value="Opera"
+        />
+        <option
+          value="Vivaldi"
+        />
+        <option
+          value="Safari"
+        />
+      </datalist>
+      
     </div>
-    <datalist
-      id="root__examples"
-    >
-      <option
-        value="Firefox"
-      />
-      <option
-        value="Chrome"
-      />
-      <option
-        value="Opera"
-      />
-      <option
-        value="Vivaldi"
-      />
-      <option
-        value="Safari"
-      />
-    </datalist>
-    
   </div>
   <div>
     <br />
@@ -2157,54 +2241,58 @@ exports[`single fields select field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-string"
   >
     <div
-      className="ms-Dropdown-container"
+      className="ms-Grid-col ms-sm12  field field-string"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        aria-describedby="root__error root__description root__help"
-        aria-disabled={false}
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        className="ms-Dropdown dropdown-121"
-        data-is-focusable={true}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        role="combobox"
-        tabIndex={0}
+        className="ms-Dropdown-container"
       >
-        <span
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
-          id="root-option"
-        />
-        <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
+        <div
+          aria-describedby="root__error root__description root__help"
+          aria-disabled={false}
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          className="ms-Dropdown dropdown-121"
+          data-is-focusable={true}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          role="combobox"
+          tabIndex={0}
         >
-          <i
-            aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-137"
-            data-icon-name="ChevronDown"
+          <span
+            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
+            id="root-option"
+          />
+          <span
+            className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
           >
-            
-          </i>
-        </span>
+            <i
+              aria-hidden={true}
+              className="ms-Dropdown-caretDown caretDown-137"
+              data-icon-name="ChevronDown"
+            >
+              
+            </i>
+          </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -2250,55 +2338,59 @@ exports[`single fields select field multiple choice 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
     <div
-      className="ms-Dropdown-container"
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        aria-describedby="root__error root__description root__help"
-        aria-disabled={false}
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-required={false}
-        className="ms-Dropdown dropdown-121"
-        data-is-focusable={true}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        role="combobox"
-        tabIndex={0}
+        className="ms-Dropdown-container"
       >
-        <span
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
-          id="root-option"
-        />
-        <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
+        <div
+          aria-describedby="root__error root__description root__help"
+          aria-disabled={false}
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-required={false}
+          className="ms-Dropdown dropdown-121"
+          data-is-focusable={true}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          role="combobox"
+          tabIndex={0}
         >
-          <i
-            aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-137"
-            data-icon-name="ChevronDown"
+          <span
+            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
+            id="root-option"
+          />
+          <span
+            className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
           >
-            
-          </i>
-        </span>
+            <i
+              aria-hidden={true}
+              className="ms-Dropdown-caretDown caretDown-137"
+              data-icon-name="ChevronDown"
+            >
+              
+            </i>
+          </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -2344,55 +2436,59 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
     <div
-      className="ms-Dropdown-container"
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        aria-describedby="root__error root__description root__help"
-        aria-disabled={false}
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-required={false}
-        className="ms-Dropdown dropdown-121"
-        data-is-focusable={true}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        role="combobox"
-        tabIndex={0}
+        className="ms-Dropdown-container"
       >
-        <span
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
-          id="root-option"
-        />
-        <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
+        <div
+          aria-describedby="root__error root__description root__help"
+          aria-disabled={false}
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-required={false}
+          className="ms-Dropdown dropdown-121"
+          data-is-focusable={true}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          role="combobox"
+          tabIndex={0}
         >
-          <i
-            aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-137"
-            data-icon-name="ChevronDown"
+          <span
+            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
+            id="root-option"
+          />
+          <span
+            className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
           >
-            
-          </i>
-        </span>
+            <i
+              aria-hidden={true}
+              className="ms-Dropdown-caretDown caretDown-137"
+              data-icon-name="ChevronDown"
+            >
+              
+            </i>
+          </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -2438,57 +2534,61 @@ exports[`single fields select field multiple choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
     <div
-      className="ms-Dropdown-container"
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        aria-describedby="root__error root__description root__help"
-        aria-disabled={false}
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-required={false}
-        className="ms-Dropdown dropdown-121"
-        data-is-focusable={true}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        role="combobox"
-        tabIndex={0}
+        className="ms-Dropdown-container"
       >
-        <span
-          className="ms-Dropdown-title title-138"
-          id="root-option"
+        <div
+          aria-describedby="root__error root__description root__help"
+          aria-disabled={false}
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-required={false}
+          className="ms-Dropdown dropdown-121"
+          data-is-focusable={true}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          role="combobox"
+          tabIndex={0}
         >
-          foo, bar
-        </span>
-        <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
-        >
-          <i
-            aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-137"
-            data-icon-name="ChevronDown"
+          <span
+            className="ms-Dropdown-title title-138"
+            id="root-option"
           >
-            
-          </i>
-        </span>
+            foo, bar
+          </span>
+          <span
+            className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Dropdown-caretDown caretDown-137"
+              data-icon-name="ChevronDown"
+            >
+              
+            </i>
+          </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -2534,55 +2634,59 @@ exports[`single fields select field multiple choice with labels 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-array"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-array"
   >
     <div
-      className="ms-Dropdown-container"
+      className="ms-Grid-col ms-sm12  field field-array"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        aria-describedby="root__error root__description root__help"
-        aria-disabled={false}
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-required={false}
-        className="ms-Dropdown dropdown-121"
-        data-is-focusable={true}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        role="combobox"
-        tabIndex={0}
+        className="ms-Dropdown-container"
       >
-        <span
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
-          id="root-option"
-        />
-        <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
+        <div
+          aria-describedby="root__error root__description root__help"
+          aria-disabled={false}
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-required={false}
+          className="ms-Dropdown dropdown-121"
+          data-is-focusable={true}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          role="combobox"
+          tabIndex={0}
         >
-          <i
-            aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-137"
-            data-icon-name="ChevronDown"
+          <span
+            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
+            id="root-option"
+          />
+          <span
+            className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
           >
-            
-          </i>
-        </span>
+            <i
+              aria-hidden={true}
+              className="ms-Dropdown-caretDown caretDown-137"
+              data-icon-name="ChevronDown"
+            >
+              
+            </i>
+          </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -2628,54 +2732,58 @@ exports[`single fields select field single choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-string"
   >
     <div
-      className="ms-Dropdown-container"
+      className="ms-Grid-col ms-sm12  field field-string"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        aria-describedby="root__error root__description root__help"
-        aria-disabled={false}
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        className="ms-Dropdown dropdown-121"
-        data-is-focusable={true}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        role="combobox"
-        tabIndex={0}
+        className="ms-Dropdown-container"
       >
-        <span
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
-          id="root-option"
-        />
-        <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
+        <div
+          aria-describedby="root__error root__description root__help"
+          aria-disabled={false}
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          className="ms-Dropdown dropdown-121"
+          data-is-focusable={true}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          role="combobox"
+          tabIndex={0}
         >
-          <i
-            aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-137"
-            data-icon-name="ChevronDown"
+          <span
+            className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
+            id="root-option"
+          />
+          <span
+            className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
           >
-            
-          </i>
-        </span>
+            <i
+              aria-hidden={true}
+              className="ms-Dropdown-caretDown caretDown-137"
+              data-icon-name="ChevronDown"
+            >
+              
+            </i>
+          </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -2721,56 +2829,60 @@ exports[`single fields select field single choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-string"
   >
     <div
-      className="ms-Dropdown-container"
+      className="ms-Grid-col ms-sm12  field field-string"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        aria-describedby="root__error root__description root__help"
-        aria-disabled={false}
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        className="ms-Dropdown dropdown-121"
-        data-is-focusable={true}
-        id="root"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        role="combobox"
-        tabIndex={0}
+        className="ms-Dropdown-container"
       >
-        <span
-          className="ms-Dropdown-title title-138"
-          id="root-option"
+        <div
+          aria-describedby="root__error root__description root__help"
+          aria-disabled={false}
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          className="ms-Dropdown dropdown-121"
+          data-is-focusable={true}
+          id="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          role="combobox"
+          tabIndex={0}
         >
-          bar
-        </span>
-        <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
-        >
-          <i
-            aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-137"
-            data-icon-name="ChevronDown"
+          <span
+            className="ms-Dropdown-title title-138"
+            id="root-option"
           >
-            
-          </i>
-        </span>
+            bar
+          </span>
+          <span
+            className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Dropdown-caretDown caretDown-137"
+              data-icon-name="ChevronDown"
+            >
+              
+            </i>
+          </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -2816,77 +2928,81 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-integer"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-integer"
   >
-    <label
-      className="ms-Label root-73"
-      htmlFor="root"
-    />
     <div
-      className="ms-Slider ms-Slider-enabled ms-Slider-row root-154"
+      className="ms-Grid-col ms-sm12  field field-integer"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
+      <label
+        className="ms-Label root-73"
+        htmlFor="root"
+      />
       <div
-        className="ms-Slider-container container-156"
+        className="ms-Slider ms-Slider-enabled ms-Slider-row root-154"
       >
         <div
-          aria-disabled={false}
-          aria-valuemax={100}
-          aria-valuemin={42}
-          aria-valuenow={42}
-          aria-valuetext="42"
-          className="ms-Slider-slideBox ms-Slider-showValue ms-Slider-showTransitions slideBox-157"
-          data-is-focusable={true}
-          id="Slider144"
-          onKeyDown={[Function]}
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
-          role="slider"
-          tabIndex={0}
+          className="ms-Slider-container container-156"
         >
           <div
-            className="ms-Slider-line line-159"
+            aria-disabled={false}
+            aria-valuemax={100}
+            aria-valuemin={42}
+            aria-valuenow={42}
+            aria-valuetext="42"
+            className="ms-Slider-slideBox ms-Slider-showValue ms-Slider-showTransitions slideBox-157"
+            data-is-focusable={true}
+            id="Slider144"
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+            role="slider"
+            tabIndex={0}
           >
-            <span
-              className="ms-Slider-thumb thumb-158"
-              style={
-                Object {
-                  "left": "0%",
+            <div
+              className="ms-Slider-line line-159"
+            >
+              <span
+                className="ms-Slider-thumb thumb-158"
+                style={
+                  Object {
+                    "left": "0%",
+                  }
                 }
-              }
-            />
-            <span
-              className="lineContainer-160 ms-Slider-active activeSection-161"
-              style={
-                Object {
-                  "width": "0%",
+              />
+              <span
+                className="lineContainer-160 ms-Slider-active activeSection-161"
+                style={
+                  Object {
+                    "width": "0%",
+                  }
                 }
-              }
-            />
-            <span
-              className="lineContainer-160 ms-Slider-inactive inactiveSection-162"
-              style={
-                Object {
-                  "width": "100%",
+              />
+              <span
+                className="lineContainer-160 ms-Slider-inactive inactiveSection-162"
+                style={
+                  Object {
+                    "width": "100%",
+                  }
                 }
-              }
-            />
+              />
+            </div>
           </div>
+          <label
+            className="ms-Label ms-Slider-value valueLabel-165"
+          >
+            42
+          </label>
         </div>
-        <label
-          className="ms-Label ms-Slider-value valueLabel-165"
-        >
-          42
-        </label>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -2932,47 +3048,51 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-string"
   >
-    <div>
-      <div
-        className="ms-TextField root-54"
-      >
+    <div
+      className="ms-Grid-col ms-sm12  field field-string"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
+    >
+      <div>
         <div
-          className="ms-TextField-wrapper"
+          className="ms-TextField root-54"
         >
           <div
-            className="ms-TextField-fieldGroup fieldGroup-55"
+            className="ms-TextField-wrapper"
           >
-            <input
-              aria-describedby="root__error root__description root__help"
-              aria-invalid={false}
-              autoFocus={false}
-              className="ms-TextField-field field-56"
-              disabled={false}
-              id="root"
-              name="root"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              onInput={[Function]}
-              placeholder=""
-              readOnly={false}
-              type="file"
-              value=""
-            />
+            <div
+              className="ms-TextField-fieldGroup fieldGroup-55"
+            >
+              <input
+                aria-describedby="root__error root__description root__help"
+                aria-invalid={false}
+                autoFocus={false}
+                className="ms-TextField-field field-56"
+                disabled={false}
+                id="root"
+                name="root"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                placeholder=""
+                readOnly={false}
+                type="file"
+                value=""
+              />
+            </div>
           </div>
         </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -3018,45 +3138,49 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-string"
   >
     <div
-      className="ms-TextField root-54"
+      className="ms-Grid-col ms-sm12  field field-string"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        className="ms-TextField-wrapper"
+        className="ms-TextField root-54"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-55"
+          className="ms-TextField-wrapper"
         >
-          <input
-            aria-describedby="root__error root__description root__help"
-            aria-invalid={false}
-            autoFocus={false}
-            className="ms-TextField-field field-56"
-            disabled={false}
-            id="root"
-            name="root"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            placeholder=""
-            readOnly={false}
-            type="email"
-            value=""
-          />
+          <div
+            className="ms-TextField-fieldGroup fieldGroup-55"
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              aria-invalid={false}
+              autoFocus={false}
+              className="ms-TextField-field field-56"
+              disabled={false}
+              id="root"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              placeholder=""
+              readOnly={false}
+              type="email"
+              value=""
+            />
+          </div>
         </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -3102,45 +3226,49 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-string"
   >
     <div
-      className="ms-TextField root-54"
+      className="ms-Grid-col ms-sm12  field field-string"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        className="ms-TextField-wrapper"
+        className="ms-TextField root-54"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-55"
+          className="ms-TextField-wrapper"
         >
-          <input
-            aria-describedby="root__error root__description root__help"
-            aria-invalid={false}
-            autoFocus={false}
-            className="ms-TextField-field field-56"
-            disabled={false}
-            id="root"
-            name="root"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            placeholder=""
-            readOnly={false}
-            type="url"
-            value=""
-          />
+          <div
+            className="ms-TextField-fieldGroup fieldGroup-55"
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              aria-invalid={false}
+              autoFocus={false}
+              className="ms-TextField-field field-56"
+              disabled={false}
+              id="root"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              placeholder=""
+              readOnly={false}
+              type="url"
+              value=""
+            />
+          </div>
         </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -3186,45 +3314,49 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-string"
   >
     <div
-      className="ms-TextField root-54"
+      className="ms-Grid-col ms-sm12  field field-string"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        className="ms-TextField-wrapper"
+        className="ms-TextField root-54"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-55"
+          className="ms-TextField-wrapper"
         >
-          <input
-            aria-describedby="root__error root__description root__help"
-            aria-invalid={false}
-            autoFocus={false}
-            className="ms-TextField-field field-56"
-            disabled={false}
-            id="root"
-            name="root"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            placeholder=""
-            readOnly={false}
-            type="text"
-            value=""
-          />
+          <div
+            className="ms-TextField-fieldGroup fieldGroup-55"
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              aria-invalid={false}
+              autoFocus={false}
+              className="ms-TextField-field field-56"
+              disabled={false}
+              id="root"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              placeholder=""
+              readOnly={false}
+              type="text"
+              value=""
+            />
+          </div>
         </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -3270,45 +3402,49 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-string"
   >
     <div
-      className="ms-TextField root-54"
+      className="ms-Grid-col ms-sm12  field field-string"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        className="ms-TextField-wrapper"
+        className="ms-TextField root-54"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-55"
+          className="ms-TextField-wrapper"
         >
-          <input
-            aria-describedby="root__error root__description root__help"
-            aria-invalid={false}
-            autoFocus={false}
-            className="ms-TextField-field field-56"
-            disabled={false}
-            id="root"
-            name="root"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            placeholder="placeholder"
-            readOnly={false}
-            type="text"
-            value=""
-          />
+          <div
+            className="ms-TextField-fieldGroup fieldGroup-55"
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              aria-invalid={false}
+              autoFocus={false}
+              className="ms-TextField-field field-56"
+              disabled={false}
+              id="root"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              placeholder="placeholder"
+              readOnly={false}
+              type="text"
+              value=""
+            />
+          </div>
         </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -3354,45 +3490,49 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-string"
   >
     <div
-      className="ms-TextField ms-TextField--multiline root-54"
+      className="ms-Grid-col ms-sm12  field field-string"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        className="ms-TextField-wrapper"
+        className="ms-TextField ms-TextField--multiline root-54"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-118"
+          className="ms-TextField-wrapper"
         >
-          <textarea
-            aria-describedby="root__error root__description root__help"
-            aria-invalid={false}
-            autoFocus={false}
-            className="ms-TextField-field field-119"
-            disabled={false}
-            id="root"
-            name="root"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            placeholder=""
-            readOnly={false}
-            type="text"
-            value=""
-          />
+          <div
+            className="ms-TextField-fieldGroup fieldGroup-118"
+          >
+            <textarea
+              aria-describedby="root__error root__description root__help"
+              aria-invalid={false}
+              autoFocus={false}
+              className="ms-TextField-field field-119"
+              disabled={false}
+              id="root"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              placeholder=""
+              readOnly={false}
+              type="text"
+              value=""
+            />
+          </div>
         </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -3438,77 +3578,85 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-object"
   >
-    <label
-      className="ms-Label root-167"
-      id="root__title"
-    >
-      Titre 1
-    </label>
     <div
-      className="ms-Grid"
-      dir="ltr"
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
+      <label
+        className="ms-Label root-167"
+        id="root__title"
+      >
+        Titre 1
+      </label>
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_title"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
+          className="ms-Grid-row"
         >
           <div
-            className="ms-TextField root-54"
+            className="form-group field field-string"
           >
             <div
-              className="ms-TextField-wrapper"
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_title"
+              style={
+                Object {
+                  "display": undefined,
+                  "marginBottom": 15,
+                }
+              }
             >
-              <label
-                className="ms-Label root-73"
-                htmlFor="root_title"
-                id="TextFieldLabel165"
-              >
-                Titre 2
-              </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
+                className="ms-TextField root-54"
               >
-                <input
-                  aria-describedby="root_title__error root_title__description root_title__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel165"
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
-                  id="root_title"
-                  name="root_title"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value=""
-                />
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-73"
+                    htmlFor="root_title"
+                    id="TextFieldLabel165"
+                  >
+                    Titre 2
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_title__error root_title__description root_title__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel165"
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_title"
+                      name="root_title"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
               </div>
+              
             </div>
           </div>
-          
         </div>
       </div>
     </div>
@@ -3557,36 +3705,40 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-undefined"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-undefined"
   >
     <div
-      className="unsupported-field"
+      className="ms-Grid-col ms-sm12  field field-undefined"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
-      <p>
-        <span>
-          Unsupported field schema for field 
-          <code>
-            root
-          </code>
-          : 
-          <em>
-            Unknown field type undefined
-          </em>
-          .
-        </span>
-      </p>
-      <pre>
-        {}
-      </pre>
+      <div
+        className="unsupported-field"
+      >
+        <p>
+          <span>
+            Unsupported field schema for field 
+            <code>
+              root
+            </code>
+            : 
+            <em>
+              Unknown field type undefined
+            </em>
+            .
+          </span>
+        </p>
+        <pre>
+          {}
+        </pre>
+      </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -3632,121 +3784,125 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-number"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-number"
   >
-    <label
-      className="ms-Label root-73"
-      htmlFor="root"
-    />
     <div
-      className="css-106"
+      className="ms-Grid-col ms-sm12  field field-number"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
-      
+      <label
+        className="ms-Label root-73"
+        htmlFor="root"
+      />
       <div
-        aria-describedby="root__error root__description root__help"
-        className="css-110"
-        id="root"
-        onChange={[Function]}
+        className="css-106"
       >
-        <input
-          aria-disabled={false}
-          aria-labelledby=""
-          aria-valuemax={Infinity}
-          aria-valuemin={-Infinity}
-          aria-valuetext=""
-          autoComplete="off"
-          className="ms-spinButton-input css-111"
-          data-lpignore={true}
-          disabled={false}
-          id="input93"
-          onBlur={[Function]}
+        
+        <div
+          aria-describedby="root__error root__description root__help"
+          className="css-110"
+          id="root"
           onChange={[Function]}
-          onFocus={[Function]}
-          onInput={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          role="spinbutton"
-          type="text"
-          value=""
-        />
-        <span
-          className="css-112"
         >
-          <button
-            aria-label="Increase value by 1"
-            className="ms-Button ms-Button--icon ms-UpButton root-113"
-            data-is-focusable={false}
-            onClick={[Function]}
+          <input
+            aria-disabled={false}
+            aria-labelledby=""
+            aria-valuemax={Infinity}
+            aria-valuemin={-Infinity}
+            aria-valuetext=""
+            autoComplete="off"
+            className="ms-spinButton-input css-111"
+            data-lpignore={true}
+            disabled={false}
+            id="input93"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
             onKeyDown={[Function]}
-            onKeyPress={[Function]}
             onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            tabIndex={-1}
-            type="button"
+            role="spinbutton"
+            type="text"
+            value=""
+          />
+          <span
+            className="css-112"
           >
-            <span
-              className="ms-Button-flexContainer flexContainer-66"
-              data-automationid="splitbuttonprimary"
+            <button
+              aria-label="Increase value by 1"
+              className="ms-Button ms-Button--icon ms-UpButton root-113"
+              data-is-focusable={false}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              tabIndex={-1}
+              type="button"
             >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-116 ms-Button-icon icon-114"
-                data-icon-name="ChevronUpSmall"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-2\\"",
-                  }
-                }
+              <span
+                className="ms-Button-flexContainer flexContainer-66"
+                data-automationid="splitbuttonprimary"
               >
-                
-              </i>
-            </span>
-          </button>
-          <button
-            aria-label="Decrease value by 1"
-            className="ms-Button ms-Button--icon ms-DownButton root-113"
-            data-is-focusable={false}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            tabIndex={-1}
-            type="button"
-          >
-            <span
-              className="ms-Button-flexContainer flexContainer-66"
-              data-automationid="splitbuttonprimary"
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-116 ms-Button-icon icon-114"
+                  data-icon-name="ChevronUpSmall"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+            <button
+              aria-label="Decrease value by 1"
+              className="ms-Button ms-Button--icon ms-DownButton root-113"
+              data-is-focusable={false}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              tabIndex={-1}
+              type="button"
             >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-117 ms-Button-icon icon-114"
-                data-icon-name="ChevronDownSmall"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-3\\"",
-                  }
-                }
+              <span
+                className="ms-Button-flexContainer flexContainer-66"
+                data-automationid="splitbuttonprimary"
               >
-                
-              </i>
-            </span>
-          </button>
-        </span>
+                <i
+                  aria-hidden={true}
+                  className="ms-Icon root-37 css-117 ms-Button-icon icon-114"
+                  data-icon-name="ChevronDownSmall"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-3\\"",
+                    }
+                  }
+                >
+                  
+                </i>
+              </span>
+            </button>
+          </span>
+        </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />
@@ -3792,45 +3948,49 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-string"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-string"
   >
     <div
-      className="ms-TextField root-54"
+      className="ms-Grid-col ms-sm12  field field-string"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
       <div
-        className="ms-TextField-wrapper"
+        className="ms-TextField root-54"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-55"
+          className="ms-TextField-wrapper"
         >
-          <input
-            aria-describedby="root__error root__description root__help"
-            aria-invalid={false}
-            autoFocus={false}
-            className="ms-TextField-field field-56"
-            disabled={false}
-            id="root"
-            name="root"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            onInput={[Function]}
-            placeholder=""
-            readOnly={false}
-            type="text"
-            value=""
-          />
+          <div
+            className="ms-TextField-fieldGroup fieldGroup-55"
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              aria-invalid={false}
+              autoFocus={false}
+              className="ms-TextField-field field-56"
+              disabled={false}
+              id="root"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onInput={[Function]}
+              placeholder=""
+              readOnly={false}
+              type="text"
+              value=""
+            />
+          </div>
         </div>
       </div>
+      
     </div>
-    
   </div>
   <div>
     <br />

--- a/packages/fluent-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Object.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`object fields additionalProperties 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -256,7 +255,6 @@ exports[`object fields object 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -273,7 +271,6 @@ exports[`object fields object 1`] = `
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string"
-          id="root_a"
           style={
             Object {
               "marginBottom": 15,
@@ -322,7 +319,6 @@ exports[`object fields object 1`] = `
         </div>
         <div
           className="ms-Grid-col ms-sm12  field field-number"
-          id="root_b"
           style={
             Object {
               "marginBottom": 15,
@@ -418,7 +414,6 @@ exports[`object fields show add button and fields if additionalProperties is tru
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -666,7 +661,6 @@ exports[`object fields with title and description additionalProperties 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -925,7 +919,6 @@ exports[`object fields with title and description from both additionalProperties
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1184,7 +1177,6 @@ exports[`object fields with title and description from both object 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1212,7 +1204,6 @@ exports[`object fields with title and description from both object 1`] = `
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string"
-          id="root_a"
           style={
             Object {
               "marginBottom": 15,
@@ -1265,7 +1256,6 @@ exports[`object fields with title and description from both object 1`] = `
         </div>
         <div
           className="ms-Grid-col ms-sm12  field field-number"
-          id="root_b"
           style={
             Object {
               "marginBottom": 15,
@@ -1365,7 +1355,6 @@ exports[`object fields with title and description from uiSchema additionalProper
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1624,7 +1613,6 @@ exports[`object fields with title and description from uiSchema object 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -1652,7 +1640,6 @@ exports[`object fields with title and description from uiSchema object 1`] = `
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string"
-          id="root_a"
           style={
             Object {
               "marginBottom": 15,
@@ -1705,7 +1692,6 @@ exports[`object fields with title and description from uiSchema object 1`] = `
         </div>
         <div
           className="ms-Grid-col ms-sm12  field field-number"
-          id="root_b"
           style={
             Object {
               "marginBottom": 15,
@@ -1805,7 +1791,6 @@ exports[`object fields with title and description from uiSchema show add button 
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2064,7 +2049,6 @@ exports[`object fields with title and description object 1`] = `
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2092,7 +2076,6 @@ exports[`object fields with title and description object 1`] = `
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string"
-          id="root_a"
           style={
             Object {
               "marginBottom": 15,
@@ -2145,7 +2128,6 @@ exports[`object fields with title and description object 1`] = `
         </div>
         <div
           className="ms-Grid-col ms-sm12  field field-number"
-          id="root_b"
           style={
             Object {
               "marginBottom": 15,
@@ -2245,7 +2227,6 @@ exports[`object fields with title and description show add button and fields if 
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2504,7 +2485,6 @@ exports[`object fields with title and description with global label off addition
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2743,7 +2723,6 @@ exports[`object fields with title and description with global label off object 1
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,
@@ -2760,7 +2739,6 @@ exports[`object fields with title and description with global label off object 1
       >
         <div
           className="ms-Grid-col ms-sm12  field field-string"
-          id="root_a"
           style={
             Object {
               "marginBottom": 15,
@@ -2800,7 +2778,6 @@ exports[`object fields with title and description with global label off object 1
         </div>
         <div
           className="ms-Grid-col ms-sm12  field field-number"
-          id="root_b"
           style={
             Object {
               "marginBottom": 15,
@@ -2887,7 +2864,6 @@ exports[`object fields with title and description with global label off show add
 >
   <div
     className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
     style={
       Object {
         "marginBottom": 15,

--- a/packages/fluent-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Object.test.tsx.snap
@@ -7,73 +7,218 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-object"
   >
-    
     <div
-      className="ms-Grid"
-      dir="ltr"
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
+      
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_foo"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
+          className="ms-Grid-row"
         >
           <div
-            className="ms-TextField root-54"
+            className="ms-Grid form-group field field-string"
+            dir="ltr"
           >
             <div
-              className="ms-TextField-wrapper"
+              className="ms-Grid-row"
             >
-              <label
-                className="ms-Label root-65"
-                htmlFor="root_foo"
-                id="TextFieldLabel11"
-              >
-                foo
-              </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
               >
-                <input
-                  aria-describedby="root_foo__error root_foo__description root_foo__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel11"
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
+                <div
+                  className="ms-TextField root-54"
+                >
+                  <div
+                    className="ms-TextField-wrapper"
+                  >
+                    <label
+                      className="ms-Label root-65"
+                      htmlFor="root_foo-key"
+                      id="TextFieldLabel11"
+                    >
+                      foo Key
+                    </label>
+                    <div
+                      className="ms-TextField-fieldGroup fieldGroup-55"
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-labelledby="TextFieldLabel11"
+                        className="ms-TextField-field field-56"
+                        disabled={false}
+                        id="root_foo-key"
+                        name="root_foo-key"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        required={false}
+                        type="text"
+                        value="foo"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+              >
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
                   id="root_foo"
-                  name="root_foo"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value="foo"
-                />
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField root-54"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-65"
+                        htmlFor="root_foo"
+                        id="TextFieldLabel14"
+                      >
+                        foo
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-55"
+                      >
+                        <input
+                          aria-describedby="root_foo__error root_foo__description root_foo__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel14"
+                          autoFocus={false}
+                          className="ms-TextField-field field-56"
+                          disabled={false}
+                          id="root_foo"
+                          name="root_foo"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={false}
+                          type="text"
+                          value="foo"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  
+                </div>
+              </div>
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
+                style={
+                  Object {
+                    "textAlign": "right",
+                  }
+                }
+              >
+                <button
+                  className="ms-Button ms-Button--icon root-74"
+                  data-is-focusable={true}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="ms-Button-flexContainer flexContainer-67"
+                    data-automationid="splitbuttonprimary"
+                  >
+                    <i
+                      aria-hidden={true}
+                      className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
+                      data-icon-name="Delete"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
+                    >
+                      
+                    </i>
+                  </span>
+                </button>
               </div>
             </div>
           </div>
-          
         </div>
+        <span
+          style={
+            Object {
+              "float": "right",
+            }
+          }
+        >
+          <button
+            className="ms-Button ms-Button--commandBar object-property-expand root-77"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            style={
+              Object {
+                "height": "32px",
+              }
+            }
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-67"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
+                data-icon-name="Add"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+              <span
+                className="ms-Button-textContainer textContainer-68"
+              >
+                <span
+                  className="ms-Button-label label-79"
+                  id="id__18"
+                >
+                  Add Item
+                </span>
+              </span>
+            </span>
+          </button>
+        </span>
       </div>
     </div>
   </div>
@@ -102,7 +247,7 @@ exports[`object fields additionalProperties 1`] = `
           >
             <span
               className="ms-Button-label label-70"
-              id="id__12"
+              id="id__21"
             >
               Submit
             </span>
@@ -121,123 +266,135 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-object"
   >
-    
     <div
-      className="ms-Grid"
-      dir="ltr"
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
+      
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_a"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
+          className="ms-Grid-row"
         >
           <div
-            className="ms-TextField root-54"
+            className="form-group field field-string"
           >
             <div
-              className="ms-TextField-wrapper"
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_a"
+              style={
+                Object {
+                  "display": undefined,
+                  "marginBottom": 15,
+                }
+              }
             >
-              <label
-                className="ms-Label root-65"
-                htmlFor="root_a"
-                id="TextFieldLabel2"
-              >
-                A
-              </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
+                className="ms-TextField root-54"
               >
-                <input
-                  aria-describedby="root_a__error root_a__description root_a__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel2"
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
-                  id="root_a"
-                  name="root_a"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value=""
-                />
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_a"
+                    id="TextFieldLabel2"
+                  >
+                    A
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_a__error root_a__description root_a__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel2"
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_a"
+                      name="root_a"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
               </div>
+              
             </div>
           </div>
-          
-        </div>
-        <div
-          className="ms-Grid-col ms-sm12  field field-number"
-          id="root_b"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
-        >
           <div
-            className="ms-TextField root-54"
+            className="form-group field field-number"
           >
             <div
-              className="ms-TextField-wrapper"
+              className="ms-Grid-col ms-sm12  field field-number"
+              id="root_b"
+              style={
+                Object {
+                  "display": undefined,
+                  "marginBottom": 15,
+                }
+              }
             >
-              <label
-                className="ms-Label root-65"
-                htmlFor="root_b"
-                id="TextFieldLabel5"
-              >
-                B
-              </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
+                className="ms-TextField root-54"
               >
-                <input
-                  aria-describedby="root_b__error root_b__description root_b__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel5"
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
-                  id="root_b"
-                  name="root_b"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  step="any"
-                  type="number"
-                  value=""
-                />
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_b"
+                    id="TextFieldLabel5"
+                  >
+                    B
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_b__error root_b__description root_b__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel5"
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_b"
+                      name="root_b"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      step="any"
+                      type="number"
+                      value=""
+                    />
+                  </div>
+                </div>
               </div>
+              
             </div>
           </div>
-          
         </div>
       </div>
     </div>
@@ -286,73 +443,218 @@ exports[`object fields show add button and fields if additionalProperties is tru
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-object"
   >
-    
     <div
-      className="ms-Grid"
-      dir="ltr"
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
+      
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_additionalProperty"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
+          className="ms-Grid-row"
         >
           <div
-            className="ms-TextField root-54"
+            className="ms-Grid form-group field field-string"
+            dir="ltr"
           >
             <div
-              className="ms-TextField-wrapper"
+              className="ms-Grid-row"
             >
-              <label
-                className="ms-Label root-65"
-                htmlFor="root_additionalProperty"
-                id="TextFieldLabel17"
-              >
-                additionalProperty
-              </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
               >
-                <input
-                  aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel17"
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
+                <div
+                  className="ms-TextField root-54"
+                >
+                  <div
+                    className="ms-TextField-wrapper"
+                  >
+                    <label
+                      className="ms-Label root-65"
+                      htmlFor="root_additionalProperty-key"
+                      id="TextFieldLabel26"
+                    >
+                      additionalProperty Key
+                    </label>
+                    <div
+                      className="ms-TextField-fieldGroup fieldGroup-55"
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-labelledby="TextFieldLabel26"
+                        className="ms-TextField-field field-56"
+                        disabled={false}
+                        id="root_additionalProperty-key"
+                        name="root_additionalProperty-key"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        required={false}
+                        type="text"
+                        value="additionalProperty"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+              >
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
                   id="root_additionalProperty"
-                  name="root_additionalProperty"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value="should appear"
-                />
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField root-54"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-65"
+                        htmlFor="root_additionalProperty"
+                        id="TextFieldLabel29"
+                      >
+                        additionalProperty
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-55"
+                      >
+                        <input
+                          aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel29"
+                          autoFocus={false}
+                          className="ms-TextField-field field-56"
+                          disabled={false}
+                          id="root_additionalProperty"
+                          name="root_additionalProperty"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={false}
+                          type="text"
+                          value="should appear"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  
+                </div>
+              </div>
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
+                style={
+                  Object {
+                    "textAlign": "right",
+                  }
+                }
+              >
+                <button
+                  className="ms-Button ms-Button--icon root-74"
+                  data-is-focusable={true}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="ms-Button-flexContainer flexContainer-67"
+                    data-automationid="splitbuttonprimary"
+                  >
+                    <i
+                      aria-hidden={true}
+                      className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
+                      data-icon-name="Delete"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
+                    >
+                      
+                    </i>
+                  </span>
+                </button>
               </div>
             </div>
           </div>
-          
         </div>
+        <span
+          style={
+            Object {
+              "float": "right",
+            }
+          }
+        >
+          <button
+            className="ms-Button ms-Button--commandBar object-property-expand root-77"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            style={
+              Object {
+                "height": "32px",
+              }
+            }
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-67"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
+                data-icon-name="Add"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+              <span
+                className="ms-Button-textContainer textContainer-68"
+              >
+                <span
+                  className="ms-Button-label label-79"
+                  id="id__33"
+                >
+                  Add Item
+                </span>
+              </span>
+            </span>
+          </button>
+        </span>
       </div>
     </div>
   </div>
@@ -381,7 +683,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
           >
             <span
               className="ms-Button-label label-70"
-              id="id__18"
+              id="id__36"
             >
               Submit
             </span>
@@ -400,827 +702,229 @@ exports[`object fields with title and description additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-object"
   >
-    <label
-      className="ms-Label root-74"
-      id="root__title"
-    >
-      Test field
-    </label>
-    <span
-      className="css-75"
-      id="root__description"
-    >
-      a test description
-    </span>
     <div
-      className="ms-Grid"
-      dir="ltr"
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
+      <label
+        className="ms-Label root-81"
+        id="root__title"
+      >
+        Test field
+      </label>
+      <span
+        className="css-82"
+        id="root__description"
+      >
+        a test description
+      </span>
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_foo"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
+          className="ms-Grid-row"
         >
           <div
-            className="ms-TextField root-54"
+            className="ms-Grid form-group field field-string"
+            dir="ltr"
           >
             <div
-              className="ms-TextField-wrapper"
+              className="ms-Grid-row"
             >
-              <label
-                className="ms-Label root-65"
-                htmlFor="root_foo"
-                id="TextFieldLabel32"
-              >
-                foo
-              </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
               >
-                <input
-                  aria-describedby="root_foo__error root_foo__description root_foo__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel32"
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
+                <div
+                  className="ms-TextField root-54"
+                >
+                  <div
+                    className="ms-TextField-wrapper"
+                  >
+                    <label
+                      className="ms-Label root-65"
+                      htmlFor="root_foo-key"
+                      id="TextFieldLabel50"
+                    >
+                      foo Key
+                    </label>
+                    <div
+                      className="ms-TextField-fieldGroup fieldGroup-55"
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-labelledby="TextFieldLabel50"
+                        className="ms-TextField-field field-56"
+                        disabled={false}
+                        id="root_foo-key"
+                        name="root_foo-key"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        required={false}
+                        type="text"
+                        value="foo"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+              >
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
                   id="root_foo"
-                  name="root_foo"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value="foo"
-                />
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField root-54"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-65"
+                        htmlFor="root_foo"
+                        id="TextFieldLabel53"
+                      >
+                        foo
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-55"
+                      >
+                        <input
+                          aria-describedby="root_foo__error root_foo__description root_foo__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel53"
+                          autoFocus={false}
+                          className="ms-TextField-field field-56"
+                          disabled={false}
+                          id="root_foo"
+                          name="root_foo"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={false}
+                          type="text"
+                          value="foo"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  
+                </div>
+              </div>
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
+                style={
+                  Object {
+                    "textAlign": "right",
+                  }
+                }
+              >
+                <button
+                  className="ms-Button ms-Button--icon root-74"
+                  data-is-focusable={true}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="ms-Button-flexContainer flexContainer-67"
+                    data-automationid="splitbuttonprimary"
+                  >
+                    <i
+                      aria-hidden={true}
+                      className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
+                      data-icon-name="Delete"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
+                    >
+                      
+                    </i>
+                  </span>
+                </button>
               </div>
             </div>
           </div>
-          
         </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <br />
-    <div
-      className="ms-Grid-col ms-sm12"
-    >
-      <button
-        className="ms-Button ms-Button--primary root-66"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        type="submit"
-      >
         <span
-          className="ms-Button-flexContainer flexContainer-67"
-          data-automationid="splitbuttonprimary"
+          style={
+            Object {
+              "float": "right",
+            }
+          }
         >
-          <span
-            className="ms-Button-textContainer textContainer-68"
+          <button
+            className="ms-Button ms-Button--commandBar object-property-expand root-77"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            style={
+              Object {
+                "height": "32px",
+              }
+            }
+            type="button"
           >
             <span
-              className="ms-Button-label label-70"
-              id="id__33"
+              className="ms-Button-flexContainer flexContainer-67"
+              data-automationid="splitbuttonprimary"
             >
-              Submit
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
+                data-icon-name="Add"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+              <span
+                className="ms-Button-textContainer textContainer-68"
+              >
+                <span
+                  className="ms-Button-label label-79"
+                  id="id__57"
+                >
+                  Add Item
+                </span>
+              </span>
             </span>
-          </span>
+          </button>
         </span>
-      </button>
-    </div>
-  </div>
-</form>
-`;
-
-exports[`object fields with title and description from both additionalProperties 1`] = `
-<form
-  className="rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
-  >
-    <label
-      className="ms-Label root-74"
-      id="root__title"
-    >
-      My Field
-    </label>
-    <span
-      className="css-75"
-      id="root__description"
-    >
-      a fancier description
-    </span>
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_foo"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
-        >
-          <div
-            className="ms-TextField root-54"
-          >
-            <div
-              className="ms-TextField-wrapper"
-            >
-              <label
-                className="ms-Label root-65"
-                htmlFor="root_foo"
-                id="TextFieldLabel74"
-              >
-                foo
-              </label>
-              <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
-              >
-                <input
-                  aria-describedby="root_foo__error root_foo__description root_foo__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel74"
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
-                  id="root_foo"
-                  name="root_foo"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value="foo"
-                />
-              </div>
-            </div>
-          </div>
-          
-        </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <br />
-    <div
-      className="ms-Grid-col ms-sm12"
-    >
-      <button
-        className="ms-Button ms-Button--primary root-66"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        type="submit"
-      >
-        <span
-          className="ms-Button-flexContainer flexContainer-67"
-          data-automationid="splitbuttonprimary"
-        >
-          <span
-            className="ms-Button-textContainer textContainer-68"
-          >
-            <span
-              className="ms-Button-label label-70"
-              id="id__75"
-            >
-              Submit
-            </span>
-          </span>
-        </span>
-      </button>
-    </div>
-  </div>
-</form>
-`;
-
-exports[`object fields with title and description from both object 1`] = `
-<form
-  className="rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
-  >
-    <label
-      className="ms-Label root-74"
-      id="root__title"
-    >
-      My Field
-    </label>
-    <span
-      className="css-75"
-      id="root__description"
-    >
-      a fancier description
-    </span>
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_a"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
-        >
-          <div
-            className="ms-TextField root-54"
-          >
-            <div
-              className="ms-TextField-wrapper"
-            >
-              <label
-                className="ms-Label root-65"
-                htmlFor="root_a"
-                id="TextFieldLabel65"
-              >
-                My Item A
-              </label>
-              <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
-              >
-                <input
-                  aria-describedby="root_a__error root_a__description root_a__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel65"
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
-                  id="root_a"
-                  name="root_a"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value=""
-                />
-              </div>
-            </div>
-          </div>
-          <span
-            className="css-75"
-          >
-            a fancier item A description
-          </span>
-        </div>
-        <div
-          className="ms-Grid-col ms-sm12  field field-number"
-          id="root_b"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
-        >
-          <div
-            className="ms-TextField root-54"
-          >
-            <div
-              className="ms-TextField-wrapper"
-            >
-              <label
-                className="ms-Label root-65"
-                htmlFor="root_b"
-                id="TextFieldLabel68"
-              >
-                My Item B
-              </label>
-              <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
-              >
-                <input
-                  aria-describedby="root_b__error root_b__description root_b__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel68"
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
-                  id="root_b"
-                  name="root_b"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  step="any"
-                  type="number"
-                  value=""
-                />
-              </div>
-            </div>
-          </div>
-          <span
-            className="css-75"
-          >
-            a fancier item B description
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <br />
-    <div
-      className="ms-Grid-col ms-sm12"
-    >
-      <button
-        className="ms-Button ms-Button--primary root-66"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        type="submit"
-      >
-        <span
-          className="ms-Button-flexContainer flexContainer-67"
-          data-automationid="splitbuttonprimary"
-        >
-          <span
-            className="ms-Button-textContainer textContainer-68"
-          >
-            <span
-              className="ms-Button-label label-70"
-              id="id__69"
-            >
-              Submit
-            </span>
-          </span>
-        </span>
-      </button>
-    </div>
-  </div>
-</form>
-`;
-
-exports[`object fields with title and description from uiSchema additionalProperties 1`] = `
-<form
-  className="rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
-  >
-    <label
-      className="ms-Label root-74"
-      id="root__title"
-    >
-      My Field
-    </label>
-    <span
-      className="css-75"
-      id="root__description"
-    >
-      a fancier description
-    </span>
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_foo"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
-        >
-          <div
-            className="ms-TextField root-54"
-          >
-            <div
-              className="ms-TextField-wrapper"
-            >
-              <label
-                className="ms-Label root-65"
-                htmlFor="root_foo"
-                id="TextFieldLabel53"
-              >
-                foo
-              </label>
-              <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
-              >
-                <input
-                  aria-describedby="root_foo__error root_foo__description root_foo__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel53"
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
-                  id="root_foo"
-                  name="root_foo"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value="foo"
-                />
-              </div>
-            </div>
-          </div>
-          
-        </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <br />
-    <div
-      className="ms-Grid-col ms-sm12"
-    >
-      <button
-        className="ms-Button ms-Button--primary root-66"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        type="submit"
-      >
-        <span
-          className="ms-Button-flexContainer flexContainer-67"
-          data-automationid="splitbuttonprimary"
-        >
-          <span
-            className="ms-Button-textContainer textContainer-68"
-          >
-            <span
-              className="ms-Button-label label-70"
-              id="id__54"
-            >
-              Submit
-            </span>
-          </span>
-        </span>
-      </button>
-    </div>
-  </div>
-</form>
-`;
-
-exports[`object fields with title and description from uiSchema object 1`] = `
-<form
-  className="rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
-  >
-    <label
-      className="ms-Label root-74"
-      id="root__title"
-    >
-      My Field
-    </label>
-    <span
-      className="css-75"
-      id="root__description"
-    >
-      a fancier description
-    </span>
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_a"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
-        >
-          <div
-            className="ms-TextField root-54"
-          >
-            <div
-              className="ms-TextField-wrapper"
-            >
-              <label
-                className="ms-Label root-65"
-                htmlFor="root_a"
-                id="TextFieldLabel44"
-              >
-                My Item A
-              </label>
-              <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
-              >
-                <input
-                  aria-describedby="root_a__error root_a__description root_a__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel44"
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
-                  id="root_a"
-                  name="root_a"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value=""
-                />
-              </div>
-            </div>
-          </div>
-          <span
-            className="css-75"
-          >
-            a fancier item A description
-          </span>
-        </div>
-        <div
-          className="ms-Grid-col ms-sm12  field field-number"
-          id="root_b"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
-        >
-          <div
-            className="ms-TextField root-54"
-          >
-            <div
-              className="ms-TextField-wrapper"
-            >
-              <label
-                className="ms-Label root-65"
-                htmlFor="root_b"
-                id="TextFieldLabel47"
-              >
-                My Item B
-              </label>
-              <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
-              >
-                <input
-                  aria-describedby="root_b__error root_b__description root_b__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel47"
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
-                  id="root_b"
-                  name="root_b"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  step="any"
-                  type="number"
-                  value=""
-                />
-              </div>
-            </div>
-          </div>
-          <span
-            className="css-75"
-          >
-            a fancier item B description
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <br />
-    <div
-      className="ms-Grid-col ms-sm12"
-    >
-      <button
-        className="ms-Button ms-Button--primary root-66"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        type="submit"
-      >
-        <span
-          className="ms-Button-flexContainer flexContainer-67"
-          data-automationid="splitbuttonprimary"
-        >
-          <span
-            className="ms-Button-textContainer textContainer-68"
-          >
-            <span
-              className="ms-Button-label label-70"
-              id="id__48"
-            >
-              Submit
-            </span>
-          </span>
-        </span>
-      </button>
-    </div>
-  </div>
-</form>
-`;
-
-exports[`object fields with title and description from uiSchema show add button and fields if additionalProperties is true and not an object 1`] = `
-<form
-  className="rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
-  >
-    <label
-      className="ms-Label root-74"
-      id="root__title"
-    >
-      My Field
-    </label>
-    <span
-      className="css-75"
-      id="root__description"
-    >
-      a fancier description
-    </span>
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_additionalProperty"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
-        >
-          <div
-            className="ms-TextField root-54"
-          >
-            <div
-              className="ms-TextField-wrapper"
-            >
-              <label
-                className="ms-Label root-65"
-                htmlFor="root_additionalProperty"
-                id="TextFieldLabel59"
-              >
-                additionalProperty
-              </label>
-              <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
-              >
-                <input
-                  aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel59"
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
-                  id="root_additionalProperty"
-                  name="root_additionalProperty"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value="should appear"
-                />
-              </div>
-            </div>
-          </div>
-          
-        </div>
       </div>
     </div>
   </div>
@@ -1261,377 +965,429 @@ exports[`object fields with title and description from uiSchema show add button 
 </form>
 `;
 
-exports[`object fields with title and description object 1`] = `
+exports[`object fields with title and description from both additionalProperties 1`] = `
 <form
   className="rjsf"
   noValidate={false}
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-object"
   >
-    <label
-      className="ms-Label root-74"
-      id="root__title"
-    >
-      Test field
-    </label>
-    <span
-      className="css-75"
-      id="root__description"
-    >
-      a test description
-    </span>
     <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_a"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
-        >
-          <div
-            className="ms-TextField root-54"
-          >
-            <div
-              className="ms-TextField-wrapper"
-            >
-              <label
-                className="ms-Label root-65"
-                htmlFor="root_a"
-                id="TextFieldLabel23"
-              >
-                A
-              </label>
-              <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
-              >
-                <input
-                  aria-describedby="root_a__error root_a__description root_a__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel23"
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
-                  id="root_a"
-                  name="root_a"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value=""
-                />
-              </div>
-            </div>
-          </div>
-          <span
-            className="css-75"
-          >
-            A description
-          </span>
-        </div>
-        <div
-          className="ms-Grid-col ms-sm12  field field-number"
-          id="root_b"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
-        >
-          <div
-            className="ms-TextField root-54"
-          >
-            <div
-              className="ms-TextField-wrapper"
-            >
-              <label
-                className="ms-Label root-65"
-                htmlFor="root_b"
-                id="TextFieldLabel26"
-              >
-                B
-              </label>
-              <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
-              >
-                <input
-                  aria-describedby="root_b__error root_b__description root_b__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel26"
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
-                  id="root_b"
-                  name="root_b"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  step="any"
-                  type="number"
-                  value=""
-                />
-              </div>
-            </div>
-          </div>
-          <span
-            className="css-75"
-          >
-            B description
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <br />
-    <div
-      className="ms-Grid-col ms-sm12"
-    >
-      <button
-        className="ms-Button ms-Button--primary root-66"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        type="submit"
-      >
-        <span
-          className="ms-Button-flexContainer flexContainer-67"
-          data-automationid="splitbuttonprimary"
-        >
-          <span
-            className="ms-Button-textContainer textContainer-68"
-          >
-            <span
-              className="ms-Button-label label-70"
-              id="id__27"
-            >
-              Submit
-            </span>
-          </span>
-        </span>
-      </button>
-    </div>
-  </div>
-</form>
-`;
-
-exports[`object fields with title and description show add button and fields if additionalProperties is true and not an object 1`] = `
-<form
-  className="rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
       }
-    }
-  >
-    <label
-      className="ms-Label root-74"
-      id="root__title"
     >
-      Test field
-    </label>
-    <span
-      className="css-75"
-      id="root__description"
-    >
-      a test description
-    </span>
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
+      <label
+        className="ms-Label root-81"
+        id="root__title"
+      >
+        My Field
+      </label>
+      <span
+        className="css-82"
+        id="root__description"
+      >
+        a fancier description
+      </span>
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_additionalProperty"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
+          className="ms-Grid-row"
         >
           <div
-            className="ms-TextField root-54"
+            className="ms-Grid form-group field field-string"
+            dir="ltr"
           >
             <div
-              className="ms-TextField-wrapper"
+              className="ms-Grid-row"
             >
-              <label
-                className="ms-Label root-65"
-                htmlFor="root_additionalProperty"
-                id="TextFieldLabel38"
-              >
-                additionalProperty
-              </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
               >
-                <input
-                  aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel38"
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
-                  id="root_additionalProperty"
-                  name="root_additionalProperty"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value="should appear"
-                />
+                <div
+                  className="ms-TextField root-54"
+                >
+                  <div
+                    className="ms-TextField-wrapper"
+                  >
+                    <label
+                      className="ms-Label root-65"
+                      htmlFor="root_foo-key"
+                      id="TextFieldLabel128"
+                    >
+                      foo Key
+                    </label>
+                    <div
+                      className="ms-TextField-fieldGroup fieldGroup-55"
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-labelledby="TextFieldLabel128"
+                        className="ms-TextField-field field-56"
+                        disabled={false}
+                        id="root_foo-key"
+                        name="root_foo-key"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        required={false}
+                        type="text"
+                        value="foo"
+                      />
+                    </div>
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
-          
-        </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <br />
-    <div
-      className="ms-Grid-col ms-sm12"
-    >
-      <button
-        className="ms-Button ms-Button--primary root-66"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        type="submit"
-      >
-        <span
-          className="ms-Button-flexContainer flexContainer-67"
-          data-automationid="splitbuttonprimary"
-        >
-          <span
-            className="ms-Button-textContainer textContainer-68"
-          >
-            <span
-              className="ms-Button-label label-70"
-              id="id__39"
-            >
-              Submit
-            </span>
-          </span>
-        </span>
-      </button>
-    </div>
-  </div>
-</form>
-`;
-
-exports[`object fields with title and description with global label off additionalProperties 1`] = `
-<form
-  className="rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
-  >
-    
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_foo"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
-        >
-          <div
-            className="ms-TextField root-54"
-          >
-            <div
-              className="ms-TextField-wrapper"
-            >
               <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
               >
-                <input
-                  aria-describedby="root_foo__error root_foo__description root_foo__help"
-                  aria-invalid={false}
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
                   id="root_foo"
-                  name="root_foo"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value="foo"
-                />
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField root-54"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-65"
+                        htmlFor="root_foo"
+                        id="TextFieldLabel131"
+                      >
+                        foo
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-55"
+                      >
+                        <input
+                          aria-describedby="root_foo__error root_foo__description root_foo__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel131"
+                          autoFocus={false}
+                          className="ms-TextField-field field-56"
+                          disabled={false}
+                          id="root_foo"
+                          name="root_foo"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={false}
+                          type="text"
+                          value="foo"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  
+                </div>
               </div>
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
+                style={
+                  Object {
+                    "textAlign": "right",
+                  }
+                }
+              >
+                <button
+                  className="ms-Button ms-Button--icon root-74"
+                  data-is-focusable={true}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="ms-Button-flexContainer flexContainer-67"
+                    data-automationid="splitbuttonprimary"
+                  >
+                    <i
+                      aria-hidden={true}
+                      className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
+                      data-icon-name="Delete"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
+                    >
+                      
+                    </i>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <span
+          style={
+            Object {
+              "float": "right",
+            }
+          }
+        >
+          <button
+            className="ms-Button ms-Button--commandBar object-property-expand root-77"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            style={
+              Object {
+                "height": "32px",
+              }
+            }
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-67"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
+                data-icon-name="Add"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+              <span
+                className="ms-Button-textContainer textContainer-68"
+              >
+                <span
+                  className="ms-Button-label label-79"
+                  id="id__135"
+                >
+                  Add Item
+                </span>
+              </span>
+            </span>
+          </button>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div>
+    <br />
+    <div
+      className="ms-Grid-col ms-sm12"
+    >
+      <button
+        className="ms-Button ms-Button--primary root-66"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="submit"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-67"
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className="ms-Button-textContainer textContainer-68"
+          >
+            <span
+              className="ms-Button-label label-70"
+              id="id__138"
+            >
+              Submit
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`object fields with title and description from both object 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-object"
+  >
+    <div
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
+    >
+      <label
+        className="ms-Label root-81"
+        id="root__title"
+      >
+        My Field
+      </label>
+      <span
+        className="css-82"
+        id="root__description"
+      >
+        a fancier description
+      </span>
+      <div
+        className="ms-Grid"
+        dir="ltr"
+      >
+        <div
+          className="ms-Grid-row"
+        >
+          <div
+            className="form-group field field-string"
+          >
+            <div
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_a"
+              style={
+                Object {
+                  "display": undefined,
+                  "marginBottom": 15,
+                }
+              }
+            >
+              <div
+                className="ms-TextField root-54"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_a"
+                    id="TextFieldLabel119"
+                  >
+                    My Item A
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_a__error root_a__description root_a__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel119"
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_a"
+                      name="root_a"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+              <span
+                className="css-82"
+              >
+                a fancier item A description
+              </span>
+            </div>
+          </div>
+          <div
+            className="form-group field field-number"
+          >
+            <div
+              className="ms-Grid-col ms-sm12  field field-number"
+              id="root_b"
+              style={
+                Object {
+                  "display": undefined,
+                  "marginBottom": 15,
+                }
+              }
+            >
+              <div
+                className="ms-TextField root-54"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_b"
+                    id="TextFieldLabel122"
+                  >
+                    My Item B
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_b__error root_b__description root_b__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel122"
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_b"
+                      name="root_b"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      step="any"
+                      type="number"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+              <span
+                className="css-82"
+              >
+                a fancier item B description
+              </span>
             </div>
           </div>
         </div>
@@ -1663,7 +1419,7 @@ exports[`object fields with title and description with global label off addition
           >
             <span
               className="ms-Button-label label-70"
-              id="id__90"
+              id="id__123"
             >
               Submit
             </span>
@@ -1675,110 +1431,429 @@ exports[`object fields with title and description with global label off addition
 </form>
 `;
 
-exports[`object fields with title and description with global label off object 1`] = `
+exports[`object fields with title and description from uiSchema additionalProperties 1`] = `
 <form
   className="rjsf"
   noValidate={false}
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-object"
   >
-    
     <div
-      className="ms-Grid"
-      dir="ltr"
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
+      <label
+        className="ms-Label root-81"
+        id="root__title"
+      >
+        My Field
+      </label>
+      <span
+        className="css-82"
+        id="root__description"
+      >
+        a fancier description
+      </span>
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_a"
-          style={
-            Object {
-              "display": undefined,
-              "marginBottom": 15,
-            }
-          }
+          className="ms-Grid-row"
         >
           <div
-            className="ms-TextField root-54"
+            className="ms-Grid form-group field field-string"
+            dir="ltr"
           >
             <div
-              className="ms-TextField-wrapper"
+              className="ms-Grid-row"
             >
               <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
               >
-                <input
-                  aria-describedby="root_a__error root_a__description root_a__help"
-                  aria-invalid={false}
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
-                  id="root_a"
-                  name="root_a"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value=""
-                />
+                <div
+                  className="ms-TextField root-54"
+                >
+                  <div
+                    className="ms-TextField-wrapper"
+                  >
+                    <label
+                      className="ms-Label root-65"
+                      htmlFor="root_foo-key"
+                      id="TextFieldLabel89"
+                    >
+                      foo Key
+                    </label>
+                    <div
+                      className="ms-TextField-fieldGroup fieldGroup-55"
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-labelledby="TextFieldLabel89"
+                        className="ms-TextField-field field-56"
+                        disabled={false}
+                        id="root_foo-key"
+                        name="root_foo-key"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        required={false}
+                        type="text"
+                        value="foo"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+              >
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_foo"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField root-54"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-65"
+                        htmlFor="root_foo"
+                        id="TextFieldLabel92"
+                      >
+                        foo
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-55"
+                      >
+                        <input
+                          aria-describedby="root_foo__error root_foo__description root_foo__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel92"
+                          autoFocus={false}
+                          className="ms-TextField-field field-56"
+                          disabled={false}
+                          id="root_foo"
+                          name="root_foo"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={false}
+                          type="text"
+                          value="foo"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  
+                </div>
+              </div>
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
+                style={
+                  Object {
+                    "textAlign": "right",
+                  }
+                }
+              >
+                <button
+                  className="ms-Button ms-Button--icon root-74"
+                  data-is-focusable={true}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="ms-Button-flexContainer flexContainer-67"
+                    data-automationid="splitbuttonprimary"
+                  >
+                    <i
+                      aria-hidden={true}
+                      className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
+                      data-icon-name="Delete"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
+                    >
+                      
+                    </i>
+                  </span>
+                </button>
               </div>
             </div>
           </div>
         </div>
-        <div
-          className="ms-Grid-col ms-sm12  field field-number"
-          id="root_b"
+        <span
           style={
             Object {
-              "display": undefined,
-              "marginBottom": 15,
+              "float": "right",
             }
           }
         >
+          <button
+            className="ms-Button ms-Button--commandBar object-property-expand root-77"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            style={
+              Object {
+                "height": "32px",
+              }
+            }
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-67"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
+                data-icon-name="Add"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+              <span
+                className="ms-Button-textContainer textContainer-68"
+              >
+                <span
+                  className="ms-Button-label label-79"
+                  id="id__96"
+                >
+                  Add Item
+                </span>
+              </span>
+            </span>
+          </button>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div>
+    <br />
+    <div
+      className="ms-Grid-col ms-sm12"
+    >
+      <button
+        className="ms-Button ms-Button--primary root-66"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="submit"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-67"
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className="ms-Button-textContainer textContainer-68"
+          >
+            <span
+              className="ms-Button-label label-70"
+              id="id__99"
+            >
+              Submit
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`object fields with title and description from uiSchema object 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-object"
+  >
+    <div
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
+    >
+      <label
+        className="ms-Label root-81"
+        id="root__title"
+      >
+        My Field
+      </label>
+      <span
+        className="css-82"
+        id="root__description"
+      >
+        a fancier description
+      </span>
+      <div
+        className="ms-Grid"
+        dir="ltr"
+      >
+        <div
+          className="ms-Grid-row"
+        >
           <div
-            className="ms-TextField root-54"
+            className="form-group field field-string"
           >
             <div
-              className="ms-TextField-wrapper"
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_a"
+              style={
+                Object {
+                  "display": undefined,
+                  "marginBottom": 15,
+                }
+              }
             >
               <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
+                className="ms-TextField root-54"
               >
-                <input
-                  aria-describedby="root_b__error root_b__description root_b__help"
-                  aria-invalid={false}
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
-                  id="root_b"
-                  name="root_b"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  step="any"
-                  type="number"
-                  value=""
-                />
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_a"
+                    id="TextFieldLabel80"
+                  >
+                    My Item A
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_a__error root_a__description root_a__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel80"
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_a"
+                      name="root_a"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
               </div>
+              <span
+                className="css-82"
+              >
+                a fancier item A description
+              </span>
+            </div>
+          </div>
+          <div
+            className="form-group field field-number"
+          >
+            <div
+              className="ms-Grid-col ms-sm12  field field-number"
+              id="root_b"
+              style={
+                Object {
+                  "display": undefined,
+                  "marginBottom": 15,
+                }
+              }
+            >
+              <div
+                className="ms-TextField root-54"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_b"
+                    id="TextFieldLabel83"
+                  >
+                    My Item B
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_b__error root_b__description root_b__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel83"
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_b"
+                      name="root_b"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      step="any"
+                      type="number"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+              <span
+                className="css-82"
+              >
+                a fancier item B description
+              </span>
             </div>
           </div>
         </div>
@@ -1822,67 +1897,1107 @@ exports[`object fields with title and description with global label off object 1
 </form>
 `;
 
-exports[`object fields with title and description with global label off show add button and fields if additionalProperties is true and not an object 1`] = `
+exports[`object fields with title and description from uiSchema show add button and fields if additionalProperties is true and not an object 1`] = `
 <form
   className="rjsf"
   noValidate={false}
   onSubmit={[Function]}
 >
   <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    id="root"
-    style={
-      Object {
-        "display": undefined,
-        "marginBottom": 15,
-      }
-    }
+    className="form-group field field-object"
   >
-    
     <div
-      className="ms-Grid"
-      dir="ltr"
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
     >
+      <label
+        className="ms-Label root-81"
+        id="root__title"
+      >
+        My Field
+      </label>
+      <span
+        className="css-82"
+        id="root__description"
+      >
+        a fancier description
+      </span>
       <div
-        className="ms-Grid-row"
+        className="ms-Grid"
+        dir="ltr"
       >
         <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          id="root_additionalProperty"
+          className="ms-Grid-row"
+        >
+          <div
+            className="ms-Grid form-group field field-string"
+            dir="ltr"
+          >
+            <div
+              className="ms-Grid-row"
+            >
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+              >
+                <div
+                  className="ms-TextField root-54"
+                >
+                  <div
+                    className="ms-TextField-wrapper"
+                  >
+                    <label
+                      className="ms-Label root-65"
+                      htmlFor="root_additionalProperty-key"
+                      id="TextFieldLabel104"
+                    >
+                      additionalProperty Key
+                    </label>
+                    <div
+                      className="ms-TextField-fieldGroup fieldGroup-55"
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-labelledby="TextFieldLabel104"
+                        className="ms-TextField-field field-56"
+                        disabled={false}
+                        id="root_additionalProperty-key"
+                        name="root_additionalProperty-key"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        required={false}
+                        type="text"
+                        value="additionalProperty"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+              >
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_additionalProperty"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField root-54"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-65"
+                        htmlFor="root_additionalProperty"
+                        id="TextFieldLabel107"
+                      >
+                        additionalProperty
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-55"
+                      >
+                        <input
+                          aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel107"
+                          autoFocus={false}
+                          className="ms-TextField-field field-56"
+                          disabled={false}
+                          id="root_additionalProperty"
+                          name="root_additionalProperty"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={false}
+                          type="text"
+                          value="should appear"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  
+                </div>
+              </div>
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
+                style={
+                  Object {
+                    "textAlign": "right",
+                  }
+                }
+              >
+                <button
+                  className="ms-Button ms-Button--icon root-74"
+                  data-is-focusable={true}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="ms-Button-flexContainer flexContainer-67"
+                    data-automationid="splitbuttonprimary"
+                  >
+                    <i
+                      aria-hidden={true}
+                      className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
+                      data-icon-name="Delete"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
+                    >
+                      
+                    </i>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <span
           style={
             Object {
-              "display": undefined,
-              "marginBottom": 15,
+              "float": "right",
             }
           }
         >
+          <button
+            className="ms-Button ms-Button--commandBar object-property-expand root-77"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            style={
+              Object {
+                "height": "32px",
+              }
+            }
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-67"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
+                data-icon-name="Add"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+              <span
+                className="ms-Button-textContainer textContainer-68"
+              >
+                <span
+                  className="ms-Button-label label-79"
+                  id="id__111"
+                >
+                  Add Item
+                </span>
+              </span>
+            </span>
+          </button>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div>
+    <br />
+    <div
+      className="ms-Grid-col ms-sm12"
+    >
+      <button
+        className="ms-Button ms-Button--primary root-66"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="submit"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-67"
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className="ms-Button-textContainer textContainer-68"
+          >
+            <span
+              className="ms-Button-label label-70"
+              id="id__114"
+            >
+              Submit
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`object fields with title and description object 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-object"
+  >
+    <div
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
+    >
+      <label
+        className="ms-Label root-81"
+        id="root__title"
+      >
+        Test field
+      </label>
+      <span
+        className="css-82"
+        id="root__description"
+      >
+        a test description
+      </span>
+      <div
+        className="ms-Grid"
+        dir="ltr"
+      >
+        <div
+          className="ms-Grid-row"
+        >
           <div
-            className="ms-TextField root-54"
+            className="form-group field field-string"
           >
             <div
-              className="ms-TextField-wrapper"
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_a"
+              style={
+                Object {
+                  "display": undefined,
+                  "marginBottom": 15,
+                }
+              }
             >
               <div
-                className="ms-TextField-fieldGroup fieldGroup-55"
+                className="ms-TextField root-54"
               >
-                <input
-                  aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
-                  aria-invalid={false}
-                  autoFocus={false}
-                  className="ms-TextField-field field-56"
-                  disabled={false}
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_a"
+                    id="TextFieldLabel41"
+                  >
+                    A
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_a__error root_a__description root_a__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel41"
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_a"
+                      name="root_a"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+              <span
+                className="css-82"
+              >
+                A description
+              </span>
+            </div>
+          </div>
+          <div
+            className="form-group field field-number"
+          >
+            <div
+              className="ms-Grid-col ms-sm12  field field-number"
+              id="root_b"
+              style={
+                Object {
+                  "display": undefined,
+                  "marginBottom": 15,
+                }
+              }
+            >
+              <div
+                className="ms-TextField root-54"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_b"
+                    id="TextFieldLabel44"
+                  >
+                    B
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_b__error root_b__description root_b__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel44"
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_b"
+                      name="root_b"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      step="any"
+                      type="number"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+              <span
+                className="css-82"
+              >
+                B description
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <br />
+    <div
+      className="ms-Grid-col ms-sm12"
+    >
+      <button
+        className="ms-Button ms-Button--primary root-66"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="submit"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-67"
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className="ms-Button-textContainer textContainer-68"
+          >
+            <span
+              className="ms-Button-label label-70"
+              id="id__45"
+            >
+              Submit
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`object fields with title and description show add button and fields if additionalProperties is true and not an object 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-object"
+  >
+    <div
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
+    >
+      <label
+        className="ms-Label root-81"
+        id="root__title"
+      >
+        Test field
+      </label>
+      <span
+        className="css-82"
+        id="root__description"
+      >
+        a test description
+      </span>
+      <div
+        className="ms-Grid"
+        dir="ltr"
+      >
+        <div
+          className="ms-Grid-row"
+        >
+          <div
+            className="ms-Grid form-group field field-string"
+            dir="ltr"
+          >
+            <div
+              className="ms-Grid-row"
+            >
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+              >
+                <div
+                  className="ms-TextField root-54"
+                >
+                  <div
+                    className="ms-TextField-wrapper"
+                  >
+                    <label
+                      className="ms-Label root-65"
+                      htmlFor="root_additionalProperty-key"
+                      id="TextFieldLabel65"
+                    >
+                      additionalProperty Key
+                    </label>
+                    <div
+                      className="ms-TextField-fieldGroup fieldGroup-55"
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-labelledby="TextFieldLabel65"
+                        className="ms-TextField-field field-56"
+                        disabled={false}
+                        id="root_additionalProperty-key"
+                        name="root_additionalProperty-key"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        required={false}
+                        type="text"
+                        value="additionalProperty"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+              >
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
                   id="root_additionalProperty"
-                  name="root_additionalProperty"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value="should appear"
-                />
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField root-54"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <label
+                        className="ms-Label root-65"
+                        htmlFor="root_additionalProperty"
+                        id="TextFieldLabel68"
+                      >
+                        additionalProperty
+                      </label>
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-55"
+                      >
+                        <input
+                          aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
+                          aria-invalid={false}
+                          aria-labelledby="TextFieldLabel68"
+                          autoFocus={false}
+                          className="ms-TextField-field field-56"
+                          disabled={false}
+                          id="root_additionalProperty"
+                          name="root_additionalProperty"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={false}
+                          type="text"
+                          value="should appear"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                  
+                </div>
+              </div>
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
+                style={
+                  Object {
+                    "textAlign": "right",
+                  }
+                }
+              >
+                <button
+                  className="ms-Button ms-Button--icon root-74"
+                  data-is-focusable={true}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="ms-Button-flexContainer flexContainer-67"
+                    data-automationid="splitbuttonprimary"
+                  >
+                    <i
+                      aria-hidden={true}
+                      className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
+                      data-icon-name="Delete"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
+                    >
+                      
+                    </i>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <span
+          style={
+            Object {
+              "float": "right",
+            }
+          }
+        >
+          <button
+            className="ms-Button ms-Button--commandBar object-property-expand root-77"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            style={
+              Object {
+                "height": "32px",
+              }
+            }
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-67"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
+                data-icon-name="Add"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+              <span
+                className="ms-Button-textContainer textContainer-68"
+              >
+                <span
+                  className="ms-Button-label label-79"
+                  id="id__72"
+                >
+                  Add Item
+                </span>
+              </span>
+            </span>
+          </button>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div>
+    <br />
+    <div
+      className="ms-Grid-col ms-sm12"
+    >
+      <button
+        className="ms-Button ms-Button--primary root-66"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="submit"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-67"
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className="ms-Button-textContainer textContainer-68"
+          >
+            <span
+              className="ms-Button-label label-70"
+              id="id__75"
+            >
+              Submit
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`object fields with title and description with global label off additionalProperties 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-object"
+  >
+    <div
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
+    >
+      
+      <div
+        className="ms-Grid"
+        dir="ltr"
+      >
+        <div
+          className="ms-Grid-row"
+        >
+          <div
+            className="ms-Grid form-group field field-string"
+            dir="ltr"
+          >
+            <div
+              className="ms-Grid-row"
+            >
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+              >
+                <div
+                  className="ms-TextField root-54"
+                >
+                  <div
+                    className="ms-TextField-wrapper"
+                  >
+                    <label
+                      className="ms-Label root-65"
+                      htmlFor="root_foo-key"
+                      id="TextFieldLabel152"
+                    >
+                      foo Key
+                    </label>
+                    <div
+                      className="ms-TextField-fieldGroup fieldGroup-55"
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-labelledby="TextFieldLabel152"
+                        className="ms-TextField-field field-56"
+                        disabled={false}
+                        id="root_foo-key"
+                        name="root_foo-key"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        required={false}
+                        type="text"
+                        value="foo"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+              >
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_foo"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField root-54"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-55"
+                      >
+                        <input
+                          aria-describedby="root_foo__error root_foo__description root_foo__help"
+                          aria-invalid={false}
+                          autoFocus={false}
+                          className="ms-TextField-field field-56"
+                          disabled={false}
+                          id="root_foo"
+                          name="root_foo"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={false}
+                          type="text"
+                          value="foo"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
+                style={
+                  Object {
+                    "textAlign": "right",
+                  }
+                }
+              >
+                <button
+                  className="ms-Button ms-Button--icon root-74"
+                  data-is-focusable={true}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="ms-Button-flexContainer flexContainer-67"
+                    data-automationid="splitbuttonprimary"
+                  >
+                    <i
+                      aria-hidden={true}
+                      className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
+                      data-icon-name="Delete"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
+                    >
+                      
+                    </i>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <span
+          style={
+            Object {
+              "float": "right",
+            }
+          }
+        >
+          <button
+            className="ms-Button ms-Button--commandBar object-property-expand root-77"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            style={
+              Object {
+                "height": "32px",
+              }
+            }
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-67"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
+                data-icon-name="Add"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+              <span
+                className="ms-Button-textContainer textContainer-68"
+              >
+                <span
+                  className="ms-Button-label label-79"
+                  id="id__159"
+                >
+                  Add Item
+                </span>
+              </span>
+            </span>
+          </button>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div>
+    <br />
+    <div
+      className="ms-Grid-col ms-sm12"
+    >
+      <button
+        className="ms-Button ms-Button--primary root-66"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="submit"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-67"
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className="ms-Button-textContainer textContainer-68"
+          >
+            <span
+              className="ms-Button-label label-70"
+              id="id__162"
+            >
+              Submit
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`object fields with title and description with global label off object 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-object"
+  >
+    <div
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
+    >
+      
+      <div
+        className="ms-Grid"
+        dir="ltr"
+      >
+        <div
+          className="ms-Grid-row"
+        >
+          <div
+            className="form-group field field-string"
+          >
+            <div
+              className="ms-Grid-col ms-sm12  field field-string"
+              id="root_a"
+              style={
+                Object {
+                  "display": undefined,
+                  "marginBottom": 15,
+                }
+              }
+            >
+              <div
+                className="ms-TextField root-54"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_a__error root_a__description root_a__help"
+                      aria-invalid={false}
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_a"
+                      name="root_a"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            className="form-group field field-number"
+          >
+            <div
+              className="ms-Grid-col ms-sm12  field field-number"
+              id="root_b"
+              style={
+                Object {
+                  "display": undefined,
+                  "marginBottom": 15,
+                }
+              }
+            >
+              <div
+                className="ms-TextField root-54"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_b__error root_b__description root_b__help"
+                      aria-invalid={false}
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_b"
+                      name="root_b"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      step="any"
+                      type="number"
+                      value=""
+                    />
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -1915,7 +3030,257 @@ exports[`object fields with title and description with global label off show add
           >
             <span
               className="ms-Button-label label-70"
-              id="id__96"
+              id="id__147"
+            >
+              Submit
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`object fields with title and description with global label off show add button and fields if additionalProperties is true and not an object 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-object"
+  >
+    <div
+      className="ms-Grid-col ms-sm12  field field-object"
+      id="root"
+      style={
+        Object {
+          "display": undefined,
+          "marginBottom": 15,
+        }
+      }
+    >
+      
+      <div
+        className="ms-Grid"
+        dir="ltr"
+      >
+        <div
+          className="ms-Grid-row"
+        >
+          <div
+            className="ms-Grid form-group field field-string"
+            dir="ltr"
+          >
+            <div
+              className="ms-Grid-row"
+            >
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+              >
+                <div
+                  className="ms-TextField root-54"
+                >
+                  <div
+                    className="ms-TextField-wrapper"
+                  >
+                    <label
+                      className="ms-Label root-65"
+                      htmlFor="root_additionalProperty-key"
+                      id="TextFieldLabel167"
+                    >
+                      additionalProperty Key
+                    </label>
+                    <div
+                      className="ms-TextField-fieldGroup fieldGroup-55"
+                    >
+                      <input
+                        aria-invalid={false}
+                        aria-labelledby="TextFieldLabel167"
+                        className="ms-TextField-field field-56"
+                        disabled={false}
+                        id="root_additionalProperty-key"
+                        name="root_additionalProperty-key"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        required={false}
+                        type="text"
+                        value="additionalProperty"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+              >
+                <div
+                  className="ms-Grid-col ms-sm12  field field-string"
+                  id="root_additionalProperty"
+                  style={
+                    Object {
+                      "display": undefined,
+                      "marginBottom": 15,
+                    }
+                  }
+                >
+                  <div
+                    className="ms-TextField root-54"
+                  >
+                    <div
+                      className="ms-TextField-wrapper"
+                    >
+                      <div
+                        className="ms-TextField-fieldGroup fieldGroup-55"
+                      >
+                        <input
+                          aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
+                          aria-invalid={false}
+                          autoFocus={false}
+                          className="ms-TextField-field field-56"
+                          disabled={false}
+                          id="root_additionalProperty"
+                          name="root_additionalProperty"
+                          onBlur={[Function]}
+                          onChange={[Function]}
+                          onFocus={[Function]}
+                          onInput={[Function]}
+                          placeholder=""
+                          readOnly={false}
+                          required={false}
+                          type="text"
+                          value="should appear"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
+                style={
+                  Object {
+                    "textAlign": "right",
+                  }
+                }
+              >
+                <button
+                  className="ms-Button ms-Button--icon root-74"
+                  data-is-focusable={true}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  type="button"
+                >
+                  <span
+                    className="ms-Button-flexContainer flexContainer-67"
+                    data-automationid="splitbuttonprimary"
+                  >
+                    <i
+                      aria-hidden={true}
+                      className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
+                      data-icon-name="Delete"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
+                    >
+                      
+                    </i>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <span
+          style={
+            Object {
+              "float": "right",
+            }
+          }
+        >
+          <button
+            className="ms-Button ms-Button--commandBar object-property-expand root-77"
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            style={
+              Object {
+                "height": "32px",
+              }
+            }
+            type="button"
+          >
+            <span
+              className="ms-Button-flexContainer flexContainer-67"
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
+                data-icon-name="Add"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
+              >
+                
+              </i>
+              <span
+                className="ms-Button-textContainer textContainer-68"
+              >
+                <span
+                  className="ms-Button-label label-79"
+                  id="id__174"
+                >
+                  Add Item
+                </span>
+              </span>
+            </span>
+          </button>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div>
+    <br />
+    <div
+      className="ms-Grid-col ms-sm12"
+    >
+      <button
+        className="ms-Button ms-Button--primary root-66"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="submit"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-67"
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className="ms-Button-textContainer textContainer-68"
+          >
+            <span
+              className="ms-Button-label label-70"
+              id="id__177"
             >
               Submit
             </span>

--- a/packages/fluent-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Object.test.tsx.snap
@@ -7,219 +7,208 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    
+    <div
+      className="ms-Grid"
+      dir="ltr"
     >
-      
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
-        >
-          <div
-            className="ms-Grid form-group field field-string"
-            dir="ltr"
-          >
-            <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
-              >
-                <div
-                  className="ms-TextField root-54"
-                >
-                  <div
-                    className="ms-TextField-wrapper"
-                  >
-                    <label
-                      className="ms-Label root-65"
-                      htmlFor="root_foo-key"
-                      id="TextFieldLabel11"
-                    >
-                      foo Key
-                    </label>
-                    <div
-                      className="ms-TextField-fieldGroup fieldGroup-55"
-                    >
-                      <input
-                        aria-invalid={false}
-                        aria-labelledby="TextFieldLabel11"
-                        className="ms-TextField-field field-56"
-                        disabled={false}
-                        id="root_foo-key"
-                        name="root_foo-key"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        onInput={[Function]}
-                        required={false}
-                        type="text"
-                        value="foo"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_foo"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField root-54"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-65"
-                        htmlFor="root_foo"
-                        id="TextFieldLabel14"
-                      >
-                        foo
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-55"
-                      >
-                        <input
-                          aria-describedby="root_foo__error root_foo__description root_foo__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel14"
-                          autoFocus={false}
-                          className="ms-TextField-field field-56"
-                          disabled={false}
-                          id="root_foo"
-                          name="root_foo"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={false}
-                          type="text"
-                          value="foo"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  
-                </div>
-              </div>
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
-                style={
-                  Object {
-                    "textAlign": "right",
-                  }
-                }
-              >
-                <button
-                  className="ms-Button ms-Button--icon root-74"
-                  data-is-focusable={true}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyPress={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  type="button"
-                >
-                  <span
-                    className="ms-Button-flexContainer flexContainer-67"
-                    data-automationid="splitbuttonprimary"
-                  >
-                    <i
-                      aria-hidden={true}
-                      className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
-                      data-icon-name="Delete"
-                      style={
-                        Object {
-                          "fontFamily": "\\"FabricMDL2Icons\\"",
-                        }
-                      }
-                    >
-                      
-                    </i>
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-        <span
+          className="ms-Grid-col ms-sm12  field field-string"
+          dir="ltr"
           style={
             Object {
-              "float": "right",
+              "marginBottom": 15,
             }
           }
         >
-          <button
-            className="ms-Button ms-Button--commandBar object-property-expand root-77"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            style={
-              Object {
-                "height": "32px",
-              }
-            }
-            type="button"
+          <div
+            className="ms-Grid-row"
           >
-            <span
-              className="ms-Button-flexContainer flexContainer-67"
-              data-automationid="splitbuttonprimary"
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
-                data-icon-name="Add"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
+              <div
+                className="ms-TextField root-54"
               >
-                
-              </i>
-              <span
-                className="ms-Button-textContainer textContainer-68"
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_foo-key"
+                    id="TextFieldLabel11"
+                  >
+                    foo Key
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel11"
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_foo-key"
+                      name="root_foo-key"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      required={false}
+                      type="text"
+                      value="foo"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+            >
+              <div
+                className="ms-TextField root-54"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_foo"
+                    id="TextFieldLabel14"
+                  >
+                    foo
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_foo__error root_foo__description root_foo__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel14"
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_foo"
+                      name="root_foo"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value="foo"
+                    />
+                  </div>
+                </div>
+              </div>
+              
+            </div>
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
+              style={
+                Object {
+                  "textAlign": "right",
+                }
+              }
+            >
+              <button
+                className="ms-Button ms-Button--icon root-74"
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                type="button"
               >
                 <span
-                  className="ms-Button-label label-79"
-                  id="id__18"
+                  className="ms-Button-flexContainer flexContainer-67"
+                  data-automationid="splitbuttonprimary"
                 >
-                  Add Item
+                  <i
+                    aria-hidden={true}
+                    className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
+                    data-icon-name="Delete"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
                 </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <span
+        style={
+          Object {
+            "float": "right",
+          }
+        }
+      >
+        <button
+          className="ms-Button ms-Button--commandBar object-property-expand root-77"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
+            }
+          }
+          type="button"
+        >
+          <span
+            className="ms-Button-flexContainer flexContainer-67"
+            data-automationid="splitbuttonprimary"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
+            >
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-68"
+            >
+              <span
+                className="ms-Button-label label-79"
+                id="id__18"
+              >
+                Add Item
               </span>
             </span>
-          </button>
-        </span>
-      </div>
+          </span>
+        </button>
+      </span>
     </div>
   </div>
   <div>
@@ -266,135 +255,120 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    
+    <div
+      className="ms-Grid"
+      dir="ltr"
     >
-      
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm12  field field-string"
+          id="root_a"
+          style={
+            Object {
+              "marginBottom": 15,
+            }
+          }
         >
           <div
-            className="form-group field field-string"
+            className="ms-TextField root-54"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_a"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-TextField-wrapper"
             >
-              <div
-                className="ms-TextField root-54"
+              <label
+                className="ms-Label root-65"
+                htmlFor="root_a"
+                id="TextFieldLabel2"
               >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-65"
-                    htmlFor="root_a"
-                    id="TextFieldLabel2"
-                  >
-                    A
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-55"
-                  >
-                    <input
-                      aria-describedby="root_a__error root_a__description root_a__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel2"
-                      autoFocus={false}
-                      className="ms-TextField-field field-56"
-                      disabled={false}
-                      id="root_a"
-                      name="root_a"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={false}
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
+                A
+              </label>
+              <div
+                className="ms-TextField-fieldGroup fieldGroup-55"
+              >
+                <input
+                  aria-describedby="root_a__error root_a__description root_a__help"
+                  aria-invalid={false}
+                  aria-labelledby="TextFieldLabel2"
+                  autoFocus={false}
+                  className="ms-TextField-field field-56"
+                  disabled={false}
+                  id="root_a"
+                  name="root_a"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
               </div>
-              
             </div>
           </div>
+          
+        </div>
+        <div
+          className="ms-Grid-col ms-sm12  field field-number"
+          id="root_b"
+          style={
+            Object {
+              "marginBottom": 15,
+            }
+          }
+        >
           <div
-            className="form-group field field-number"
+            className="ms-TextField root-54"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-number"
-              id="root_b"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-TextField-wrapper"
             >
-              <div
-                className="ms-TextField root-54"
+              <label
+                className="ms-Label root-65"
+                htmlFor="root_b"
+                id="TextFieldLabel5"
               >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-65"
-                    htmlFor="root_b"
-                    id="TextFieldLabel5"
-                  >
-                    B
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-55"
-                  >
-                    <input
-                      aria-describedby="root_b__error root_b__description root_b__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel5"
-                      autoFocus={false}
-                      className="ms-TextField-field field-56"
-                      disabled={false}
-                      id="root_b"
-                      name="root_b"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={false}
-                      step="any"
-                      type="number"
-                      value=""
-                    />
-                  </div>
-                </div>
+                B
+              </label>
+              <div
+                className="ms-TextField-fieldGroup fieldGroup-55"
+              >
+                <input
+                  aria-describedby="root_b__error root_b__description root_b__help"
+                  aria-invalid={false}
+                  aria-labelledby="TextFieldLabel5"
+                  autoFocus={false}
+                  className="ms-TextField-field field-56"
+                  disabled={false}
+                  id="root_b"
+                  name="root_b"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  step="any"
+                  type="number"
+                  value=""
+                />
               </div>
-              
             </div>
           </div>
+          
         </div>
       </div>
     </div>
@@ -443,219 +417,208 @@ exports[`object fields show add button and fields if additionalProperties is tru
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    
+    <div
+      className="ms-Grid"
+      dir="ltr"
     >
-      
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
-        >
-          <div
-            className="ms-Grid form-group field field-string"
-            dir="ltr"
-          >
-            <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
-              >
-                <div
-                  className="ms-TextField root-54"
-                >
-                  <div
-                    className="ms-TextField-wrapper"
-                  >
-                    <label
-                      className="ms-Label root-65"
-                      htmlFor="root_additionalProperty-key"
-                      id="TextFieldLabel26"
-                    >
-                      additionalProperty Key
-                    </label>
-                    <div
-                      className="ms-TextField-fieldGroup fieldGroup-55"
-                    >
-                      <input
-                        aria-invalid={false}
-                        aria-labelledby="TextFieldLabel26"
-                        className="ms-TextField-field field-56"
-                        disabled={false}
-                        id="root_additionalProperty-key"
-                        name="root_additionalProperty-key"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        onInput={[Function]}
-                        required={false}
-                        type="text"
-                        value="additionalProperty"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_additionalProperty"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField root-54"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-65"
-                        htmlFor="root_additionalProperty"
-                        id="TextFieldLabel29"
-                      >
-                        additionalProperty
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-55"
-                      >
-                        <input
-                          aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel29"
-                          autoFocus={false}
-                          className="ms-TextField-field field-56"
-                          disabled={false}
-                          id="root_additionalProperty"
-                          name="root_additionalProperty"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={false}
-                          type="text"
-                          value="should appear"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  
-                </div>
-              </div>
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
-                style={
-                  Object {
-                    "textAlign": "right",
-                  }
-                }
-              >
-                <button
-                  className="ms-Button ms-Button--icon root-74"
-                  data-is-focusable={true}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyPress={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  type="button"
-                >
-                  <span
-                    className="ms-Button-flexContainer flexContainer-67"
-                    data-automationid="splitbuttonprimary"
-                  >
-                    <i
-                      aria-hidden={true}
-                      className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
-                      data-icon-name="Delete"
-                      style={
-                        Object {
-                          "fontFamily": "\\"FabricMDL2Icons\\"",
-                        }
-                      }
-                    >
-                      
-                    </i>
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-        <span
+          className="ms-Grid-col ms-sm12  field field-string"
+          dir="ltr"
           style={
             Object {
-              "float": "right",
+              "marginBottom": 15,
             }
           }
         >
-          <button
-            className="ms-Button ms-Button--commandBar object-property-expand root-77"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            style={
-              Object {
-                "height": "32px",
-              }
-            }
-            type="button"
+          <div
+            className="ms-Grid-row"
           >
-            <span
-              className="ms-Button-flexContainer flexContainer-67"
-              data-automationid="splitbuttonprimary"
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
-                data-icon-name="Add"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
+              <div
+                className="ms-TextField root-54"
               >
-                
-              </i>
-              <span
-                className="ms-Button-textContainer textContainer-68"
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_additionalProperty-key"
+                    id="TextFieldLabel26"
+                  >
+                    additionalProperty Key
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel26"
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_additionalProperty-key"
+                      name="root_additionalProperty-key"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      required={false}
+                      type="text"
+                      value="additionalProperty"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+            >
+              <div
+                className="ms-TextField root-54"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_additionalProperty"
+                    id="TextFieldLabel29"
+                  >
+                    additionalProperty
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel29"
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_additionalProperty"
+                      name="root_additionalProperty"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value="should appear"
+                    />
+                  </div>
+                </div>
+              </div>
+              
+            </div>
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
+              style={
+                Object {
+                  "textAlign": "right",
+                }
+              }
+            >
+              <button
+                className="ms-Button ms-Button--icon root-74"
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                type="button"
               >
                 <span
-                  className="ms-Button-label label-79"
-                  id="id__33"
+                  className="ms-Button-flexContainer flexContainer-67"
+                  data-automationid="splitbuttonprimary"
                 >
-                  Add Item
+                  <i
+                    aria-hidden={true}
+                    className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
+                    data-icon-name="Delete"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
                 </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <span
+        style={
+          Object {
+            "float": "right",
+          }
+        }
+      >
+        <button
+          className="ms-Button ms-Button--commandBar object-property-expand root-77"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
+            }
+          }
+          type="button"
+        >
+          <span
+            className="ms-Button-flexContainer flexContainer-67"
+            data-automationid="splitbuttonprimary"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
+            >
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-68"
+            >
+              <span
+                className="ms-Button-label label-79"
+                id="id__33"
+              >
+                Add Item
               </span>
             </span>
-          </button>
-        </span>
-      </div>
+          </span>
+        </button>
+      </span>
     </div>
   </div>
   <div>
@@ -702,230 +665,219 @@ exports[`object fields with title and description additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    <label
+      className="ms-Label root-81"
+      id="root__title"
     >
-      <label
-        className="ms-Label root-81"
-        id="root__title"
-      >
-        Test field
-      </label>
-      <span
-        className="css-82"
-        id="root__description"
-      >
-        a test description
-      </span>
+      Test field
+    </label>
+    <span
+      className="css-82"
+      id="root__description"
+    >
+      a test description
+    </span>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
-        >
-          <div
-            className="ms-Grid form-group field field-string"
-            dir="ltr"
-          >
-            <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
-              >
-                <div
-                  className="ms-TextField root-54"
-                >
-                  <div
-                    className="ms-TextField-wrapper"
-                  >
-                    <label
-                      className="ms-Label root-65"
-                      htmlFor="root_foo-key"
-                      id="TextFieldLabel50"
-                    >
-                      foo Key
-                    </label>
-                    <div
-                      className="ms-TextField-fieldGroup fieldGroup-55"
-                    >
-                      <input
-                        aria-invalid={false}
-                        aria-labelledby="TextFieldLabel50"
-                        className="ms-TextField-field field-56"
-                        disabled={false}
-                        id="root_foo-key"
-                        name="root_foo-key"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        onInput={[Function]}
-                        required={false}
-                        type="text"
-                        value="foo"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_foo"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField root-54"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-65"
-                        htmlFor="root_foo"
-                        id="TextFieldLabel53"
-                      >
-                        foo
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-55"
-                      >
-                        <input
-                          aria-describedby="root_foo__error root_foo__description root_foo__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel53"
-                          autoFocus={false}
-                          className="ms-TextField-field field-56"
-                          disabled={false}
-                          id="root_foo"
-                          name="root_foo"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={false}
-                          type="text"
-                          value="foo"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  
-                </div>
-              </div>
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
-                style={
-                  Object {
-                    "textAlign": "right",
-                  }
-                }
-              >
-                <button
-                  className="ms-Button ms-Button--icon root-74"
-                  data-is-focusable={true}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyPress={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  type="button"
-                >
-                  <span
-                    className="ms-Button-flexContainer flexContainer-67"
-                    data-automationid="splitbuttonprimary"
-                  >
-                    <i
-                      aria-hidden={true}
-                      className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
-                      data-icon-name="Delete"
-                      style={
-                        Object {
-                          "fontFamily": "\\"FabricMDL2Icons\\"",
-                        }
-                      }
-                    >
-                      
-                    </i>
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-        <span
+          className="ms-Grid-col ms-sm12  field field-string"
+          dir="ltr"
           style={
             Object {
-              "float": "right",
+              "marginBottom": 15,
             }
           }
         >
-          <button
-            className="ms-Button ms-Button--commandBar object-property-expand root-77"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            style={
-              Object {
-                "height": "32px",
-              }
-            }
-            type="button"
+          <div
+            className="ms-Grid-row"
           >
-            <span
-              className="ms-Button-flexContainer flexContainer-67"
-              data-automationid="splitbuttonprimary"
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
-                data-icon-name="Add"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
+              <div
+                className="ms-TextField root-54"
               >
-                
-              </i>
-              <span
-                className="ms-Button-textContainer textContainer-68"
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_foo-key"
+                    id="TextFieldLabel50"
+                  >
+                    foo Key
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel50"
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_foo-key"
+                      name="root_foo-key"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      required={false}
+                      type="text"
+                      value="foo"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+            >
+              <div
+                className="ms-TextField root-54"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_foo"
+                    id="TextFieldLabel53"
+                  >
+                    foo
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_foo__error root_foo__description root_foo__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel53"
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_foo"
+                      name="root_foo"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value="foo"
+                    />
+                  </div>
+                </div>
+              </div>
+              
+            </div>
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
+              style={
+                Object {
+                  "textAlign": "right",
+                }
+              }
+            >
+              <button
+                className="ms-Button ms-Button--icon root-74"
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                type="button"
               >
                 <span
-                  className="ms-Button-label label-79"
-                  id="id__57"
+                  className="ms-Button-flexContainer flexContainer-67"
+                  data-automationid="splitbuttonprimary"
                 >
-                  Add Item
+                  <i
+                    aria-hidden={true}
+                    className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
+                    data-icon-name="Delete"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
                 </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <span
+        style={
+          Object {
+            "float": "right",
+          }
+        }
+      >
+        <button
+          className="ms-Button ms-Button--commandBar object-property-expand root-77"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
+            }
+          }
+          type="button"
+        >
+          <span
+            className="ms-Button-flexContainer flexContainer-67"
+            data-automationid="splitbuttonprimary"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
+            >
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-68"
+            >
+              <span
+                className="ms-Button-label label-79"
+                id="id__57"
+              >
+                Add Item
               </span>
             </span>
-          </button>
-        </span>
-      </div>
+          </span>
+        </button>
+      </span>
     </div>
   </div>
   <div>
@@ -972,230 +924,219 @@ exports[`object fields with title and description from both additionalProperties
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    <label
+      className="ms-Label root-81"
+      id="root__title"
     >
-      <label
-        className="ms-Label root-81"
-        id="root__title"
-      >
-        My Field
-      </label>
-      <span
-        className="css-82"
-        id="root__description"
-      >
-        a fancier description
-      </span>
+      My Field
+    </label>
+    <span
+      className="css-82"
+      id="root__description"
+    >
+      a fancier description
+    </span>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
-        >
-          <div
-            className="ms-Grid form-group field field-string"
-            dir="ltr"
-          >
-            <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
-              >
-                <div
-                  className="ms-TextField root-54"
-                >
-                  <div
-                    className="ms-TextField-wrapper"
-                  >
-                    <label
-                      className="ms-Label root-65"
-                      htmlFor="root_foo-key"
-                      id="TextFieldLabel128"
-                    >
-                      foo Key
-                    </label>
-                    <div
-                      className="ms-TextField-fieldGroup fieldGroup-55"
-                    >
-                      <input
-                        aria-invalid={false}
-                        aria-labelledby="TextFieldLabel128"
-                        className="ms-TextField-field field-56"
-                        disabled={false}
-                        id="root_foo-key"
-                        name="root_foo-key"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        onInput={[Function]}
-                        required={false}
-                        type="text"
-                        value="foo"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_foo"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField root-54"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-65"
-                        htmlFor="root_foo"
-                        id="TextFieldLabel131"
-                      >
-                        foo
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-55"
-                      >
-                        <input
-                          aria-describedby="root_foo__error root_foo__description root_foo__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel131"
-                          autoFocus={false}
-                          className="ms-TextField-field field-56"
-                          disabled={false}
-                          id="root_foo"
-                          name="root_foo"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={false}
-                          type="text"
-                          value="foo"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  
-                </div>
-              </div>
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
-                style={
-                  Object {
-                    "textAlign": "right",
-                  }
-                }
-              >
-                <button
-                  className="ms-Button ms-Button--icon root-74"
-                  data-is-focusable={true}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyPress={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  type="button"
-                >
-                  <span
-                    className="ms-Button-flexContainer flexContainer-67"
-                    data-automationid="splitbuttonprimary"
-                  >
-                    <i
-                      aria-hidden={true}
-                      className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
-                      data-icon-name="Delete"
-                      style={
-                        Object {
-                          "fontFamily": "\\"FabricMDL2Icons\\"",
-                        }
-                      }
-                    >
-                      
-                    </i>
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-        <span
+          className="ms-Grid-col ms-sm12  field field-string"
+          dir="ltr"
           style={
             Object {
-              "float": "right",
+              "marginBottom": 15,
             }
           }
         >
-          <button
-            className="ms-Button ms-Button--commandBar object-property-expand root-77"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            style={
-              Object {
-                "height": "32px",
-              }
-            }
-            type="button"
+          <div
+            className="ms-Grid-row"
           >
-            <span
-              className="ms-Button-flexContainer flexContainer-67"
-              data-automationid="splitbuttonprimary"
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
-                data-icon-name="Add"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
+              <div
+                className="ms-TextField root-54"
               >
-                
-              </i>
-              <span
-                className="ms-Button-textContainer textContainer-68"
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_foo-key"
+                    id="TextFieldLabel128"
+                  >
+                    foo Key
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel128"
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_foo-key"
+                      name="root_foo-key"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      required={false}
+                      type="text"
+                      value="foo"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+            >
+              <div
+                className="ms-TextField root-54"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_foo"
+                    id="TextFieldLabel131"
+                  >
+                    foo
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_foo__error root_foo__description root_foo__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel131"
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_foo"
+                      name="root_foo"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value="foo"
+                    />
+                  </div>
+                </div>
+              </div>
+              
+            </div>
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
+              style={
+                Object {
+                  "textAlign": "right",
+                }
+              }
+            >
+              <button
+                className="ms-Button ms-Button--icon root-74"
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                type="button"
               >
                 <span
-                  className="ms-Button-label label-79"
-                  id="id__135"
+                  className="ms-Button-flexContainer flexContainer-67"
+                  data-automationid="splitbuttonprimary"
                 >
-                  Add Item
+                  <i
+                    aria-hidden={true}
+                    className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
+                    data-icon-name="Delete"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
                 </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <span
+        style={
+          Object {
+            "float": "right",
+          }
+        }
+      >
+        <button
+          className="ms-Button ms-Button--commandBar object-property-expand root-77"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
+            }
+          }
+          type="button"
+        >
+          <span
+            className="ms-Button-flexContainer flexContainer-67"
+            data-automationid="splitbuttonprimary"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
+            >
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-68"
+            >
+              <span
+                className="ms-Button-label label-79"
+                id="id__135"
+              >
+                Add Item
               </span>
             </span>
-          </button>
-        </span>
-      </div>
+          </span>
+        </button>
+      </span>
     </div>
   </div>
   <div>
@@ -1242,154 +1183,139 @@ exports[`object fields with title and description from both object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    <label
+      className="ms-Label root-81"
+      id="root__title"
     >
-      <label
-        className="ms-Label root-81"
-        id="root__title"
-      >
-        My Field
-      </label>
-      <span
-        className="css-82"
-        id="root__description"
-      >
-        a fancier description
-      </span>
+      My Field
+    </label>
+    <span
+      className="css-82"
+      id="root__description"
+    >
+      a fancier description
+    </span>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm12  field field-string"
+          id="root_a"
+          style={
+            Object {
+              "marginBottom": 15,
+            }
+          }
         >
           <div
-            className="form-group field field-string"
+            className="ms-TextField root-54"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_a"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-TextField-wrapper"
             >
+              <label
+                className="ms-Label root-65"
+                htmlFor="root_a"
+                id="TextFieldLabel119"
+              >
+                My Item A
+              </label>
               <div
-                className="ms-TextField root-54"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-65"
-                    htmlFor="root_a"
-                    id="TextFieldLabel119"
-                  >
-                    My Item A
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-55"
-                  >
-                    <input
-                      aria-describedby="root_a__error root_a__description root_a__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel119"
-                      autoFocus={false}
-                      className="ms-TextField-field field-56"
-                      disabled={false}
-                      id="root_a"
-                      name="root_a"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={false}
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
+                <input
+                  aria-describedby="root_a__error root_a__description root_a__help"
+                  aria-invalid={false}
+                  aria-labelledby="TextFieldLabel119"
+                  autoFocus={false}
+                  className="ms-TextField-field field-56"
+                  disabled={false}
+                  id="root_a"
+                  name="root_a"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
               </div>
-              <span
-                className="css-82"
-              >
-                a fancier item A description
-              </span>
             </div>
           </div>
+          <span
+            className="css-82"
+          >
+            a fancier item A description
+          </span>
+        </div>
+        <div
+          className="ms-Grid-col ms-sm12  field field-number"
+          id="root_b"
+          style={
+            Object {
+              "marginBottom": 15,
+            }
+          }
+        >
           <div
-            className="form-group field field-number"
+            className="ms-TextField root-54"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-number"
-              id="root_b"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-TextField-wrapper"
             >
+              <label
+                className="ms-Label root-65"
+                htmlFor="root_b"
+                id="TextFieldLabel122"
+              >
+                My Item B
+              </label>
               <div
-                className="ms-TextField root-54"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-65"
-                    htmlFor="root_b"
-                    id="TextFieldLabel122"
-                  >
-                    My Item B
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-55"
-                  >
-                    <input
-                      aria-describedby="root_b__error root_b__description root_b__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel122"
-                      autoFocus={false}
-                      className="ms-TextField-field field-56"
-                      disabled={false}
-                      id="root_b"
-                      name="root_b"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={false}
-                      step="any"
-                      type="number"
-                      value=""
-                    />
-                  </div>
-                </div>
+                <input
+                  aria-describedby="root_b__error root_b__description root_b__help"
+                  aria-invalid={false}
+                  aria-labelledby="TextFieldLabel122"
+                  autoFocus={false}
+                  className="ms-TextField-field field-56"
+                  disabled={false}
+                  id="root_b"
+                  name="root_b"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  step="any"
+                  type="number"
+                  value=""
+                />
               </div>
-              <span
-                className="css-82"
-              >
-                a fancier item B description
-              </span>
             </div>
           </div>
+          <span
+            className="css-82"
+          >
+            a fancier item B description
+          </span>
         </div>
       </div>
     </div>
@@ -1438,230 +1364,219 @@ exports[`object fields with title and description from uiSchema additionalProper
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    <label
+      className="ms-Label root-81"
+      id="root__title"
     >
-      <label
-        className="ms-Label root-81"
-        id="root__title"
-      >
-        My Field
-      </label>
-      <span
-        className="css-82"
-        id="root__description"
-      >
-        a fancier description
-      </span>
+      My Field
+    </label>
+    <span
+      className="css-82"
+      id="root__description"
+    >
+      a fancier description
+    </span>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
-        >
-          <div
-            className="ms-Grid form-group field field-string"
-            dir="ltr"
-          >
-            <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
-              >
-                <div
-                  className="ms-TextField root-54"
-                >
-                  <div
-                    className="ms-TextField-wrapper"
-                  >
-                    <label
-                      className="ms-Label root-65"
-                      htmlFor="root_foo-key"
-                      id="TextFieldLabel89"
-                    >
-                      foo Key
-                    </label>
-                    <div
-                      className="ms-TextField-fieldGroup fieldGroup-55"
-                    >
-                      <input
-                        aria-invalid={false}
-                        aria-labelledby="TextFieldLabel89"
-                        className="ms-TextField-field field-56"
-                        disabled={false}
-                        id="root_foo-key"
-                        name="root_foo-key"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        onInput={[Function]}
-                        required={false}
-                        type="text"
-                        value="foo"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_foo"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField root-54"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-65"
-                        htmlFor="root_foo"
-                        id="TextFieldLabel92"
-                      >
-                        foo
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-55"
-                      >
-                        <input
-                          aria-describedby="root_foo__error root_foo__description root_foo__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel92"
-                          autoFocus={false}
-                          className="ms-TextField-field field-56"
-                          disabled={false}
-                          id="root_foo"
-                          name="root_foo"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={false}
-                          type="text"
-                          value="foo"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  
-                </div>
-              </div>
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
-                style={
-                  Object {
-                    "textAlign": "right",
-                  }
-                }
-              >
-                <button
-                  className="ms-Button ms-Button--icon root-74"
-                  data-is-focusable={true}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyPress={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  type="button"
-                >
-                  <span
-                    className="ms-Button-flexContainer flexContainer-67"
-                    data-automationid="splitbuttonprimary"
-                  >
-                    <i
-                      aria-hidden={true}
-                      className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
-                      data-icon-name="Delete"
-                      style={
-                        Object {
-                          "fontFamily": "\\"FabricMDL2Icons\\"",
-                        }
-                      }
-                    >
-                      
-                    </i>
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-        <span
+          className="ms-Grid-col ms-sm12  field field-string"
+          dir="ltr"
           style={
             Object {
-              "float": "right",
+              "marginBottom": 15,
             }
           }
         >
-          <button
-            className="ms-Button ms-Button--commandBar object-property-expand root-77"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            style={
-              Object {
-                "height": "32px",
-              }
-            }
-            type="button"
+          <div
+            className="ms-Grid-row"
           >
-            <span
-              className="ms-Button-flexContainer flexContainer-67"
-              data-automationid="splitbuttonprimary"
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
-                data-icon-name="Add"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
+              <div
+                className="ms-TextField root-54"
               >
-                
-              </i>
-              <span
-                className="ms-Button-textContainer textContainer-68"
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_foo-key"
+                    id="TextFieldLabel89"
+                  >
+                    foo Key
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel89"
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_foo-key"
+                      name="root_foo-key"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      required={false}
+                      type="text"
+                      value="foo"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+            >
+              <div
+                className="ms-TextField root-54"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_foo"
+                    id="TextFieldLabel92"
+                  >
+                    foo
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_foo__error root_foo__description root_foo__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel92"
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_foo"
+                      name="root_foo"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value="foo"
+                    />
+                  </div>
+                </div>
+              </div>
+              
+            </div>
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
+              style={
+                Object {
+                  "textAlign": "right",
+                }
+              }
+            >
+              <button
+                className="ms-Button ms-Button--icon root-74"
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                type="button"
               >
                 <span
-                  className="ms-Button-label label-79"
-                  id="id__96"
+                  className="ms-Button-flexContainer flexContainer-67"
+                  data-automationid="splitbuttonprimary"
                 >
-                  Add Item
+                  <i
+                    aria-hidden={true}
+                    className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
+                    data-icon-name="Delete"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
                 </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <span
+        style={
+          Object {
+            "float": "right",
+          }
+        }
+      >
+        <button
+          className="ms-Button ms-Button--commandBar object-property-expand root-77"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
+            }
+          }
+          type="button"
+        >
+          <span
+            className="ms-Button-flexContainer flexContainer-67"
+            data-automationid="splitbuttonprimary"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
+            >
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-68"
+            >
+              <span
+                className="ms-Button-label label-79"
+                id="id__96"
+              >
+                Add Item
               </span>
             </span>
-          </button>
-        </span>
-      </div>
+          </span>
+        </button>
+      </span>
     </div>
   </div>
   <div>
@@ -1708,154 +1623,139 @@ exports[`object fields with title and description from uiSchema object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    <label
+      className="ms-Label root-81"
+      id="root__title"
     >
-      <label
-        className="ms-Label root-81"
-        id="root__title"
-      >
-        My Field
-      </label>
-      <span
-        className="css-82"
-        id="root__description"
-      >
-        a fancier description
-      </span>
+      My Field
+    </label>
+    <span
+      className="css-82"
+      id="root__description"
+    >
+      a fancier description
+    </span>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm12  field field-string"
+          id="root_a"
+          style={
+            Object {
+              "marginBottom": 15,
+            }
+          }
         >
           <div
-            className="form-group field field-string"
+            className="ms-TextField root-54"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_a"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-TextField-wrapper"
             >
+              <label
+                className="ms-Label root-65"
+                htmlFor="root_a"
+                id="TextFieldLabel80"
+              >
+                My Item A
+              </label>
               <div
-                className="ms-TextField root-54"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-65"
-                    htmlFor="root_a"
-                    id="TextFieldLabel80"
-                  >
-                    My Item A
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-55"
-                  >
-                    <input
-                      aria-describedby="root_a__error root_a__description root_a__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel80"
-                      autoFocus={false}
-                      className="ms-TextField-field field-56"
-                      disabled={false}
-                      id="root_a"
-                      name="root_a"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={false}
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
+                <input
+                  aria-describedby="root_a__error root_a__description root_a__help"
+                  aria-invalid={false}
+                  aria-labelledby="TextFieldLabel80"
+                  autoFocus={false}
+                  className="ms-TextField-field field-56"
+                  disabled={false}
+                  id="root_a"
+                  name="root_a"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
               </div>
-              <span
-                className="css-82"
-              >
-                a fancier item A description
-              </span>
             </div>
           </div>
+          <span
+            className="css-82"
+          >
+            a fancier item A description
+          </span>
+        </div>
+        <div
+          className="ms-Grid-col ms-sm12  field field-number"
+          id="root_b"
+          style={
+            Object {
+              "marginBottom": 15,
+            }
+          }
+        >
           <div
-            className="form-group field field-number"
+            className="ms-TextField root-54"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-number"
-              id="root_b"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-TextField-wrapper"
             >
+              <label
+                className="ms-Label root-65"
+                htmlFor="root_b"
+                id="TextFieldLabel83"
+              >
+                My Item B
+              </label>
               <div
-                className="ms-TextField root-54"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-65"
-                    htmlFor="root_b"
-                    id="TextFieldLabel83"
-                  >
-                    My Item B
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-55"
-                  >
-                    <input
-                      aria-describedby="root_b__error root_b__description root_b__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel83"
-                      autoFocus={false}
-                      className="ms-TextField-field field-56"
-                      disabled={false}
-                      id="root_b"
-                      name="root_b"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={false}
-                      step="any"
-                      type="number"
-                      value=""
-                    />
-                  </div>
-                </div>
+                <input
+                  aria-describedby="root_b__error root_b__description root_b__help"
+                  aria-invalid={false}
+                  aria-labelledby="TextFieldLabel83"
+                  autoFocus={false}
+                  className="ms-TextField-field field-56"
+                  disabled={false}
+                  id="root_b"
+                  name="root_b"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  step="any"
+                  type="number"
+                  value=""
+                />
               </div>
-              <span
-                className="css-82"
-              >
-                a fancier item B description
-              </span>
             </div>
           </div>
+          <span
+            className="css-82"
+          >
+            a fancier item B description
+          </span>
         </div>
       </div>
     </div>
@@ -1904,230 +1804,219 @@ exports[`object fields with title and description from uiSchema show add button 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    <label
+      className="ms-Label root-81"
+      id="root__title"
     >
-      <label
-        className="ms-Label root-81"
-        id="root__title"
-      >
-        My Field
-      </label>
-      <span
-        className="css-82"
-        id="root__description"
-      >
-        a fancier description
-      </span>
+      My Field
+    </label>
+    <span
+      className="css-82"
+      id="root__description"
+    >
+      a fancier description
+    </span>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
-        >
-          <div
-            className="ms-Grid form-group field field-string"
-            dir="ltr"
-          >
-            <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
-              >
-                <div
-                  className="ms-TextField root-54"
-                >
-                  <div
-                    className="ms-TextField-wrapper"
-                  >
-                    <label
-                      className="ms-Label root-65"
-                      htmlFor="root_additionalProperty-key"
-                      id="TextFieldLabel104"
-                    >
-                      additionalProperty Key
-                    </label>
-                    <div
-                      className="ms-TextField-fieldGroup fieldGroup-55"
-                    >
-                      <input
-                        aria-invalid={false}
-                        aria-labelledby="TextFieldLabel104"
-                        className="ms-TextField-field field-56"
-                        disabled={false}
-                        id="root_additionalProperty-key"
-                        name="root_additionalProperty-key"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        onInput={[Function]}
-                        required={false}
-                        type="text"
-                        value="additionalProperty"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_additionalProperty"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField root-54"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-65"
-                        htmlFor="root_additionalProperty"
-                        id="TextFieldLabel107"
-                      >
-                        additionalProperty
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-55"
-                      >
-                        <input
-                          aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel107"
-                          autoFocus={false}
-                          className="ms-TextField-field field-56"
-                          disabled={false}
-                          id="root_additionalProperty"
-                          name="root_additionalProperty"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={false}
-                          type="text"
-                          value="should appear"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  
-                </div>
-              </div>
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
-                style={
-                  Object {
-                    "textAlign": "right",
-                  }
-                }
-              >
-                <button
-                  className="ms-Button ms-Button--icon root-74"
-                  data-is-focusable={true}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyPress={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  type="button"
-                >
-                  <span
-                    className="ms-Button-flexContainer flexContainer-67"
-                    data-automationid="splitbuttonprimary"
-                  >
-                    <i
-                      aria-hidden={true}
-                      className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
-                      data-icon-name="Delete"
-                      style={
-                        Object {
-                          "fontFamily": "\\"FabricMDL2Icons\\"",
-                        }
-                      }
-                    >
-                      
-                    </i>
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-        <span
+          className="ms-Grid-col ms-sm12  field field-string"
+          dir="ltr"
           style={
             Object {
-              "float": "right",
+              "marginBottom": 15,
             }
           }
         >
-          <button
-            className="ms-Button ms-Button--commandBar object-property-expand root-77"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            style={
-              Object {
-                "height": "32px",
-              }
-            }
-            type="button"
+          <div
+            className="ms-Grid-row"
           >
-            <span
-              className="ms-Button-flexContainer flexContainer-67"
-              data-automationid="splitbuttonprimary"
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
-                data-icon-name="Add"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
+              <div
+                className="ms-TextField root-54"
               >
-                
-              </i>
-              <span
-                className="ms-Button-textContainer textContainer-68"
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_additionalProperty-key"
+                    id="TextFieldLabel104"
+                  >
+                    additionalProperty Key
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel104"
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_additionalProperty-key"
+                      name="root_additionalProperty-key"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      required={false}
+                      type="text"
+                      value="additionalProperty"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+            >
+              <div
+                className="ms-TextField root-54"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_additionalProperty"
+                    id="TextFieldLabel107"
+                  >
+                    additionalProperty
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel107"
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_additionalProperty"
+                      name="root_additionalProperty"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value="should appear"
+                    />
+                  </div>
+                </div>
+              </div>
+              
+            </div>
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
+              style={
+                Object {
+                  "textAlign": "right",
+                }
+              }
+            >
+              <button
+                className="ms-Button ms-Button--icon root-74"
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                type="button"
               >
                 <span
-                  className="ms-Button-label label-79"
-                  id="id__111"
+                  className="ms-Button-flexContainer flexContainer-67"
+                  data-automationid="splitbuttonprimary"
                 >
-                  Add Item
+                  <i
+                    aria-hidden={true}
+                    className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
+                    data-icon-name="Delete"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
                 </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <span
+        style={
+          Object {
+            "float": "right",
+          }
+        }
+      >
+        <button
+          className="ms-Button ms-Button--commandBar object-property-expand root-77"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
+            }
+          }
+          type="button"
+        >
+          <span
+            className="ms-Button-flexContainer flexContainer-67"
+            data-automationid="splitbuttonprimary"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
+            >
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-68"
+            >
+              <span
+                className="ms-Button-label label-79"
+                id="id__111"
+              >
+                Add Item
               </span>
             </span>
-          </button>
-        </span>
-      </div>
+          </span>
+        </button>
+      </span>
     </div>
   </div>
   <div>
@@ -2174,154 +2063,139 @@ exports[`object fields with title and description object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    <label
+      className="ms-Label root-81"
+      id="root__title"
     >
-      <label
-        className="ms-Label root-81"
-        id="root__title"
-      >
-        Test field
-      </label>
-      <span
-        className="css-82"
-        id="root__description"
-      >
-        a test description
-      </span>
+      Test field
+    </label>
+    <span
+      className="css-82"
+      id="root__description"
+    >
+      a test description
+    </span>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm12  field field-string"
+          id="root_a"
+          style={
+            Object {
+              "marginBottom": 15,
+            }
+          }
         >
           <div
-            className="form-group field field-string"
+            className="ms-TextField root-54"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_a"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-TextField-wrapper"
             >
+              <label
+                className="ms-Label root-65"
+                htmlFor="root_a"
+                id="TextFieldLabel41"
+              >
+                A
+              </label>
               <div
-                className="ms-TextField root-54"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-65"
-                    htmlFor="root_a"
-                    id="TextFieldLabel41"
-                  >
-                    A
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-55"
-                  >
-                    <input
-                      aria-describedby="root_a__error root_a__description root_a__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel41"
-                      autoFocus={false}
-                      className="ms-TextField-field field-56"
-                      disabled={false}
-                      id="root_a"
-                      name="root_a"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={false}
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
+                <input
+                  aria-describedby="root_a__error root_a__description root_a__help"
+                  aria-invalid={false}
+                  aria-labelledby="TextFieldLabel41"
+                  autoFocus={false}
+                  className="ms-TextField-field field-56"
+                  disabled={false}
+                  id="root_a"
+                  name="root_a"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
               </div>
-              <span
-                className="css-82"
-              >
-                A description
-              </span>
             </div>
           </div>
+          <span
+            className="css-82"
+          >
+            A description
+          </span>
+        </div>
+        <div
+          className="ms-Grid-col ms-sm12  field field-number"
+          id="root_b"
+          style={
+            Object {
+              "marginBottom": 15,
+            }
+          }
+        >
           <div
-            className="form-group field field-number"
+            className="ms-TextField root-54"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-number"
-              id="root_b"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-TextField-wrapper"
             >
+              <label
+                className="ms-Label root-65"
+                htmlFor="root_b"
+                id="TextFieldLabel44"
+              >
+                B
+              </label>
               <div
-                className="ms-TextField root-54"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <label
-                    className="ms-Label root-65"
-                    htmlFor="root_b"
-                    id="TextFieldLabel44"
-                  >
-                    B
-                  </label>
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-55"
-                  >
-                    <input
-                      aria-describedby="root_b__error root_b__description root_b__help"
-                      aria-invalid={false}
-                      aria-labelledby="TextFieldLabel44"
-                      autoFocus={false}
-                      className="ms-TextField-field field-56"
-                      disabled={false}
-                      id="root_b"
-                      name="root_b"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={false}
-                      step="any"
-                      type="number"
-                      value=""
-                    />
-                  </div>
-                </div>
+                <input
+                  aria-describedby="root_b__error root_b__description root_b__help"
+                  aria-invalid={false}
+                  aria-labelledby="TextFieldLabel44"
+                  autoFocus={false}
+                  className="ms-TextField-field field-56"
+                  disabled={false}
+                  id="root_b"
+                  name="root_b"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  step="any"
+                  type="number"
+                  value=""
+                />
               </div>
-              <span
-                className="css-82"
-              >
-                B description
-              </span>
             </div>
           </div>
+          <span
+            className="css-82"
+          >
+            B description
+          </span>
         </div>
       </div>
     </div>
@@ -2370,230 +2244,219 @@ exports[`object fields with title and description show add button and fields if 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    <label
+      className="ms-Label root-81"
+      id="root__title"
     >
-      <label
-        className="ms-Label root-81"
-        id="root__title"
-      >
-        Test field
-      </label>
-      <span
-        className="css-82"
-        id="root__description"
-      >
-        a test description
-      </span>
+      Test field
+    </label>
+    <span
+      className="css-82"
+      id="root__description"
+    >
+      a test description
+    </span>
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
-        >
-          <div
-            className="ms-Grid form-group field field-string"
-            dir="ltr"
-          >
-            <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
-              >
-                <div
-                  className="ms-TextField root-54"
-                >
-                  <div
-                    className="ms-TextField-wrapper"
-                  >
-                    <label
-                      className="ms-Label root-65"
-                      htmlFor="root_additionalProperty-key"
-                      id="TextFieldLabel65"
-                    >
-                      additionalProperty Key
-                    </label>
-                    <div
-                      className="ms-TextField-fieldGroup fieldGroup-55"
-                    >
-                      <input
-                        aria-invalid={false}
-                        aria-labelledby="TextFieldLabel65"
-                        className="ms-TextField-field field-56"
-                        disabled={false}
-                        id="root_additionalProperty-key"
-                        name="root_additionalProperty-key"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        onInput={[Function]}
-                        required={false}
-                        type="text"
-                        value="additionalProperty"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_additionalProperty"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField root-54"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <label
-                        className="ms-Label root-65"
-                        htmlFor="root_additionalProperty"
-                        id="TextFieldLabel68"
-                      >
-                        additionalProperty
-                      </label>
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-55"
-                      >
-                        <input
-                          aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
-                          aria-invalid={false}
-                          aria-labelledby="TextFieldLabel68"
-                          autoFocus={false}
-                          className="ms-TextField-field field-56"
-                          disabled={false}
-                          id="root_additionalProperty"
-                          name="root_additionalProperty"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={false}
-                          type="text"
-                          value="should appear"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  
-                </div>
-              </div>
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
-                style={
-                  Object {
-                    "textAlign": "right",
-                  }
-                }
-              >
-                <button
-                  className="ms-Button ms-Button--icon root-74"
-                  data-is-focusable={true}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyPress={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  type="button"
-                >
-                  <span
-                    className="ms-Button-flexContainer flexContainer-67"
-                    data-automationid="splitbuttonprimary"
-                  >
-                    <i
-                      aria-hidden={true}
-                      className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
-                      data-icon-name="Delete"
-                      style={
-                        Object {
-                          "fontFamily": "\\"FabricMDL2Icons\\"",
-                        }
-                      }
-                    >
-                      
-                    </i>
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-        <span
+          className="ms-Grid-col ms-sm12  field field-string"
+          dir="ltr"
           style={
             Object {
-              "float": "right",
+              "marginBottom": 15,
             }
           }
         >
-          <button
-            className="ms-Button ms-Button--commandBar object-property-expand root-77"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            style={
-              Object {
-                "height": "32px",
-              }
-            }
-            type="button"
+          <div
+            className="ms-Grid-row"
           >
-            <span
-              className="ms-Button-flexContainer flexContainer-67"
-              data-automationid="splitbuttonprimary"
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
-                data-icon-name="Add"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
+              <div
+                className="ms-TextField root-54"
               >
-                
-              </i>
-              <span
-                className="ms-Button-textContainer textContainer-68"
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_additionalProperty-key"
+                    id="TextFieldLabel65"
+                  >
+                    additionalProperty Key
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel65"
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_additionalProperty-key"
+                      name="root_additionalProperty-key"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      required={false}
+                      type="text"
+                      value="additionalProperty"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+            >
+              <div
+                className="ms-TextField root-54"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_additionalProperty"
+                    id="TextFieldLabel68"
+                  >
+                    additionalProperty
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel68"
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_additionalProperty"
+                      name="root_additionalProperty"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value="should appear"
+                    />
+                  </div>
+                </div>
+              </div>
+              
+            </div>
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
+              style={
+                Object {
+                  "textAlign": "right",
+                }
+              }
+            >
+              <button
+                className="ms-Button ms-Button--icon root-74"
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                type="button"
               >
                 <span
-                  className="ms-Button-label label-79"
-                  id="id__72"
+                  className="ms-Button-flexContainer flexContainer-67"
+                  data-automationid="splitbuttonprimary"
                 >
-                  Add Item
+                  <i
+                    aria-hidden={true}
+                    className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
+                    data-icon-name="Delete"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
                 </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <span
+        style={
+          Object {
+            "float": "right",
+          }
+        }
+      >
+        <button
+          className="ms-Button ms-Button--commandBar object-property-expand root-77"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
+            }
+          }
+          type="button"
+        >
+          <span
+            className="ms-Button-flexContainer flexContainer-67"
+            data-automationid="splitbuttonprimary"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
+            >
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-68"
+            >
+              <span
+                className="ms-Button-label label-79"
+                id="id__72"
+              >
+                Add Item
               </span>
             </span>
-          </button>
-        </span>
-      </div>
+          </span>
+        </button>
+      </span>
     </div>
   </div>
   <div>
@@ -2640,210 +2503,199 @@ exports[`object fields with title and description with global label off addition
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    
+    <div
+      className="ms-Grid"
+      dir="ltr"
     >
-      
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
-        >
-          <div
-            className="ms-Grid form-group field field-string"
-            dir="ltr"
-          >
-            <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
-              >
-                <div
-                  className="ms-TextField root-54"
-                >
-                  <div
-                    className="ms-TextField-wrapper"
-                  >
-                    <label
-                      className="ms-Label root-65"
-                      htmlFor="root_foo-key"
-                      id="TextFieldLabel152"
-                    >
-                      foo Key
-                    </label>
-                    <div
-                      className="ms-TextField-fieldGroup fieldGroup-55"
-                    >
-                      <input
-                        aria-invalid={false}
-                        aria-labelledby="TextFieldLabel152"
-                        className="ms-TextField-field field-56"
-                        disabled={false}
-                        id="root_foo-key"
-                        name="root_foo-key"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        onInput={[Function]}
-                        required={false}
-                        type="text"
-                        value="foo"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_foo"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField root-54"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-55"
-                      >
-                        <input
-                          aria-describedby="root_foo__error root_foo__description root_foo__help"
-                          aria-invalid={false}
-                          autoFocus={false}
-                          className="ms-TextField-field field-56"
-                          disabled={false}
-                          id="root_foo"
-                          name="root_foo"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={false}
-                          type="text"
-                          value="foo"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
-                style={
-                  Object {
-                    "textAlign": "right",
-                  }
-                }
-              >
-                <button
-                  className="ms-Button ms-Button--icon root-74"
-                  data-is-focusable={true}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyPress={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  type="button"
-                >
-                  <span
-                    className="ms-Button-flexContainer flexContainer-67"
-                    data-automationid="splitbuttonprimary"
-                  >
-                    <i
-                      aria-hidden={true}
-                      className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
-                      data-icon-name="Delete"
-                      style={
-                        Object {
-                          "fontFamily": "\\"FabricMDL2Icons\\"",
-                        }
-                      }
-                    >
-                      
-                    </i>
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-        <span
+          className="ms-Grid-col ms-sm12  field field-string"
+          dir="ltr"
           style={
             Object {
-              "float": "right",
+              "marginBottom": 15,
             }
           }
         >
-          <button
-            className="ms-Button ms-Button--commandBar object-property-expand root-77"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            style={
-              Object {
-                "height": "32px",
-              }
-            }
-            type="button"
+          <div
+            className="ms-Grid-row"
           >
-            <span
-              className="ms-Button-flexContainer flexContainer-67"
-              data-automationid="splitbuttonprimary"
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
-                data-icon-name="Add"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
+              <div
+                className="ms-TextField root-54"
               >
-                
-              </i>
-              <span
-                className="ms-Button-textContainer textContainer-68"
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_foo-key"
+                    id="TextFieldLabel152"
+                  >
+                    foo Key
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel152"
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_foo-key"
+                      name="root_foo-key"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      required={false}
+                      type="text"
+                      value="foo"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+            >
+              <div
+                className="ms-TextField root-54"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_foo__error root_foo__description root_foo__help"
+                      aria-invalid={false}
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_foo"
+                      name="root_foo"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value="foo"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
+              style={
+                Object {
+                  "textAlign": "right",
+                }
+              }
+            >
+              <button
+                className="ms-Button ms-Button--icon root-74"
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                type="button"
               >
                 <span
-                  className="ms-Button-label label-79"
-                  id="id__159"
+                  className="ms-Button-flexContainer flexContainer-67"
+                  data-automationid="splitbuttonprimary"
                 >
-                  Add Item
+                  <i
+                    aria-hidden={true}
+                    className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
+                    data-icon-name="Delete"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
                 </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <span
+        style={
+          Object {
+            "float": "right",
+          }
+        }
+      >
+        <button
+          className="ms-Button ms-Button--commandBar object-property-expand root-77"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
+            }
+          }
+          type="button"
+        >
+          <span
+            className="ms-Button-flexContainer flexContainer-67"
+            data-automationid="splitbuttonprimary"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
+            >
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-68"
+            >
+              <span
+                className="ms-Button-label label-79"
+                id="id__159"
+              >
+                Add Item
               </span>
             </span>
-          </button>
-        </span>
-      </div>
+          </span>
+        </button>
+      </span>
     </div>
   </div>
   <div>
@@ -2890,114 +2742,99 @@ exports[`object fields with title and description with global label off object 1
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    
+    <div
+      className="ms-Grid"
+      dir="ltr"
     >
-      
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
+          className="ms-Grid-col ms-sm12  field field-string"
+          id="root_a"
+          style={
+            Object {
+              "marginBottom": 15,
+            }
+          }
         >
           <div
-            className="form-group field field-string"
+            className="ms-TextField root-54"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-string"
-              id="root_a"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-TextField-wrapper"
             >
               <div
-                className="ms-TextField root-54"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-55"
-                  >
-                    <input
-                      aria-describedby="root_a__error root_a__description root_a__help"
-                      aria-invalid={false}
-                      autoFocus={false}
-                      className="ms-TextField-field field-56"
-                      disabled={false}
-                      id="root_a"
-                      name="root_a"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={false}
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                </div>
+                <input
+                  aria-describedby="root_a__error root_a__description root_a__help"
+                  aria-invalid={false}
+                  autoFocus={false}
+                  className="ms-TextField-field field-56"
+                  disabled={false}
+                  id="root_a"
+                  name="root_a"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
               </div>
             </div>
           </div>
+        </div>
+        <div
+          className="ms-Grid-col ms-sm12  field field-number"
+          id="root_b"
+          style={
+            Object {
+              "marginBottom": 15,
+            }
+          }
+        >
           <div
-            className="form-group field field-number"
+            className="ms-TextField root-54"
           >
             <div
-              className="ms-Grid-col ms-sm12  field field-number"
-              id="root_b"
-              style={
-                Object {
-                  "display": undefined,
-                  "marginBottom": 15,
-                }
-              }
+              className="ms-TextField-wrapper"
             >
               <div
-                className="ms-TextField root-54"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
-                <div
-                  className="ms-TextField-wrapper"
-                >
-                  <div
-                    className="ms-TextField-fieldGroup fieldGroup-55"
-                  >
-                    <input
-                      aria-describedby="root_b__error root_b__description root_b__help"
-                      aria-invalid={false}
-                      autoFocus={false}
-                      className="ms-TextField-field field-56"
-                      disabled={false}
-                      id="root_b"
-                      name="root_b"
-                      onBlur={[Function]}
-                      onChange={[Function]}
-                      onFocus={[Function]}
-                      onInput={[Function]}
-                      placeholder=""
-                      readOnly={false}
-                      required={false}
-                      step="any"
-                      type="number"
-                      value=""
-                    />
-                  </div>
-                </div>
+                <input
+                  aria-describedby="root_b__error root_b__description root_b__help"
+                  aria-invalid={false}
+                  autoFocus={false}
+                  className="ms-TextField-field field-56"
+                  disabled={false}
+                  id="root_b"
+                  name="root_b"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  step="any"
+                  type="number"
+                  value=""
+                />
               </div>
             </div>
           </div>
@@ -3049,210 +2886,199 @@ exports[`object fields with title and description with global label off show add
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
-  >
-    <div
-      className="ms-Grid-col ms-sm12  field field-object"
-      id="root"
-      style={
-        Object {
-          "display": undefined,
-          "marginBottom": 15,
-        }
+    className="ms-Grid-col ms-sm12  field field-object"
+    id="root"
+    style={
+      Object {
+        "marginBottom": 15,
       }
+    }
+  >
+    
+    <div
+      className="ms-Grid"
+      dir="ltr"
     >
-      
       <div
-        className="ms-Grid"
-        dir="ltr"
+        className="ms-Grid-row"
       >
         <div
-          className="ms-Grid-row"
-        >
-          <div
-            className="ms-Grid form-group field field-string"
-            dir="ltr"
-          >
-            <div
-              className="ms-Grid-row"
-            >
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
-              >
-                <div
-                  className="ms-TextField root-54"
-                >
-                  <div
-                    className="ms-TextField-wrapper"
-                  >
-                    <label
-                      className="ms-Label root-65"
-                      htmlFor="root_additionalProperty-key"
-                      id="TextFieldLabel167"
-                    >
-                      additionalProperty Key
-                    </label>
-                    <div
-                      className="ms-TextField-fieldGroup fieldGroup-55"
-                    >
-                      <input
-                        aria-invalid={false}
-                        aria-labelledby="TextFieldLabel167"
-                        className="ms-TextField-field field-56"
-                        disabled={false}
-                        id="root_additionalProperty-key"
-                        name="root_additionalProperty-key"
-                        onBlur={[Function]}
-                        onChange={[Function]}
-                        onFocus={[Function]}
-                        onInput={[Function]}
-                        required={false}
-                        type="text"
-                        value="additionalProperty"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
-              >
-                <div
-                  className="ms-Grid-col ms-sm12  field field-string"
-                  id="root_additionalProperty"
-                  style={
-                    Object {
-                      "display": undefined,
-                      "marginBottom": 15,
-                    }
-                  }
-                >
-                  <div
-                    className="ms-TextField root-54"
-                  >
-                    <div
-                      className="ms-TextField-wrapper"
-                    >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-55"
-                      >
-                        <input
-                          aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
-                          aria-invalid={false}
-                          autoFocus={false}
-                          className="ms-TextField-field field-56"
-                          disabled={false}
-                          id="root_additionalProperty"
-                          name="root_additionalProperty"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          placeholder=""
-                          readOnly={false}
-                          required={false}
-                          type="text"
-                          value="should appear"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
-                style={
-                  Object {
-                    "textAlign": "right",
-                  }
-                }
-              >
-                <button
-                  className="ms-Button ms-Button--icon root-74"
-                  data-is-focusable={true}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyPress={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  type="button"
-                >
-                  <span
-                    className="ms-Button-flexContainer flexContainer-67"
-                    data-automationid="splitbuttonprimary"
-                  >
-                    <i
-                      aria-hidden={true}
-                      className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
-                      data-icon-name="Delete"
-                      style={
-                        Object {
-                          "fontFamily": "\\"FabricMDL2Icons\\"",
-                        }
-                      }
-                    >
-                      
-                    </i>
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-        <span
+          className="ms-Grid-col ms-sm12  field field-string"
+          dir="ltr"
           style={
             Object {
-              "float": "right",
+              "marginBottom": 15,
             }
           }
         >
-          <button
-            className="ms-Button ms-Button--commandBar object-property-expand root-77"
-            data-is-focusable={true}
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            style={
-              Object {
-                "height": "32px",
-              }
-            }
-            type="button"
+          <div
+            className="ms-Grid-row"
           >
-            <span
-              className="ms-Button-flexContainer flexContainer-67"
-              data-automationid="splitbuttonprimary"
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
-              <i
-                aria-hidden={true}
-                className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
-                data-icon-name="Add"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons\\"",
-                  }
-                }
+              <div
+                className="ms-TextField root-54"
               >
-                
-              </i>
-              <span
-                className="ms-Button-textContainer textContainer-68"
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <label
+                    className="ms-Label root-65"
+                    htmlFor="root_additionalProperty-key"
+                    id="TextFieldLabel167"
+                  >
+                    additionalProperty Key
+                  </label>
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-invalid={false}
+                      aria-labelledby="TextFieldLabel167"
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_additionalProperty-key"
+                      name="root_additionalProperty-key"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      required={false}
+                      type="text"
+                      value="additionalProperty"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
+            >
+              <div
+                className="ms-TextField root-54"
+              >
+                <div
+                  className="ms-TextField-wrapper"
+                >
+                  <div
+                    className="ms-TextField-fieldGroup fieldGroup-55"
+                  >
+                    <input
+                      aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
+                      aria-invalid={false}
+                      autoFocus={false}
+                      className="ms-TextField-field field-56"
+                      disabled={false}
+                      id="root_additionalProperty"
+                      name="root_additionalProperty"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      onInput={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value="should appear"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className="ms-Grid-col ms-sm4 ms-md4 ms-lg2"
+              style={
+                Object {
+                  "textAlign": "right",
+                }
+              }
+            >
+              <button
+                className="ms-Button ms-Button--icon root-74"
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                type="button"
               >
                 <span
-                  className="ms-Button-label label-79"
-                  id="id__174"
+                  className="ms-Button-flexContainer flexContainer-67"
+                  data-automationid="splitbuttonprimary"
                 >
-                  Add Item
+                  <i
+                    aria-hidden={true}
+                    className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
+                    data-icon-name="Delete"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
                 </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <span
+        style={
+          Object {
+            "float": "right",
+          }
+        }
+      >
+        <button
+          className="ms-Button ms-Button--commandBar object-property-expand root-77"
+          data-is-focusable={true}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          onKeyPress={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+          style={
+            Object {
+              "height": "32px",
+            }
+          }
+          type="button"
+        >
+          <span
+            className="ms-Button-flexContainer flexContainer-67"
+            data-automationid="splitbuttonprimary"
+          >
+            <i
+              aria-hidden={true}
+              className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
+              data-icon-name="Add"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
+            >
+              
+            </i>
+            <span
+              className="ms-Button-textContainer textContainer-68"
+            >
+              <span
+                className="ms-Button-label label-79"
+                id="id__174"
+              >
+                Add Item
               </span>
             </span>
-          </button>
-        </span>
-      </div>
+          </span>
+        </button>
+      </span>
     </div>
   </div>
   <div>


### PR DESCRIPTION
### Reasons for making this change

Additional properties should be handled in the fluent-ui theme equivalently to how they are handled in the other themes.

- Adds "Add Item" button to objects that support additional properties.
- Adds editable key and a remove button to additional properties.
- Fixes #2777.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

### Screenshots

The playground still does not render fluent-ui styles per #2734. Regardless, here is a before-and-after of the additionalProperties example:

Before
![image](https://user-images.githubusercontent.com/6611239/234990716-ab6d68de-48c0-45ef-b08e-2652e72ff014.png)

After
![image](https://user-images.githubusercontent.com/6611239/234990796-448a8743-26bf-42b5-b571-e8ccbd38f685.png)