### PR TITLE
Adding empty object fields state behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Updated the `MultiSchemaField` to use the new `getDiscriminatorFieldFromSchema()` API
 - Added new `experimental_defaultFormStateBehavior` prop to `Form` 
-  - to specify alternate behavior when dealing with the rendering of array fields where `minItems` is set but field is not `required` (fixes [3363](https://github.com/rjsf-team/react-jsonschema-form/issues/3363)) ([3602](https://github.com/rjsf-team/react-jsonschema-form/issues/3602))
+  - to specify alternate behavior when dealing with the rendering of array fields where `minItems` is set but field is not `required` (fixes [#3363](https://github.com/rjsf-team/react-jsonschema-form/issues/3363)) ([#3602](https://github.com/rjsf-team/react-jsonschema-form/issues/3602))
   - to handle setting object defaults based on the value of `emptyObjectFields` supporting required fields only and skipping defaults entirely, fixing [#2980](https://github.com/rjsf-team/react-jsonschema-form/issues/2980)
 - Fixed regression [#3650](https://github.com/rjsf-team/react-jsonschema-form/issues/3650) in `FileWidget` to again support adding multiple files to arrays
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 
 - Updated the `MultiSchemaField` to use the new `getDiscriminatorFieldFromSchema()` API
-- Added new `experimental_defaultFormStateBehavior` prop to `Form` to specify alternate behavior when dealing with the rendering of array fields where `minItems` is set but field is not `required` (fixes [3363](https://github.com/rjsf-team/react-jsonschema-form/issues/3363)) ([3602](https://github.com/rjsf-team/react-jsonschema-form/issues/3602))
+- Added new `experimental_defaultFormStateBehavior` prop to `Form` 
+  - to specify alternate behavior when dealing with the rendering of array fields where `minItems` is set but field is not `required` (fixes [3363](https://github.com/rjsf-team/react-jsonschema-form/issues/3363)) ([3602](https://github.com/rjsf-team/react-jsonschema-form/issues/3602))
+  - to handle setting defaults based on the value of `emptyObjectFields`
 - Fixed regression [#3650](https://github.com/rjsf-team/react-jsonschema-form/issues/3650) in `FileWidget` to again support adding multiple files to arrays
 
 ## @rjsf/fluent-ui

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated the `MultiSchemaField` to use the new `getDiscriminatorFieldFromSchema()` API
 - Added new `experimental_defaultFormStateBehavior` prop to `Form` 
   - to specify alternate behavior when dealing with the rendering of array fields where `minItems` is set but field is not `required` (fixes [3363](https://github.com/rjsf-team/react-jsonschema-form/issues/3363)) ([3602](https://github.com/rjsf-team/react-jsonschema-form/issues/3602))
-  - to handle setting defaults based on the value of `emptyObjectFields`
+  - to handle setting object defaults based on the value of `emptyObjectFields` supporting required fields only and skipping defaults entirely, fixing [#2980](https://github.com/rjsf-team/react-jsonschema-form/issues/2980)
 - Fixed regression [#3650](https://github.com/rjsf-team/react-jsonschema-form/issues/3650) in `FileWidget` to again support adding multiple files to arrays
 
 ## @rjsf/fluent-ui

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -183,7 +183,9 @@ export interface FormProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
    */
   translateString?: Registry['translateString'];
   /** Optional configuration object with flags, if provided, allows users to override default form state behavior
-   * Currently only affecting minItems on array fields */
+   * Currently only affecting minItems on array fields and handling of setting defaults based on the value of
+   * `emptyObjectFields`
+   */
   experimental_defaultFormStateBehavior?: Experimental_DefaultFormStateBehavior;
   // Private
   /**

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -72,6 +72,14 @@ The following sub-sections represent the different keys in this object, with the
 | `populate`     | Legacy behavior - populate minItems entries with default values initially and include empty array when no values have been defined |
 | `requiredOnly` | Ignore `minItems` on a field when calculating defaults unless the field is required                                                |
 
+### `emptyObjectFields
+
+| Flag Value     | Description                                                       |
+| -------------- |-------------------------------------------------------------------|
+| `populateAllDefaults`     | Legacy behavior - set default when there is an empty object field |
+| `populateRequiredDefaults` | Only sets default when the field is required                      |
+| `skipDefaults` | Does not set defaults to enmpty object field                      |
+
 ```tsx
 import { RJSFSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -74,11 +74,11 @@ The following sub-sections represent the different keys in this object, with the
 
 ### `emptyObjectFields
 
-| Flag Value     | Description                                                       |
-| -------------- |-------------------------------------------------------------------|
-| `populateAllDefaults`     | Legacy behavior - set default when there is an empty object field |
-| `populateRequiredDefaults` | Only sets default when the field is required                      |
-| `skipDefaults` | Does not set defaults to enmpty object field                      |
+| Flag Value                 | Description                                                                                                                |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `populateAllDefaults`      | Legacy behavior - set default when there is a primitive value, an non-empty object field, or the field itself is required  |
+| `populateRequiredDefaults` | Only sets default when a value is an object and its parent field is required or it is a primitive value and it is required |
+| `skipDefaults`             | Does not set defaults                                                                                                      |
 
 ```tsx
 import { RJSFSchema } from '@rjsf/utils';

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -89,7 +89,7 @@ function maybeAddDefaultToObject<T = any>(
   key: string,
   computedDefault: T | T[] | undefined,
   includeUndefinedValues: boolean | 'excludeObjectChildren',
-  isParentRequired = false,
+  isParentRequired: boolean,
   requiredFields: string[] = [],
   experimental_defaultFormStateBehavior: Experimental_DefaultFormStateBehavior = {}
 ) {
@@ -277,10 +277,15 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
             .filter((key) => !schema.properties || !schema.properties[key])
             .forEach((key) => keys.add(key));
         }
+        let formDataRequired: string[];
         if (isObject(formData)) {
+          formDataRequired = [];
           Object.keys(formData as GenericObjectType)
             .filter((key) => !schema.properties || !schema.properties[key])
-            .forEach((key) => keys.add(key));
+            .forEach((key) => {
+              keys.add(key);
+              formDataRequired.push(key);
+            });
         }
         keys.forEach((key) => {
           const computedDefault = computeDefaults(validator, additionalPropertiesSchema as S, {
@@ -298,7 +303,8 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
             key,
             computedDefault,
             includeUndefinedValues,
-            required
+            required,
+            formDataRequired
           );
         });
       }

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -65,10 +65,11 @@ export function getInnerSchemaForArrayItem<S extends StrictRJSFSchema = RJSFSche
   return {} as S;
 }
 
-/** Either add `computedDefault` at `key` into `obj` or not add it based on its value and the value of
- * `includeUndefinedValues`. Generally undefined `computedDefault` values are added only when `includeUndefinedValues`
- * is either true or "excludeObjectChildren". If `includeUndefinedValues` is false, then non-undefined and
- * non-empty-object values will be added.
+/** Either add `computedDefault` at `key` into `obj` or not add it based on its value, the value of
+ * `includeUndefinedValues`, the value of `emptyObjectFields` and if its parent field is required. Generally undefined
+ * `computedDefault` values are added only when `includeUndefinedValues` is either true/"excludeObjectChildren". If `
+ * includeUndefinedValues` is false and `emptyObjectFields` is not "skipDefaults", then non-undefined and non-empty-object
+ * values will be added based on certain conditions.
  *
  * @param obj - The object into which the computed default may be added
  * @param key - The key into the object at which the computed default may be added
@@ -78,25 +79,43 @@ export function getInnerSchemaForArrayItem<S extends StrictRJSFSchema = RJSFSche
  *          false when computing defaults for any nested object properties. If "allowEmptyObject", prevents undefined
  *          values in this object while allow the object itself to be empty and passing `includeUndefinedValues` as
  *          false when computing defaults for any nested object properties.
+ * @param isParentRequired - The optional boolean that indicates whether the parent field is required
  * @param requiredFields - The list of fields that are required
+ * @param experimental_defaultFormStateBehavior - Optional configuration object, if provided, allows users to override
+ *        default form state behavior
  */
 function maybeAddDefaultToObject<T = any>(
   obj: GenericObjectType,
   key: string,
   computedDefault: T | T[] | undefined,
   includeUndefinedValues: boolean | 'excludeObjectChildren',
-  requiredFields: string[] = []
+  isParentRequired = false,
+  requiredFields: string[] = [],
+  experimental_defaultFormStateBehavior: Experimental_DefaultFormStateBehavior = {}
 ) {
+  const { emptyObjectFields = 'populateAllDefaults' } = experimental_defaultFormStateBehavior;
   if (includeUndefinedValues) {
     obj[key] = computedDefault;
-  } else if (isObject(computedDefault)) {
-    // Store computedDefault if it's a non-empty object (e.g. not {})
-    if (!isEmpty(computedDefault) || requiredFields.includes(key)) {
+  } else if (emptyObjectFields !== 'skipDefaults') {
+    if (isObject(computedDefault)) {
+      // Store computedDefault if it's a non-empty object(e.g. not {}) and satisfies certain conditions
+      // Condition 1: If computedDefault is not empty or if the key is a required field
+      // Condition 2: If the parent object is required or emptyObjectFields is not 'populateRequiredDefaults'
+      if (
+        (!isEmpty(computedDefault) || requiredFields.includes(key)) &&
+        (isParentRequired || emptyObjectFields !== 'populateRequiredDefaults')
+      ) {
+        obj[key] = computedDefault;
+      }
+    } else if (
+      // Store computedDefault if it's a defined primitive (e.g., true) and satisfies certain conditions
+      // Condition 1: computedDefault is not undefined
+      // Condition 2: If emptyObjectFields is 'populateAllDefaults' or if the key is a required field
+      computedDefault !== undefined &&
+      (emptyObjectFields === 'populateAllDefaults' || requiredFields.includes(key))
+    ) {
       obj[key] = computedDefault;
     }
-  } else if (computedDefault !== undefined) {
-    // Store computedDefault if it's a defined primitive (e.g. true)
-    obj[key] = computedDefault;
   }
 }
 
@@ -238,7 +257,15 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
           rawFormData: get(formData, [key]),
           required: schema.required?.includes(key),
         });
-        maybeAddDefaultToObject<T>(acc, key, computedDefault, includeUndefinedValues, schema.required);
+        maybeAddDefaultToObject<T>(
+          acc,
+          key,
+          computedDefault,
+          includeUndefinedValues,
+          required,
+          schema.required,
+          experimental_defaultFormStateBehavior
+        );
         return acc;
       }, {}) as T;
       if (schema.additionalProperties) {
@@ -265,7 +292,14 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
             rawFormData: get(formData, [key]),
             required: schema.required?.includes(key),
           });
-          maybeAddDefaultToObject<T>(objectDefaults as GenericObjectType, key, computedDefault, includeUndefinedValues);
+          // Since these are additional properties we don’t need to add the `experimental_defaultFormStateBehavior` prop
+          maybeAddDefaultToObject<T>(
+            objectDefaults as GenericObjectType,
+            key,
+            computedDefault,
+            includeUndefinedValues,
+            required
+          );
         });
       }
       return objectDefaults;

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -31,11 +31,13 @@ export type RJSFSchema = StrictRJSFSchema & GenericObjectType;
  */
 export type FormContextType = GenericObjectType;
 
-/** Experimental features to specify different form state behavior. Currently, this only affects the
- * handling of optional array fields where `minItems` is set.
+/** Experimental features to specify different form state behavior. Currently, this affects the
+ * handling of optional array fields where `minItems` is set and handling of setting defaults based on the
+ * value of `emptyObjectFields`
  */
 export type Experimental_DefaultFormStateBehavior = {
   arrayMinItems?: 'populate' | 'requiredOnly';
+  emptyObjectFields?: 'populateAllDefaults' | 'populateRequiredDefaults' | 'skipDefaults';
 };
 
 /** The interface representing a Date object that contains an optional time */
@@ -963,7 +965,7 @@ export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchem
    *
    * @param validator - An implementation of the `ValidatorType` interface that will be compared against the current one
    * @param rootSchema - The root schema that will be compared against the current one
-   * @param [experimental_defaultFormStateBehavior] Optional configuration object, if provided, allows users to override default form state behavior
+   * @param [experimental_defaultFormStateBehavior] - Optional configuration object, if provided, allows users to override default form state behavior
    * @returns - True if the `SchemaUtilsType` differs from the given `validator` or `rootSchema`
    */
   doesSchemaUtilsDiffer(

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -203,7 +203,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           foo: 'bar',
         });
       });
-      it('test an object with additionalProperties type object with and formdata', () => {
+      it('test an object with additionalProperties type object with defaults and formdata', () => {
         const schema: RJSFSchema = {
           type: 'object',
           properties: {
@@ -244,6 +244,45 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
               host: 'localhost',
               port: 389,
             },
+          },
+        });
+      });
+      it('test an object with additionalProperties type object with no defaults and formdata', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            test: {
+              title: 'Test',
+              type: 'object',
+              properties: {
+                foo: {
+                  type: 'string',
+                },
+              },
+              additionalProperties: {
+                type: 'object',
+                properties: {
+                  host: {
+                    title: 'Host',
+                    type: 'string',
+                  },
+                  port: {
+                    title: 'Port',
+                    type: 'integer',
+                  },
+                },
+              },
+            },
+          },
+        };
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            rawFormData: { test: { foo: 'x', newKey: {} } },
+          })
+        ).toEqual({
+          test: {
+            newKey: {},
           },
         });
       });

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -60,6 +60,32 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         };
         expect(computeDefaults(testValidator, schema, { rootSchema: schema })).toEqual({ requiredProperty: 'foo' });
       });
