### PR TITLE
feature: Add two new APIs and a schema parser refactor of retrieveSchema functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Added two new APIs `getDiscriminatorFieldFromSchema()` (a refactor of code from `MultiSchemaField`) and `hashForSchema()`
   - Updated `getDefaultFormState()` and `toPathSchema()` to use `getDiscriminatorFieldFromSchema()` to provide a discriminator field to `getClosestMatchingOption()` calls.
-- Refactored the `retrieveSchema()` internal API functions to support implementing an internal `schemaParser()` API for use in precompiling schemas, in support of [3543](https://github.com/rjsf-team/react-jsonschema-form/issues/3543) 
+- Refactored the `retrieveSchema()` internal API functions to support implementing an internal `schemaParser()` API for use in precompiling schemas, in support of [3543](https://github.com/rjsf-team/react-jsonschema-form/issues/3543)
+- Fixed `toPathSchema()` to handle `properties` in an object along with `anyOf`/`oneOf`, fixing [3628](https://github.com/rjsf-team/react-jsonschema-form/issues/3628) and [1628](https://github.com/rjsf-team/react-jsonschema-form/issues/1628)
+
+## Dev / docs / playground
+
+- Added documentation to `custom-templates` describing how to extend the `BaseInputTemplate`
 
 # 5.6.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,8 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Added two new APIs `getDiscriminatorFieldFromSchema()` (a refactor of code from `MultiSchemaField`) and `hashForSchema()`
   - Updated `getDefaultFormState()` and `toPathSchema()` to use `getDiscriminatorFieldFromSchema()` to provide a discriminator field to `getClosestMatchingOption()` calls.
-- Refactored the `retrieveSchema()` internal API functions to support implementing an internal `schemaParser()` API for use in precompiling schemas, in support of [3543](https://github.com/rjsf-team/react-jsonschema-form/issues/3543)
-- Fixed `toPathSchema()` to handle `properties` in an object along with `anyOf`/`oneOf`, fixing [3628](https://github.com/rjsf-team/react-jsonschema-form/issues/3628) and [1628](https://github.com/rjsf-team/react-jsonschema-form/issues/1628)
+- Refactored the `retrieveSchema()` internal API functions to support implementing an internal `schemaParser()` API for use in precompiling schemas, in support of [#3543](https://github.com/rjsf-team/react-jsonschema-form/issues/3543)
+- Fixed `toPathSchema()` to handle `properties` in an object along with `anyOf`/`oneOf`, fixing [#3628](https://github.com/rjsf-team/react-jsonschema-form/issues/3628) and [#1628](https://github.com/rjsf-team/react-jsonschema-form/issues/1628)
 
 ## Dev / docs / playground
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,25 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
-# 5.6.3
+# 5.7.0
 
 ## @rjsf/antd
 
 - Fix [#3608](https://github.com/rjsf-team/react-jsonschema-form/issues/3608) by ensuring the root field is always wrapped in Form.Item
 
+## @rjsf/core
+
+- Updated the `MultiSchemaField` to use the new `getDiscriminatorFieldFromSchema()` API
+
 ## @rjsf/fluent-ui
 
 - Added support for `additionalProperties` to fluent-ui theme, fixing [#2777](https://github.com/rjsf-team/react-jsonschema-form/issues/2777).
+
+## @rjsf/utils
+
+- Added two new APIs `getDiscriminatorFieldFromSchema()` (a refactor of code from `MultiSchemaField`) and `hashForSchema()`
+  - Updated `getDefaultFormState()` and `toPathSchema()` to use `getDiscriminatorFieldFromSchema()` to provide a discriminator field to `getClosestMatchingOption()` calls.
+- Refactored the `retrieveSchema()` internal API functions to support implementing an internal `schemaParser()` API for use in precompiling schemas, in support of [3543](https://github.com/rjsf-team/react-jsonschema-form/issues/3543) 
 
 # 5.6.2
 

--- a/packages/core/src/components/fields/MultiSchemaField.tsx
+++ b/packages/core/src/components/fields/MultiSchemaField.tsx
@@ -1,13 +1,13 @@
 import { Component } from 'react';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
-import isString from 'lodash/isString';
 import omit from 'lodash/omit';
 import {
   deepEquals,
   ERRORS_KEY,
   FieldProps,
   FormContextType,
+  getDiscriminatorFieldFromSchema,
   getUiOptions,
   getWidget,
   RJSFSchema,
@@ -96,13 +96,7 @@ class AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
       registry: { schemaUtils },
     } = this.props;
 
-    let discriminator: string | undefined;
-    const maybeString = get(schema, 'discriminator.propertyName', undefined);
-    if (isString(maybeString)) {
-      discriminator = maybeString;
-    } else if (maybeString !== undefined) {
-      console.warn(`Expecting discriminator to be a string, got "${typeof maybeString}" instead`);
-    }
+    const discriminator = getDiscriminatorFieldFromSchema<S>(schema);
     const option = schemaUtils.getClosestMatchingOption(formData, options, selectedOption, discriminator);
     if (option > 0) {
       return option;

--- a/packages/docs/docs/advanced-customization/custom-templates.md
+++ b/packages/docs/docs/advanced-customization/custom-templates.md
@@ -361,6 +361,25 @@ render(
 );
 ```
 
+Sometimes you just need to pass some additional properties to the existing `BaseInputTemplate`.
+The way to do this varies based upon whether you are using `core` or some other theme (such as `mui`):
+
+```tsx
+import { BaseInputTemplateProps } from '@rjsf/utils';
+import { getDefaultRegistry } from '@rjsf/core';
+import { Templates } from '@rjsf/mui';
+
+const { templates: { BaseInputTemplate } } = getDefaultRegistry();  // To get templates from core
+// const { BaseInputTemplate } = Templates; // To get templates from a theme do this
+
+function MyBaseInputTemplate(props: BaseInputTemplateProps)
+{
+  const customProps = {};
+  // get your custom props from where you need to
+  return <BaseInputTemplate {...props} {...customProps} />;
+}
+```
+
 The following props are passed to the `BaseInputTemplate`:
 
 - `id`: The generated id for this widget;

--- a/packages/docs/docs/api-reference/utility-functions.md
+++ b/packages/docs/docs/api-reference/utility-functions.md
@@ -268,6 +268,19 @@ Otherwise, return the sub-schema. Also deals with nested `$ref`s in the sub-sche
 
 - Error indicating that no schema for that reference exists
 
+### getDiscriminatorFieldFromSchema&lt;S extends StrictRJSFSchema = RJSFSchema>()
+
+Returns the `discriminator.propertyName` when defined in the `schema` if it is a string. A warning is generated when it is not a string.
+Returns `undefined` when a valid discriminator is not present.
+
+#### Parameters
+
+- schema: S - The schema from which the discriminator is potentially obtained
+
+#### Returns
+
+- string | undefined: The `discriminator.propertyName` if it exists in the schema, otherwise `undefined`
+
 ### getInputProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>()
 
 Using the `schema`, `defaultType` and `options`, extract out the props for the `<input>` element that make sense.
@@ -376,6 +389,18 @@ create a schema, it is useful to know what type to use based on the data we are 
 #### Returns
 
 - string: The best guess for the object type
+
+### hashForSchema&lt;S extends StrictRJSFSchema = RJSFSchema>()
+
+Stringifies the schema and returns the hash of the resulting string.
+
+#### Parameters
+
+- schema: S - The schema for which the hash is desired
+
+#### Returns
+
+- string: The string obtained from the hash of the stringified schema
 
 ### hasWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>()
 

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -14,6 +14,7 @@ export const DEPENDENCIES_KEY = 'dependencies';
 export const ENUM_KEY = 'enum';
 export const ERRORS_KEY = '__errors';
 export const ID_KEY = '$id';
+export const IF_KEY = 'if';
 export const ITEMS_KEY = 'items';
 export const NAME_KEY = '$name';
 export const ONE_OF_KEY = 'oneOf';

--- a/packages/utils/src/getDiscriminatorFieldFromSchema.ts
+++ b/packages/utils/src/getDiscriminatorFieldFromSchema.ts
@@ -1,0 +1,21 @@
+import get from 'lodash/get';
+import isString from 'lodash/isString';
+
+import { RJSFSchema, StrictRJSFSchema } from './types';
+
+/** Returns the `discriminator.propertyName` when defined in the `schema` if it is a string. A warning is generated when
+ * it is not a string. Returns `undefined` when a valid discriminator is not present.
+ *
+ * @param schema - The schema from which the discriminator is potentially obtained
+ * @returns - The `discriminator.propertyName` if it exists in the schema, otherwise `undefined`
+ */
+export default function getDiscriminatorFieldFromSchema<S extends StrictRJSFSchema = RJSFSchema>(schema: S) {
+  let discriminator: string | undefined;
+  const maybeString = get(schema, 'discriminator.propertyName', undefined);
+  if (isString(maybeString)) {
+    discriminator = maybeString;
+  } else if (maybeString !== undefined) {
+    console.warn(`Expecting discriminator to be a string, got "${typeof maybeString}" instead`);
+  }
+  return discriminator;
+}

--- a/packages/utils/src/hashForSchema.ts
+++ b/packages/utils/src/hashForSchema.ts
@@ -1,0 +1,27 @@
+import { RJSFSchema, StrictRJSFSchema } from './types';
+
+/** JS has no built-in hashing function, so rolling our own
+ *  based on Java's hashing fn:
+ *  http://werxltd.com/wp/2010/05/13/javascript-implementation-of-javas-string-hashcode-method/
+ *
+ * @param string - The string for which to get the hash
+ * @returns - The resulting hash of the string
+ */
+function hashString(string: string): string {
+  let hash = 0;
+  for (let i = 0; i < string.length; i += 1) {
+    const chr = string.charCodeAt(i);
+    hash = (hash << 5) - hash + chr;
+    hash |= 0; // Convert to 32bit integer
+  }
+  return String(hash);
+}
+
+/** Stringifies the schema and returns the hash of the resulting string.
+ *
+ * @param schema - The schema for which the hash is desired
+ * @returns - The string obtained from the hash of the stringified schema
+ */
+export default function hashForSchema<S extends StrictRJSFSchema = RJSFSchema>(schema: S) {
+  return hashString(JSON.stringify(schema));
+}

--- a/packages/utils/src/hashForSchema.ts
+++ b/packages/utils/src/hashForSchema.ts
@@ -2,19 +2,19 @@ import { RJSFSchema, StrictRJSFSchema } from './types';
 
 /** JS has no built-in hashing function, so rolling our own
  *  based on Java's hashing fn:
- *  http://werxltd.com/wp/2010/05/13/javascript-implementation-of-javas-string-hashcode-method/
+ *  http://www.java2s.com/example/nodejs-utility-method/string-hash/hashcode-4dc2b.html
  *
  * @param string - The string for which to get the hash
- * @returns - The resulting hash of the string
+ * @returns - The resulting hash of the string in hex format
  */
 function hashString(string: string): string {
   let hash = 0;
   for (let i = 0; i < string.length; i += 1) {
     const chr = string.charCodeAt(i);
     hash = (hash << 5) - hash + chr;
-    hash |= 0; // Convert to 32bit integer
+    hash = hash & hash; // Convert to 32bit integer
   }
-  return String(hash);
+  return hash.toString(16);
 }
 
 /** Stringifies the schema and returns the hash of the resulting string.

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -13,6 +13,7 @@ import enumOptionsSelectValue from './enumOptionsSelectValue';
 import enumOptionsValueForIndex from './enumOptionsValueForIndex';
 import ErrorSchemaBuilder from './ErrorSchemaBuilder';
 import findSchemaDefinition from './findSchemaDefinition';
+import getDiscriminatorFieldFromSchema from './getDiscriminatorFieldFromSchema';
 import getInputProps from './getInputProps';
 import getSchemaType from './getSchemaType';
 import getSubmitButtonOptions from './getSubmitButtonOptions';
@@ -20,6 +21,7 @@ import getTemplate from './getTemplate';
 import getUiOptions from './getUiOptions';
 import getWidget from './getWidget';
 import guessType from './guessType';
+import hashForSchema from './hashForSchema';
 import hasWidget from './hasWidget';
 import { ariaDescribedByIds, descriptionId, errorId, examplesId, helpId, optionId, titleId } from './idGenerators';
 import isConstant from './isConstant';
@@ -52,6 +54,7 @@ export * from './types';
 export * from './enums';
 
 export * from './constants';
+export * from './parser';
 export * from './schema';
 
 export {
@@ -74,6 +77,7 @@ export {
   examplesId,
   ErrorSchemaBuilder,
   findSchemaDefinition,
+  getDiscriminatorFieldFromSchema,
   getInputProps,
   getSchemaType,
   getSubmitButtonOptions,
@@ -82,6 +86,7 @@ export {
   getWidget,
   guessType,
   hasWidget,
+  hashForSchema,
   helpId,
   isConstant,
   isCustomWidget,

--- a/packages/utils/src/parser/ParserValidator.ts
+++ b/packages/utils/src/parser/ParserValidator.ts
@@ -58,7 +58,16 @@ export default class ParserValidator<T = any, S extends StrictRJSFSchema = RJSFS
   addSchema(schema: S, hash: string) {
     const key = get(schema, ID_KEY, hash);
     const identifiedSchema = { ...schema, [ID_KEY]: key };
-    this.schemaMap[key] = identifiedSchema;
+    const existing = this.schemaMap[key];
+    if (!existing) {
+      this.schemaMap[key] = identifiedSchema;
+    } else if (!isEqual(existing, identifiedSchema)) {
+      console.error('existing schema:', JSON.stringify(existing, null, 2));
+      console.error('new schema:', JSON.stringify(identifiedSchema, null, 2));
+      throw new Error(
+        `Two different schemas exist with the same key ${key}! What a bad coincidence. If possible, try adding an $ID to one of the schemas`
+      );
+    }
   }
 
   /** Returns the current `schemaMap` to the caller

--- a/packages/utils/src/parser/ParserValidator.ts
+++ b/packages/utils/src/parser/ParserValidator.ts
@@ -65,7 +65,7 @@ export default class ParserValidator<T = any, S extends StrictRJSFSchema = RJSFS
       console.error('existing schema:', JSON.stringify(existing, null, 2));
       console.error('new schema:', JSON.stringify(identifiedSchema, null, 2));
       throw new Error(
-        `Two different schemas exist with the same key ${key}! What a bad coincidence. If possible, try adding an $ID to one of the schemas`
+        `Two different schemas exist with the same key ${key}! What a bad coincidence. If possible, try adding an $id to one of the schemas`
       );
     }
   }

--- a/packages/utils/src/parser/ParserValidator.ts
+++ b/packages/utils/src/parser/ParserValidator.ts
@@ -1,0 +1,123 @@
+import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
+
+import { ID_KEY } from '../constants';
+import hashForSchema from '../hashForSchema';
+import {
+  CustomValidator,
+  ErrorSchema,
+  ErrorTransformer,
+  FormContextType,
+  RJSFSchema,
+  RJSFValidationError,
+  StrictRJSFSchema,
+  UiSchema,
+  ValidationData,
+  ValidatorType,
+} from '../types';
+
+/** The type of the map of schema hash to schema
+ */
+export type SchemaMap<S extends StrictRJSFSchema = RJSFSchema> = {
+  [hash: string]: S;
+};
+
+/** An implementation of the `ValidatorType` interface that is designed for use in capturing schemas used by the
+ * `isValid()` function. The rest of the implementation of the interface throws errors when it is attempted to be used.
+ * An instance of the object allows the caller to capture the schemas used in calls to the `isValid()` function. These
+ * captured schema, along with the root schema used to construct the object are stored in the map of schemas keyed by
+ * the hashed value of the schema. NOTE: After hashing the schema, an $id with the hash value is added to the
+ * schema IF that schema doesn't already have an $id, prior to putting the schema into the map.
+ */
+export default class ParserValidator<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>
+  implements ValidatorType<T, S, F>
+{
+  /** The rootSchema provided during construction of the class */
+  readonly rootSchema: S;
+
+  /** The map of schemas encountered by the ParserValidator */
+  schemaMap: SchemaMap<S> = {};
+
+  /** Construct the ParserValidator for the given `rootSchema`. This `rootSchema` will be stashed in the `schemaMap`
+   * first.
+   *
+   * @param rootSchema - The root schema against which this validator will be executed
+   */
+  constructor(rootSchema: S) {
+    this.rootSchema = rootSchema;
+    this.addSchema(rootSchema, hashForSchema<S>(rootSchema));
+  }
+
+  /** Adds the given `schema` to the `schemaMap` keyed by the `hash` or `ID_KEY` if present on the `schema`. If the
+   * schema does not have an `ID_KEY`, then the `hash` will be added as the `ID_KEY` to allow the schema to be
+   * associated with it's `hash` for future use (by a schema compiler).
+   *
+   * @param schema - The schema which is to be added to the map
+   * @param hash - The hash value at which to map the schema
+   */
+  addSchema(schema: S, hash: string) {
+    const key = get(schema, ID_KEY, hash);
+    const identifiedSchema = { ...schema, [ID_KEY]: key };
+    this.schemaMap[key] = identifiedSchema;
+  }
+
+  /** Returns the current `schemaMap` to the caller
+   */
+  getSchemaMap() {
+    return this.schemaMap;
+  }
+
+  /** Implements the `ValidatorType` `isValid()` method to capture the `schema` in the `schemaMap`. Throws an error when
+   * the `rootSchema` is not the same as the root schema provided during construction.
+   *
+   * @param schema - The schema to record in the `schemaMap`
+   * @param _formData - The formData parameter that is ignored
+   * @param rootSchema - The root schema associated with the schema
+   * @throws - Error when the given `rootSchema` differs from the root schema provided during construction
+   */
+  isValid(schema: S, _formData: T, rootSchema: S): boolean {
+    if (!isEqual(rootSchema, this.rootSchema)) {
+      throw new Error('Unexpectedly calling isValid() with a rootSchema that differs from the construction rootSchema');
+    }
+    this.addSchema(schema, hashForSchema<S>(schema));
+
+    return false;
+  }
+
+  /** Implements the `ValidatorType` `rawValidation()` method to throw an error since it is never supposed to be called
+   *
+   * @param _schema - The schema parameter that is ignored
+   * @param _formData - The formData parameter that is ignored
+   */
+  rawValidation<Result = any>(_schema: S, _formData?: T): { errors?: Result[]; validationError?: Error } {
+    throw new Error('Unexpectedly calling the `rawValidation()` method during schema parsing');
+  }
+
+  /** Implements the `ValidatorType` `toErrorList()` method to throw an error since it is never supposed to be called
+   *
+   * @param _errorSchema - The error schema parameter that is ignored
+   * @param _fieldPath - The field path parameter that is ignored
+   */
+  toErrorList(_errorSchema?: ErrorSchema<T>, _fieldPath?: string[]): RJSFValidationError[] {
+    throw new Error('Unexpectedly calling the `toErrorList()` method during schema parsing');
+  }
+
+  /** Implements the `ValidatorType` `validateFormData()` method to throw an error since it is never supposed to be
+   * called
+   *
+   * @param _formData - The formData parameter that is ignored
+   * @param _schema - The schema parameter that is ignored
+   * @param _customValidate - The customValidate parameter that is ignored
+   * @param _transformErrors - The transformErrors parameter that is ignored
+   * @param _uiSchema - The uiSchema parameter that is ignored
+   */
+  validateFormData(
+    _formData: T,
+    _schema: S,
+    _customValidate?: CustomValidator<T, S, F>,
+    _transformErrors?: ErrorTransformer<T, S, F>,
+    _uiSchema?: UiSchema<T, S, F>
+  ): ValidationData<T> {
+    throw new Error('Unexpectedly calling the `validateFormData()` method during schema parsing');
+  }
+}

--- a/packages/utils/src/parser/index.ts
+++ b/packages/utils/src/parser/index.ts
@@ -1,0 +1,6 @@
+import schemaParser from './schemaParser';
+import { SchemaMap } from './ParserValidator';
+
+export type { SchemaMap };
+
+export { schemaParser };

--- a/packages/utils/src/parser/schemaParser.ts
+++ b/packages/utils/src/parser/schemaParser.ts
@@ -1,0 +1,57 @@
+import forEach from 'lodash/forEach';
+import isEqual from 'lodash/isEqual';
+
+import { FormContextType, RJSFSchema, StrictRJSFSchema } from '../types';
+import { PROPERTIES_KEY } from '../constants';
+import ParserValidator, { SchemaMap } from './ParserValidator';
+import { retrieveSchemaInternal, resolveAnyOrOneOfSchemas } from '../schema/retrieveSchema';
+
+/** Recursive function used to parse the given `schema` belonging to the `rootSchema`. The `validator` is used to
+ * capture the sub-schemas that the `isValid()` function is called with. For each schema returned by the
+ * `retrieveSchemaInternal()`, the `resolveAnyOrOneOfSchemas()` function is called. For each of the schemas returned
+ * from THAT call have `properties`, then each of the sub-schema property objects are then recursively parsed.
+ *
+ * @param validator - The `ParserValidator` implementation used to capture `isValid()` calls during parsing
+ * @param recurseList - The list of schemas returned from the `retrieveSchemaInternal`, preventing infinite recursion
+ * @param rootSchema - The root schema from which the schema parsing began
+ * @param schema - The current schema element being parsed
+ */
+function parseSchema<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  validator: ParserValidator<T, S, F>,
+  recurseList: S[],
+  rootSchema: S,
+  schema: S
+) {
+  const schemas = retrieveSchemaInternal<T, S, F>(validator, schema, rootSchema, undefined, true);
+  schemas.forEach((schema) => {
+    const sameSchemaIndex = recurseList.findIndex((item) => isEqual(item, schema));
+    if (sameSchemaIndex === -1) {
+      recurseList.push(schema);
+      const allOptions = resolveAnyOrOneOfSchemas<T, S, F>(validator, schema, rootSchema, true);
+      allOptions.forEach((s) => {
+        if (PROPERTIES_KEY in s && s[PROPERTIES_KEY]) {
+          forEach(schema[PROPERTIES_KEY], (value) => {
+            parseSchema<T, S, F>(validator, recurseList, rootSchema, value as S);
+          });
+        }
+      });
+    }
+  });
+}
+
+/** Parses the given `rootSchema` to extract out all the sub-schemas that maybe contained within it. Returns a map of
+ * the hash of the schema to schema/sub-schema.
+ *
+ * @param rootSchema - The root schema to parse for sub-schemas used by `isValid()` calls
+ * @returns - The `SchemaMap` of all schemas that were parsed
+ */
+export default function schemaParser<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  rootSchema: S
+): SchemaMap<S> {
+  const validator = new ParserValidator<T, S, F>(rootSchema);
+  const recurseList: S[] = [];
+
+  parseSchema(validator, recurseList, rootSchema, rootSchema);
+
+  return validator.getSchemaMap();
+}

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -1,5 +1,6 @@
 import get from 'lodash/get';
 import set from 'lodash/set';
+import times from 'lodash/times';
 import mergeAllOf, { Options } from 'json-schema-merge-allof';
 
 import {
@@ -8,108 +9,192 @@ import {
   ALL_OF_KEY,
   ANY_OF_KEY,
   DEPENDENCIES_KEY,
+  IF_KEY,
   ONE_OF_KEY,
   REF_KEY,
 } from '../constants';
 import findSchemaDefinition, { splitKeyElementFromObject } from '../findSchemaDefinition';
+import getDiscriminatorFieldFromSchema from '../getDiscriminatorFieldFromSchema';
 import guessType from '../guessType';
 import isObject from '../isObject';
 import mergeSchemas from '../mergeSchemas';
 import { FormContextType, GenericObjectType, RJSFSchema, StrictRJSFSchema, ValidatorType } from '../types';
 import getFirstMatchingOption from './getFirstMatchingOption';
 
-/** Resolves a conditional block (if/else/then) by removing the condition and merging the appropriate conditional branch
- * with the rest of the schema
+/** Retrieves an expanded schema that has had all of its conditions, additional properties, references and dependencies
+ * resolved and merged into the `schema` given a `validator`, `rootSchema` and `rawFormData` that is used to do the
+ * potentially recursive resolution.
  *
- * @param validator - An implementation of the `ValidatorType<T, S>` interface that is used to detect valid schema conditions
+ * @param validator - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
+ * @param schema - The schema for which retrieving a schema is desired
+ * @param [rootSchema={}] - The root schema that will be forwarded to all the APIs
+ * @param [rawFormData] - The current formData, if any, to assist retrieving a schema
+ * @returns - The schema having its conditions, additional properties, references and dependencies resolved
+ */
+export default function retrieveSchema<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
+>(validator: ValidatorType<T, S, F>, schema: S, rootSchema: S = {} as S, rawFormData?: T): S {
+  return retrieveSchemaInternal<T, S, F>(validator, schema, rootSchema, rawFormData)[0];
+}
+
+/** Resolves a conditional block (if/else/then) by removing the condition and merging the appropriate conditional branch
+ * with the rest of the schema. If `expandAllBranches` is true, then the `retrieveSchemaInteral()` results for both
+ * conditions will be returned.
+ *
+ * @param validator - An implementation of the `ValidatorType` interface that is used to detect valid schema conditions
  * @param schema - The schema for which resolving a condition is desired
  * @param rootSchema - The root schema that will be forwarded to all the APIs
+ * @param expandAllBranches - Flag, if true, will return all possible branches of conditions, any/oneOf and
+ *          dependencies as a list of schemas
  * @param [formData] - The current formData to assist retrieving a schema
- * @returns - A schema with the appropriate condition resolved
+ * @returns - A list of schemas with the appropriate conditions resolved, possibly with all branches expanded
  */
 export function resolveCondition<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   validator: ValidatorType<T, S, F>,
   schema: S,
   rootSchema: S,
+  expandAllBranches: boolean,
   formData?: T
-) {
+): S[] {
   const { if: expression, then, else: otherwise, ...resolvedSchemaLessConditional } = schema;
 
-  const conditionalSchema = validator.isValid(expression as S, formData, rootSchema) ? then : otherwise;
-
-  if (conditionalSchema && typeof conditionalSchema !== 'boolean') {
-    return retrieveSchema<T, S>(
-      validator,
-      mergeSchemas(
-        resolvedSchemaLessConditional,
-        retrieveSchema<T, S, F>(validator, conditionalSchema as S, rootSchema, formData)
-      ) as S,
-      rootSchema,
-      formData
-    );
+  const conditionValue = validator.isValid(expression as S, formData, rootSchema);
+  let resolvedSchemas = [resolvedSchemaLessConditional as S];
+  let schemas: S[] = [];
+  if (expandAllBranches) {
+    if (then && typeof then !== 'boolean') {
+      schemas = schemas.concat(
+        retrieveSchemaInternal<T, S, F>(validator, then as S, rootSchema, formData, expandAllBranches)
+      );
+    }
+    if (otherwise && typeof otherwise !== 'boolean') {
+      schemas = schemas.concat(
+        retrieveSchemaInternal<T, S, F>(validator, otherwise as S, rootSchema, formData, expandAllBranches)
+      );
+    }
+  } else {
+    const conditionalSchema = conditionValue ? then : otherwise;
+    if (conditionalSchema && typeof conditionalSchema !== 'boolean') {
+      schemas = schemas.concat(
+        retrieveSchemaInternal<T, S, F>(validator, conditionalSchema as S, rootSchema, formData, expandAllBranches)
+      );
+    }
   }
-  return retrieveSchema<T, S, F>(validator, resolvedSchemaLessConditional as S, rootSchema, formData);
+  if (schemas.length) {
+    resolvedSchemas = schemas.map((s) => mergeSchemas(resolvedSchemaLessConditional, s) as S);
+  }
+  return resolvedSchemas.flatMap((s) =>
+    retrieveSchemaInternal<T, S, F>(validator, s, rootSchema, formData, expandAllBranches)
+  );
 }
 
-/** Resolves references and dependencies within a schema and its 'allOf' children.
- * Called internally by retrieveSchema.
+/** Given a list of lists of allOf, anyOf or oneOf values, create a list of lists of all permutations of the values. The
+ * `listOfLists` is expected to be all resolved values of the 1st...nth schemas within an `allOf`, `anyOf` or `oneOf`.
+ * From those lists, build a matrix for each `xxxOf` where there is more than one schema for a row in the list of lists.
  *
- * @param validator - An implementation of the `ValidatorType<T, S>` interface that will be forwarded to all the APIs
+ * For example:
+ * - If there are three xxxOf rows (A, B, C) and they have been resolved such that there is only one A, two B and three
+ *   C schemas then:
+ *   - The permutation for the first row is `[[A]]`
+ *   - The permutations for the second row are `[[A,B1], [A,B2]]`
+ *   - The permutations for the third row are `[[A,B1,C1], [A,B1,C2], [A,B1,C3], [A,B2,C1], [A,B2,C2], [A,B2,C3]]`
+ *
+ * @param listOfLists - The list of lists of elements that represent the allOf, anyOf or oneOf resolved values in order
+ * @returns - The list of all permutations of schemas for a set of `xxxOf`s
+ */
+export function getAllPermutationsOfXxxOf<S extends StrictRJSFSchema = RJSFSchema>(listOfLists: S[][]) {
+  const allPermutations: S[][] = listOfLists.reduce<S[][]>(
+    (permutations, list) => {
+      // When there are more than one set of schemas for a row, duplicate the set of permutations and add in the values
+      if (list.length > 1) {
+        return list.flatMap((element) => times(permutations.length, (i) => [...permutations[i]].concat(element)));
+      }
+      // Otherwise just push in the single value into the current set of permutations
+      permutations.forEach((permutation) => permutation.push(list[0]));
+      return permutations;
+    },
+    [[]] as S[][] // Start with an empty list
+  );
+
+  return allPermutations;
+}
+
+/** Resolves references and dependencies within a schema and its 'allOf' children. Passes the `expandAllBranches` flag
+ * down to the `retrieveSchemaInternal()`, `resolveReference()` and `resolveDependencies()` helper calls. If
+ * `expandAllBranches` is true, then all possible dependencies and/or allOf branches are returned.
+ *
+ * @param validator - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
  * @param schema - The schema for which resolving a schema is desired
- * @param [rootSchema={}] - The root schema that will be forwarded to all the APIs
+ * @param rootSchema - The root schema that will be forwarded to all the APIs
+ * @param expandAllBranches - Flag, if true, will return all possible branches of conditions, any/oneOf and dependencies
+ *          as a list of schemas
  * @param [formData] - The current formData, if any, to assist retrieving a schema
- * @returns - The schema having its references and dependencies resolved
+ * @returns - The list of schemas having its references, dependencies and allOf schemas resolved
  */
 export function resolveSchema<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   validator: ValidatorType<T, S, F>,
   schema: S,
-  rootSchema: S = {} as S,
+  rootSchema: S,
+  expandAllBranches: boolean,
   formData?: T
-): S {
+): S[] {
   if (REF_KEY in schema) {
-    return resolveReference<T, S, F>(validator, schema, rootSchema, formData);
+    return resolveReference<T, S, F>(validator, schema, rootSchema, expandAllBranches, formData);
   }
   if (DEPENDENCIES_KEY in schema) {
-    const resolvedSchema = resolveDependencies<T, S, F>(validator, schema, rootSchema, formData);
-    return retrieveSchema<T, S, F>(validator, resolvedSchema, rootSchema, formData);
+    const resolvedSchemas = resolveDependencies<T, S, F>(validator, schema, rootSchema, expandAllBranches, formData);
+    return resolvedSchemas.flatMap((s) => {
+      return retrieveSchemaInternal<T, S, F>(validator, s, rootSchema, formData, expandAllBranches);
+    });
   }
-  if (ALL_OF_KEY in schema) {
-    return {
-      ...schema,
-      allOf: schema.allOf!.map((allOfSubschema) =>
-        retrieveSchema<T, S, F>(validator, allOfSubschema as S, rootSchema, formData)
-      ),
-    };
+  if (ALL_OF_KEY in schema && Array.isArray(schema.allOf)) {
+    const allOfSchemaElements: S[][] = schema.allOf.map((allOfSubschema) =>
+      retrieveSchemaInternal<T, S, F>(validator, allOfSubschema as S, rootSchema, formData, expandAllBranches)
+    );
+    const allPermutations = getAllPermutationsOfXxxOf<S>(allOfSchemaElements);
+    return allPermutations.map((permutation) => ({ ...schema, allOf: permutation }));
   }
-  // No $ref or dependencies attribute found, returning the original schema.
-  return schema;
+  // No $ref or dependencies or allOf attribute was found, returning the original schema.
+  return [schema];
 }
 
-/** Resolves references within a schema and its 'allOf' children.
+/** Resolves references within a schema and then returns the `retrieveSchemaInternal()` of the resolved schema. Passes
+ * the `expandAllBranches` flag down to the `retrieveSchemaInternal()` helper call.
  *
- * @param validator - An implementation of the `ValidatorType<T, S>` interface that will be forwarded to all the APIs
+ * @param validator - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
  * @param schema - The schema for which resolving a reference is desired
  * @param rootSchema - The root schema that will be forwarded to all the APIs
+ * @param expandAllBranches - Flag, if true, will return all possible branches of conditions, any/oneOf and dependencies
+ *          as a list of schemas
  * @param [formData] - The current formData, if any, to assist retrieving a schema
- * @returns - The schema having its references resolved
+ * @returns - The list schemas retrieved after having all references resolved
  */
 export function resolveReference<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   validator: ValidatorType<T, S, F>,
   schema: S,
   rootSchema: S,
+  expandAllBranches: boolean,
   formData?: T
-): S {
-  // Retrieve the referenced schema definition.
-  const $refSchema = findSchemaDefinition<S>(schema.$ref, rootSchema);
+): S[] {
   // Drop the $ref property of the source schema.
   const { $ref, ...localSchema } = schema;
+  // Retrieve the referenced schema definition.
+  const refSchema = findSchemaDefinition<S>($ref, rootSchema);
   // Update referenced schema definition with local schema properties.
-  return retrieveSchema<T, S, F>(validator, { ...$refSchema, ...localSchema }, rootSchema, formData);
+  return retrieveSchemaInternal<T, S, F>(
+    validator,
+    { ...refSchema, ...localSchema },
+    rootSchema,
+    formData,
+    expandAllBranches
+  );
 }
 
 /** Creates new 'properties' items for each key in the `formData`
  *
- * @param validator - An implementation of the `ValidatorType<T, S>` interface that will be used when necessary
+ * @param validator - An implementation of the `ValidatorType` interface that will be used when necessary
  * @param theSchema - The schema for which the existing additional properties is desired
  * @param [rootSchema] - The root schema, used to primarily to look up `$ref`s * @param validator
  * @param [aFormData] - The current formData, if any, to assist retrieving a schema
@@ -120,7 +205,7 @@ export function stubExistingAdditionalProperties<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any
 >(validator: ValidatorType<T, S, F>, theSchema: S, rootSchema?: S, aFormData?: T): S {
-  // Clone the schema so we don't ruin the consumer's original
+  // Clone the schema so that we don't ruin the consumer's original
   const schema = {
     ...theSchema,
     properties: { ...theSchema.properties },
@@ -166,86 +251,139 @@ export function stubExistingAdditionalProperties<
   return schema;
 }
 
-/** Retrieves an expanded schema that has had all of its conditions, additional properties, references and dependencies
- * resolved and merged into the `schema` given a `validator`, `rootSchema` and `rawFormData` that is used to do the
- * potentially recursive resolution.
+/** Internal handler that retrieves an expanded schema that has had all of its conditions, additional properties,
+ * references and dependencies resolved and merged into the `schema` given a `validator`, `rootSchema` and `rawFormData`
+ * that is used to do the potentially recursive resolution. If `expandAllBranches` is true, then all possible branches
+ * of the schema and its references, conditions and dependencies are returned.
  *
- * @param validator - An implementation of the `ValidatorType<T, S>` interface that will be forwarded to all the APIs
+ * @param validator - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
  * @param schema - The schema for which retrieving a schema is desired
- * @param [rootSchema={}] - The root schema that will be forwarded to all the APIs
+ * @param rootSchema - The root schema that will be forwarded to all the APIs
  * @param [rawFormData] - The current formData, if any, to assist retrieving a schema
- * @returns - The schema having its conditions, additional properties, references and dependencies resolved
+ * @param [expandAllBranches=false] - Flag, if true, will return all possible branches of conditions, any/oneOf and
+ *          dependencies as a list of schemas
+ * @returns - The schema(s) resulting from having its conditions, additional properties, references and dependencies
+ *          resolved. Multiple schemas may be returned if `expandAllBranches` is true.
  */
-export default function retrieveSchema<
+export function retrieveSchemaInternal<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any
->(validator: ValidatorType<T, S, F>, schema: S, rootSchema: S = {} as S, rawFormData?: T): S {
+>(validator: ValidatorType<T, S, F>, schema: S, rootSchema: S, rawFormData?: T, expandAllBranches = false): S[] {
   if (!isObject(schema)) {
-    return {} as S;
+    return [{} as S];
   }
-  let resolvedSchema = resolveSchema<T, S, F>(validator, schema, rootSchema, rawFormData);
-
-  if ('if' in schema) {
-    return resolveCondition<T, S, F>(validator, schema, rootSchema, rawFormData as T);
-  }
-
-  const formData: GenericObjectType = rawFormData || {};
-
-  if (ALL_OF_KEY in schema) {
-    try {
-      resolvedSchema = mergeAllOf(resolvedSchema, {
-        deep: false,
-      } as Options) as S;
-    } catch (e) {
-      console.warn('could not merge subschemas in allOf:\n', e);
-      const { allOf, ...resolvedSchemaWithoutAllOf } = resolvedSchema;
-      return resolvedSchemaWithoutAllOf as S;
+  const resolvedSchemas = resolveSchema<T, S, F>(validator, schema, rootSchema, expandAllBranches, rawFormData);
+  return resolvedSchemas.flatMap((s: S) => {
+    let resolvedSchema = s;
+    if (IF_KEY in resolvedSchema) {
+      return resolveCondition<T, S, F>(validator, resolvedSchema, rootSchema, expandAllBranches, rawFormData as T);
     }
-  }
-  const hasAdditionalProperties =
-    ADDITIONAL_PROPERTIES_KEY in resolvedSchema && resolvedSchema.additionalProperties !== false;
-  if (hasAdditionalProperties) {
-    return stubExistingAdditionalProperties<T, S, F>(validator, resolvedSchema, rootSchema, formData as T);
-  }
-  return resolvedSchema;
+    if (ALL_OF_KEY in schema) {
+      try {
+        resolvedSchema = mergeAllOf(s, {
+          deep: false,
+        } as Options) as S;
+      } catch (e) {
+        console.warn('could not merge subschemas in allOf:\n', e);
+        const { allOf, ...resolvedSchemaWithoutAllOf } = resolvedSchema;
+        return resolvedSchemaWithoutAllOf as S;
+      }
+    }
+    const hasAdditionalProperties =
+      ADDITIONAL_PROPERTIES_KEY in resolvedSchema && resolvedSchema.additionalProperties !== false;
+    if (hasAdditionalProperties) {
+      return stubExistingAdditionalProperties<T, S, F>(validator, resolvedSchema, rootSchema, rawFormData as T);
+    }
+
+    return resolvedSchema;
+  });
 }
 
-/** Resolves dependencies within a schema and its 'allOf' children.
+/** Resolves an `anyOf` or `oneOf` within a schema (if present) to the list of schemas returned from
+ * `retrieveSchemaInternal()` for the best matching option. If `expandAllBranches` is true, then a list of schemas for ALL
+ * options are retrieved and returned.
  *
- * @param validator - An implementation of the `ValidatorType<T, S>` interface that will be forwarded to all the APIs
+ * @param validator - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
+ * @param schema - The schema for which retrieving a schema is desired
+ * @param rootSchema - The root schema that will be forwarded to all the APIs
+ * @param expandAllBranches - Flag, if true, will return all possible branches of conditions, any/oneOf and dependencies
+ *          as a list of schemas
+ * @param [rawFormData] - The current formData, if any, to assist retrieving a schema, defaults to an empty object
+ * @returns - Either an array containing the best matching option or all options if `expandAllBranches` is true
+ */
+export function resolveAnyOrOneOfSchemas<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any
+>(validator: ValidatorType<T, S, F>, schema: S, rootSchema: S, expandAllBranches: boolean, rawFormData?: T) {
+  let anyOrOneOf: S[] | undefined;
+  if (Array.isArray(schema.oneOf)) {
+    anyOrOneOf = schema.oneOf as S[];
+  } else if (Array.isArray(schema.anyOf)) {
+    anyOrOneOf = schema.anyOf as S[];
+  }
+  if (anyOrOneOf) {
+    // Ensure that during expand all branches we pass an object rather than undefined so that all options are interrogated
+    const formData = rawFormData === undefined && expandAllBranches ? ({} as T) : rawFormData;
+    const discriminator = getDiscriminatorFieldFromSchema<S>(schema);
+    anyOrOneOf = anyOrOneOf.map((s) => {
+      if (REF_KEY in s) {
+        // For this ref situation, don't expand all branches and just pick the first/only schema result
+        return resolveReference<T, S, F>(validator, s, rootSchema, false, formData)[0];
+      }
+      return s;
+    });
+    const option = getFirstMatchingOption<T, S, F>(validator, formData, anyOrOneOf, rootSchema, discriminator);
+    if (expandAllBranches) {
+      return anyOrOneOf;
+    }
+    schema = anyOrOneOf[option] as S;
+  }
+  return [schema];
+}
+
+/** Resolves dependencies within a schema and its 'anyOf/oneOf' children. Passes the `expandAllBranches` flag down to
+ * the `resolveAnyOrOneOfSchema()` and `processDependencies()` helper calls.
+ *
+ * @param validator - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
  * @param schema - The schema for which resolving a dependency is desired
  * @param rootSchema - The root schema that will be forwarded to all the APIs
+ * @param expandAllBranches - Flag, if true, will return all possible branches of conditions, any/oneOf and dependencies
+ *          as a list of schemas
  * @param [formData] - The current formData, if any, to assist retrieving a schema
- * @returns - The schema with its dependencies resolved
+ * @returns - The list of schemas with their dependencies resolved
  */
 export function resolveDependencies<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   validator: ValidatorType<T, S, F>,
   schema: S,
   rootSchema: S,
+  expandAllBranches: boolean,
   formData?: T
-): S {
+): S[] {
   // Drop the dependencies from the source schema.
   const { dependencies, ...remainingSchema } = schema;
-  let resolvedSchema: S = remainingSchema as S;
-  if (Array.isArray(resolvedSchema.oneOf)) {
-    resolvedSchema = resolvedSchema.oneOf[
-      getFirstMatchingOption<T, S, F>(validator, formData, resolvedSchema.oneOf as S[], rootSchema)
-    ] as S;
-  } else if (Array.isArray(resolvedSchema.anyOf)) {
-    resolvedSchema = resolvedSchema.anyOf[
-      getFirstMatchingOption<T, S, F>(validator, formData, resolvedSchema.anyOf as S[], rootSchema)
-    ] as S;
-  }
-  return processDependencies<T, S, F>(validator, dependencies, resolvedSchema, rootSchema, formData);
+  const resolvedSchemas = resolveAnyOrOneOfSchemas<T, S, F>(
+    validator,
+    remainingSchema as S,
+    rootSchema,
+    expandAllBranches,
+    formData
+  );
+  return resolvedSchemas.flatMap((resolvedSchema) =>
+    processDependencies<T, S, F>(validator, dependencies, resolvedSchema, rootSchema, expandAllBranches, formData)
+  );
 }
 
-/** Processes all the `dependencies` recursively into the `resolvedSchema` as needed
+/** Processes all the `dependencies` recursively into the list of `resolvedSchema`s as needed. Passes the
+ * `expandAllBranches` flag down to the `withDependentSchema()` and the recursive `processDependencies()` helper calls.
  *
- * @param validator - An implementation of the `ValidatorType<T, S>` interface that will be forwarded to all the APIs
+ * @param validator - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
  * @param dependencies - The set of dependencies that needs to be processed
  * @param resolvedSchema - The schema for which processing dependencies is desired
  * @param rootSchema - The root schema that will be forwarded to all the APIs
+ * @param expandAllBranches - Flag, if true, will return all possible branches of conditions, any/oneOf and dependencies
+ *          as a list of schemas
  * @param [formData] - The current formData, if any, to assist retrieving a schema
  * @returns - The schema with the `dependencies` resolved into it
  */
@@ -254,17 +392,18 @@ export function processDependencies<T = any, S extends StrictRJSFSchema = RJSFSc
   dependencies: S['dependencies'],
   resolvedSchema: S,
   rootSchema: S,
+  expandAllBranches: boolean,
   formData?: T
-): S {
-  let schema = resolvedSchema;
+): S[] {
+  let schemas = [resolvedSchema];
   // Process dependencies updating the local schema properties as appropriate.
   for (const dependencyKey in dependencies) {
     // Skip this dependency if its trigger property is not present.
-    if (get(formData, [dependencyKey]) === undefined) {
+    if (!expandAllBranches && get(formData, [dependencyKey]) === undefined) {
       continue;
     }
     // Skip this dependency if it is not included in the schema (such as when dependencyKey is itself a hidden dependency.)
-    if (schema.properties && !(dependencyKey in schema.properties)) {
+    if (resolvedSchema.properties && !(dependencyKey in resolvedSchema.properties)) {
       continue;
     }
     const [remainingDependencies, dependencyValue] = splitKeyElementFromObject(
@@ -272,20 +411,23 @@ export function processDependencies<T = any, S extends StrictRJSFSchema = RJSFSc
       dependencies as GenericObjectType
     );
     if (Array.isArray(dependencyValue)) {
-      schema = withDependentProperties<S>(schema, dependencyValue);
+      schemas[0] = withDependentProperties<S>(resolvedSchema, dependencyValue);
     } else if (isObject(dependencyValue)) {
-      schema = withDependentSchema<T, S, F>(
+      schemas = withDependentSchema<T, S, F>(
         validator,
-        schema,
+        resolvedSchema,
         rootSchema,
         dependencyKey,
         dependencyValue as S,
+        expandAllBranches,
         formData
       );
     }
-    return processDependencies<T, S, F>(validator, remainingDependencies, schema, rootSchema, formData);
+    return schemas.flatMap((schema) =>
+      processDependencies<T, S, F>(validator, remainingDependencies, schema, rootSchema, expandAllBranches, formData)
+    );
   }
-  return schema;
+  return schemas;
 }
 
 /** Updates a schema with additionally required properties added
@@ -307,15 +449,18 @@ export function withDependentProperties<S extends StrictRJSFSchema = RJSFSchema>
   return { ...schema, required: required };
 }
 
-/** Merges a dependent schema into the `schema` dealing with oneOfs and references
+/** Merges a dependent schema into the `schema` dealing with oneOfs and references. Passes the `expandAllBranches` flag
+ * down to the `retrieveSchemaInternal()`, `resolveReference()` and `withExactlyOneSubschema()` helper calls.
  *
- * @param validator - An implementation of the `ValidatorType<T, S>` interface that will be forwarded to all the APIs
+ * @param validator - An implementation of the `ValidatorType` interface that will be forwarded to all the APIs
  * @param schema - The schema for which resolving a dependent schema is desired
  * @param rootSchema - The root schema that will be forwarded to all the APIs
  * @param dependencyKey - The key name of the dependency
  * @param dependencyValue - The potentially dependent schema
- * @param formData- The current formData to assist retrieving a schema
- * @returns - The schema with the dependent schema resolved into it
+ * @param expandAllBranches - Flag, if true, will return all possible branches of conditions, any/oneOf and dependencies
+ *          as a list of schemas
+ * @param [formData]- The current formData to assist retrieving a schema
+ * @returns - The list of schemas with the dependent schema resolved into them
  */
 export function withDependentSchema<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   validator: ValidatorType<T, S, F>,
@@ -323,33 +468,58 @@ export function withDependentSchema<T = any, S extends StrictRJSFSchema = RJSFSc
   rootSchema: S,
   dependencyKey: string,
   dependencyValue: S,
+  expandAllBranches: boolean,
   formData?: T
-) {
-  const { oneOf, ...dependentSchema } = retrieveSchema<T, S, F>(validator, dependencyValue, rootSchema, formData);
-  schema = mergeSchemas(schema, dependentSchema) as S;
-  // Since it does not contain oneOf, we return the original schema.
-  if (oneOf === undefined) {
-    return schema;
-  }
-  // Resolve $refs inside oneOf.
-  const resolvedOneOf = oneOf.map((subschema) => {
-    if (typeof subschema === 'boolean' || !(REF_KEY in subschema)) {
-      return subschema;
+): S[] {
+  const dependentSchemas = retrieveSchemaInternal<T, S, F>(
+    validator,
+    dependencyValue,
+    rootSchema,
+    formData,
+    expandAllBranches
+  );
+  return dependentSchemas.flatMap((dependent) => {
+    const { oneOf, ...dependentSchema } = dependent;
+    schema = mergeSchemas(schema, dependentSchema) as S;
+    // Since it does not contain oneOf, we return the original schema.
+    if (oneOf === undefined) {
+      return schema;
     }
-    return resolveReference<T, S, F>(validator, subschema as S, rootSchema, formData);
+    // Resolve $refs inside oneOf.
+    const resolvedOneOfs = oneOf.map((subschema) => {
+      if (typeof subschema === 'boolean' || !(REF_KEY in subschema)) {
+        return [subschema as S];
+      }
+      return resolveReference<T, S, F>(validator, subschema as S, rootSchema, expandAllBranches, formData);
+    });
+    const allPermutations = getAllPermutationsOfXxxOf(resolvedOneOfs);
+    return allPermutations.flatMap((resolvedOneOf) =>
+      withExactlyOneSubschema<T, S, F>(
+        validator,
+        schema,
+        rootSchema,
+        dependencyKey,
+        resolvedOneOf,
+        expandAllBranches,
+        formData
+      )
+    );
   });
-  return withExactlyOneSubschema<T, S, F>(validator, schema, rootSchema, dependencyKey, resolvedOneOf, formData);
 }
 
-/** Returns a `schema` with the best choice from the `oneOf` options merged into it
+/** Returns a list of `schema`s with the best choice from the `oneOf` options merged into it. If `expandAllBranches` is
+ * true, then a list of schemas for ALL options are retrieved and returned. Passes the `expandAllBranches` flag down to
+ * the `retrieveSchemaInternal()` helper call.
  *
- * @param validator - An implementation of the `ValidatorType<T, S>` interface that will be used to validate oneOf options
+ * @param validator - An implementation of the `ValidatorType` interface that will be used to validate oneOf options
  * @param schema - The schema for which resolving a oneOf subschema is desired
  * @param rootSchema - The root schema that will be forwarded to all the APIs
  * @param dependencyKey - The key name of the oneOf dependency
  * @param oneOf - The list of schemas representing the oneOf options
+ * @param expandAllBranches - Flag, if true, will return all possible branches of conditions, any/oneOf and dependencies
+ *          as a list of schemas
  * @param [formData] - The current formData to assist retrieving a schema
- * @returns  The schema with the best choice of oneOf schemas merged into
+ * @returns - Either an array containing the best matching option or all options if `expandAllBranches` is true
  */
 export function withExactlyOneSubschema<
   T = any,
@@ -361,8 +531,9 @@ export function withExactlyOneSubschema<
   rootSchema: S,
   dependencyKey: string,
   oneOf: S['oneOf'],
+  expandAllBranches: boolean,
   formData?: T
-): S {
+): S[] {
   const validSubschemas = oneOf!.filter((subschema) => {
     if (typeof subschema === 'boolean' || !subschema || !subschema.properties) {
       return false;
@@ -375,17 +546,26 @@ export function withExactlyOneSubschema<
           [dependencyKey]: conditionPropertySchema,
         },
       } as S;
-      return validator.isValid(conditionSchema, formData, rootSchema);
+      return validator.isValid(conditionSchema, formData, rootSchema) || expandAllBranches;
     }
     return false;
   });
 
-  if (validSubschemas!.length !== 1) {
+  if (!expandAllBranches && validSubschemas!.length !== 1) {
     console.warn("ignoring oneOf in dependencies because there isn't exactly one subschema that is valid");
-    return schema;
+    return [schema];
   }
-  const subschema: S = validSubschemas[0] as S;
-  const [dependentSubschema] = splitKeyElementFromObject(dependencyKey, subschema.properties as GenericObjectType);
-  const dependentSchema = { ...subschema, properties: dependentSubschema };
-  return mergeSchemas(schema, retrieveSchema<T, S>(validator, dependentSchema, rootSchema, formData)) as S;
+  return validSubschemas.flatMap((s) => {
+    const subschema: S = s as S;
+    const [dependentSubschema] = splitKeyElementFromObject(dependencyKey, subschema.properties as GenericObjectType);
+    const dependentSchema = { ...subschema, properties: dependentSubschema };
+    const schemas = retrieveSchemaInternal<T, S, F>(
+      validator,
+      dependentSchema,
+      rootSchema,
+      formData,
+      expandAllBranches
+    );
+    return schemas.map((s) => mergeSchemas(schema, s) as S);
+  });
 }

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -334,6 +334,7 @@ export function resolveAnyOrOneOfSchemas<
       }
       return s;
     });
+    // Call this to trigger the set of isValid() calls that the schema parser will need
     const option = getFirstMatchingOption<T, S, F>(validator, formData, anyOrOneOf, rootSchema, discriminator);
     if (expandAllBranches) {
       return anyOrOneOf;

--- a/packages/utils/src/schema/toPathSchema.ts
+++ b/packages/utils/src/schema/toPathSchema.ts
@@ -14,6 +14,7 @@ import {
   REF_KEY,
   RJSF_ADDITONAL_PROPERTIES_FLAG,
 } from '../constants';
+import getDiscriminatorFieldFromSchema from '../getDiscriminatorFieldFromSchema';
 import { FormContextType, PathSchema, RJSFSchema, StrictRJSFSchema, ValidatorType } from '../types';
 import getClosestMatchingOption from './getClosestMatchingOption';
 import retrieveSchema from './retrieveSchema';
@@ -57,13 +58,29 @@ function toPathSchemaInternal<T = any, S extends StrictRJSFSchema = RJSFSchema, 
   } as PathSchema;
 
   if (ONE_OF_KEY in schema) {
-    const index = getClosestMatchingOption<T, S, F>(validator, rootSchema!, formData, schema.oneOf as S[], 0);
+    const discriminator = getDiscriminatorFieldFromSchema<S>(schema);
+    const index = getClosestMatchingOption<T, S, F>(
+      validator,
+      rootSchema!,
+      formData,
+      schema.oneOf as S[],
+      0,
+      discriminator
+    );
     const _schema: S = schema.oneOf![index] as S;
     return toPathSchemaInternal<T, S, F>(validator, _schema, name, rootSchema, formData, _recurseList);
   }
 
   if (ANY_OF_KEY in schema) {
-    const index = getClosestMatchingOption<T, S, F>(validator, rootSchema!, formData, schema.anyOf as S[], 0);
+    const discriminator = getDiscriminatorFieldFromSchema<S>(schema);
+    const index = getClosestMatchingOption<T, S, F>(
+      validator,
+      rootSchema!,
+      formData,
+      schema.anyOf as S[],
+      0,
+      discriminator
+    );
     const _schema: S = schema.anyOf![index] as S;
     return toPathSchemaInternal<T, S, F>(validator, _schema, name, rootSchema, formData, _recurseList);
   }

--- a/packages/utils/test/__snapshots__/hashFromSchema.test.ts.snap
+++ b/packages/utils/test/__snapshots__/hashFromSchema.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`hashForSchema returns a hash for a more complex schema 1`] = `"-6bbb062a"`;
+
+exports[`hashForSchema returns a hash for a tiny schema 1`] = `"5b2fed3d"`;

--- a/packages/utils/test/getDiscriminatorFieldFromSchema.test.ts
+++ b/packages/utils/test/getDiscriminatorFieldFromSchema.test.ts
@@ -1,0 +1,30 @@
+import { getDiscriminatorFieldFromSchema, RJSFSchema } from '../src';
+
+const PROPERTY_NAME = 'testProp';
+const BAD_DISCRIMINATOR: RJSFSchema = { discriminator: { propertyName: 5 } };
+const GOOD_DISCRIMINATOR: RJSFSchema = { discriminator: { propertyName: PROPERTY_NAME } };
+
+describe('getDiscriminatorFieldFromSchema()', () => {
+  it('returns undefined when no discriminator is present', () => {
+    expect(getDiscriminatorFieldFromSchema({})).toBeUndefined();
+  });
+  it('returns the propertyName when discriminator is present', () => {
+    expect(getDiscriminatorFieldFromSchema(GOOD_DISCRIMINATOR)).toEqual(PROPERTY_NAME);
+  });
+  describe('bad discriminator', () => {
+    let consoleWarn: jest.SpyInstance;
+    beforeAll(() => {
+      // Spy and mock to be silent
+      consoleWarn = jest.spyOn(console, 'warn').mockImplementation();
+    });
+    afterAll(() => {
+      consoleWarn.mockRestore();
+    });
+    it('returns undefined when discriminator is present, but not a string', () => {
+      expect(getDiscriminatorFieldFromSchema(BAD_DISCRIMINATOR)).toBeUndefined();
+    });
+    it('it also warns about the bad discriminator', () => {
+      expect(consoleWarn).toHaveBeenCalledWith('Expecting discriminator to be a string, got "number" instead');
+    });
+  });
+});

--- a/packages/utils/test/hashFromSchema.test.ts
+++ b/packages/utils/test/hashFromSchema.test.ts
@@ -1,0 +1,16 @@
+import { hashForSchema, RJSFSchema } from '../src';
+import { RECURSIVE_REF } from './testUtils/testData';
+
+const TINY_SCHEMA: RJSFSchema = {
+  type: 'string',
+  title: 'test',
+};
+
+describe('hashForSchema', () => {
+  it('returns a hash for a tiny schema', () => {
+    expect(hashForSchema(TINY_SCHEMA)).toEqual('1529867581');
+  });
+  it('returns a hash for a more complex schema', () => {
+    expect(hashForSchema(RECURSIVE_REF)).toEqual('-1807418922');
+  });
+});

--- a/packages/utils/test/hashFromSchema.test.ts
+++ b/packages/utils/test/hashFromSchema.test.ts
@@ -8,9 +8,9 @@ const TINY_SCHEMA: RJSFSchema = {
 
 describe('hashForSchema', () => {
   it('returns a hash for a tiny schema', () => {
-    expect(hashForSchema(TINY_SCHEMA)).toEqual('1529867581');
+    expect(hashForSchema(TINY_SCHEMA)).toMatchSnapshot();
   });
   it('returns a hash for a more complex schema', () => {
-    expect(hashForSchema(RECURSIVE_REF)).toEqual('-1807418922');
+    expect(hashForSchema(RECURSIVE_REF)).toMatchSnapshot();
   });
 });

--- a/packages/utils/test/parser/ParserValidator.test.ts
+++ b/packages/utils/test/parser/ParserValidator.test.ts
@@ -77,7 +77,7 @@ describe('ParserValidator', () => {
     validator.schemaMap[DUPLICATE_HASH] = TINY_SCHEMA;
     expect(() => validator.isValid(DUPLICATE_SCHEMA, undefined, RECURSIVE_REF)).toThrowError(
       new Error(
-        `Two different schemas exist with the same key ${DUPLICATE_HASH}! What a bad coincidence. If possible, try adding an $ID to one of the schemas`
+        `Two different schemas exist with the same key ${DUPLICATE_HASH}! What a bad coincidence. If possible, try adding an $id to one of the schemas`
       )
     );
   });

--- a/packages/utils/test/parser/ParserValidator.test.ts
+++ b/packages/utils/test/parser/ParserValidator.test.ts
@@ -1,0 +1,66 @@
+import { hashForSchema, ID_KEY, RJSFSchema } from '../../src';
+import ParserValidator from '../../src/parser/ParserValidator';
+import { RECURSIVE_REF } from '../testUtils/testData';
+
+const TINY_SCHEMA: RJSFSchema = {
+  type: 'string',
+  title: 'test',
+};
+const ID_HASH = 'foo';
+const ID_SCHEMA: RJSFSchema = {
+  type: 'number',
+  [ID_KEY]: ID_HASH,
+};
+const RECURSIVE_HASH = hashForSchema(RECURSIVE_REF);
+const TINY_HASH = hashForSchema(TINY_SCHEMA);
+
+describe('ParserValidator', () => {
+  let validator: ParserValidator;
+  beforeAll(() => {
+    validator = new ParserValidator(RECURSIVE_REF);
+  });
+  it('map after construction, contains the rootSchema with the hash injected as the ID_KEY', () => {
+    expect(validator.getSchemaMap()).toEqual({
+      [RECURSIVE_HASH]: { ...RECURSIVE_REF, [ID_KEY]: RECURSIVE_HASH },
+    });
+  });
+  it('isValid() throws error when rootSchema differs', () => {
+    expect(() => validator.isValid(TINY_SCHEMA, undefined, ID_SCHEMA)).toThrowError(
+      new Error('Unexpectedly calling isValid() with a rootSchema that differs from the construction rootSchema')
+    );
+  });
+  it('rawValidation() throws error when called', () => {
+    expect(() => validator.rawValidation(TINY_SCHEMA, undefined)).toThrowError(
+      new Error('Unexpectedly calling the `rawValidation()` method during schema parsing')
+    );
+  });
+  it('toErrorList() throws error when called', () => {
+    expect(() => validator.toErrorList({})).toThrowError(
+      new Error('Unexpectedly calling the `toErrorList()` method during schema parsing')
+    );
+  });
+  it('validateFormData() throws error when called', () => {
+    expect(() => validator.validateFormData({}, TINY_SCHEMA)).toThrowError(
+      new Error('Unexpectedly calling the `validateFormData()` method during schema parsing')
+    );
+  });
+  it('calling isValid() with TINY_SCHEMA, without setting explicit return value returns false', () => {
+    expect(validator.isValid(TINY_SCHEMA, undefined, RECURSIVE_REF)).toBe(false);
+  });
+  it('the TINY_SCHEMA was added to the map, with the hash injected as the ID_KEY', () => {
+    expect(validator.getSchemaMap()).toEqual({
+      [RECURSIVE_HASH]: { ...RECURSIVE_REF, [ID_KEY]: RECURSIVE_HASH },
+      [TINY_HASH]: { ...TINY_SCHEMA, [ID_KEY]: TINY_HASH },
+    });
+  });
+  it('calling isValid() will shift out and return the first isValidReturn value', () => {
+    expect(validator.isValid(ID_SCHEMA, undefined, RECURSIVE_REF)).toBe(false);
+  });
+  it('the ID_SCHEMA was added to the map without injecting the hash because it has an ID', () => {
+    expect(validator.getSchemaMap()).toEqual({
+      [RECURSIVE_HASH]: { ...RECURSIVE_REF, [ID_KEY]: RECURSIVE_HASH },
+      [TINY_HASH]: { ...TINY_SCHEMA, [ID_KEY]: TINY_HASH },
+      [ID_HASH]: ID_SCHEMA,
+    });
+  });
+});

--- a/packages/utils/test/parser/__snapshots__/schemaParser.test.ts.snap
+++ b/packages/utils/test/parser/__snapshots__/schemaParser.test.ts.snap
@@ -1,0 +1,883 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`schemaParser() parses property dependencies properly 1`] = `
+Object {
+  "741607452": Object {
+    "$id": "741607452",
+    "dependencies": Object {
+      "a": Array [
+        "b",
+      ],
+    },
+    "properties": Object {
+      "a": Object {
+        "type": "string",
+      },
+      "b": Object {
+        "type": "integer",
+      },
+    },
+    "required": Array [
+      "a",
+    ],
+    "type": "object",
+  },
+}
+`;
+
+exports[`schemaParser() parses recursive refs in allOf properly 1`] = `
+Object {
+  "64139818": Object {
+    "$id": "64139818",
+    "definitions": Object {
+      "@enum": Object {
+        "properties": Object {
+          "_id": Object {
+            "title": "Value",
+            "type": "number",
+          },
+          "children": Object {
+            "items": Object {
+              "allOf": Array [
+                Object {
+                  "$ref": "#/definitions/@enum",
+                },
+              ],
+            },
+            "title": "Subvalues",
+            "type": "array",
+          },
+          "name": Object {
+            "default": "",
+            "title": "Name",
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+    },
+    "properties": Object {
+      "value": Object {
+        "items": Object {
+          "allOf": Array [
+            Object {
+              "$ref": "#/definitions/@enum",
+            },
+          ],
+        },
+        "minItems": 1,
+        "type": "array",
+      },
+    },
+    "type": "object",
+  },
+}
+`;
+
+exports[`schemaParser() parses recursive refs properly 1`] = `
+Object {
+  "-1807418922": Object {
+    "$id": "-1807418922",
+    "$ref": "#/definitions/@enum",
+    "definitions": Object {
+      "@enum": Object {
+        "properties": Object {
+          "children": Object {
+            "$ref": "#/definitions/@enum",
+          },
+          "name": Object {
+            "default": "",
+            "title": "Name",
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+    },
+  },
+}
+`;
+
+exports[`schemaParser() parses schema and required dependencies properly 1`] = `
+Object {
+  "-173295518": Object {
+    "$id": "-173295518",
+    "dependencies": Object {
+      "a": Object {
+        "properties": Object {
+          "a": Object {
+            "type": "string",
+          },
+        },
+        "required": Array [
+          "b",
+        ],
+      },
+    },
+    "properties": Object {
+      "a": Object {
+        "type": "string",
+      },
+      "b": Object {
+        "type": "integer",
+      },
+    },
+    "required": Array [
+      "a",
+    ],
+    "type": "object",
+  },
+}
+`;
+
+exports[`schemaParser() parses schema dependencies properly 1`] = `
+Object {
+  "-2011303755": Object {
+    "$id": "-2011303755",
+    "dependencies": Object {
+      "a": Object {
+        "properties": Object {
+          "b": Object {
+            "type": "integer",
+          },
+        },
+      },
+    },
+    "properties": Object {
+      "a": Object {
+        "type": "string",
+      },
+    },
+    "type": "object",
+  },
+}
+`;
+
+exports[`schemaParser() parses schema dependencies with one of and refs properly 1`] = `
+Object {
+  "-172742607": Object {
+    "$id": "-172742607",
+    "properties": Object {
+      "a": Object {
+        "enum": Array [
+          "int",
+        ],
+      },
+    },
+    "type": "object",
+  },
+  "-1793193922": Object {
+    "$id": "-1793193922",
+    "definitions": Object {
+      "needsA": Object {
+        "properties": Object {
+          "a": Object {
+            "enum": Array [
+              "int",
+            ],
+          },
+          "b": Object {
+            "type": "integer",
+          },
+        },
+      },
+      "needsB": Object {
+        "properties": Object {
+          "a": Object {
+            "enum": Array [
+              "bool",
+            ],
+          },
+          "b": Object {
+            "type": "boolean",
+          },
+        },
+      },
+    },
+    "dependencies": Object {
+      "a": Object {
+        "oneOf": Array [
+          Object {
+            "$ref": "#/definitions/needsA",
+          },
+          Object {
+            "$ref": "#/definitions/needsB",
+          },
+        ],
+      },
+    },
+    "properties": Object {
+      "a": Object {
+        "enum": Array [
+          "int",
+          "bool",
+        ],
+        "type": "string",
+      },
+    },
+    "type": "object",
+  },
+  "-1924365990": Object {
+    "$id": "-1924365990",
+    "properties": Object {
+      "a": Object {
+        "enum": Array [
+          "bool",
+        ],
+      },
+    },
+    "type": "object",
+  },
+}
+`;
+
+exports[`schemaParser() parses schema with a single condition 1`] = `
+Object {
+  "-869848892": Object {
+    "$id": "-869848892",
+    "properties": Object {
+      "country": Object {
+        "const": "United States of America",
+      },
+    },
+  },
+  "1992009743": Object {
+    "$id": "1992009743",
+    "else": Object {
+      "properties": Object {
+        "postal_code": Object {
+          "pattern": "[A-Z][0-9][A-Z] [0-9][A-Z][0-9]",
+        },
+      },
+    },
+    "if": Object {
+      "properties": Object {
+        "country": Object {
+          "const": "United States of America",
+        },
+      },
+    },
+    "properties": Object {
+      "country": Object {
+        "default": "United States of America",
+        "enum": Array [
+          "United States of America",
+          "Canada",
+        ],
+      },
+    },
+    "then": Object {
+      "properties": Object {
+        "postal_code": Object {
+          "pattern": "[0-9]{5}(-[0-9]{4})?",
+        },
+      },
+    },
+    "type": "object",
+  },
+}
+`;
+
+exports[`schemaParser() parses schema with multiple conditions 1`] = `
+Object {
+  "-227845973": Object {
+    "$id": "-227845973",
+    "properties": Object {
+      "Animal": Object {
+        "const": "Cat",
+      },
+    },
+    "required": Array [
+      "Animal",
+    ],
+  },
+  "-917519938": Object {
+    "$id": "-917519938",
+    "properties": Object {
+      "BreedName": Object {
+        "const": "Alsatian",
+      },
+    },
+    "required": Array [
+      "BreedName",
+    ],
+  },
+  "1048460049": Object {
+    "$id": "1048460049",
+    "properties": Object {
+      "Animal": Object {
+        "const": "Dog",
+      },
+    },
+    "required": Array [
+      "Animal",
+    ],
+  },
+  "1531238602": Object {
+    "$id": "1531238602",
+    "properties": Object {
+      "BreedName": Object {
+        "const": "Dalmation",
+      },
+    },
+    "required": Array [
+      "BreedName",
+    ],
+  },
+  "2133215231": Object {
+    "$id": "2133215231",
+    "allOf": Array [
+      Object {
+        "if": Object {
+          "properties": Object {
+            "Animal": Object {
+              "const": "Cat",
+            },
+          },
+          "required": Array [
+            "Animal",
+          ],
+        },
+        "then": Object {
+          "properties": Object {
+            "Tail": Object {
+              "default": "Long",
+              "enum": Array [
+                "Long",
+                "Short",
+                "None",
+              ],
+              "title": "Tail length",
+              "type": "string",
+            },
+          },
+          "required": Array [
+            "Tail",
+          ],
+        },
+      },
+      Object {
+        "if": Object {
+          "properties": Object {
+            "Animal": Object {
+              "const": "Dog",
+            },
+          },
+          "required": Array [
+            "Animal",
+          ],
+        },
+        "then": Object {
+          "properties": Object {
+            "Breed": Object {
+              "allOf": Array [
+                Object {
+                  "if": Object {
+                    "properties": Object {
+                      "BreedName": Object {
+                        "const": "Alsatian",
+                      },
+                    },
+                    "required": Array [
+                      "BreedName",
+                    ],
+                  },
+                  "then": Object {
+                    "properties": Object {
+                      "Fur": Object {
+                        "default": "brown",
+                        "enum": Array [
+                          "black",
+                          "brown",
+                        ],
+                        "title": "Fur",
+                        "type": "string",
+                      },
+                    },
+                    "required": Array [
+                      "Fur",
+                    ],
+                  },
+                },
+                Object {
+                  "if": Object {
+                    "properties": Object {
+                      "BreedName": Object {
+                        "const": "Dalmation",
+                      },
+                    },
+                    "required": Array [
+                      "BreedName",
+                    ],
+                  },
+                  "then": Object {
+                    "properties": Object {
+                      "Spots": Object {
+                        "default": "small",
+                        "enum": Array [
+                          "large",
+                          "small",
+                        ],
+                        "title": "Spots",
+                        "type": "string",
+                      },
+                    },
+                    "required": Array [
+                      "Spots",
+                    ],
+                  },
+                },
+              ],
+              "properties": Object {
+                "BreedName": Object {
+                  "default": "Alsatian",
+                  "enum": Array [
+                    "Alsatian",
+                    "Dalmation",
+                  ],
+                  "title": "Breed name",
+                  "type": "string",
+                },
+              },
+              "required": Array [
+                "BreedName",
+              ],
+              "title": "Breed",
+            },
+          },
+        },
+      },
+    ],
+    "properties": Object {
+      "Animal": Object {
+        "default": "Cat",
+        "enum": Array [
+          "Cat",
+          "Dog",
+        ],
+        "title": "Animal",
+        "type": "string",
+      },
+    },
+    "required": Array [
+      "Animal",
+    ],
+    "type": "object",
+  },
+}
+`;
+
+exports[`schemaParser() parses schema with nested conditions 1`] = `
+Object {
+  "-256025126": Object {
+    "$id": "-256025126",
+    "properties": Object {
+      "state": Object {
+        "const": "New York",
+      },
+    },
+    "required": Array [
+      "state",
+    ],
+  },
+  "1524164913": Object {
+    "$id": "1524164913",
+    "properties": Object {
+      "state": Object {
+        "const": "California",
+      },
+    },
+    "required": Array [
+      "state",
+    ],
+  },
+  "351550690": Object {
+    "$id": "351550690",
+    "properties": Object {
+      "country": Object {
+        "const": "USA",
+      },
+    },
+    "required": Array [
+      "country",
+    ],
+  },
+  "757201982": Object {
+    "$id": "757201982",
+    "if": Object {
+      "properties": Object {
+        "country": Object {
+          "const": "USA",
+        },
+      },
+      "required": Array [
+        "country",
+      ],
+    },
+    "properties": Object {
+      "country": Object {
+        "enum": Array [
+          "USA",
+        ],
+      },
+    },
+    "required": Array [
+      "country",
+    ],
+    "then": Object {
+      "else": Object {
+        "if": Object {
+          "properties": Object {
+            "state": Object {
+              "const": "California",
+            },
+          },
+          "required": Array [
+            "state",
+          ],
+        },
+        "then": Object {
+          "properties": Object {
+            "city": Object {
+              "enum": Array [
+                "Los Angeles",
+                "San Diego",
+                "San Jose",
+              ],
+              "type": "string",
+            },
+          },
+        },
+      },
+      "if": Object {
+        "properties": Object {
+          "state": Object {
+            "const": "New York",
+          },
+        },
+        "required": Array [
+          "state",
+        ],
+      },
+      "properties": Object {
+        "state": Object {
+          "enum": Array [
+            "California",
+            "New York",
+          ],
+          "type": "string",
+        },
+      },
+      "required": Array [
+        "state",
+      ],
+      "then": Object {
+        "properties": Object {
+          "city": Object {
+            "enum": Array [
+              "New York City",
+              "Buffalo",
+              "Rochester",
+            ],
+            "type": "string",
+          },
+        },
+      },
+    },
+    "type": "object",
+  },
+}
+`;
+
+exports[`schemaParser() parses schema with oneof and nested dependencies 1`] = `
+Object {
+  "-1467217627": Object {
+    "$id": "-1467217627",
+    "properties": Object {
+      "update_absences": Object {
+        "const": "MEDICAL_ONLY",
+      },
+    },
+    "type": "object",
+  },
+  "-44018569": Object {
+    "$id": "-44018569",
+    "properties": Object {
+      "update_absences": Object {
+        "const": "NON_MEDICAL_ONLY",
+      },
+    },
+    "type": "object",
+  },
+  "-460680344": Object {
+    "$id": "-460680344",
+    "properties": Object {
+      "employee_accounts": Object {
+        "const": true,
+      },
+    },
+    "type": "object",
+  },
+  "1382654078": Object {
+    "$id": "1382654078",
+    "dependencies": Object {
+      "employee_accounts": Object {
+        "oneOf": Array [
+          Object {
+            "properties": Object {
+              "employee_accounts": Object {
+                "const": true,
+              },
+              "update_absences": Object {
+                "oneOf": Array [
+                  Object {
+                    "const": "BOTH",
+                    "title": "Both",
+                  },
+                ],
+                "title": "Update Absences",
+                "type": "string",
+              },
+            },
+          },
+        ],
+      },
+      "update_absences": Object {
+        "oneOf": Array [
+          Object {
+            "properties": Object {
+              "permitted_extension": Object {
+                "title": "Permitted Extension",
+                "type": "integer",
+              },
+              "update_absences": Object {
+                "const": "BOTH",
+              },
+            },
+          },
+          Object {
+            "properties": Object {
+              "permitted_extension": Object {
+                "title": "Permitted Extension",
+                "type": "integer",
+              },
+              "update_absences": Object {
+                "const": "MEDICAL_ONLY",
+              },
+            },
+          },
+          Object {
+            "properties": Object {
+              "permitted_extension": Object {
+                "title": "Permitted Extension",
+                "type": "integer",
+              },
+              "update_absences": Object {
+                "const": "NON_MEDICAL_ONLY",
+              },
+            },
+          },
+        ],
+      },
+    },
+    "properties": Object {
+      "employee_accounts": Object {
+        "title": "Employee Accounts",
+        "type": "boolean",
+      },
+    },
+    "type": "object",
+  },
+  "641263724": Object {
+    "$id": "641263724",
+    "properties": Object {
+      "update_absences": Object {
+        "const": "BOTH",
+      },
+    },
+    "type": "object",
+  },
+  "788120801": Object {
+    "$id": "788120801",
+    "const": "BOTH",
+    "title": "Both",
+  },
+}
+`;
+
+exports[`schemaParser() parses superSchema properly 1`] = `
+Object {
+  "-1210616464": Object {
+    "$id": "-1210616464",
+    "anyOf": Array [
+      Object {
+        "required": Array [
+          "choice",
+        ],
+      },
+      Object {
+        "required": Array [
+          "more",
+        ],
+      },
+    ],
+    "properties": Object {
+      "choice": Object {
+        "const": "two",
+        "type": "string",
+      },
+      "more": Object {
+        "type": "string",
+      },
+    },
+    "type": "object",
+  },
+  "-439549521": Object {
+    "$id": "-439549521",
+    "anyOf": Array [
+      Object {
+        "required": Array [
+          "name",
+        ],
+      },
+    ],
+    "properties": Object {
+      "name": Object {
+        "type": "string",
+      },
+    },
+    "type": "object",
+  },
+  "1252507262": Object {
+    "$id": "1252507262",
+    "anyOf": Array [
+      Object {
+        "required": Array [
+          "choice",
+        ],
+      },
+      Object {
+        "required": Array [
+          "other",
+        ],
+      },
+    ],
+    "properties": Object {
+      "choice": Object {
+        "const": "one",
+        "type": "string",
+      },
+      "other": Object {
+        "type": "number",
+      },
+    },
+    "type": "object",
+  },
+  "super-schema": Object {
+    "$id": "super-schema",
+    "definitions": Object {
+      "choice1": Object {
+        "properties": Object {
+          "choice": Object {
+            "const": "one",
+            "type": "string",
+          },
+          "other": Object {
+            "type": "number",
+          },
+        },
+        "type": "object",
+      },
+      "choice2": Object {
+        "properties": Object {
+          "choice": Object {
+            "const": "two",
+            "type": "string",
+          },
+          "more": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "foo": Object {
+        "properties": Object {
+          "name": Object {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      },
+      "list": Object {
+        "items": Object {
+          "type": "string",
+        },
+        "type": "array",
+      },
+      "passwords": Object {
+        "properties": Object {
+          "pass1": Object {
+            "type": "string",
+          },
+          "pass2": Object {
+            "type": "string",
+          },
+        },
+        "required": Array [
+          "pass1",
+          "pass2",
+        ],
+        "type": "object",
+      },
+      "price": Object {
+        "minimum": 0,
+        "multipleOf": 0.03,
+        "title": "Price per task ($)",
+        "type": "number",
+      },
+    },
+    "properties": Object {
+      "anything": Object {
+        "additionalProperties": Object {
+          "type": "string",
+        },
+        "type": "object",
+      },
+      "dataUrlWithName": Object {
+        "format": "data-url",
+        "type": "string",
+      },
+      "foo": Object {
+        "type": "string",
+      },
+      "list": Object {
+        "$ref": "#/definitions/list",
+      },
+      "multi": Object {
+        "anyOf": Array [
+          Object {
+            "$ref": "#/definitions/foo",
+          },
+        ],
+      },
+      "passwords": Object {
+        "$ref": "#/definitions/passwords",
+      },
+      "price": Object {
+        "$ref": "#/definitions/price",
+      },
+      "single": Object {
+        "oneOf": Array [
+          Object {
+            "$ref": "#/definitions/choice1",
+          },
+          Object {
+            "$ref": "#/definitions/choice2",
+          },
+        ],
+      },
+    },
+    "type": "object",
+  },
+}
+`;

--- a/packages/utils/test/parser/__snapshots__/schemaParser.test.ts.snap
+++ b/packages/utils/test/parser/__snapshots__/schemaParser.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`schemaParser() parses property dependencies properly 1`] = `
 Object {
-  "741607452": Object {
-    "$id": "741607452",
+  "2c34081c": Object {
+    "$id": "2c34081c",
     "dependencies": Object {
       "a": Array [
         "b",
@@ -27,8 +27,8 @@ Object {
 
 exports[`schemaParser() parses recursive refs in allOf properly 1`] = `
 Object {
-  "64139818": Object {
-    "$id": "64139818",
+  "3d2b22a": Object {
+    "$id": "3d2b22a",
     "definitions": Object {
       "@enum": Object {
         "properties": Object {
@@ -76,8 +76,8 @@ Object {
 
 exports[`schemaParser() parses recursive refs properly 1`] = `
 Object {
-  "-1807418922": Object {
-    "$id": "-1807418922",
+  "-6bbb062a": Object {
+    "$id": "-6bbb062a",
     "$ref": "#/definitions/@enum",
     "definitions": Object {
       "@enum": Object {
@@ -100,8 +100,8 @@ Object {
 
 exports[`schemaParser() parses schema and required dependencies properly 1`] = `
 Object {
-  "-173295518": Object {
-    "$id": "-173295518",
+  "-a54479e": Object {
+    "$id": "-a54479e",
     "dependencies": Object {
       "a": Object {
         "properties": Object {
@@ -132,8 +132,8 @@ Object {
 
 exports[`schemaParser() parses schema dependencies properly 1`] = `
 Object {
-  "-2011303755": Object {
-    "$id": "-2011303755",
+  "-77e20f4b": Object {
+    "$id": "-77e20f4b",
     "dependencies": Object {
       "a": Object {
         "properties": Object {
@@ -155,19 +155,8 @@ Object {
 
 exports[`schemaParser() parses schema dependencies with one of and refs properly 1`] = `
 Object {
-  "-172742607": Object {
-    "$id": "-172742607",
-    "properties": Object {
-      "a": Object {
-        "enum": Array [
-          "int",
-        ],
-      },
-    },
-    "type": "object",
-  },
-  "-1793193922": Object {
-    "$id": "-1793193922",
+  "-6ae1f7c2": Object {
+    "$id": "-6ae1f7c2",
     "definitions": Object {
       "needsA": Object {
         "properties": Object {
@@ -217,12 +206,23 @@ Object {
     },
     "type": "object",
   },
-  "-1924365990": Object {
-    "$id": "-1924365990",
+  "-72b37ea6": Object {
+    "$id": "-72b37ea6",
     "properties": Object {
       "a": Object {
         "enum": Array [
           "bool",
+        ],
+      },
+    },
+    "type": "object",
+  },
+  "-a4bd7cf": Object {
+    "$id": "-a4bd7cf",
+    "properties": Object {
+      "a": Object {
+        "enum": Array [
+          "int",
         ],
       },
     },
@@ -233,16 +233,16 @@ Object {
 
 exports[`schemaParser() parses schema with a single condition 1`] = `
 Object {
-  "-869848892": Object {
-    "$id": "-869848892",
+  "-33d8d73c": Object {
+    "$id": "-33d8d73c",
     "properties": Object {
       "country": Object {
         "const": "United States of America",
       },
     },
   },
-  "1992009743": Object {
-    "$id": "1992009743",
+  "76bba80f": Object {
+    "$id": "76bba80f",
     "else": Object {
       "properties": Object {
         "postal_code": Object {
@@ -280,19 +280,8 @@ Object {
 
 exports[`schemaParser() parses schema with multiple conditions 1`] = `
 Object {
-  "-227845973": Object {
-    "$id": "-227845973",
-    "properties": Object {
-      "Animal": Object {
-        "const": "Cat",
-      },
-    },
-    "required": Array [
-      "Animal",
-    ],
-  },
-  "-917519938": Object {
-    "$id": "-917519938",
+  "-36b03e42": Object {
+    "$id": "-36b03e42",
     "properties": Object {
       "BreedName": Object {
         "const": "Alsatian",
@@ -302,8 +291,19 @@ Object {
       "BreedName",
     ],
   },
-  "1048460049": Object {
-    "$id": "1048460049",
+  "-d94a755": Object {
+    "$id": "-d94a755",
+    "properties": Object {
+      "Animal": Object {
+        "const": "Cat",
+      },
+    },
+    "required": Array [
+      "Animal",
+    ],
+  },
+  "3e7e3b11": Object {
+    "$id": "3e7e3b11",
     "properties": Object {
       "Animal": Object {
         "const": "Dog",
@@ -313,8 +313,8 @@ Object {
       "Animal",
     ],
   },
-  "1531238602": Object {
-    "$id": "1531238602",
+  "5b44d8ca": Object {
+    "$id": "5b44d8ca",
     "properties": Object {
       "BreedName": Object {
         "const": "Dalmation",
@@ -324,8 +324,8 @@ Object {
       "BreedName",
     ],
   },
-  "2133215231": Object {
-    "$id": "2133215231",
+  "7f2647ff": Object {
+    "$id": "7f2647ff",
     "allOf": Array [
       Object {
         "if": Object {
@@ -469,8 +469,8 @@ Object {
 
 exports[`schemaParser() parses schema with nested conditions 1`] = `
 Object {
-  "-256025126": Object {
-    "$id": "-256025126",
+  "-f42a226": Object {
+    "$id": "-f42a226",
     "properties": Object {
       "state": Object {
         "const": "New York",
@@ -480,19 +480,8 @@ Object {
       "state",
     ],
   },
-  "1524164913": Object {
-    "$id": "1524164913",
-    "properties": Object {
-      "state": Object {
-        "const": "California",
-      },
-    },
-    "required": Array [
-      "state",
-    ],
-  },
-  "351550690": Object {
-    "$id": "351550690",
+  "14f43ce2": Object {
+    "$id": "14f43ce2",
     "properties": Object {
       "country": Object {
         "const": "USA",
@@ -502,8 +491,8 @@ Object {
       "country",
     ],
   },
-  "757201982": Object {
-    "$id": "757201982",
+  "2d21fc3e": Object {
+    "$id": "2d21fc3e",
     "if": Object {
       "properties": Object {
         "country": Object {
@@ -586,31 +575,24 @@ Object {
     },
     "type": "object",
   },
+  "5ad8e931": Object {
+    "$id": "5ad8e931",
+    "properties": Object {
+      "state": Object {
+        "const": "California",
+      },
+    },
+    "required": Array [
+      "state",
+    ],
+  },
 }
 `;
 
 exports[`schemaParser() parses schema with oneof and nested dependencies 1`] = `
 Object {
-  "-1467217627": Object {
-    "$id": "-1467217627",
-    "properties": Object {
-      "update_absences": Object {
-        "const": "MEDICAL_ONLY",
-      },
-    },
-    "type": "object",
-  },
-  "-44018569": Object {
-    "$id": "-44018569",
-    "properties": Object {
-      "update_absences": Object {
-        "const": "NON_MEDICAL_ONLY",
-      },
-    },
-    "type": "object",
-  },
-  "-460680344": Object {
-    "$id": "-460680344",
+  "-1b756c98": Object {
+    "$id": "-1b756c98",
     "properties": Object {
       "employee_accounts": Object {
         "const": true,
@@ -618,8 +600,40 @@ Object {
     },
     "type": "object",
   },
-  "1382654078": Object {
-    "$id": "1382654078",
+  "-29fab89": Object {
+    "$id": "-29fab89",
+    "properties": Object {
+      "update_absences": Object {
+        "const": "NON_MEDICAL_ONLY",
+      },
+    },
+    "type": "object",
+  },
+  "-5773f6db": Object {
+    "$id": "-5773f6db",
+    "properties": Object {
+      "update_absences": Object {
+        "const": "MEDICAL_ONLY",
+      },
+    },
+    "type": "object",
+  },
+  "2638e86c": Object {
+    "$id": "2638e86c",
+    "properties": Object {
+      "update_absences": Object {
+        "const": "BOTH",
+      },
+    },
+    "type": "object",
+  },
+  "2ef9c4e1": Object {
+    "$id": "2ef9c4e1",
+    "const": "BOTH",
+    "title": "Both",
+  },
+  "5269a07e": Object {
+    "$id": "5269a07e",
     "dependencies": Object {
       "employee_accounts": Object {
         "oneOf": Array [
@@ -688,27 +702,29 @@ Object {
     },
     "type": "object",
   },
-  "641263724": Object {
-    "$id": "641263724",
-    "properties": Object {
-      "update_absences": Object {
-        "const": "BOTH",
-      },
-    },
-    "type": "object",
-  },
-  "788120801": Object {
-    "$id": "788120801",
-    "const": "BOTH",
-    "title": "Both",
-  },
 }
 `;
 
 exports[`schemaParser() parses superSchema properly 1`] = `
 Object {
-  "-1210616464": Object {
-    "$id": "-1210616464",
+  "-1a32fe51": Object {
+    "$id": "-1a32fe51",
+    "anyOf": Array [
+      Object {
+        "required": Array [
+          "name",
+        ],
+      },
+    ],
+    "properties": Object {
+      "name": Object {
+        "type": "string",
+      },
+    },
+    "type": "object",
+  },
+  "-48288a90": Object {
+    "$id": "-48288a90",
     "anyOf": Array [
       Object {
         "required": Array [
@@ -732,24 +748,8 @@ Object {
     },
     "type": "object",
   },
-  "-439549521": Object {
-    "$id": "-439549521",
-    "anyOf": Array [
-      Object {
-        "required": Array [
-          "name",
-        ],
-      },
-    ],
-    "properties": Object {
-      "name": Object {
-        "type": "string",
-      },
-    },
-    "type": "object",
-  },
-  "1252507262": Object {
-    "$id": "1252507262",
+  "4aa7be7e": Object {
+    "$id": "4aa7be7e",
     "anyOf": Array [
       Object {
         "required": Array [

--- a/packages/utils/test/parser/schemaParser.test.ts
+++ b/packages/utils/test/parser/schemaParser.test.ts
@@ -1,0 +1,61 @@
+import { schemaParser } from '../../src';
+import {
+  PROPERTY_DEPENDENCIES,
+  RECURSIVE_REF,
+  RECURSIVE_REF_ALLOF,
+  SCHEMA_DEPENDENCIES,
+  SCHEMA_AND_ONEOF_REF_DEPENDENCIES,
+  SCHEMA_AND_REQUIRED_DEPENDENCIES,
+  SCHEMA_WITH_ONEOF_NESTED_DEPENDENCIES,
+  SCHEMA_WITH_SINGLE_CONDITION,
+  SCHEMA_WITH_MULTIPLE_CONDITIONS,
+  SCHEMA_WITH_NESTED_CONDITIONS,
+  SUPER_SCHEMA,
+} from '../testUtils/testData';
+
+describe('schemaParser()', () => {
+  it('parses property dependencies properly', () => {
+    const schemaMap = schemaParser(PROPERTY_DEPENDENCIES);
+    expect(schemaMap).toMatchSnapshot();
+  });
+  it('parses recursive refs properly', () => {
+    const schemaMap = schemaParser(RECURSIVE_REF);
+    expect(schemaMap).toMatchSnapshot();
+  });
+  it('parses recursive refs in allOf properly', () => {
+    const schemaMap = schemaParser(RECURSIVE_REF_ALLOF);
+    expect(schemaMap).toMatchSnapshot();
+  });
+  it('parses schema dependencies properly', () => {
+    const schemaMap = schemaParser(SCHEMA_DEPENDENCIES);
+    expect(schemaMap).toMatchSnapshot();
+  });
+  it('parses schema dependencies with one of and refs properly', () => {
+    const schemaMap = schemaParser(SCHEMA_AND_ONEOF_REF_DEPENDENCIES);
+    expect(schemaMap).toMatchSnapshot();
+  });
+  it('parses schema and required dependencies properly', () => {
+    const schemaMap = schemaParser(SCHEMA_AND_REQUIRED_DEPENDENCIES);
+    expect(schemaMap).toMatchSnapshot();
+  });
+  it('parses schema with oneof and nested dependencies', () => {
+    const schemaMap = schemaParser(SCHEMA_WITH_ONEOF_NESTED_DEPENDENCIES);
+    expect(schemaMap).toMatchSnapshot();
+  });
+  it('parses schema with a single condition', () => {
+    const schemaMap = schemaParser(SCHEMA_WITH_SINGLE_CONDITION);
+    expect(schemaMap).toMatchSnapshot();
+  });
+  it('parses schema with multiple conditions', () => {
+    const schemaMap = schemaParser(SCHEMA_WITH_MULTIPLE_CONDITIONS);
+    expect(schemaMap).toMatchSnapshot();
+  });
+  it('parses schema with nested conditions', () => {
+    const schemaMap = schemaParser(SCHEMA_WITH_NESTED_CONDITIONS);
+    expect(schemaMap).toMatchSnapshot();
+  });
+  it('parses superSchema properly', () => {
+    const schemaMap = schemaParser(SUPER_SCHEMA);
+    expect(schemaMap).toMatchSnapshot();
+  });
+});

--- a/packages/utils/test/schema/toPathSchemaTest.ts
+++ b/packages/utils/test/schema/toPathSchemaTest.ts
@@ -594,6 +594,9 @@ export default function toPathSchemaTest(testValidator: TestValidatorType) {
     it('should return a pathSchema for a schema with oneOf', () => {
       const schema: RJSFSchema = {
         type: 'object',
+        properties: {
+          str: { type: 'string' },
+        },
         oneOf: [
           {
             properties: {
@@ -613,6 +616,7 @@ export default function toPathSchemaTest(testValidator: TestValidatorType) {
       };
 
       const formData = {
+        str: 'string',
         lorem: 'loremValue',
       };
 
@@ -624,11 +628,17 @@ export default function toPathSchemaTest(testValidator: TestValidatorType) {
         lorem: {
           $name: 'lorem',
         },
+        str: {
+          $name: 'str',
+        },
       });
     });
     it('should return a pathSchema for a schema with anyOf', () => {
       const schema: RJSFSchema = {
         type: 'object',
+        properties: {
+          str: { type: 'string' },
+        },
         anyOf: [
           {
             properties: {
@@ -648,6 +658,7 @@ export default function toPathSchemaTest(testValidator: TestValidatorType) {
       };
 
       const formData = {
+        str: 'string',
         ipsum: 'ipsumValue',
       };
       // Two per option using getClosestMatchingOption, the first ones are both false
@@ -658,6 +669,9 @@ export default function toPathSchemaTest(testValidator: TestValidatorType) {
         $name: '',
         ipsum: {
           $name: 'ipsum',
+        },
+        str: {
+          $name: 'str',
         },
       });
     });


### PR DESCRIPTION
### Reasons for making this change

First part of the process to support precompiled AJV8 validators

Also fixes: #3628 and #1628

- Updated `@rjsf/utils` to support precompiled AJV8 validators as follows:
  - Refactored `getDiscriminatorFieldFromSchema()` from inside of `MultiSchemaField`, using it everywhere that `getClosestMatchingOption()` and `getFirstMatchingOption()` are called - This included changing `getDefaultFormState.ts` and `toPathSchema.ts` - Added 100% unit tests for the new functions
  - Added a new `hashForSchema()` function that returns a hash string for the given schema
    - Added 100% unit tests for the new functions
  - Did a major refactor of the functions in `retrieveSchema.ts` to have them all support returning lists of schemas and for most of them to take a `expandAllBranches` flag - Added renamed the original `retrieveSchema()` to `retrieveSchemaInternal()` function that is used as the entry point into the returning lists of schemas worlds
      - This function added the optional `expandAllBranches` flag with the default value set to false
    - Added a new default exported function `retrieveSchema()` that calls `retrieveSchemaInternal()` without the optional value, returning the first element in the list - Also added two new helpers, `getAllPermutationsOfXxxOf()` and `resolveAnyOrOneOfSchemas()` to support the new schema array return values - Updated the `retrieveSchemaTests.ts` file to extract a bunch of schemas into the `testData.ts` file while making sure all lines of new code are tested
  - Added a new `parser` subdirectory that contains the `ParserValidator` implementation of the `ValidatorType` interface for the new `schemaParser()` function - This new function uses the `expandAllBranches()` to capture and return the map of schema $id -> schema/sub-schema as captured by the `ParserValidator` - Added 100% unit testing for the new `schemaParser()` function - NOTE: while this function is being exported from `@rjsf/utils` it is meant to be kept undocument in the `docs`
- Updated `@rjsf/core` to use the new `getDiscriminatorFieldFromSchema()` function in `MultiSchemaField`
- Updated the `utility-functions` docs to add documentation for `getDiscriminatorFieldFromSchema()` and `hashForSchema()`
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
