### PR TITLE
fix: Allow array of files to actually upload multiple files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 
 - Updated the `MultiSchemaField` to use the new `getDiscriminatorFieldFromSchema()` API
-
-- Added new `experimental_defaultFormStateBehavior` prop to `Form` to specify alternate behavior when dealing with the rendering of array fields where `minItems` is set but field is not `required` (fixes [3363](https://github.com/rjsf-team/react-jsonschema-form/issues/3363)) ([3604](https://github.com/rjsf-team/react-jsonschema-form/pull/3604))
+- Added new `experimental_defaultFormStateBehavior` prop to `Form` to specify alternate behavior when dealing with the rendering of array fields where `minItems` is set but field is not `required` (fixes [3363](https://github.com/rjsf-team/react-jsonschema-form/issues/3363)) ([3602](https://github.com/rjsf-team/react-jsonschema-form/issues/3602))
+- Fixed regression [#3650](https://github.com/rjsf-team/react-jsonschema-form/issues/3650) in `FileWidget` to again support adding multiple files to arrays
 
 ## @rjsf/fluent-ui
 

--- a/packages/core/test/ArrayField.test.jsx
+++ b/packages/core/test/ArrayField.test.jsx
@@ -1500,7 +1500,7 @@ describe('ArrayField', () => {
       expect(node.querySelector('.field [type=file]').getAttribute('multiple')).not.to.be.null;
     });
 
-    it('should handle a change event', async () => {
+    it('should handle a two change events that results in two items in the list', async () => {
       sandbox.stub(window, 'FileReader').returns({
         set onload(fn) {
           fn({ target: { result: 'data:text/plain;base64,x=' } });
@@ -1513,10 +1513,23 @@ describe('ArrayField', () => {
 
       Simulate.change(node.querySelector('.field input[type=file]'), {
         target: {
-          files: [
-            { name: 'file1.txt', size: 1, type: 'type' },
-            { name: 'file2.txt', size: 2, type: 'type' },
-          ],
+          files: [{ name: 'file1.txt', size: 1, type: 'type' }],
+        },
+      });
+
+      await new Promise(setImmediate);
+
+      sinon.assert.calledWithMatch(
+        onChange.lastCall,
+        {
+          formData: ['data:text/plain;name=file1.txt;base64,x='],
+        },
+        'root'
+      );
+
+      Simulate.change(node.querySelector('.field input[type=file]'), {
+        target: {
+          files: [{ name: 'file2.txt', size: 2, type: 'type' }],
         },
       });
 


### PR DESCRIPTION
### Reasons for making this change

Fixes #3650 which was a regression
- Updated `@rjsf/core` to allow the `FileWidget` to properly deal with multiple files one upload at a time, which is how it works now
- Updated the tests to verify this event paradigm shift works
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