+      it('test an object with an optional property that has a nested required property with default', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            optionalProperty: {
+              type: 'object',
+              properties: {
+                nestedRequiredProperty: {
+                  type: 'string',
+                  default: '',
+                },
+              },
+              required: ['nestedRequiredProperty'],
+            },
+            requiredProperty: {
+              type: 'string',
+              default: 'foo',
+            },
+          },
+          required: ['requiredProperty'],
+        };
+        expect(computeDefaults(testValidator, schema, { rootSchema: schema })).toEqual({
+          requiredProperty: 'foo',
+          optionalProperty: { nestedRequiredProperty: '' },
+        });
+      });
       it('test an object with an optional property that has a nested required property and includeUndefinedValues', () => {
         const schema: RJSFSchema = {
           type: 'object',
@@ -345,6 +371,280 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
             experimental_defaultFormStateBehavior: { arrayMinItems: 'requiredOnly' },
           })
         ).toEqual({ requiredArray: ['raw0', 'default0'] });
+      });
+    });
+    describe('default form state behavior: emptyObjectFields = "populateRequiredDefaults"', () => {
+      it('test an object with an optional property that has a nested required property', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            optionalProperty: {
+              type: 'object',
+              properties: {
+                nestedRequiredProperty: {
+                  type: 'string',
+                },
+              },
+              required: ['nestedRequiredProperty'],
+            },
+            requiredProperty: {
+              type: 'string',
+              default: 'foo',
+            },
+          },
+          required: ['requiredProperty'],
+        };
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            experimental_defaultFormStateBehavior: { emptyObjectFields: 'populateRequiredDefaults' },
+          })
+        ).toEqual({ requiredProperty: 'foo' });
+      });
+      it('test an object with an optional property that has a nested required property with default', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            optionalProperty: {
+              type: 'object',
+              properties: {
+                nestedRequiredProperty: {
+                  type: 'string',
+                  default: '',
+                },
+              },
+              required: ['nestedRequiredProperty'],
+            },
+            requiredProperty: {
+              type: 'string',
+              default: 'foo',
+            },
+          },
+          required: ['requiredProperty'],
+        };
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            experimental_defaultFormStateBehavior: { emptyObjectFields: 'populateRequiredDefaults' },
+          })
+        ).toEqual({ requiredProperty: 'foo' });
+      });
+      it('test an object with an optional property that has a nested required property and includeUndefinedValues', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            optionalProperty: {
+              type: 'object',
+              properties: {
+                nestedRequiredProperty: {
+                  type: 'object',
+                  properties: {
+                    undefinedProperty: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+              required: ['nestedRequiredProperty'],
+            },
+            requiredProperty: {
+              type: 'string',
+              default: 'foo',
+            },
+          },
+          required: ['requiredProperty'],
+        };
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            includeUndefinedValues: true,
+            experimental_defaultFormStateBehavior: { emptyObjectFields: 'populateRequiredDefaults' },
+          })
+        ).toEqual({
+          optionalProperty: {
+            nestedRequiredProperty: {
+              undefinedProperty: undefined,
+            },
+          },
+          requiredProperty: 'foo',
+        });
+      });
+      it("test an object with an optional property that has a nested required property and includeUndefinedValues is 'excludeObjectChildren'", () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            optionalNumberProperty: {
+              type: 'number',
+            },
+            optionalObjectProperty: {
+              type: 'object',
+              properties: {
+                nestedRequiredProperty: {
+                  type: 'object',
+                  properties: {
+                    undefinedProperty: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+              required: ['nestedRequiredProperty'],
+            },
+            requiredProperty: {
+              type: 'string',
+              default: 'foo',
+            },
+          },
+          required: ['requiredProperty'],
+        };
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            includeUndefinedValues: 'excludeObjectChildren',
+            experimental_defaultFormStateBehavior: { emptyObjectFields: 'populateRequiredDefaults' },
+          })
+        ).toEqual({
+          optionalNumberProperty: undefined,
+          optionalObjectProperty: {},
+          requiredProperty: 'foo',
+        });
+      });
+    });
+    describe('default form state behavior: emptyObjectFields = "skipDefaults"', () => {
+      it('test an object with an optional property that has a nested required property', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            optionalProperty: {
+              type: 'object',
+              properties: {
+                nestedRequiredProperty: {
+                  type: 'string',
+                },
+              },
+              required: ['nestedRequiredProperty'],
+            },
+            requiredProperty: {
+              type: 'string',
+              default: 'foo',
+            },
+          },
+          required: ['requiredProperty'],
+        };
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            experimental_defaultFormStateBehavior: { emptyObjectFields: 'skipDefaults' },
+          })
+        ).toEqual({});
+      });
+      it('test an object with an optional property that has a nested required property with default', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            optionalProperty: {
+              type: 'object',
+              properties: {
+                nestedRequiredProperty: {
+                  type: 'string',
+                  default: '',
+                },
+              },
+              required: ['nestedRequiredProperty'],
+            },
+            requiredProperty: {
+              type: 'string',
+              default: 'foo',
+            },
+          },
+          required: ['requiredProperty'],
+        };
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            experimental_defaultFormStateBehavior: { emptyObjectFields: 'skipDefaults' },
+          })
+        ).toEqual({});
+      });
+      it('test an object with an optional property that has a nested required property and includeUndefinedValues', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            optionalProperty: {
+              type: 'object',
+              properties: {
+                nestedRequiredProperty: {
+                  type: 'object',
+                  properties: {
+                    undefinedProperty: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+              required: ['nestedRequiredProperty'],
+            },
+            requiredProperty: {
+              type: 'string',
+              default: 'foo',
+            },
+          },
+          required: ['requiredProperty'],
+        };
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            includeUndefinedValues: true,
+            experimental_defaultFormStateBehavior: { emptyObjectFields: 'skipDefaults' },
+          })
+        ).toEqual({
+          optionalProperty: {
+            nestedRequiredProperty: {
+              undefinedProperty: undefined,
+            },
+          },
+          requiredProperty: 'foo',
+        });
+      });
+      it("test an object with an optional property that has a nested required property and includeUndefinedValues is 'excludeObjectChildren'", () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            optionalNumberProperty: {
+              type: 'number',
+            },
+            optionalObjectProperty: {
+              type: 'object',
+              properties: {
+                nestedRequiredProperty: {
+                  type: 'object',
+                  properties: {
+                    undefinedProperty: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+              required: ['nestedRequiredProperty'],
+            },
+            requiredProperty: {
+              type: 'string',
+              default: 'foo',
+            },
+          },
+          required: ['requiredProperty'],
+        };
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            includeUndefinedValues: 'excludeObjectChildren',
+            experimental_defaultFormStateBehavior: { emptyObjectFields: 'skipDefaults' },
+          })
+        ).toEqual({
+          optionalNumberProperty: undefined,
+          optionalObjectProperty: {},
+          requiredProperty: 'foo',
+        });
       });
     });
     describe('root default', () => {


### PR DESCRIPTION
### Reasons for making this change

I want to add a condition where if we have an object with an optional property that has a nested required property with default, the default does not get set because the parent property is optional.

### Checklist

- [X] **I'm updating documentation**
  - [X] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [X] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
