### PR TITLE
fix(core): prevent from breaking when element to focus cannot be found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.7.1
+
+## @rjsf/core
+
+- Added a check to prevent from breaking when the element to focus - in case `focusOnFirstError` is set - cannot be found
+
 # 5.7.0
 
 ## @rjsf/antd

--- a/packages/antd/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Form.test.tsx.snap
@@ -192,6 +192,7 @@ exports[`single fields checkbox field 1`] = `
               >
                 <span
                   className="ant-checkbox"
+                  style={Object {}}
                 >
                   <input
                     aria-describedby="root__error root__description root__help"
@@ -204,6 +205,9 @@ exports[`single fields checkbox field 1`] = `
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyPress={[Function]}
+                    onKeyUp={[Function]}
                     type="checkbox"
                   />
                   <span
@@ -264,6 +268,7 @@ exports[`single fields checkbox field with label 1`] = `
               >
                 <span
                   className="ant-checkbox"
+                  style={Object {}}
                 >
                   <input
                     aria-describedby="root__error root__description root__help"
@@ -276,6 +281,9 @@ exports[`single fields checkbox field with label 1`] = `
                     onBlur={[Function]}
                     onChange={[Function]}
                     onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyPress={[Function]}
+                    onKeyUp={[Function]}
                     type="checkbox"
                   />
                   <span
@@ -345,6 +353,7 @@ exports[`single fields checkboxes field 1`] = `
                   >
                     <span
                       className="ant-checkbox"
+                      style={Object {}}
                     >
                       <input
                         autoFocus={false}
@@ -353,7 +362,12 @@ exports[`single fields checkboxes field 1`] = `
                         disabled={false}
                         id="root-0"
                         name="root"
+                        onBlur={[Function]}
                         onChange={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onKeyPress={[Function]}
+                        onKeyUp={[Function]}
                         type="checkbox"
                         value="0"
                       />
@@ -373,6 +387,7 @@ exports[`single fields checkboxes field 1`] = `
                   >
                     <span
                       className="ant-checkbox"
+                      style={Object {}}
                     >
                       <input
                         autoFocus={false}
@@ -381,7 +396,12 @@ exports[`single fields checkboxes field 1`] = `
                         disabled={false}
                         id="root-1"
                         name="root"
+                        onBlur={[Function]}
                         onChange={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onKeyPress={[Function]}
+                        onKeyUp={[Function]}
                         type="checkbox"
                         value="1"
                       />
@@ -401,6 +421,7 @@ exports[`single fields checkboxes field 1`] = `
                   >
                     <span
                       className="ant-checkbox"
+                      style={Object {}}
                     >
                       <input
                         autoFocus={false}
@@ -409,7 +430,12 @@ exports[`single fields checkboxes field 1`] = `
                         disabled={false}
                         id="root-2"
                         name="root"
+                        onBlur={[Function]}
                         onChange={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onKeyPress={[Function]}
+                        onKeyUp={[Function]}
                         type="checkbox"
                         value="2"
                       />
@@ -429,6 +455,7 @@ exports[`single fields checkboxes field 1`] = `
                   >
                     <span
                       className="ant-checkbox"
+                      style={Object {}}
                     >
                       <input
                         autoFocus={false}
@@ -437,7 +464,12 @@ exports[`single fields checkboxes field 1`] = `
                         disabled={false}
                         id="root-3"
                         name="root"
+                        onBlur={[Function]}
                         onChange={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onKeyPress={[Function]}
+                        onKeyUp={[Function]}
                         type="checkbox"
                         value="3"
                       />
@@ -1900,6 +1932,7 @@ exports[`single fields radio field 1`] = `
                 >
                   <span
                     className="ant-radio"
+                    style={Object {}}
                   >
                     <input
                       autoFocus={false}
@@ -1908,7 +1941,12 @@ exports[`single fields radio field 1`] = `
                       disabled={false}
                       id="root-0"
                       name="root"
+                      onBlur={[Function]}
                       onChange={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onKeyPress={[Function]}
+                      onKeyUp={[Function]}
                       type="radio"
                       value="0"
                     />
@@ -1925,6 +1963,7 @@ exports[`single fields radio field 1`] = `
                 >
                   <span
                     className="ant-radio"
+                    style={Object {}}
                   >
                     <input
                       autoFocus={false}
@@ -1933,7 +1972,12 @@ exports[`single fields radio field 1`] = `
                       disabled={false}
                       id="root-1"
                       name="root"
+                      onBlur={[Function]}
                       onChange={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onKeyPress={[Function]}
+                      onKeyUp={[Function]}
                       type="radio"
                       value="1"
                     />

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -710,7 +710,7 @@ export default class Form<
       // if not an exact match, try finding an input starting with the element id (like radio buttons or checkboxes)
       field = this.formElement.current.querySelector(`input[id^=${elementId}`);
     }
-    if (field.length) {
+    if (field?.length) {
       // If we got a list with length > 0
       field = field[0];
     }

--- a/packages/fluent-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Array.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`array fields array 1`] = `
       }
     >
       <button
-        className="ms-Button ms-Button--commandBar array-item-add root-110"
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -38,12 +38,12 @@ exports[`array fields array 1`] = `
         type="button"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <i
             aria-hidden={true}
-            className="ms-Icon root-105 css-119 ms-Button-icon icon-113"
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
             data-icon-name="Add"
             style={
               Object {
@@ -54,10 +54,10 @@ exports[`array fields array 1`] = `
             
           </i>
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-114"
+              className="ms-Button-label label-57"
               id="id__0"
             >
               Add Item
@@ -73,7 +73,7 @@ exports[`array fields array 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -84,14 +84,14 @@ exports[`array fields array 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
+              className="ms-Button-label label-64"
               id="id__3"
             >
               Submit
@@ -140,19 +140,19 @@ exports[`array fields array icons 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-126"
+                    className="ms-TextField-fieldGroup fieldGroup-68"
                   >
                     <input
                       aria-describedby="root_0__error root_0__description root_0__help"
                       aria-invalid={false}
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_0"
                       name="root_0"
@@ -183,7 +183,7 @@ exports[`array fields array icons 1`] = `
         >
           <button
             aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-155"
+            className="ms-Button ms-Button--icon is-disabled root-95"
             data-is-focusable={false}
             disabled={true}
             onClick={[Function]}
@@ -195,12 +195,12 @@ exports[`array fields array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-156"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
                 data-icon-name="Up"
                 style={
                   Object {
@@ -213,7 +213,7 @@ exports[`array fields array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -224,12 +224,12 @@ exports[`array fields array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
                 data-icon-name="Down"
                 style={
                   Object {
@@ -242,7 +242,7 @@ exports[`array fields array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -253,12 +253,12 @@ exports[`array fields array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-163 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
                 data-icon-name="Copy"
                 style={
                   Object {
@@ -271,7 +271,7 @@ exports[`array fields array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -282,12 +282,12 @@ exports[`array fields array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-119 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
                 data-icon-name="Delete"
                 style={
                   Object {
@@ -324,19 +324,19 @@ exports[`array fields array icons 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-126"
+                    className="ms-TextField-fieldGroup fieldGroup-68"
                   >
                     <input
                       aria-describedby="root_1__error root_1__description root_1__help"
                       aria-invalid={false}
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_1"
                       name="root_1"
@@ -366,7 +366,7 @@ exports[`array fields array icons 1`] = `
           }
         >
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -377,12 +377,12 @@ exports[`array fields array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
                 data-icon-name="Up"
                 style={
                   Object {
@@ -396,7 +396,7 @@ exports[`array fields array icons 1`] = `
           </button>
           <button
             aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-155"
+            className="ms-Button ms-Button--icon is-disabled root-95"
             data-is-focusable={false}
             disabled={true}
             onClick={[Function]}
@@ -408,12 +408,12 @@ exports[`array fields array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-156"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
                 data-icon-name="Down"
                 style={
                   Object {
@@ -426,7 +426,7 @@ exports[`array fields array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -437,12 +437,12 @@ exports[`array fields array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-163 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
                 data-icon-name="Copy"
                 style={
                   Object {
@@ -455,7 +455,7 @@ exports[`array fields array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -466,12 +466,12 @@ exports[`array fields array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-119 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
                 data-icon-name="Delete"
                 style={
                   Object {
@@ -494,7 +494,7 @@ exports[`array fields array icons 1`] = `
       }
     >
       <button
-        className="ms-Button ms-Button--commandBar array-item-add root-110"
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -510,12 +510,12 @@ exports[`array fields array icons 1`] = `
         type="button"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <i
             aria-hidden={true}
-            className="ms-Icon root-105 css-119 ms-Button-icon icon-113"
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
             data-icon-name="Add"
             style={
               Object {
@@ -526,11 +526,11 @@ exports[`array fields array icons 1`] = `
             
           </i>
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-114"
-              id="id__56"
+              className="ms-Button-label label-57"
+              id="id__48"
             >
               Add Item
             </span>
@@ -545,7 +545,7 @@ exports[`array fields array icons 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -556,15 +556,15 @@ exports[`array fields array icons 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__59"
+              className="ms-Button-label label-64"
+              id="id__51"
             >
               Submit
             </span>
@@ -599,9 +599,8 @@ exports[`array fields checkboxes 1`] = `
         aria-expanded="false"
         aria-haspopup="listbox"
         aria-required={false}
-        className="ms-Dropdown dropdown-136"
+        className="ms-Dropdown dropdown-78"
         data-is-focusable={true}
-        data-ktp-target={true}
         id="root"
         onBlur={[Function]}
         onChange={[Function]}
@@ -614,16 +613,15 @@ exports[`array fields checkboxes 1`] = `
         tabIndex={0}
       >
         <span
-          aria-invalid={false}
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-137"
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
           id="root-option"
         />
         <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-138"
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-154"
+            className="ms-Dropdown-caretDown caretDown-94"
             data-icon-name="ChevronDown"
           >
             
@@ -639,7 +637,7 @@ exports[`array fields checkboxes 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -650,15 +648,15 @@ exports[`array fields checkboxes 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__19"
+              className="ms-Button-label label-64"
+              id="id__15"
             >
               Submit
             </span>
@@ -701,27 +699,27 @@ exports[`array fields empty errors array 1`] = `
           }
         >
           <div
-            className="ms-TextField root-125"
+            className="ms-TextField root-67"
           >
             <div
               className="ms-TextField-wrapper"
             >
               <label
-                className="ms-Label root-177"
+                className="ms-Label root-114"
                 htmlFor="root_name"
-                id="TextFieldLabel81"
+                id="TextFieldLabel69"
               >
                 name
               </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-178"
+                className="ms-TextField-fieldGroup fieldGroup-115"
               >
                 <input
                   aria-describedby="root_name__error root_name__description root_name__help"
                   aria-invalid={false}
-                  aria-labelledby="TextFieldLabel81"
+                  aria-labelledby="TextFieldLabel69"
                   autoFocus={false}
-                  className="ms-TextField-field field-127"
+                  className="ms-TextField-field field-69"
                   disabled={false}
                   id="root_name"
                   name="root_name"
@@ -749,7 +747,7 @@ exports[`array fields empty errors array 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -760,15 +758,15 @@ exports[`array fields empty errors array 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__84"
+              className="ms-Button-label label-64"
+              id="id__70"
             >
               Submit
             </span>
@@ -816,19 +814,19 @@ exports[`array fields fixed array 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-126"
+                    className="ms-TextField-fieldGroup fieldGroup-68"
                   >
                     <input
                       aria-describedby="root_0__error root_0__description root_0__help"
                       aria-invalid={false}
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_0"
                       name="root_0"
@@ -873,19 +871,19 @@ exports[`array fields fixed array 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-126"
+                    className="ms-TextField-fieldGroup fieldGroup-68"
                   >
                     <input
                       aria-describedby="root_1__error root_1__description root_1__help"
                       aria-invalid={false}
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_1"
                       name="root_1"
@@ -916,7 +914,7 @@ exports[`array fields fixed array 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -927,15 +925,15 @@ exports[`array fields fixed array 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__16"
+              className="ms-Button-label label-64"
+              id="id__12"
             >
               Submit
             </span>
@@ -954,18 +952,18 @@ exports[`array fields has errors 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-MessageBar ms-MessageBar--error ms-MessageBar-singleline root-164"
+    className="ms-MessageBar ms-MessageBar--error ms-MessageBar-singleline root-102"
   >
     <div
-      className="ms-MessageBar-content content-165"
+      className="ms-MessageBar-content content-103"
     >
       <div
         aria-hidden={true}
-        className="ms-MessageBar-icon iconContainer-166"
+        className="ms-MessageBar-icon iconContainer-104"
       >
         <i
           aria-hidden={true}
-          className="icon-175"
+          className="icon-112"
           data-icon-name="ErrorBadge"
         >
           
@@ -973,12 +971,12 @@ exports[`array fields has errors 1`] = `
       </div>
       <div
         aria-live="assertive"
-        className="ms-MessageBar-text text-168"
-        id="MessageBar62"
-        role="alert"
+        className="ms-MessageBar-text text-106"
+        id="MessageBar54"
+        role="status"
       >
         <span
-          className="ms-MessageBar-innerText innerText-169"
+          className="ms-MessageBar-innerText innerText-107"
         />
       </div>
     </div>
@@ -1008,27 +1006,27 @@ exports[`array fields has errors 1`] = `
           }
         >
           <div
-            className="ms-TextField root-125"
+            className="ms-TextField root-67"
           >
             <div
               className="ms-TextField-wrapper"
             >
               <label
-                className="ms-Label root-177"
+                className="ms-Label root-114"
                 htmlFor="root_name"
-                id="TextFieldLabel65"
+                id="TextFieldLabel57"
               >
                 name
               </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-176"
+                className="ms-TextField-fieldGroup fieldGroup-113"
               >
                 <input
-                  aria-describedby="TextFieldDescription64"
+                  aria-describedby="TextFieldDescription56"
                   aria-invalid={true}
-                  aria-labelledby="TextFieldLabel65"
+                  aria-labelledby="TextFieldLabel57"
                   autoFocus={false}
-                  className="ms-TextField-field field-127"
+                  className="ms-TextField-field field-69"
                   disabled={false}
                   id="root_name"
                   name="root_name"
@@ -1045,7 +1043,7 @@ exports[`array fields has errors 1`] = `
               </div>
             </div>
             <span
-              id="TextFieldDescription64"
+              id="TextFieldDescription56"
             >
               <div
                 role="alert"
@@ -1088,7 +1086,7 @@ exports[`array fields has errors 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1099,15 +1097,15 @@ exports[`array fields has errors 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__68"
+              className="ms-Button-label label-64"
+              id="id__58"
             >
               Submit
             </span>
@@ -1150,27 +1148,27 @@ exports[`array fields no errors 1`] = `
           }
         >
           <div
-            className="ms-TextField root-125"
+            className="ms-TextField root-67"
           >
             <div
               className="ms-TextField-wrapper"
             >
               <label
-                className="ms-Label root-177"
+                className="ms-Label root-114"
                 htmlFor="root_name"
-                id="TextFieldLabel73"
+                id="TextFieldLabel63"
               >
                 name
               </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-178"
+                className="ms-TextField-fieldGroup fieldGroup-115"
               >
                 <input
                   aria-describedby="root_name__error root_name__description root_name__help"
                   aria-invalid={false}
-                  aria-labelledby="TextFieldLabel73"
+                  aria-labelledby="TextFieldLabel63"
                   autoFocus={false}
-                  className="ms-TextField-field field-127"
+                  className="ms-TextField-field field-69"
                   disabled={false}
                   id="root_name"
                   name="root_name"
@@ -1198,7 +1196,7 @@ exports[`array fields no errors 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1209,15 +1207,15 @@ exports[`array fields no errors 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__76"
+              className="ms-Button-label label-64"
+              id="id__64"
             >
               Submit
             </span>
@@ -1244,13 +1242,13 @@ exports[`with title and description array 1`] = `
     }
   >
     <label
-      className="ms-Label root-179"
+      className="ms-Label root-116"
       id="root__title"
     >
       Test field
     </label>
     <span
-      className="css-180"
+      className="css-117"
       id="root__description"
     >
       a test description
@@ -1263,7 +1261,7 @@ exports[`with title and description array 1`] = `
       }
     >
       <button
-        className="ms-Button ms-Button--commandBar array-item-add root-110"
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1279,12 +1277,12 @@ exports[`with title and description array 1`] = `
         type="button"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <i
             aria-hidden={true}
-            className="ms-Icon root-105 css-119 ms-Button-icon icon-113"
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
             data-icon-name="Add"
             style={
               Object {
@@ -1295,11 +1293,11 @@ exports[`with title and description array 1`] = `
             
           </i>
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-114"
-              id="id__87"
+              className="ms-Button-label label-57"
+              id="id__73"
             >
               Add Item
             </span>
@@ -1314,7 +1312,7 @@ exports[`with title and description array 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1325,15 +1323,15 @@ exports[`with title and description array 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__90"
+              className="ms-Button-label label-64"
+              id="id__76"
             >
               Submit
             </span>
@@ -1360,13 +1358,13 @@ exports[`with title and description array icons 1`] = `
     }
   >
     <label
-      className="ms-Label root-179"
+      className="ms-Label root-116"
       id="root__title"
     >
       Test field
     </label>
     <span
-      className="css-180"
+      className="css-117"
       id="root__description"
     >
       a test description
@@ -1393,27 +1391,27 @@ exports[`with title and description array icons 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-181"
+                    className="ms-Label root-118"
                     htmlFor="root_0"
-                    id="TextFieldLabel111"
+                    id="TextFieldLabel93"
                   >
                     Test item
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-178"
+                    className="ms-TextField-fieldGroup fieldGroup-115"
                   >
                     <input
                       aria-describedby="root_0__error root_0__description root_0__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel111"
+                      aria-labelledby="TextFieldLabel93"
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_0"
                       name="root_0"
@@ -1431,7 +1429,7 @@ exports[`with title and description array icons 1`] = `
                 </div>
               </div>
               <span
-                className="css-180"
+                className="css-117"
               >
                 a test item description
               </span>
@@ -1448,7 +1446,7 @@ exports[`with title and description array icons 1`] = `
         >
           <button
             aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-155"
+            className="ms-Button ms-Button--icon is-disabled root-95"
             data-is-focusable={false}
             disabled={true}
             onClick={[Function]}
@@ -1460,12 +1458,12 @@ exports[`with title and description array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-156"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
                 data-icon-name="Up"
                 style={
                   Object {
@@ -1478,7 +1476,7 @@ exports[`with title and description array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1489,12 +1487,12 @@ exports[`with title and description array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
                 data-icon-name="Down"
                 style={
                   Object {
@@ -1507,7 +1505,7 @@ exports[`with title and description array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1518,12 +1516,12 @@ exports[`with title and description array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-163 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
                 data-icon-name="Copy"
                 style={
                   Object {
@@ -1536,7 +1534,7 @@ exports[`with title and description array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1547,12 +1545,12 @@ exports[`with title and description array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-119 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
                 data-icon-name="Delete"
                 style={
                   Object {
@@ -1589,27 +1587,27 @@ exports[`with title and description array icons 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-181"
+                    className="ms-Label root-118"
                     htmlFor="root_1"
-                    id="TextFieldLabel128"
+                    id="TextFieldLabel108"
                   >
                     Test item
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-178"
+                    className="ms-TextField-fieldGroup fieldGroup-115"
                   >
                     <input
                       aria-describedby="root_1__error root_1__description root_1__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel128"
+                      aria-labelledby="TextFieldLabel108"
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_1"
                       name="root_1"
@@ -1627,7 +1625,7 @@ exports[`with title and description array icons 1`] = `
                 </div>
               </div>
               <span
-                className="css-180"
+                className="css-117"
               >
                 a test item description
               </span>
@@ -1643,7 +1641,7 @@ exports[`with title and description array icons 1`] = `
           }
         >
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1654,12 +1652,12 @@ exports[`with title and description array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
                 data-icon-name="Up"
                 style={
                   Object {
@@ -1673,7 +1671,7 @@ exports[`with title and description array icons 1`] = `
           </button>
           <button
             aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-155"
+            className="ms-Button ms-Button--icon is-disabled root-95"
             data-is-focusable={false}
             disabled={true}
             onClick={[Function]}
@@ -1685,12 +1683,12 @@ exports[`with title and description array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-156"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
                 data-icon-name="Down"
                 style={
                   Object {
@@ -1703,7 +1701,7 @@ exports[`with title and description array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1714,12 +1712,12 @@ exports[`with title and description array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-163 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
                 data-icon-name="Copy"
                 style={
                   Object {
@@ -1732,7 +1730,7 @@ exports[`with title and description array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -1743,12 +1741,12 @@ exports[`with title and description array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-119 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
                 data-icon-name="Delete"
                 style={
                   Object {
@@ -1771,7 +1769,7 @@ exports[`with title and description array icons 1`] = `
       }
     >
       <button
-        className="ms-Button ms-Button--commandBar array-item-add root-110"
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1787,12 +1785,12 @@ exports[`with title and description array icons 1`] = `
         type="button"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <i
             aria-hidden={true}
-            className="ms-Icon root-105 css-119 ms-Button-icon icon-113"
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
             data-icon-name="Add"
             style={
               Object {
@@ -1803,11 +1801,11 @@ exports[`with title and description array icons 1`] = `
             
           </i>
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-114"
-              id="id__143"
+              className="ms-Button-label label-57"
+              id="id__121"
             >
               Add Item
             </span>
@@ -1822,7 +1820,7 @@ exports[`with title and description array icons 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1833,15 +1831,15 @@ exports[`with title and description array icons 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__146"
+              className="ms-Button-label label-64"
+              id="id__124"
             >
               Submit
             </span>
@@ -1871,7 +1869,7 @@ exports[`with title and description checkboxes 1`] = `
       className="ms-Dropdown-container"
     >
       <label
-        className="ms-Label ms-Dropdown-label root-182"
+        className="ms-Label ms-Dropdown-label root-119"
         id="root-label"
       >
         Test field
@@ -1883,9 +1881,8 @@ exports[`with title and description checkboxes 1`] = `
         aria-haspopup="listbox"
         aria-labelledby="root-label root-option"
         aria-required={false}
-        className="ms-Dropdown dropdown-136"
+        className="ms-Dropdown dropdown-78"
         data-is-focusable={true}
-        data-ktp-target={true}
         id="root"
         onBlur={[Function]}
         onChange={[Function]}
@@ -1898,16 +1895,15 @@ exports[`with title and description checkboxes 1`] = `
         tabIndex={0}
       >
         <span
-          aria-invalid={false}
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-137"
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
           id="root-option"
         />
         <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-138"
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-154"
+            className="ms-Dropdown-caretDown caretDown-94"
             data-icon-name="ChevronDown"
           >
             
@@ -1916,7 +1912,7 @@ exports[`with title and description checkboxes 1`] = `
       </div>
     </div>
     <span
-      className="css-180"
+      className="css-117"
     >
       a test description
     </span>
@@ -1927,7 +1923,7 @@ exports[`with title and description checkboxes 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1938,15 +1934,15 @@ exports[`with title and description checkboxes 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__106"
+              className="ms-Button-label label-64"
+              id="id__88"
             >
               Submit
             </span>
@@ -1973,13 +1969,13 @@ exports[`with title and description fixed array 1`] = `
     }
   >
     <label
-      className="ms-Label root-179"
+      className="ms-Label root-116"
       id="root__title"
     >
       Test field
     </label>
     <span
-      className="css-180"
+      className="css-117"
       id="root__description"
     >
       a test description
@@ -2006,27 +2002,27 @@ exports[`with title and description fixed array 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-181"
+                    className="ms-Label root-118"
                     htmlFor="root_0"
-                    id="TextFieldLabel95"
+                    id="TextFieldLabel81"
                   >
                     Test item
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-178"
+                    className="ms-TextField-fieldGroup fieldGroup-115"
                   >
                     <input
                       aria-describedby="root_0__error root_0__description root_0__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel95"
+                      aria-labelledby="TextFieldLabel81"
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_0"
                       name="root_0"
@@ -2044,7 +2040,7 @@ exports[`with title and description fixed array 1`] = `
                 </div>
               </div>
               <span
-                className="css-180"
+                className="css-117"
               >
                 a test item description
               </span>
@@ -2075,27 +2071,27 @@ exports[`with title and description fixed array 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-181"
+                    className="ms-Label root-118"
                     htmlFor="root_1"
-                    id="TextFieldLabel100"
+                    id="TextFieldLabel84"
                   >
                     Test item
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-178"
+                    className="ms-TextField-fieldGroup fieldGroup-115"
                   >
                     <input
                       aria-describedby="root_1__error root_1__description root_1__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel100"
+                      aria-labelledby="TextFieldLabel84"
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_1"
                       name="root_1"
@@ -2114,7 +2110,7 @@ exports[`with title and description fixed array 1`] = `
                 </div>
               </div>
               <span
-                className="css-180"
+                className="css-117"
               >
                 a test item description
               </span>
@@ -2130,7 +2126,7 @@ exports[`with title and description fixed array 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2141,15 +2137,15 @@ exports[`with title and description fixed array 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__103"
+              className="ms-Button-label label-64"
+              id="id__85"
             >
               Submit
             </span>
@@ -2176,13 +2172,13 @@ exports[`with title and description from both array 1`] = `
     }
   >
     <label
-      className="ms-Label root-179"
+      className="ms-Label root-116"
       id="root__title"
     >
       My Field
     </label>
     <span
-      className="css-180"
+      className="css-117"
       id="root__description"
     >
       a fancier description
@@ -2195,7 +2191,7 @@ exports[`with title and description from both array 1`] = `
       }
     >
       <button
-        className="ms-Button ms-Button--commandBar array-item-add root-110"
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2211,12 +2207,12 @@ exports[`with title and description from both array 1`] = `
         type="button"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <i
             aria-hidden={true}
-            className="ms-Icon root-105 css-119 ms-Button-icon icon-113"
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
             data-icon-name="Add"
             style={
               Object {
@@ -2227,11 +2223,11 @@ exports[`with title and description from both array 1`] = `
             
           </i>
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-114"
-              id="id__211"
+              className="ms-Button-label label-57"
+              id="id__181"
             >
               Add Item
             </span>
@@ -2246,7 +2242,7 @@ exports[`with title and description from both array 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2257,15 +2253,15 @@ exports[`with title and description from both array 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__214"
+              className="ms-Button-label label-64"
+              id="id__184"
             >
               Submit
             </span>
@@ -2292,13 +2288,13 @@ exports[`with title and description from both array icons 1`] = `
     }
   >
     <label
-      className="ms-Label root-179"
+      className="ms-Label root-116"
       id="root__title"
     >
       My Field
     </label>
     <span
-      className="css-180"
+      className="css-117"
       id="root__description"
     >
       a fancier description
@@ -2325,27 +2321,27 @@ exports[`with title and description from both array icons 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-181"
+                    className="ms-Label root-118"
                     htmlFor="root_0"
-                    id="TextFieldLabel235"
+                    id="TextFieldLabel201"
                   >
                     My Item
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-178"
+                    className="ms-TextField-fieldGroup fieldGroup-115"
                   >
                     <input
                       aria-describedby="root_0__error root_0__description root_0__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel235"
+                      aria-labelledby="TextFieldLabel201"
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_0"
                       name="root_0"
@@ -2363,7 +2359,7 @@ exports[`with title and description from both array icons 1`] = `
                 </div>
               </div>
               <span
-                className="css-180"
+                className="css-117"
               >
                 a fancier item description
               </span>
@@ -2380,7 +2376,7 @@ exports[`with title and description from both array icons 1`] = `
         >
           <button
             aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-155"
+            className="ms-Button ms-Button--icon is-disabled root-95"
             data-is-focusable={false}
             disabled={true}
             onClick={[Function]}
@@ -2392,12 +2388,12 @@ exports[`with title and description from both array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-156"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
                 data-icon-name="Up"
                 style={
                   Object {
@@ -2410,7 +2406,7 @@ exports[`with title and description from both array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -2421,12 +2417,12 @@ exports[`with title and description from both array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
                 data-icon-name="Down"
                 style={
                   Object {
@@ -2439,7 +2435,7 @@ exports[`with title and description from both array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -2450,12 +2446,12 @@ exports[`with title and description from both array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-163 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
                 data-icon-name="Copy"
                 style={
                   Object {
@@ -2468,7 +2464,7 @@ exports[`with title and description from both array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -2479,12 +2475,12 @@ exports[`with title and description from both array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-119 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
                 data-icon-name="Delete"
                 style={
                   Object {
@@ -2521,27 +2517,27 @@ exports[`with title and description from both array icons 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-181"
+                    className="ms-Label root-118"
                     htmlFor="root_1"
-                    id="TextFieldLabel252"
+                    id="TextFieldLabel216"
                   >
                     My Item
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-178"
+                    className="ms-TextField-fieldGroup fieldGroup-115"
                   >
                     <input
                       aria-describedby="root_1__error root_1__description root_1__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel252"
+                      aria-labelledby="TextFieldLabel216"
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_1"
                       name="root_1"
@@ -2559,7 +2555,7 @@ exports[`with title and description from both array icons 1`] = `
                 </div>
               </div>
               <span
-                className="css-180"
+                className="css-117"
               >
                 a fancier item description
               </span>
@@ -2575,7 +2571,7 @@ exports[`with title and description from both array icons 1`] = `
           }
         >
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -2586,12 +2582,12 @@ exports[`with title and description from both array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
                 data-icon-name="Up"
                 style={
                   Object {
@@ -2605,7 +2601,7 @@ exports[`with title and description from both array icons 1`] = `
           </button>
           <button
             aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-155"
+            className="ms-Button ms-Button--icon is-disabled root-95"
             data-is-focusable={false}
             disabled={true}
             onClick={[Function]}
@@ -2617,12 +2613,12 @@ exports[`with title and description from both array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-156"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
                 data-icon-name="Down"
                 style={
                   Object {
@@ -2635,7 +2631,7 @@ exports[`with title and description from both array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -2646,12 +2642,12 @@ exports[`with title and description from both array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-163 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
                 data-icon-name="Copy"
                 style={
                   Object {
@@ -2664,7 +2660,7 @@ exports[`with title and description from both array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -2675,12 +2671,12 @@ exports[`with title and description from both array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-119 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
                 data-icon-name="Delete"
                 style={
                   Object {
@@ -2703,7 +2699,7 @@ exports[`with title and description from both array icons 1`] = `
       }
     >
       <button
-        className="ms-Button ms-Button--commandBar array-item-add root-110"
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2719,12 +2715,12 @@ exports[`with title and description from both array icons 1`] = `
         type="button"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <i
             aria-hidden={true}
-            className="ms-Icon root-105 css-119 ms-Button-icon icon-113"
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
             data-icon-name="Add"
             style={
               Object {
@@ -2735,11 +2731,11 @@ exports[`with title and description from both array icons 1`] = `
             
           </i>
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-114"
-              id="id__267"
+              className="ms-Button-label label-57"
+              id="id__229"
             >
               Add Item
             </span>
@@ -2754,7 +2750,7 @@ exports[`with title and description from both array icons 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2765,15 +2761,15 @@ exports[`with title and description from both array icons 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__270"
+              className="ms-Button-label label-64"
+              id="id__232"
             >
               Submit
             </span>
@@ -2803,7 +2799,7 @@ exports[`with title and description from both checkboxes 1`] = `
       className="ms-Dropdown-container"
     >
       <label
-        className="ms-Label ms-Dropdown-label root-182"
+        className="ms-Label ms-Dropdown-label root-119"
         id="root-label"
       >
         My Field
@@ -2815,9 +2811,8 @@ exports[`with title and description from both checkboxes 1`] = `
         aria-haspopup="listbox"
         aria-labelledby="root-label root-option"
         aria-required={false}
-        className="ms-Dropdown dropdown-136"
+        className="ms-Dropdown dropdown-78"
         data-is-focusable={true}
-        data-ktp-target={true}
         id="root"
         onBlur={[Function]}
         onChange={[Function]}
@@ -2830,16 +2825,15 @@ exports[`with title and description from both checkboxes 1`] = `
         tabIndex={0}
       >
         <span
-          aria-invalid={false}
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-137"
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
           id="root-option"
         />
         <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-138"
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-154"
+            className="ms-Dropdown-caretDown caretDown-94"
             data-icon-name="ChevronDown"
           >
             
@@ -2848,7 +2842,7 @@ exports[`with title and description from both checkboxes 1`] = `
       </div>
     </div>
     <span
-      className="css-180"
+      className="css-117"
     >
       a fancier description
     </span>
@@ -2859,7 +2853,7 @@ exports[`with title and description from both checkboxes 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2870,15 +2864,15 @@ exports[`with title and description from both checkboxes 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__230"
+              className="ms-Button-label label-64"
+              id="id__196"
             >
               Submit
             </span>
@@ -2905,13 +2899,13 @@ exports[`with title and description from both fixed array 1`] = `
     }
   >
     <label
-      className="ms-Label root-179"
+      className="ms-Label root-116"
       id="root__title"
     >
       My Field
     </label>
     <span
-      className="css-180"
+      className="css-117"
       id="root__description"
     >
       a fancier description
@@ -2938,27 +2932,27 @@ exports[`with title and description from both fixed array 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-181"
+                    className="ms-Label root-118"
                     htmlFor="root_0"
-                    id="TextFieldLabel219"
+                    id="TextFieldLabel189"
                   >
                     My Item
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-178"
+                    className="ms-TextField-fieldGroup fieldGroup-115"
                   >
                     <input
                       aria-describedby="root_0__error root_0__description root_0__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel219"
+                      aria-labelledby="TextFieldLabel189"
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_0"
                       name="root_0"
@@ -2976,7 +2970,7 @@ exports[`with title and description from both fixed array 1`] = `
                 </div>
               </div>
               <span
-                className="css-180"
+                className="css-117"
               >
                 a fancier item description
               </span>
@@ -3007,27 +3001,27 @@ exports[`with title and description from both fixed array 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-181"
+                    className="ms-Label root-118"
                     htmlFor="root_1"
-                    id="TextFieldLabel224"
+                    id="TextFieldLabel192"
                   >
                     My Item
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-178"
+                    className="ms-TextField-fieldGroup fieldGroup-115"
                   >
                     <input
                       aria-describedby="root_1__error root_1__description root_1__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel224"
+                      aria-labelledby="TextFieldLabel192"
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_1"
                       name="root_1"
@@ -3046,7 +3040,7 @@ exports[`with title and description from both fixed array 1`] = `
                 </div>
               </div>
               <span
-                className="css-180"
+                className="css-117"
               >
                 a fancier item description
               </span>
@@ -3062,7 +3056,7 @@ exports[`with title and description from both fixed array 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -3073,15 +3067,15 @@ exports[`with title and description from both fixed array 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__227"
+              className="ms-Button-label label-64"
+              id="id__193"
             >
               Submit
             </span>
@@ -3108,13 +3102,13 @@ exports[`with title and description from uiSchema array 1`] = `
     }
   >
     <label
-      className="ms-Label root-179"
+      className="ms-Label root-116"
       id="root__title"
     >
       My Field
     </label>
     <span
-      className="css-180"
+      className="css-117"
       id="root__description"
     >
       a fancier description
@@ -3127,7 +3121,7 @@ exports[`with title and description from uiSchema array 1`] = `
       }
     >
       <button
-        className="ms-Button ms-Button--commandBar array-item-add root-110"
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -3143,12 +3137,12 @@ exports[`with title and description from uiSchema array 1`] = `
         type="button"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <i
             aria-hidden={true}
-            className="ms-Icon root-105 css-119 ms-Button-icon icon-113"
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
             data-icon-name="Add"
             style={
               Object {
@@ -3159,11 +3153,11 @@ exports[`with title and description from uiSchema array 1`] = `
             
           </i>
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-114"
-              id="id__149"
+              className="ms-Button-label label-57"
+              id="id__127"
             >
               Add Item
             </span>
@@ -3178,7 +3172,7 @@ exports[`with title and description from uiSchema array 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -3189,15 +3183,15 @@ exports[`with title and description from uiSchema array 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__152"
+              className="ms-Button-label label-64"
+              id="id__130"
             >
               Submit
             </span>
@@ -3224,13 +3218,13 @@ exports[`with title and description from uiSchema array icons 1`] = `
     }
   >
     <label
-      className="ms-Label root-179"
+      className="ms-Label root-116"
       id="root__title"
     >
       My Field
     </label>
     <span
-      className="css-180"
+      className="css-117"
       id="root__description"
     >
       a fancier description
@@ -3257,27 +3251,27 @@ exports[`with title and description from uiSchema array icons 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-181"
+                    className="ms-Label root-118"
                     htmlFor="root_0"
-                    id="TextFieldLabel173"
+                    id="TextFieldLabel147"
                   >
                     My Item
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-178"
+                    className="ms-TextField-fieldGroup fieldGroup-115"
                   >
                     <input
                       aria-describedby="root_0__error root_0__description root_0__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel173"
+                      aria-labelledby="TextFieldLabel147"
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_0"
                       name="root_0"
@@ -3295,7 +3289,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                 </div>
               </div>
               <span
-                className="css-180"
+                className="css-117"
               >
                 a fancier item description
               </span>
@@ -3312,7 +3306,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
         >
           <button
             aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-155"
+            className="ms-Button ms-Button--icon is-disabled root-95"
             data-is-focusable={false}
             disabled={true}
             onClick={[Function]}
@@ -3324,12 +3318,12 @@ exports[`with title and description from uiSchema array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-156"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
                 data-icon-name="Up"
                 style={
                   Object {
@@ -3342,7 +3336,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -3353,12 +3347,12 @@ exports[`with title and description from uiSchema array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
                 data-icon-name="Down"
                 style={
                   Object {
@@ -3371,7 +3365,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -3382,12 +3376,12 @@ exports[`with title and description from uiSchema array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-163 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
                 data-icon-name="Copy"
                 style={
                   Object {
@@ -3400,7 +3394,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -3411,12 +3405,12 @@ exports[`with title and description from uiSchema array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-119 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
                 data-icon-name="Delete"
                 style={
                   Object {
@@ -3453,27 +3447,27 @@ exports[`with title and description from uiSchema array icons 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-181"
+                    className="ms-Label root-118"
                     htmlFor="root_1"
-                    id="TextFieldLabel190"
+                    id="TextFieldLabel162"
                   >
                     My Item
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-178"
+                    className="ms-TextField-fieldGroup fieldGroup-115"
                   >
                     <input
                       aria-describedby="root_1__error root_1__description root_1__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel190"
+                      aria-labelledby="TextFieldLabel162"
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_1"
                       name="root_1"
@@ -3491,7 +3485,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                 </div>
               </div>
               <span
-                className="css-180"
+                className="css-117"
               >
                 a fancier item description
               </span>
@@ -3507,7 +3501,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
           }
         >
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -3518,12 +3512,12 @@ exports[`with title and description from uiSchema array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
                 data-icon-name="Up"
                 style={
                   Object {
@@ -3537,7 +3531,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
           </button>
           <button
             aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-155"
+            className="ms-Button ms-Button--icon is-disabled root-95"
             data-is-focusable={false}
             disabled={true}
             onClick={[Function]}
@@ -3549,12 +3543,12 @@ exports[`with title and description from uiSchema array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-156"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
                 data-icon-name="Down"
                 style={
                   Object {
@@ -3567,7 +3561,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -3578,12 +3572,12 @@ exports[`with title and description from uiSchema array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-163 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
                 data-icon-name="Copy"
                 style={
                   Object {
@@ -3596,7 +3590,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -3607,12 +3601,12 @@ exports[`with title and description from uiSchema array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-119 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
                 data-icon-name="Delete"
                 style={
                   Object {
@@ -3635,7 +3629,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
       }
     >
       <button
-        className="ms-Button ms-Button--commandBar array-item-add root-110"
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -3651,12 +3645,12 @@ exports[`with title and description from uiSchema array icons 1`] = `
         type="button"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <i
             aria-hidden={true}
-            className="ms-Icon root-105 css-119 ms-Button-icon icon-113"
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
             data-icon-name="Add"
             style={
               Object {
@@ -3667,11 +3661,11 @@ exports[`with title and description from uiSchema array icons 1`] = `
             
           </i>
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-114"
-              id="id__205"
+              className="ms-Button-label label-57"
+              id="id__175"
             >
               Add Item
             </span>
@@ -3686,7 +3680,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -3697,15 +3691,15 @@ exports[`with title and description from uiSchema array icons 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__208"
+              className="ms-Button-label label-64"
+              id="id__178"
             >
               Submit
             </span>
@@ -3735,7 +3729,7 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
       className="ms-Dropdown-container"
     >
       <label
-        className="ms-Label ms-Dropdown-label root-182"
+        className="ms-Label ms-Dropdown-label root-119"
         id="root-label"
       >
         My Field
@@ -3747,9 +3741,8 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
         aria-haspopup="listbox"
         aria-labelledby="root-label root-option"
         aria-required={false}
-        className="ms-Dropdown dropdown-136"
+        className="ms-Dropdown dropdown-78"
         data-is-focusable={true}
-        data-ktp-target={true}
         id="root"
         onBlur={[Function]}
         onChange={[Function]}
@@ -3762,16 +3755,15 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
         tabIndex={0}
       >
         <span
-          aria-invalid={false}
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-137"
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
           id="root-option"
         />
         <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-138"
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-154"
+            className="ms-Dropdown-caretDown caretDown-94"
             data-icon-name="ChevronDown"
           >
             
@@ -3780,7 +3772,7 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
       </div>
     </div>
     <span
-      className="css-180"
+      className="css-117"
     >
       a fancier description
     </span>
@@ -3791,7 +3783,7 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -3802,15 +3794,15 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__168"
+              className="ms-Button-label label-64"
+              id="id__142"
             >
               Submit
             </span>
@@ -3837,13 +3829,13 @@ exports[`with title and description from uiSchema fixed array 1`] = `
     }
   >
     <label
-      className="ms-Label root-179"
+      className="ms-Label root-116"
       id="root__title"
     >
       My Field
     </label>
     <span
-      className="css-180"
+      className="css-117"
       id="root__description"
     >
       a fancier description
@@ -3870,27 +3862,27 @@ exports[`with title and description from uiSchema fixed array 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-181"
+                    className="ms-Label root-118"
                     htmlFor="root_0"
-                    id="TextFieldLabel157"
+                    id="TextFieldLabel135"
                   >
                     My Item
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-178"
+                    className="ms-TextField-fieldGroup fieldGroup-115"
                   >
                     <input
                       aria-describedby="root_0__error root_0__description root_0__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel157"
+                      aria-labelledby="TextFieldLabel135"
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_0"
                       name="root_0"
@@ -3908,7 +3900,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                 </div>
               </div>
               <span
-                className="css-180"
+                className="css-117"
               >
                 a fancier item description
               </span>
@@ -3939,27 +3931,27 @@ exports[`with title and description from uiSchema fixed array 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-181"
+                    className="ms-Label root-118"
                     htmlFor="root_1"
-                    id="TextFieldLabel162"
+                    id="TextFieldLabel138"
                   >
                     My Item
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-178"
+                    className="ms-TextField-fieldGroup fieldGroup-115"
                   >
                     <input
                       aria-describedby="root_1__error root_1__description root_1__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel162"
+                      aria-labelledby="TextFieldLabel138"
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_1"
                       name="root_1"
@@ -3978,7 +3970,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                 </div>
               </div>
               <span
-                className="css-180"
+                className="css-117"
               >
                 a fancier item description
               </span>
@@ -3994,7 +3986,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -4005,15 +3997,15 @@ exports[`with title and description from uiSchema fixed array 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__165"
+              className="ms-Button-label label-64"
+              id="id__139"
             >
               Submit
             </span>
@@ -4047,7 +4039,7 @@ exports[`with title and description with global label off array 1`] = `
       }
     >
       <button
-        className="ms-Button ms-Button--commandBar array-item-add root-110"
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -4063,12 +4055,12 @@ exports[`with title and description with global label off array 1`] = `
         type="button"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <i
             aria-hidden={true}
-            className="ms-Icon root-105 css-119 ms-Button-icon icon-113"
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
             data-icon-name="Add"
             style={
               Object {
@@ -4079,11 +4071,11 @@ exports[`with title and description with global label off array 1`] = `
             
           </i>
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-114"
-              id="id__273"
+              className="ms-Button-label label-57"
+              id="id__235"
             >
               Add Item
             </span>
@@ -4098,7 +4090,7 @@ exports[`with title and description with global label off array 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -4109,15 +4101,15 @@ exports[`with title and description with global label off array 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__276"
+              className="ms-Button-label label-64"
+              id="id__238"
             >
               Submit
             </span>
@@ -4165,19 +4157,19 @@ exports[`with title and description with global label off array icons 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-126"
+                    className="ms-TextField-fieldGroup fieldGroup-68"
                   >
                     <input
                       aria-describedby="root_0__error root_0__description root_0__help"
                       aria-invalid={false}
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_0"
                       name="root_0"
@@ -4207,7 +4199,7 @@ exports[`with title and description with global label off array icons 1`] = `
         >
           <button
             aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-155"
+            className="ms-Button ms-Button--icon is-disabled root-95"
             data-is-focusable={false}
             disabled={true}
             onClick={[Function]}
@@ -4219,12 +4211,12 @@ exports[`with title and description with global label off array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-156"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
                 data-icon-name="Up"
                 style={
                   Object {
@@ -4237,7 +4229,7 @@ exports[`with title and description with global label off array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -4248,12 +4240,12 @@ exports[`with title and description with global label off array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
                 data-icon-name="Down"
                 style={
                   Object {
@@ -4266,7 +4258,7 @@ exports[`with title and description with global label off array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -4277,12 +4269,12 @@ exports[`with title and description with global label off array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-163 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
                 data-icon-name="Copy"
                 style={
                   Object {
@@ -4295,7 +4287,7 @@ exports[`with title and description with global label off array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -4306,12 +4298,12 @@ exports[`with title and description with global label off array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-119 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
                 data-icon-name="Delete"
                 style={
                   Object {
@@ -4348,19 +4340,19 @@ exports[`with title and description with global label off array icons 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-126"
+                    className="ms-TextField-fieldGroup fieldGroup-68"
                   >
                     <input
                       aria-describedby="root_1__error root_1__description root_1__help"
                       aria-invalid={false}
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_1"
                       name="root_1"
@@ -4389,7 +4381,7 @@ exports[`with title and description with global label off array icons 1`] = `
           }
         >
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -4400,12 +4392,12 @@ exports[`with title and description with global label off array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-63"
                 data-icon-name="Up"
                 style={
                   Object {
@@ -4419,7 +4411,7 @@ exports[`with title and description with global label off array icons 1`] = `
           </button>
           <button
             aria-disabled={true}
-            className="ms-Button ms-Button--icon is-disabled root-155"
+            className="ms-Button ms-Button--icon is-disabled root-95"
             data-is-focusable={false}
             disabled={true}
             onClick={[Function]}
@@ -4431,12 +4423,12 @@ exports[`with title and description with global label off array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-160 ms-Button-icon icon-156"
+                className="ms-Icon root-37 css-99 ms-Button-icon icon-96"
                 data-icon-name="Down"
                 style={
                   Object {
@@ -4449,7 +4441,7 @@ exports[`with title and description with global label off array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -4460,12 +4452,12 @@ exports[`with title and description with global label off array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-163 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-101 ms-Button-icon icon-63"
                 data-icon-name="Copy"
                 style={
                   Object {
@@ -4478,7 +4470,7 @@ exports[`with title and description with global label off array icons 1`] = `
             </span>
           </button>
           <button
-            className="ms-Button ms-Button--icon root-161"
+            className="ms-Button ms-Button--icon root-100"
             data-is-focusable={true}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -4489,12 +4481,12 @@ exports[`with title and description with global label off array icons 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-111"
+              className="ms-Button-flexContainer flexContainer-54"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-119 ms-Button-icon icon-121"
+                className="ms-Icon root-37 css-61 ms-Button-icon icon-63"
                 data-icon-name="Delete"
                 style={
                   Object {
@@ -4517,7 +4509,7 @@ exports[`with title and description with global label off array icons 1`] = `
       }
     >
       <button
-        className="ms-Button ms-Button--commandBar array-item-add root-110"
+        className="ms-Button ms-Button--commandBar array-item-add root-53"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -4533,12 +4525,12 @@ exports[`with title and description with global label off array icons 1`] = `
         type="button"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <i
             aria-hidden={true}
-            className="ms-Icon root-105 css-119 ms-Button-icon icon-113"
+            className="ms-Icon root-37 css-61 ms-Button-icon icon-56"
             data-icon-name="Add"
             style={
               Object {
@@ -4549,11 +4541,11 @@ exports[`with title and description with global label off array icons 1`] = `
             
           </i>
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-114"
-              id="id__329"
+              className="ms-Button-label label-57"
+              id="id__283"
             >
               Add Item
             </span>
@@ -4568,7 +4560,7 @@ exports[`with title and description with global label off array icons 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -4579,15 +4571,15 @@ exports[`with title and description with global label off array icons 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__332"
+              className="ms-Button-label label-64"
+              id="id__286"
             >
               Submit
             </span>
@@ -4617,7 +4609,7 @@ exports[`with title and description with global label off checkboxes 1`] = `
       className="ms-Dropdown-container"
     >
       <label
-        className="ms-Label ms-Dropdown-label root-182"
+        className="ms-Label ms-Dropdown-label root-119"
         id="root-label"
       >
         Test field
@@ -4629,9 +4621,8 @@ exports[`with title and description with global label off checkboxes 1`] = `
         aria-haspopup="listbox"
         aria-labelledby="root-label root-option"
         aria-required={false}
-        className="ms-Dropdown dropdown-136"
+        className="ms-Dropdown dropdown-78"
         data-is-focusable={true}
-        data-ktp-target={true}
         id="root"
         onBlur={[Function]}
         onChange={[Function]}
@@ -4644,16 +4635,15 @@ exports[`with title and description with global label off checkboxes 1`] = `
         tabIndex={0}
       >
         <span
-          aria-invalid={false}
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-137"
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-79"
           id="root-option"
         />
         <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-138"
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-80"
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-154"
+            className="ms-Dropdown-caretDown caretDown-94"
             data-icon-name="ChevronDown"
           >
             
@@ -4662,7 +4652,7 @@ exports[`with title and description with global label off checkboxes 1`] = `
       </div>
     </div>
     <span
-      className="css-180"
+      className="css-117"
     >
       a test description
     </span>
@@ -4673,7 +4663,7 @@ exports[`with title and description with global label off checkboxes 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -4684,15 +4674,15 @@ exports[`with title and description with global label off checkboxes 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__292"
+              className="ms-Button-label label-64"
+              id="id__250"
             >
               Submit
             </span>
@@ -4740,19 +4730,19 @@ exports[`with title and description with global label off fixed array 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-126"
+                    className="ms-TextField-fieldGroup fieldGroup-68"
                   >
                     <input
                       aria-describedby="root_0__error root_0__description root_0__help"
                       aria-invalid={false}
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_0"
                       name="root_0"
@@ -4796,19 +4786,19 @@ exports[`with title and description with global label off fixed array 1`] = `
               }
             >
               <div
-                className="ms-TextField is-required root-125"
+                className="ms-TextField is-required root-67"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-126"
+                    className="ms-TextField-fieldGroup fieldGroup-68"
                   >
                     <input
                       aria-describedby="root_1__error root_1__description root_1__help"
                       aria-invalid={false}
                       autoFocus={false}
-                      className="ms-TextField-field field-127"
+                      className="ms-TextField-field field-69"
                       disabled={false}
                       id="root_1"
                       name="root_1"
@@ -4838,7 +4828,7 @@ exports[`with title and description with global label off fixed array 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-120"
+        className="ms-Button ms-Button--primary root-62"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -4849,15 +4839,15 @@ exports[`with title and description with global label off fixed array 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-111"
+          className="ms-Button-flexContainer flexContainer-54"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-112"
+            className="ms-Button-textContainer textContainer-55"
           >
             <span
-              className="ms-Button-label label-122"
-              id="id__289"
+              className="ms-Button-label label-64"
+              id="id__247"
             >
               Submit
             </span>

--- a/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
@@ -15,14 +15,14 @@ exports[`single fields checkbox field 1`] = `
     }
   >
     <div
-      className="ms-Checkbox is-enabled root-201"
+      className="ms-Checkbox is-enabled root-139"
     >
       <input
+        aria-checked="false"
         aria-disabled={false}
         autoFocus={false}
         checked={false}
-        className="input-202"
-        data-ktp-execute-target={true}
+        className="input-140"
         disabled={false}
         id="root"
         name="root"
@@ -32,16 +32,15 @@ exports[`single fields checkbox field 1`] = `
         type="checkbox"
       />
       <label
-        className="ms-Checkbox-label label-203"
+        className="ms-Checkbox-label label-141"
         htmlFor="root"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-204"
-          data-ktp-target={true}
+          className="ms-Checkbox-checkbox checkbox-142"
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-207"
+            className="ms-Checkbox-checkmark checkmark-145"
             data-icon-name="CheckMark"
           >
             
@@ -56,7 +55,7 @@ exports[`single fields checkbox field 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -67,15 +66,15 @@ exports[`single fields checkbox field 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__169"
+              className="ms-Button-label label-69"
+              id="id__130"
             >
               Submit
             </span>
@@ -102,14 +101,15 @@ exports[`single fields checkbox field with label 1`] = `
     }
   >
     <div
-      className="ms-Checkbox is-enabled root-201"
+      className="ms-Checkbox is-enabled root-139"
     >
       <input
+        aria-checked="false"
         aria-disabled={false}
+        aria-label="test"
         autoFocus={false}
         checked={false}
-        className="input-202"
-        data-ktp-execute-target={true}
+        className="input-140"
         disabled={false}
         id="root"
         name="root"
@@ -119,23 +119,23 @@ exports[`single fields checkbox field with label 1`] = `
         type="checkbox"
       />
       <label
-        className="ms-Checkbox-label label-203"
+        className="ms-Checkbox-label label-141"
         htmlFor="root"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-204"
-          data-ktp-target={true}
+          className="ms-Checkbox-checkbox checkbox-142"
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-207"
+            className="ms-Checkbox-checkmark checkmark-145"
             data-icon-name="CheckMark"
           >
             
           </i>
         </div>
         <span
-          className="ms-Checkbox-text text-206"
+          aria-hidden="true"
+          className="ms-Checkbox-text text-144"
         >
           test
         </span>
@@ -148,7 +148,7 @@ exports[`single fields checkbox field with label 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -159,15 +159,15 @@ exports[`single fields checkbox field with label 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__172"
+              className="ms-Button-label label-69"
+              id="id__133"
             >
               Submit
             </span>
@@ -194,17 +194,18 @@ exports[`single fields checkboxes field 1`] = `
     }
   >
     <label
-      className="ms-Label root-130"
+      className="ms-Label root-73"
     />
     <div
-      className="ms-Checkbox is-enabled root-201"
+      className="ms-Checkbox is-enabled root-139"
     >
       <input
+        aria-checked="false"
         aria-disabled={false}
+        aria-label="foo"
         autoFocus={false}
         checked={false}
-        className="input-202"
-        data-ktp-execute-target={true}
+        className="input-140"
         disabled={false}
         id="root-0"
         name="root"
@@ -214,37 +215,38 @@ exports[`single fields checkboxes field 1`] = `
         type="checkbox"
       />
       <label
-        className="ms-Checkbox-label label-203"
+        className="ms-Checkbox-label label-141"
         htmlFor="root-0"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-204"
-          data-ktp-target={true}
+          className="ms-Checkbox-checkbox checkbox-142"
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-207"
+            className="ms-Checkbox-checkmark checkmark-145"
             data-icon-name="CheckMark"
           >
             
           </i>
         </div>
         <span
-          className="ms-Checkbox-text text-206"
+          aria-hidden="true"
+          className="ms-Checkbox-text text-144"
         >
           foo
         </span>
       </label>
     </div>
     <div
-      className="ms-Checkbox is-enabled root-201"
+      className="ms-Checkbox is-enabled root-139"
     >
       <input
+        aria-checked="false"
         aria-disabled={false}
+        aria-label="bar"
         autoFocus={false}
         checked={false}
-        className="input-202"
-        data-ktp-execute-target={true}
+        className="input-140"
         disabled={false}
         id="root-1"
         name="root"
@@ -254,37 +256,38 @@ exports[`single fields checkboxes field 1`] = `
         type="checkbox"
       />
       <label
-        className="ms-Checkbox-label label-203"
+        className="ms-Checkbox-label label-141"
         htmlFor="root-1"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-204"
-          data-ktp-target={true}
+          className="ms-Checkbox-checkbox checkbox-142"
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-207"
+            className="ms-Checkbox-checkmark checkmark-145"
             data-icon-name="CheckMark"
           >
             
           </i>
         </div>
         <span
-          className="ms-Checkbox-text text-206"
+          aria-hidden="true"
+          className="ms-Checkbox-text text-144"
         >
           bar
         </span>
       </label>
     </div>
     <div
-      className="ms-Checkbox is-enabled root-201"
+      className="ms-Checkbox is-enabled root-139"
     >
       <input
+        aria-checked="false"
         aria-disabled={false}
+        aria-label="fuzz"
         autoFocus={false}
         checked={false}
-        className="input-202"
-        data-ktp-execute-target={true}
+        className="input-140"
         disabled={false}
         id="root-2"
         name="root"
@@ -294,37 +297,38 @@ exports[`single fields checkboxes field 1`] = `
         type="checkbox"
       />
       <label
-        className="ms-Checkbox-label label-203"
+        className="ms-Checkbox-label label-141"
         htmlFor="root-2"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-204"
-          data-ktp-target={true}
+          className="ms-Checkbox-checkbox checkbox-142"
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-207"
+            className="ms-Checkbox-checkmark checkmark-145"
             data-icon-name="CheckMark"
           >
             
           </i>
         </div>
         <span
-          className="ms-Checkbox-text text-206"
+          aria-hidden="true"
+          className="ms-Checkbox-text text-144"
         >
           fuzz
         </span>
       </label>
     </div>
     <div
-      className="ms-Checkbox is-enabled root-201"
+      className="ms-Checkbox is-enabled root-139"
     >
       <input
+        aria-checked="false"
         aria-disabled={false}
+        aria-label="qux"
         autoFocus={false}
         checked={false}
-        className="input-202"
-        data-ktp-execute-target={true}
+        className="input-140"
         disabled={false}
         id="root-3"
         name="root"
@@ -334,23 +338,23 @@ exports[`single fields checkboxes field 1`] = `
         type="checkbox"
       />
       <label
-        className="ms-Checkbox-label label-203"
+        className="ms-Checkbox-label label-141"
         htmlFor="root-3"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-204"
-          data-ktp-target={true}
+          className="ms-Checkbox-checkbox checkbox-142"
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-207"
+            className="ms-Checkbox-checkmark checkmark-145"
             data-icon-name="CheckMark"
           >
             
           </i>
         </div>
         <span
-          className="ms-Checkbox-text text-206"
+          aria-hidden="true"
+          className="ms-Checkbox-text text-144"
         >
           qux
         </span>
@@ -376,7 +380,7 @@ exports[`single fields checkboxes field 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -387,15 +391,15 @@ exports[`single fields checkboxes field 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__175"
+              className="ms-Button-label label-69"
+              id="id__136"
             >
               Submit
             </span>
@@ -438,27 +442,27 @@ exports[`single fields field with description 1`] = `
           }
         >
           <div
-            className="ms-TextField root-111"
+            className="ms-TextField root-54"
           >
             <div
               className="ms-TextField-wrapper"
             >
               <label
-                className="ms-Label root-130"
+                className="ms-Label root-73"
                 htmlFor="root_my-field"
-                id="TextFieldLabel191"
+                id="TextFieldLabel153"
               >
                 my-field
               </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-112"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
                 <input
                   aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
                   aria-invalid={false}
-                  aria-labelledby="TextFieldLabel191"
+                  aria-labelledby="TextFieldLabel153"
                   autoFocus={false}
-                  className="ms-TextField-field field-113"
+                  className="ms-TextField-field field-56"
                   disabled={false}
                   id="root_my-field"
                   name="root_my-field"
@@ -476,7 +480,7 @@ exports[`single fields field with description 1`] = `
             </div>
           </div>
           <span
-            className="css-229"
+            className="css-166"
           >
             some description
           </span>
@@ -490,7 +494,7 @@ exports[`single fields field with description 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -501,15 +505,15 @@ exports[`single fields field with description 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__194"
+              className="ms-Button-label label-69"
+              id="id__154"
             >
               Submit
             </span>
@@ -552,27 +556,27 @@ exports[`single fields field with description in uiSchema 1`] = `
           }
         >
           <div
-            className="ms-TextField root-111"
+            className="ms-TextField root-54"
           >
             <div
               className="ms-TextField-wrapper"
             >
               <label
-                className="ms-Label root-130"
+                className="ms-Label root-73"
                 htmlFor="root_my-field"
-                id="TextFieldLabel199"
+                id="TextFieldLabel159"
               >
                 my-field
               </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-112"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
                 <input
                   aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
                   aria-invalid={false}
-                  aria-labelledby="TextFieldLabel199"
+                  aria-labelledby="TextFieldLabel159"
                   autoFocus={false}
-                  className="ms-TextField-field field-113"
+                  className="ms-TextField-field field-56"
                   disabled={false}
                   id="root_my-field"
                   name="root_my-field"
@@ -590,7 +594,7 @@ exports[`single fields field with description in uiSchema 1`] = `
             </div>
           </div>
           <span
-            className="css-229"
+            className="css-166"
           >
             some other description
           </span>
@@ -604,7 +608,7 @@ exports[`single fields field with description in uiSchema 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -615,15 +619,15 @@ exports[`single fields field with description in uiSchema 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__202"
+              className="ms-Button-label label-69"
+              id="id__160"
             >
               Submit
             </span>
@@ -650,25 +654,25 @@ exports[`single fields format color 1`] = `
     }
   >
     <label
-      className="ms-Label root-130"
+      className="ms-Label root-73"
       htmlFor="root"
     />
     <div
       aria-label="Color picker, Red 255 Green 255 Blue 255 Alpha 100% selected."
-      className="ms-ColorPicker root-131"
+      className="ms-ColorPicker root-74"
       role="group"
     >
       <div
-        className="ms-ColorPicker-panel panel-132"
+        className="ms-ColorPicker-panel panel-75"
       >
         <div
-          aria-describedby="ColorRectangle-description62"
+          aria-describedby="ColorRectangle-description48"
           aria-label="Saturation and brightness"
           aria-valuemax={100}
           aria-valuemin={0}
           aria-valuenow={0}
           aria-valuetext="Saturation 0 brightness 100"
-          className="ms-ColorPicker-colorRect root-141"
+          className="ms-ColorPicker-colorRect root-84"
           data-is-focusable={true}
           onKeyDown={[Function]}
           onMouseDown={[Function]}
@@ -681,19 +685,19 @@ exports[`single fields format color 1`] = `
           tabIndex={0}
         >
           <div
-            className="description-145"
-            id="ColorRectangle-description62"
+            className="description-88"
+            id="ColorRectangle-description48"
           >
             Use left and right arrow keys to set saturation. Use up and down arrow keys to set brightness.
           </div>
           <div
-            className="ms-ColorPicker-light light-142"
+            className="ms-ColorPicker-light light-85"
           />
           <div
-            className="ms-ColorPicker-dark dark-143"
+            className="ms-ColorPicker-dark dark-86"
           />
           <div
-            className="ms-ColorPicker-thumb thumb-144"
+            className="ms-ColorPicker-thumb thumb-87"
             style={
               Object {
                 "backgroundColor": "#ffffff",
@@ -704,10 +708,10 @@ exports[`single fields format color 1`] = `
           />
         </div>
         <div
-          className="flexContainer-137"
+          className="flexContainer-80"
         >
           <div
-            className="flexSlider-138"
+            className="flexSlider-81"
           >
             <div
               aria-label="Hue"
@@ -715,7 +719,7 @@ exports[`single fields format color 1`] = `
               aria-valuemin={0}
               aria-valuenow={0}
               aria-valuetext="0"
-              className="ms-ColorPicker-slider is-hue root-146"
+              className="ms-ColorPicker-slider is-hue root-89"
               data-is-focusable={true}
               onKeyDown={[Function]}
               onMouseDown={[Function]}
@@ -723,7 +727,7 @@ exports[`single fields format color 1`] = `
               tabIndex={0}
             >
               <div
-                className="ms-ColorPicker-thumb is-slider sliderThumb-148"
+                className="ms-ColorPicker-thumb is-slider sliderThumb-91"
                 style={
                   Object {
                     "left": "0%",
@@ -737,7 +741,7 @@ exports[`single fields format color 1`] = `
               aria-valuemin={0}
               aria-valuenow={100}
               aria-valuetext="100"
-              className="ms-ColorPicker-slider is-alpha root-149"
+              className="ms-ColorPicker-slider is-alpha root-92"
               data-is-focusable={true}
               onKeyDown={[Function]}
               onMouseDown={[Function]}
@@ -745,7 +749,7 @@ exports[`single fields format color 1`] = `
               tabIndex={0}
             >
               <div
-                className="ms-ColorPicker-sliderOverlay sliderOverlay-147"
+                className="ms-ColorPicker-sliderOverlay sliderOverlay-90"
                 style={
                   Object {
                     "background": "linear-gradient(to right, transparent, #ffffff)",
@@ -753,7 +757,7 @@ exports[`single fields format color 1`] = `
                 }
               />
               <div
-                className="ms-ColorPicker-thumb is-slider sliderThumb-148"
+                className="ms-ColorPicker-thumb is-slider sliderThumb-91"
                 style={
                   Object {
                     "left": "100%",
@@ -763,10 +767,10 @@ exports[`single fields format color 1`] = `
             </div>
           </div>
           <div
-            className="flexPreviewBox-139"
+            className="flexPreviewBox-82"
           >
             <div
-              className="ms-ColorPicker-colorSquare colorSquare-136 is-preview"
+              className="ms-ColorPicker-colorSquare colorSquare-79 is-preview"
               style={
                 Object {
                   "backgroundColor": "#ffffff",
@@ -778,15 +782,15 @@ exports[`single fields format color 1`] = `
         <table
           cellPadding="0"
           cellSpacing="0"
-          className="ms-ColorPicker-table table-133"
+          className="ms-ColorPicker-table table-76"
           role="group"
         >
           <thead>
             <tr
-              className="tableHeader-134"
+              className="tableHeader-77"
             >
               <td
-                className="tableHexCell-135"
+                className="tableHexCell-78"
               >
                 Hex
               </td>
@@ -810,272 +814,146 @@ exports[`single fields format color 1`] = `
             <tr>
               <td>
                 <div
-                  className="ms-TooltipHost root-150"
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="none"
+                  className="ms-TextField ms-ColorPicker-input input-93"
                 >
                   <div
-                    className="ms-TextField ms-ColorPicker-input input-151"
+                    className="ms-TextField-wrapper"
                   >
                     <div
-                      className="ms-TextField-wrapper"
+                      className="ms-TextField-fieldGroup fieldGroup-55"
                     >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-112"
-                      >
-                        <input
-                          aria-invalid={false}
-                          aria-label="Hex"
-                          autoComplete="off"
-                          className="ms-TextField-field field-113"
-                          id="TextField64"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          spellCheck={false}
-                          type="text"
-                          value="ffffff"
-                        />
-                      </div>
+                      <input
+                        aria-invalid={false}
+                        aria-label="Hex"
+                        autoComplete="off"
+                        className="ms-TextField-field field-56"
+                        id="TextField49"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        spellCheck={false}
+                        type="text"
+                        value="ffffff"
+                      />
                     </div>
                   </div>
-                  <div
-                    hidden={true}
-                    id="tooltip63"
-                    style={
-                      Object {
-                        "border": 0,
-                        "height": 1,
-                        "margin": -1,
-                        "overflow": "hidden",
-                        "padding": 0,
-                        "position": "absolute",
-                        "whiteSpace": "nowrap",
-                        "width": 1,
-                      }
-                    }
-                  />
                 </div>
               </td>
               <td>
                 <div
-                  className="ms-TooltipHost root-150"
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="none"
+                  className="ms-TextField ms-ColorPicker-input input-93"
                 >
                   <div
-                    className="ms-TextField ms-ColorPicker-input input-151"
+                    className="ms-TextField-wrapper"
                   >
                     <div
-                      className="ms-TextField-wrapper"
+                      className="ms-TextField-fieldGroup fieldGroup-55"
                     >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-112"
-                      >
-                        <input
-                          aria-invalid={false}
-                          aria-label="Red"
-                          autoComplete="off"
-                          className="ms-TextField-field field-113"
-                          id="TextField70"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          spellCheck={false}
-                          type="text"
-                          value="255"
-                        />
-                      </div>
+                      <input
+                        aria-invalid={false}
+                        aria-label="Red"
+                        aria-live="assertive"
+                        autoComplete="off"
+                        className="ms-TextField-field field-56"
+                        id="TextField52"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        spellCheck={false}
+                        type="text"
+                        value="255"
+                      />
                     </div>
                   </div>
-                  <div
-                    hidden={true}
-                    id="tooltip69"
-                    style={
-                      Object {
-                        "border": 0,
-                        "height": 1,
-                        "margin": -1,
-                        "overflow": "hidden",
-                        "padding": 0,
-                        "position": "absolute",
-                        "whiteSpace": "nowrap",
-                        "width": 1,
-                      }
-                    }
-                  />
                 </div>
               </td>
               <td>
                 <div
-                  className="ms-TooltipHost root-150"
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="none"
+                  className="ms-TextField ms-ColorPicker-input input-93"
                 >
                   <div
-                    className="ms-TextField ms-ColorPicker-input input-151"
+                    className="ms-TextField-wrapper"
                   >
                     <div
-                      className="ms-TextField-wrapper"
+                      className="ms-TextField-fieldGroup fieldGroup-55"
                     >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-112"
-                      >
-                        <input
-                          aria-invalid={false}
-                          aria-label="Green"
-                          autoComplete="off"
-                          className="ms-TextField-field field-113"
-                          id="TextField76"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          spellCheck={false}
-                          type="text"
-                          value="255"
-                        />
-                      </div>
+                      <input
+                        aria-invalid={false}
+                        aria-label="Green"
+                        aria-live="assertive"
+                        autoComplete="off"
+                        className="ms-TextField-field field-56"
+                        id="TextField55"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        spellCheck={false}
+                        type="text"
+                        value="255"
+                      />
                     </div>
                   </div>
-                  <div
-                    hidden={true}
-                    id="tooltip75"
-                    style={
-                      Object {
-                        "border": 0,
-                        "height": 1,
-                        "margin": -1,
-                        "overflow": "hidden",
-                        "padding": 0,
-                        "position": "absolute",
-                        "whiteSpace": "nowrap",
-                        "width": 1,
-                      }
-                    }
-                  />
                 </div>
               </td>
               <td>
                 <div
-                  className="ms-TooltipHost root-150"
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="none"
+                  className="ms-TextField ms-ColorPicker-input input-93"
                 >
                   <div
-                    className="ms-TextField ms-ColorPicker-input input-151"
+                    className="ms-TextField-wrapper"
                   >
                     <div
-                      className="ms-TextField-wrapper"
+                      className="ms-TextField-fieldGroup fieldGroup-55"
                     >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-112"
-                      >
-                        <input
-                          aria-invalid={false}
-                          aria-label="Blue"
-                          autoComplete="off"
-                          className="ms-TextField-field field-113"
-                          id="TextField82"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          spellCheck={false}
-                          type="text"
-                          value="255"
-                        />
-                      </div>
+                      <input
+                        aria-invalid={false}
+                        aria-label="Blue"
+                        aria-live="assertive"
+                        autoComplete="off"
+                        className="ms-TextField-field field-56"
+                        id="TextField58"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        spellCheck={false}
+                        type="text"
+                        value="255"
+                      />
                     </div>
                   </div>
-                  <div
-                    hidden={true}
-                    id="tooltip81"
-                    style={
-                      Object {
-                        "border": 0,
-                        "height": 1,
-                        "margin": -1,
-                        "overflow": "hidden",
-                        "padding": 0,
-                        "position": "absolute",
-                        "whiteSpace": "nowrap",
-                        "width": 1,
-                      }
-                    }
-                  />
                 </div>
               </td>
               <td>
                 <div
-                  className="ms-TooltipHost root-150"
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  role="none"
+                  className="ms-TextField ms-ColorPicker-input input-93"
                 >
                   <div
-                    className="ms-TextField ms-ColorPicker-input input-151"
+                    className="ms-TextField-wrapper"
                   >
                     <div
-                      className="ms-TextField-wrapper"
+                      className="ms-TextField-fieldGroup fieldGroup-55"
                     >
-                      <div
-                        className="ms-TextField-fieldGroup fieldGroup-112"
-                      >
-                        <input
-                          aria-invalid={false}
-                          aria-label="Alpha"
-                          autoComplete="off"
-                          className="ms-TextField-field field-113"
-                          id="TextField88"
-                          onBlur={[Function]}
-                          onChange={[Function]}
-                          onFocus={[Function]}
-                          onInput={[Function]}
-                          spellCheck={false}
-                          type="text"
-                          value="100"
-                        />
-                      </div>
+                      <input
+                        aria-invalid={false}
+                        aria-label="Alpha"
+                        aria-live="assertive"
+                        autoComplete="off"
+                        className="ms-TextField-field field-56"
+                        id="TextField61"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        onInput={[Function]}
+                        spellCheck={false}
+                        type="text"
+                        value="100"
+                      />
                     </div>
                   </div>
-                  <div
-                    hidden={true}
-                    id="tooltip87"
-                    style={
-                      Object {
-                        "border": 0,
-                        "height": 1,
-                        "margin": -1,
-                        "overflow": "hidden",
-                        "padding": 0,
-                        "position": "absolute",
-                        "whiteSpace": "nowrap",
-                        "width": 1,
-                      }
-                    }
-                  />
                 </div>
               </td>
             </tr>
@@ -1091,7 +969,7 @@ exports[`single fields format color 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1102,15 +980,15 @@ exports[`single fields format color 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__93"
+              className="ms-Button-label label-69"
+              id="id__64"
             >
               Submit
             </span>
@@ -1138,29 +1016,28 @@ exports[`single fields format date 1`] = `
   >
     <div
       aria-describedby="root__error root__description root__help"
-      className="ms-DatePicker control-152"
+      className="ms-DatePicker control-94"
       id="root"
       onBlur={[Function]}
       onFocus={[Function]}
     >
-      <div>
+      <div
+        aria-haspopup="true"
+      >
         <div
-          className="ms-TextField textField-158"
+          className="ms-TextField textField-100"
         >
           <div
             className="ms-TextField-wrapper"
           >
             <div
-              className="ms-TextField-fieldGroup fieldGroup-112"
+              className="ms-TextField-fieldGroup fieldGroup-55"
             >
               <div
-                aria-describedby="TextFieldDescription98"
                 aria-expanded={false}
-                aria-haspopup="dialog"
                 aria-invalid={false}
                 aria-label="Select a date"
-                className="ms-TextField-field field-159 readOnlyTextField-156"
-                data-is-focusable={true}
+                className="ms-TextField-field field-101 readOnlyTextField-98"
                 id="root-label"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -1172,14 +1049,14 @@ exports[`single fields format date 1`] = `
                 tabIndex={0}
               >
                 <span
-                  className="readOnlyPlaceholder-157"
+                  className="readOnlyPlaceholder-99"
                 >
                   
                 </span>
               </div>
               <i
                 aria-hidden={true}
-                className="ms-DatePicker-event--without-label msDatePickerDisabled icon-163"
+                className="ms-DatePicker-event--without-label msDatePickerDisabled icon-105"
                 data-icon-name="Calendar"
                 onClick={[Function]}
               >
@@ -1187,15 +1064,6 @@ exports[`single fields format date 1`] = `
               </i>
             </div>
           </div>
-          <span
-            id="TextFieldDescription98"
-          >
-            <div
-              aria-live="assertive"
-              className="statusMessage-155"
-            />
-            
-          </span>
         </div>
       </div>
     </div>
@@ -1207,7 +1075,7 @@ exports[`single fields format date 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1218,15 +1086,15 @@ exports[`single fields format date 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__102"
+              className="ms-Button-label label-69"
+              id="id__71"
             >
               Submit
             </span>
@@ -1253,19 +1121,19 @@ exports[`single fields format datetime 1`] = `
     }
   >
     <div
-      className="ms-TextField root-111"
+      className="ms-TextField root-54"
     >
       <div
         className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-112"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
           <input
             aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
-            className="ms-TextField-field field-113"
+            className="ms-TextField-field field-56"
             disabled={false}
             id="root"
             name="root"
@@ -1289,7 +1157,7 @@ exports[`single fields format datetime 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1300,15 +1168,15 @@ exports[`single fields format datetime 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__110"
+              className="ms-Button-label label-69"
+              id="id__77"
             >
               Submit
             </span>
@@ -1335,19 +1203,19 @@ exports[`single fields format time 1`] = `
     }
   >
     <div
-      className="ms-TextField root-111"
+      className="ms-TextField root-54"
     >
       <div
         className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-112"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
           <input
             aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
-            className="ms-TextField-field field-113"
+            className="ms-TextField-field field-56"
             disabled={false}
             id="root"
             name="root"
@@ -1371,7 +1239,7 @@ exports[`single fields format time 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1382,15 +1250,15 @@ exports[`single fields format time 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__118"
+              className="ms-Button-label label-69"
+              id="id__83"
             >
               Submit
             </span>
@@ -1409,18 +1277,18 @@ exports[`single fields help and error display 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-MessageBar ms-MessageBar--error ms-MessageBar-singleline root-231"
+    className="ms-MessageBar ms-MessageBar--error ms-MessageBar-singleline root-168"
   >
     <div
-      className="ms-MessageBar-content content-232"
+      className="ms-MessageBar-content content-169"
     >
       <div
         aria-hidden={true}
-        className="ms-MessageBar-icon iconContainer-233"
+        className="ms-MessageBar-icon iconContainer-170"
       >
         <i
           aria-hidden={true}
-          className="icon-240"
+          className="icon-177"
           data-icon-name="ErrorBadge"
         >
           
@@ -1428,12 +1296,12 @@ exports[`single fields help and error display 1`] = `
       </div>
       <div
         aria-live="assertive"
-        className="ms-MessageBar-text text-235"
-        id="MessageBar237"
-        role="alert"
+        className="ms-MessageBar-text text-172"
+        id="MessageBar187"
+        role="status"
       >
         <span
-          className="ms-MessageBar-innerText innerText-236"
+          className="ms-MessageBar-innerText innerText-173"
         />
       </div>
     </div>
@@ -1447,19 +1315,19 @@ exports[`single fields help and error display 1`] = `
     }
   >
     <div
-      className="ms-TextField root-111"
+      className="ms-TextField root-54"
     >
       <div
         className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-241"
+          className="ms-TextField-fieldGroup fieldGroup-178"
         >
           <input
-            aria-describedby="TextFieldDescription239"
+            aria-describedby="TextFieldDescription189"
             aria-invalid={true}
             autoFocus={false}
-            className="ms-TextField-field field-113"
+            className="ms-TextField-field field-56"
             disabled={false}
             id="root"
             name="root"
@@ -1475,7 +1343,7 @@ exports[`single fields help and error display 1`] = `
         </div>
       </div>
       <span
-        id="TextFieldDescription239"
+        id="TextFieldDescription189"
       >
         <div
           role="alert"
@@ -1509,7 +1377,7 @@ exports[`single fields help and error display 1`] = `
       </div>
     </div>
     <span
-      className="css-229"
+      className="css-166"
       id="root__help"
     >
       help me!
@@ -1521,7 +1389,7 @@ exports[`single fields help and error display 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1532,15 +1400,15 @@ exports[`single fields help and error display 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__243"
+              className="ms-Button-label label-69"
+              id="id__191"
             >
               Submit
             </span>
@@ -1597,7 +1465,7 @@ exports[`single fields hidden field 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1608,15 +1476,15 @@ exports[`single fields hidden field 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__186"
+              className="ms-Button-label label-69"
+              id="id__148"
             >
               Submit
             </span>
@@ -1643,19 +1511,19 @@ exports[`single fields hidden label 1`] = `
     }
   >
     <div
-      className="ms-TextField root-111"
+      className="ms-TextField root-54"
     >
       <div
         className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-112"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
           <input
             aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
-            className="ms-TextField-field field-113"
+            className="ms-TextField-field field-56"
             disabled={false}
             id="root"
             name="root"
@@ -1678,7 +1546,7 @@ exports[`single fields hidden label 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1689,15 +1557,15 @@ exports[`single fields hidden label 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__218"
+              className="ms-Button-label label-69"
+              id="id__172"
             >
               Submit
             </span>
@@ -1731,7 +1599,7 @@ exports[`single fields null field 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1742,15 +1610,15 @@ exports[`single fields null field 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__56"
+              className="ms-Button-label label-69"
+              id="id__42"
             >
               Submit
             </span>
@@ -1777,19 +1645,19 @@ exports[`single fields number field 0 1`] = `
     }
   >
     <div
-      className="ms-TextField root-111"
+      className="ms-TextField root-54"
     >
       <div
         className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-112"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
           <input
             aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
-            className="ms-TextField-field field-113"
+            className="ms-TextField-field field-56"
             disabled={false}
             id="root"
             name="root"
@@ -1814,7 +1682,7 @@ exports[`single fields number field 0 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1825,15 +1693,15 @@ exports[`single fields number field 0 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__53"
+              className="ms-Button-label label-69"
+              id="id__39"
             >
               Submit
             </span>
@@ -1860,19 +1728,19 @@ exports[`single fields number field 1`] = `
     }
   >
     <div
-      className="ms-TextField root-111"
+      className="ms-TextField root-54"
     >
       <div
         className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-112"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
           <input
             aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
-            className="ms-TextField-field field-113"
+            className="ms-TextField-field field-56"
             disabled={false}
             id="root"
             name="root"
@@ -1897,7 +1765,7 @@ exports[`single fields number field 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1908,15 +1776,15 @@ exports[`single fields number field 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__45"
+              className="ms-Button-label label-69"
+              id="id__33"
             >
               Submit
             </span>
@@ -1943,19 +1811,19 @@ exports[`single fields password field 1`] = `
     }
   >
     <div
-      className="ms-TextField root-111"
+      className="ms-TextField root-54"
     >
       <div
         className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-112"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
           <input
             aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
-            className="ms-TextField-field field-113"
+            className="ms-TextField-field field-56"
             disabled={false}
             id="root"
             name="root"
@@ -1979,7 +1847,7 @@ exports[`single fields password field 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1990,15 +1858,15 @@ exports[`single fields password field 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__126"
+              className="ms-Button-label label-69"
+              id="id__89"
             >
               Submit
             </span>
@@ -2025,21 +1893,21 @@ exports[`single fields radio field 1`] = `
     }
   >
     <div
-      className="ms-ChoiceFieldGroup root-208"
+      className=""
       id="root"
       name="root"
       onBlur={[Function]}
       onFocus={[Function]}
     >
       <div
-        onFocus={[Function]}
+        className="ms-ChoiceFieldGroup root-146"
         role="radiogroup"
       >
         <div
           className="ms-ChoiceFieldGroup-flexContainer"
         >
           <div
-            className="ms-ChoiceField root-209"
+            className="ms-ChoiceField root-147"
           >
             <div
               className="ms-ChoiceField-wrapper"
@@ -2047,9 +1915,9 @@ exports[`single fields radio field 1`] = `
               <input
                 aria-describedby="root__error root__description root__help"
                 checked={false}
-                className="ms-ChoiceField-input input-210"
+                className="ms-ChoiceField-input input-148"
                 disabled={false}
-                id="ChoiceGroup178-0"
+                id="root-0"
                 name="root"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -2057,12 +1925,12 @@ exports[`single fields radio field 1`] = `
                 type="radio"
               />
               <label
-                className="ms-ChoiceField-field field-211"
-                htmlFor="ChoiceGroup178-0"
+                className="ms-ChoiceField-field field-149"
+                htmlFor="root-0"
               >
                 <span
                   className="ms-ChoiceFieldLabel"
-                  id="ChoiceGroupLabel179-0"
+                  id="ChoiceGroupLabel140-0"
                 >
                   Yes
                 </span>
@@ -2070,7 +1938,7 @@ exports[`single fields radio field 1`] = `
             </div>
           </div>
           <div
-            className="ms-ChoiceField root-209"
+            className="ms-ChoiceField root-147"
           >
             <div
               className="ms-ChoiceField-wrapper"
@@ -2078,9 +1946,9 @@ exports[`single fields radio field 1`] = `
               <input
                 aria-describedby="root__error root__description root__help"
                 checked={false}
-                className="ms-ChoiceField-input input-210"
+                className="ms-ChoiceField-input input-148"
                 disabled={false}
-                id="ChoiceGroup178-1"
+                id="root-1"
                 name="root"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -2088,12 +1956,12 @@ exports[`single fields radio field 1`] = `
                 type="radio"
               />
               <label
-                className="ms-ChoiceField-field field-211"
-                htmlFor="ChoiceGroup178-1"
+                className="ms-ChoiceField-field field-149"
+                htmlFor="root-1"
               >
                 <span
                   className="ms-ChoiceFieldLabel"
-                  id="ChoiceGroupLabel179-1"
+                  id="ChoiceGroupLabel140-1"
                 >
                   No
                 </span>
@@ -2111,7 +1979,7 @@ exports[`single fields radio field 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2122,15 +1990,15 @@ exports[`single fields radio field 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__180"
+              className="ms-Button-label label-69"
+              id="id__141"
             >
               Submit
             </span>
@@ -2157,19 +2025,19 @@ exports[`single fields schema examples 1`] = `
     }
   >
     <div
-      className="ms-TextField root-111"
+      className="ms-TextField root-54"
     >
       <div
         className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-112"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
           <input
             aria-describedby="root__error root__description root__help root__examples"
             aria-invalid={false}
             autoFocus={false}
-            className="ms-TextField-field field-113"
+            className="ms-TextField-field field-56"
             disabled={false}
             id="root"
             list="root__examples"
@@ -2213,7 +2081,7 @@ exports[`single fields schema examples 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2224,15 +2092,15 @@ exports[`single fields schema examples 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__234"
+              className="ms-Button-label label-69"
+              id="id__184"
             >
               Submit
             </span>
@@ -2266,9 +2134,8 @@ exports[`single fields select field 1`] = `
         aria-disabled={false}
         aria-expanded="false"
         aria-haspopup="listbox"
-        className="ms-Dropdown dropdown-181"
+        className="ms-Dropdown dropdown-121"
         data-is-focusable={true}
-        data-ktp-target={true}
         id="root"
         onBlur={[Function]}
         onChange={[Function]}
@@ -2281,16 +2148,15 @@ exports[`single fields select field 1`] = `
         tabIndex={0}
       >
         <span
-          aria-invalid={false}
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-182"
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
           id="root-option"
         />
         <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-183"
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-199"
+            className="ms-Dropdown-caretDown caretDown-137"
             data-icon-name="ChevronDown"
           >
             
@@ -2306,7 +2172,7 @@ exports[`single fields select field 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2317,15 +2183,15 @@ exports[`single fields select field 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__148"
+              className="ms-Button-label label-69"
+              id="id__109"
             >
               Submit
             </span>
@@ -2360,9 +2226,8 @@ exports[`single fields select field multiple choice 1`] = `
         aria-expanded="false"
         aria-haspopup="listbox"
         aria-required={false}
-        className="ms-Dropdown dropdown-181"
+        className="ms-Dropdown dropdown-121"
         data-is-focusable={true}
-        data-ktp-target={true}
         id="root"
         onBlur={[Function]}
         onChange={[Function]}
@@ -2375,16 +2240,15 @@ exports[`single fields select field multiple choice 1`] = `
         tabIndex={0}
       >
         <span
-          aria-invalid={false}
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-182"
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
           id="root-option"
         />
         <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-183"
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-199"
+            className="ms-Dropdown-caretDown caretDown-137"
             data-icon-name="ChevronDown"
           >
             
@@ -2400,7 +2264,7 @@ exports[`single fields select field multiple choice 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2411,15 +2275,15 @@ exports[`single fields select field multiple choice 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__151"
+              className="ms-Button-label label-69"
+              id="id__112"
             >
               Submit
             </span>
@@ -2454,9 +2318,8 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
         aria-expanded="false"
         aria-haspopup="listbox"
         aria-required={false}
-        className="ms-Dropdown dropdown-181"
+        className="ms-Dropdown dropdown-121"
         data-is-focusable={true}
-        data-ktp-target={true}
         id="root"
         onBlur={[Function]}
         onChange={[Function]}
@@ -2469,16 +2332,15 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
         tabIndex={0}
       >
         <span
-          aria-invalid={false}
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-182"
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
           id="root-option"
         />
         <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-183"
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-199"
+            className="ms-Dropdown-caretDown caretDown-137"
             data-icon-name="ChevronDown"
           >
             
@@ -2494,7 +2356,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2505,15 +2367,15 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__160"
+              className="ms-Button-label label-69"
+              id="id__121"
             >
               Submit
             </span>
@@ -2548,9 +2410,8 @@ exports[`single fields select field multiple choice formData 1`] = `
         aria-expanded="false"
         aria-haspopup="listbox"
         aria-required={false}
-        className="ms-Dropdown dropdown-181"
+        className="ms-Dropdown dropdown-121"
         data-is-focusable={true}
-        data-ktp-target={true}
         id="root"
         onBlur={[Function]}
         onChange={[Function]}
@@ -2563,16 +2424,17 @@ exports[`single fields select field multiple choice formData 1`] = `
         tabIndex={0}
       >
         <span
-          aria-invalid={false}
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-182"
+          className="ms-Dropdown-title title-138"
           id="root-option"
-        />
+        >
+          foo, bar
+        </span>
         <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-183"
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-199"
+            className="ms-Dropdown-caretDown caretDown-137"
             data-icon-name="ChevronDown"
           >
             
@@ -2588,7 +2450,7 @@ exports[`single fields select field multiple choice formData 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2599,15 +2461,15 @@ exports[`single fields select field multiple choice formData 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__166"
+              className="ms-Button-label label-69"
+              id="id__127"
             >
               Submit
             </span>
@@ -2642,9 +2504,8 @@ exports[`single fields select field multiple choice with labels 1`] = `
         aria-expanded="false"
         aria-haspopup="listbox"
         aria-required={false}
-        className="ms-Dropdown dropdown-181"
+        className="ms-Dropdown dropdown-121"
         data-is-focusable={true}
-        data-ktp-target={true}
         id="root"
         onBlur={[Function]}
         onChange={[Function]}
@@ -2657,16 +2518,15 @@ exports[`single fields select field multiple choice with labels 1`] = `
         tabIndex={0}
       >
         <span
-          aria-invalid={false}
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-182"
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
           id="root-option"
         />
         <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-183"
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-199"
+            className="ms-Dropdown-caretDown caretDown-137"
             data-icon-name="ChevronDown"
           >
             
@@ -2682,7 +2542,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2693,15 +2553,15 @@ exports[`single fields select field multiple choice with labels 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__154"
+              className="ms-Button-label label-69"
+              id="id__115"
             >
               Submit
             </span>
@@ -2735,9 +2595,8 @@ exports[`single fields select field single choice enumDisabled 1`] = `
         aria-disabled={false}
         aria-expanded="false"
         aria-haspopup="listbox"
-        className="ms-Dropdown dropdown-181"
+        className="ms-Dropdown dropdown-121"
         data-is-focusable={true}
-        data-ktp-target={true}
         id="root"
         onBlur={[Function]}
         onChange={[Function]}
@@ -2750,16 +2609,15 @@ exports[`single fields select field single choice enumDisabled 1`] = `
         tabIndex={0}
       >
         <span
-          aria-invalid={false}
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-182"
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-122"
           id="root-option"
         />
         <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-183"
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-199"
+            className="ms-Dropdown-caretDown caretDown-137"
             data-icon-name="ChevronDown"
           >
             
@@ -2775,7 +2633,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2786,15 +2644,15 @@ exports[`single fields select field single choice enumDisabled 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__157"
+              className="ms-Button-label label-69"
+              id="id__118"
             >
               Submit
             </span>
@@ -2828,9 +2686,8 @@ exports[`single fields select field single choice formData 1`] = `
         aria-disabled={false}
         aria-expanded="false"
         aria-haspopup="listbox"
-        className="ms-Dropdown dropdown-181"
+        className="ms-Dropdown dropdown-121"
         data-is-focusable={true}
-        data-ktp-target={true}
         id="root"
         onBlur={[Function]}
         onChange={[Function]}
@@ -2843,18 +2700,17 @@ exports[`single fields select field single choice formData 1`] = `
         tabIndex={0}
       >
         <span
-          aria-invalid={false}
-          className="ms-Dropdown-title title-200"
+          className="ms-Dropdown-title title-138"
           id="root-option"
         >
           bar
         </span>
         <span
-          className="ms-Dropdown-caretDownWrapper caretDownWrapper-183"
+          className="ms-Dropdown-caretDownWrapper caretDownWrapper-123"
         >
           <i
             aria-hidden={true}
-            className="ms-Dropdown-caretDown caretDown-199"
+            className="ms-Dropdown-caretDown caretDown-137"
             data-icon-name="ChevronDown"
           >
             
@@ -2870,7 +2726,7 @@ exports[`single fields select field single choice formData 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2881,15 +2737,15 @@ exports[`single fields select field single choice formData 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__163"
+              className="ms-Button-label label-69"
+              id="id__124"
             >
               Submit
             </span>
@@ -2916,18 +2772,14 @@ exports[`single fields slider field 1`] = `
     }
   >
     <label
-      className="ms-Label root-130"
+      className="ms-Label root-73"
       htmlFor="root"
     />
     <div
-      className="ms-Slider ms-Slider-enabled ms-Slider-row root-216"
+      className="ms-Slider ms-Slider-enabled ms-Slider-row root-154"
     >
-      <label
-        className="ms-Label titleLabel-227"
-        htmlFor="root"
-      />
       <div
-        className="ms-Slider-container container-218"
+        className="ms-Slider-container container-156"
       >
         <div
           aria-disabled={false}
@@ -2935,9 +2787,9 @@ exports[`single fields slider field 1`] = `
           aria-valuemin={42}
           aria-valuenow={42}
           aria-valuetext="42"
-          className="ms-Slider-slideBox ms-Slider-showValue slideBox-219"
+          className="ms-Slider-slideBox ms-Slider-showValue ms-Slider-showTransitions slideBox-157"
           data-is-focusable={true}
-          id="root"
+          id="Slider144"
           onKeyDown={[Function]}
           onMouseDown={[Function]}
           onTouchStart={[Function]}
@@ -2945,10 +2797,10 @@ exports[`single fields slider field 1`] = `
           tabIndex={0}
         >
           <div
-            className="ms-Slider-line line-221"
+            className="ms-Slider-line line-159"
           >
             <span
-              className="ms-Slider-thumb thumb-220"
+              className="ms-Slider-thumb thumb-158"
               style={
                 Object {
                   "left": "0%",
@@ -2956,7 +2808,7 @@ exports[`single fields slider field 1`] = `
               }
             />
             <span
-              className="lineContainer-222 ms-Slider-inactive inactiveSection-224"
+              className="lineContainer-160 ms-Slider-active activeSection-161"
               style={
                 Object {
                   "width": "0%",
@@ -2964,15 +2816,7 @@ exports[`single fields slider field 1`] = `
               }
             />
             <span
-              className="lineContainer-222 ms-Slider-active activeSection-223"
-              style={
-                Object {
-                  "width": "0%",
-                }
-              }
-            />
-            <span
-              className="lineContainer-222 ms-Slider-inactive inactiveSection-224"
+              className="lineContainer-160 ms-Slider-inactive inactiveSection-162"
               style={
                 Object {
                   "width": "100%",
@@ -2982,7 +2826,7 @@ exports[`single fields slider field 1`] = `
           </div>
         </div>
         <label
-          className="ms-Label ms-Slider-value valueLabel-228"
+          className="ms-Label ms-Slider-value valueLabel-165"
         >
           42
         </label>
@@ -2996,7 +2840,7 @@ exports[`single fields slider field 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -3007,15 +2851,15 @@ exports[`single fields slider field 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__183"
+              className="ms-Button-label label-69"
+              id="id__145"
             >
               Submit
             </span>
@@ -3043,19 +2887,19 @@ exports[`single fields string field format data-url 1`] = `
   >
     <div>
       <div
-        className="ms-TextField root-111"
+        className="ms-TextField root-54"
       >
         <div
           className="ms-TextField-wrapper"
         >
           <div
-            className="ms-TextField-fieldGroup fieldGroup-112"
+            className="ms-TextField-fieldGroup fieldGroup-55"
           >
             <input
               aria-describedby="root__error root__description root__help"
               aria-invalid={false}
               autoFocus={false}
-              className="ms-TextField-field field-113"
+              className="ms-TextField-field field-56"
               disabled={false}
               id="root"
               name="root"
@@ -3080,7 +2924,7 @@ exports[`single fields string field format data-url 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -3091,15 +2935,15 @@ exports[`single fields string field format data-url 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__29"
+              className="ms-Button-label label-69"
+              id="id__21"
             >
               Submit
             </span>
@@ -3126,19 +2970,19 @@ exports[`single fields string field format email 1`] = `
     }
   >
     <div
-      className="ms-TextField root-111"
+      className="ms-TextField root-54"
     >
       <div
         className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-112"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
           <input
             aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
-            className="ms-TextField-field field-113"
+            className="ms-TextField-field field-56"
             disabled={false}
             id="root"
             name="root"
@@ -3162,7 +3006,7 @@ exports[`single fields string field format email 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -3173,15 +3017,15 @@ exports[`single fields string field format email 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__13"
+              className="ms-Button-label label-69"
+              id="id__9"
             >
               Submit
             </span>
@@ -3208,19 +3052,19 @@ exports[`single fields string field format uri 1`] = `
     }
   >
     <div
-      className="ms-TextField root-111"
+      className="ms-TextField root-54"
     >
       <div
         className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-112"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
           <input
             aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
-            className="ms-TextField-field field-113"
+            className="ms-TextField-field field-56"
             disabled={false}
             id="root"
             name="root"
@@ -3244,7 +3088,7 @@ exports[`single fields string field format uri 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -3255,15 +3099,15 @@ exports[`single fields string field format uri 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__21"
+              className="ms-Button-label label-69"
+              id="id__15"
             >
               Submit
             </span>
@@ -3290,19 +3134,19 @@ exports[`single fields string field regular 1`] = `
     }
   >
     <div
-      className="ms-TextField root-111"
+      className="ms-TextField root-54"
     >
       <div
         className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-112"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
           <input
             aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
-            className="ms-TextField-field field-113"
+            className="ms-TextField-field field-56"
             disabled={false}
             id="root"
             name="root"
@@ -3326,7 +3170,7 @@ exports[`single fields string field regular 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -3337,15 +3181,15 @@ exports[`single fields string field regular 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__5"
+              className="ms-Button-label label-69"
+              id="id__3"
             >
               Submit
             </span>
@@ -3372,19 +3216,19 @@ exports[`single fields string field with placeholder 1`] = `
     }
   >
     <div
-      className="ms-TextField root-111"
+      className="ms-TextField root-54"
     >
       <div
         className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-112"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
           <input
             aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
-            className="ms-TextField-field field-113"
+            className="ms-TextField-field field-56"
             disabled={false}
             id="root"
             name="root"
@@ -3408,7 +3252,7 @@ exports[`single fields string field with placeholder 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -3419,15 +3263,15 @@ exports[`single fields string field with placeholder 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__37"
+              className="ms-Button-label label-69"
+              id="id__27"
             >
               Submit
             </span>
@@ -3454,19 +3298,19 @@ exports[`single fields textarea field 1`] = `
     }
   >
     <div
-      className="ms-TextField ms-TextField--multiline root-111"
+      className="ms-TextField ms-TextField--multiline root-54"
     >
       <div
         className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-178"
+          className="ms-TextField-fieldGroup fieldGroup-118"
         >
           <textarea
             aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
-            className="ms-TextField-field field-179"
+            className="ms-TextField-field field-119"
             disabled={false}
             id="root"
             name="root"
@@ -3490,7 +3334,7 @@ exports[`single fields textarea field 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -3501,15 +3345,15 @@ exports[`single fields textarea field 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__145"
+              className="ms-Button-label label-69"
+              id="id__106"
             >
               Submit
             </span>
@@ -3536,7 +3380,7 @@ exports[`single fields title field 1`] = `
     }
   >
     <label
-      className="ms-Label root-230"
+      className="ms-Label root-167"
       id="root__title"
     >
       Titre 1
@@ -3557,27 +3401,27 @@ exports[`single fields title field 1`] = `
           }
         >
           <div
-            className="ms-TextField root-111"
+            className="ms-TextField root-54"
           >
             <div
               className="ms-TextField-wrapper"
             >
               <label
-                className="ms-Label root-130"
+                className="ms-Label root-73"
                 htmlFor="root_title"
-                id="TextFieldLabel207"
+                id="TextFieldLabel165"
               >
                 Titre 2
               </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-112"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
                 <input
                   aria-describedby="root_title__error root_title__description root_title__help"
                   aria-invalid={false}
-                  aria-labelledby="TextFieldLabel207"
+                  aria-labelledby="TextFieldLabel165"
                   autoFocus={false}
-                  className="ms-TextField-field field-113"
+                  className="ms-TextField-field field-56"
                   disabled={false}
                   id="root_title"
                   name="root_title"
@@ -3605,7 +3449,7 @@ exports[`single fields title field 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -3616,15 +3460,15 @@ exports[`single fields title field 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__210"
+              className="ms-Button-label label-69"
+              id="id__166"
             >
               Submit
             </span>
@@ -3678,7 +3522,7 @@ exports[`single fields unsupported field 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -3689,15 +3533,15 @@ exports[`single fields unsupported field 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__59"
+              className="ms-Button-label label-69"
+              id="id__45"
             >
               Submit
             </span>
@@ -3724,18 +3568,18 @@ exports[`single fields up/down field 1`] = `
     }
   >
     <label
-      className="ms-Label root-130"
+      className="ms-Label root-73"
       htmlFor="root"
     />
     <div
-      className="root-164"
+      className="css-106"
     >
       
       <div
         aria-describedby="root__error root__description root__help"
-        className="spinButtonWrapper-168"
-        data-ktp-target={true}
+        className="css-110"
         id="root"
+        onChange={[Function]}
       >
         <input
           aria-disabled={false}
@@ -3744,11 +3588,10 @@ exports[`single fields up/down field 1`] = `
           aria-valuemin={-Infinity}
           aria-valuetext=""
           autoComplete="off"
-          className="ms-spinButton-input input-169"
-          data-ktp-execute-target={true}
+          className="ms-spinButton-input css-111"
           data-lpignore={true}
           disabled={false}
-          id="input129"
+          id="input93"
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}
@@ -3760,11 +3603,11 @@ exports[`single fields up/down field 1`] = `
           value=""
         />
         <span
-          className="arrowButtonsContainer-170"
+          className="css-112"
         >
           <button
             aria-label="Increase value by 1"
-            className="ms-Button ms-Button--icon ms-UpButton root-171"
+            className="ms-Button ms-Button--icon ms-UpButton root-113"
             data-is-focusable={false}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -3777,12 +3620,12 @@ exports[`single fields up/down field 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-123"
+              className="ms-Button-flexContainer flexContainer-66"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-175 ms-Button-icon icon-172"
+                className="ms-Icon root-37 css-116 ms-Button-icon icon-114"
                 data-icon-name="ChevronUpSmall"
                 style={
                   Object {
@@ -3796,7 +3639,7 @@ exports[`single fields up/down field 1`] = `
           </button>
           <button
             aria-label="Decrease value by 1"
-            className="ms-Button ms-Button--icon ms-DownButton root-171"
+            className="ms-Button ms-Button--icon ms-DownButton root-113"
             data-is-focusable={false}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -3809,12 +3652,12 @@ exports[`single fields up/down field 1`] = `
             type="button"
           >
             <span
-              className="ms-Button-flexContainer flexContainer-123"
+              className="ms-Button-flexContainer flexContainer-66"
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
-                className="ms-Icon root-105 css-177 ms-Button-icon icon-172"
+                className="ms-Icon root-37 css-117 ms-Button-icon icon-114"
                 data-icon-name="ChevronDownSmall"
                 style={
                   Object {
@@ -3837,7 +3680,7 @@ exports[`single fields up/down field 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -3848,15 +3691,15 @@ exports[`single fields up/down field 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__137"
+              className="ms-Button-label label-69"
+              id="id__100"
             >
               Submit
             </span>
@@ -3883,19 +3726,19 @@ exports[`single fields using custom tagName 1`] = `
     }
   >
     <div
-      className="ms-TextField root-111"
+      className="ms-TextField root-54"
     >
       <div
         className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-112"
+          className="ms-TextField-fieldGroup fieldGroup-55"
         >
           <input
             aria-describedby="root__error root__description root__help"
             aria-invalid={false}
             autoFocus={false}
-            className="ms-TextField-field field-113"
+            className="ms-TextField-field field-56"
             disabled={false}
             id="root"
             name="root"
@@ -3919,7 +3762,7 @@ exports[`single fields using custom tagName 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-122"
+        className="ms-Button ms-Button--primary root-65"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -3930,15 +3773,15 @@ exports[`single fields using custom tagName 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-123"
+          className="ms-Button-flexContainer flexContainer-66"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-124"
+            className="ms-Button-textContainer textContainer-67"
           >
             <span
-              className="ms-Button-label label-126"
-              id="id__226"
+              className="ms-Button-label label-69"
+              id="id__178"
             >
               Submit
             </span>

--- a/packages/fluent-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Object.test.tsx.snap
@@ -38,25 +38,25 @@ exports[`object fields additionalProperties 1`] = `
               className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
               <div
-                className="ms-TextField root-111"
+                className="ms-TextField root-54"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-122"
+                    className="ms-Label root-65"
                     htmlFor="root_foo-key"
-                    id="TextFieldLabel15"
+                    id="TextFieldLabel11"
                   >
                     foo Key
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-112"
+                    className="ms-TextField-fieldGroup fieldGroup-55"
                   >
                     <input
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel15"
-                      className="ms-TextField-field field-113"
+                      aria-labelledby="TextFieldLabel11"
+                      className="ms-TextField-field field-56"
                       disabled={false}
                       id="root_foo-key"
                       name="root_foo-key"
@@ -76,27 +76,27 @@ exports[`object fields additionalProperties 1`] = `
               className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
               <div
-                className="ms-TextField root-111"
+                className="ms-TextField root-54"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-122"
+                    className="ms-Label root-65"
                     htmlFor="root_foo"
-                    id="TextFieldLabel20"
+                    id="TextFieldLabel14"
                   >
                     foo
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-112"
+                    className="ms-TextField-fieldGroup fieldGroup-55"
                   >
                     <input
                       aria-describedby="root_foo__error root_foo__description root_foo__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel20"
+                      aria-labelledby="TextFieldLabel14"
                       autoFocus={false}
-                      className="ms-TextField-field field-113"
+                      className="ms-TextField-field field-56"
                       disabled={false}
                       id="root_foo"
                       name="root_foo"
@@ -124,7 +124,7 @@ exports[`object fields additionalProperties 1`] = `
               }
             >
               <button
-                className="ms-Button ms-Button--icon root-131"
+                className="ms-Button ms-Button--icon root-74"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -135,12 +135,12 @@ exports[`object fields additionalProperties 1`] = `
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer flexContainer-124"
+                  className="ms-Button-flexContainer flexContainer-67"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-105 css-134 ms-Button-icon icon-126"
+                    className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
                     data-icon-name="Delete"
                     style={
                       Object {
@@ -164,7 +164,7 @@ exports[`object fields additionalProperties 1`] = `
         }
       >
         <button
-          className="ms-Button ms-Button--commandBar object-property-expand root-135"
+          className="ms-Button ms-Button--commandBar object-property-expand root-77"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -180,12 +180,12 @@ exports[`object fields additionalProperties 1`] = `
           type="button"
         >
           <span
-            className="ms-Button-flexContainer flexContainer-124"
+            className="ms-Button-flexContainer flexContainer-67"
             data-automationid="splitbuttonprimary"
           >
             <i
               aria-hidden={true}
-              className="ms-Icon root-105 css-134 ms-Button-icon icon-136"
+              className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
               data-icon-name="Add"
               style={
                 Object {
@@ -196,11 +196,11 @@ exports[`object fields additionalProperties 1`] = `
               
             </i>
             <span
-              className="ms-Button-textContainer textContainer-125"
+              className="ms-Button-textContainer textContainer-68"
             >
               <span
-                className="ms-Button-label label-137"
-                id="id__26"
+                className="ms-Button-label label-79"
+                id="id__18"
               >
                 Add Item
               </span>
@@ -216,7 +216,7 @@ exports[`object fields additionalProperties 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-123"
+        className="ms-Button ms-Button--primary root-66"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -227,15 +227,15 @@ exports[`object fields additionalProperties 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-124"
+          className="ms-Button-flexContainer flexContainer-67"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-125"
+            className="ms-Button-textContainer textContainer-68"
           >
             <span
-              className="ms-Button-label label-127"
-              id="id__29"
+              className="ms-Button-label label-70"
+              id="id__21"
             >
               Submit
             </span>
@@ -278,27 +278,27 @@ exports[`object fields object 1`] = `
           }
         >
           <div
-            className="ms-TextField root-111"
+            className="ms-TextField root-54"
           >
             <div
               className="ms-TextField-wrapper"
             >
               <label
-                className="ms-Label root-122"
+                className="ms-Label root-65"
                 htmlFor="root_a"
                 id="TextFieldLabel2"
               >
                 A
               </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-112"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
                 <input
                   aria-describedby="root_a__error root_a__description root_a__help"
                   aria-invalid={false}
                   aria-labelledby="TextFieldLabel2"
                   autoFocus={false}
-                  className="ms-TextField-field field-113"
+                  className="ms-TextField-field field-56"
                   disabled={false}
                   id="root_a"
                   name="root_a"
@@ -326,27 +326,27 @@ exports[`object fields object 1`] = `
           }
         >
           <div
-            className="ms-TextField root-111"
+            className="ms-TextField root-54"
           >
             <div
               className="ms-TextField-wrapper"
             >
               <label
-                className="ms-Label root-122"
+                className="ms-Label root-65"
                 htmlFor="root_b"
-                id="TextFieldLabel7"
+                id="TextFieldLabel5"
               >
                 B
               </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-112"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
                 <input
                   aria-describedby="root_b__error root_b__description root_b__help"
                   aria-invalid={false}
-                  aria-labelledby="TextFieldLabel7"
+                  aria-labelledby="TextFieldLabel5"
                   autoFocus={false}
-                  className="ms-TextField-field field-113"
+                  className="ms-TextField-field field-56"
                   disabled={false}
                   id="root_b"
                   name="root_b"
@@ -375,7 +375,7 @@ exports[`object fields object 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-123"
+        className="ms-Button ms-Button--primary root-66"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -386,15 +386,15 @@ exports[`object fields object 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-124"
+          className="ms-Button-flexContainer flexContainer-67"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-125"
+            className="ms-Button-textContainer textContainer-68"
           >
             <span
-              className="ms-Button-label label-127"
-              id="id__10"
+              className="ms-Button-label label-70"
+              id="id__6"
             >
               Submit
             </span>
@@ -444,25 +444,25 @@ exports[`object fields show add button and fields if additionalProperties is tru
               className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
               <div
-                className="ms-TextField root-111"
+                className="ms-TextField root-54"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-122"
+                    className="ms-Label root-65"
                     htmlFor="root_additionalProperty-key"
-                    id="TextFieldLabel34"
+                    id="TextFieldLabel26"
                   >
                     additionalProperty Key
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-112"
+                    className="ms-TextField-fieldGroup fieldGroup-55"
                   >
                     <input
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel34"
-                      className="ms-TextField-field field-113"
+                      aria-labelledby="TextFieldLabel26"
+                      className="ms-TextField-field field-56"
                       disabled={false}
                       id="root_additionalProperty-key"
                       name="root_additionalProperty-key"
@@ -482,27 +482,27 @@ exports[`object fields show add button and fields if additionalProperties is tru
               className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
               <div
-                className="ms-TextField root-111"
+                className="ms-TextField root-54"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-122"
+                    className="ms-Label root-65"
                     htmlFor="root_additionalProperty"
-                    id="TextFieldLabel39"
+                    id="TextFieldLabel29"
                   >
                     additionalProperty
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-112"
+                    className="ms-TextField-fieldGroup fieldGroup-55"
                   >
                     <input
                       aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel39"
+                      aria-labelledby="TextFieldLabel29"
                       autoFocus={false}
-                      className="ms-TextField-field field-113"
+                      className="ms-TextField-field field-56"
                       disabled={false}
                       id="root_additionalProperty"
                       name="root_additionalProperty"
@@ -530,7 +530,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
               }
             >
               <button
-                className="ms-Button ms-Button--icon root-131"
+                className="ms-Button ms-Button--icon root-74"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -541,12 +541,12 @@ exports[`object fields show add button and fields if additionalProperties is tru
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer flexContainer-124"
+                  className="ms-Button-flexContainer flexContainer-67"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-105 css-134 ms-Button-icon icon-126"
+                    className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
                     data-icon-name="Delete"
                     style={
                       Object {
@@ -570,7 +570,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
         }
       >
         <button
-          className="ms-Button ms-Button--commandBar object-property-expand root-135"
+          className="ms-Button ms-Button--commandBar object-property-expand root-77"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -586,12 +586,12 @@ exports[`object fields show add button and fields if additionalProperties is tru
           type="button"
         >
           <span
-            className="ms-Button-flexContainer flexContainer-124"
+            className="ms-Button-flexContainer flexContainer-67"
             data-automationid="splitbuttonprimary"
           >
             <i
               aria-hidden={true}
-              className="ms-Icon root-105 css-134 ms-Button-icon icon-136"
+              className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
               data-icon-name="Add"
               style={
                 Object {
@@ -602,11 +602,11 @@ exports[`object fields show add button and fields if additionalProperties is tru
               
             </i>
             <span
-              className="ms-Button-textContainer textContainer-125"
+              className="ms-Button-textContainer textContainer-68"
             >
               <span
-                className="ms-Button-label label-137"
-                id="id__45"
+                className="ms-Button-label label-79"
+                id="id__33"
               >
                 Add Item
               </span>
@@ -622,7 +622,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-123"
+        className="ms-Button ms-Button--primary root-66"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -633,15 +633,15 @@ exports[`object fields show add button and fields if additionalProperties is tru
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-124"
+          className="ms-Button-flexContainer flexContainer-67"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-125"
+            className="ms-Button-textContainer textContainer-68"
           >
             <span
-              className="ms-Button-label label-127"
-              id="id__48"
+              className="ms-Button-label label-70"
+              id="id__36"
             >
               Submit
             </span>
@@ -668,13 +668,13 @@ exports[`object fields with title and description additionalProperties 1`] = `
     }
   >
     <label
-      className="ms-Label root-139"
+      className="ms-Label root-81"
       id="root__title"
     >
       Test field
     </label>
     <span
-      className="css-140"
+      className="css-82"
       id="root__description"
     >
       a test description
@@ -702,25 +702,25 @@ exports[`object fields with title and description additionalProperties 1`] = `
               className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
               <div
-                className="ms-TextField root-111"
+                className="ms-TextField root-54"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-122"
+                    className="ms-Label root-65"
                     htmlFor="root_foo-key"
-                    id="TextFieldLabel66"
+                    id="TextFieldLabel50"
                   >
                     foo Key
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-112"
+                    className="ms-TextField-fieldGroup fieldGroup-55"
                   >
                     <input
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel66"
-                      className="ms-TextField-field field-113"
+                      aria-labelledby="TextFieldLabel50"
+                      className="ms-TextField-field field-56"
                       disabled={false}
                       id="root_foo-key"
                       name="root_foo-key"
@@ -740,27 +740,27 @@ exports[`object fields with title and description additionalProperties 1`] = `
               className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
               <div
-                className="ms-TextField root-111"
+                className="ms-TextField root-54"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-122"
+                    className="ms-Label root-65"
                     htmlFor="root_foo"
-                    id="TextFieldLabel71"
+                    id="TextFieldLabel53"
                   >
                     foo
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-112"
+                    className="ms-TextField-fieldGroup fieldGroup-55"
                   >
                     <input
                       aria-describedby="root_foo__error root_foo__description root_foo__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel71"
+                      aria-labelledby="TextFieldLabel53"
                       autoFocus={false}
-                      className="ms-TextField-field field-113"
+                      className="ms-TextField-field field-56"
                       disabled={false}
                       id="root_foo"
                       name="root_foo"
@@ -788,7 +788,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
               }
             >
               <button
-                className="ms-Button ms-Button--icon root-131"
+                className="ms-Button ms-Button--icon root-74"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -799,12 +799,12 @@ exports[`object fields with title and description additionalProperties 1`] = `
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer flexContainer-124"
+                  className="ms-Button-flexContainer flexContainer-67"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-105 css-134 ms-Button-icon icon-126"
+                    className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
                     data-icon-name="Delete"
                     style={
                       Object {
@@ -828,7 +828,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
         }
       >
         <button
-          className="ms-Button ms-Button--commandBar object-property-expand root-135"
+          className="ms-Button ms-Button--commandBar object-property-expand root-77"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -844,12 +844,12 @@ exports[`object fields with title and description additionalProperties 1`] = `
           type="button"
         >
           <span
-            className="ms-Button-flexContainer flexContainer-124"
+            className="ms-Button-flexContainer flexContainer-67"
             data-automationid="splitbuttonprimary"
           >
             <i
               aria-hidden={true}
-              className="ms-Icon root-105 css-134 ms-Button-icon icon-136"
+              className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
               data-icon-name="Add"
               style={
                 Object {
@@ -860,11 +860,11 @@ exports[`object fields with title and description additionalProperties 1`] = `
               
             </i>
             <span
-              className="ms-Button-textContainer textContainer-125"
+              className="ms-Button-textContainer textContainer-68"
             >
               <span
-                className="ms-Button-label label-137"
-                id="id__77"
+                className="ms-Button-label label-79"
+                id="id__57"
               >
                 Add Item
               </span>
@@ -880,7 +880,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-123"
+        className="ms-Button ms-Button--primary root-66"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -891,15 +891,15 @@ exports[`object fields with title and description additionalProperties 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-124"
+          className="ms-Button-flexContainer flexContainer-67"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-125"
+            className="ms-Button-textContainer textContainer-68"
           >
             <span
-              className="ms-Button-label label-127"
-              id="id__80"
+              className="ms-Button-label label-70"
+              id="id__60"
             >
               Submit
             </span>
@@ -926,13 +926,13 @@ exports[`object fields with title and description from both additionalProperties
     }
   >
     <label
-      className="ms-Label root-139"
+      className="ms-Label root-81"
       id="root__title"
     >
       My Field
     </label>
     <span
-      className="css-140"
+      className="css-82"
       id="root__description"
     >
       a fancier description
@@ -960,25 +960,25 @@ exports[`object fields with title and description from both additionalProperties
               className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
               <div
-                className="ms-TextField root-111"
+                className="ms-TextField root-54"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-122"
+                    className="ms-Label root-65"
                     htmlFor="root_foo-key"
-                    id="TextFieldLabel168"
+                    id="TextFieldLabel128"
                   >
                     foo Key
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-112"
+                    className="ms-TextField-fieldGroup fieldGroup-55"
                   >
                     <input
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel168"
-                      className="ms-TextField-field field-113"
+                      aria-labelledby="TextFieldLabel128"
+                      className="ms-TextField-field field-56"
                       disabled={false}
                       id="root_foo-key"
                       name="root_foo-key"
@@ -998,27 +998,27 @@ exports[`object fields with title and description from both additionalProperties
               className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
               <div
-                className="ms-TextField root-111"
+                className="ms-TextField root-54"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-122"
+                    className="ms-Label root-65"
                     htmlFor="root_foo"
-                    id="TextFieldLabel173"
+                    id="TextFieldLabel131"
                   >
                     foo
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-112"
+                    className="ms-TextField-fieldGroup fieldGroup-55"
                   >
                     <input
                       aria-describedby="root_foo__error root_foo__description root_foo__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel173"
+                      aria-labelledby="TextFieldLabel131"
                       autoFocus={false}
-                      className="ms-TextField-field field-113"
+                      className="ms-TextField-field field-56"
                       disabled={false}
                       id="root_foo"
                       name="root_foo"
@@ -1046,7 +1046,7 @@ exports[`object fields with title and description from both additionalProperties
               }
             >
               <button
-                className="ms-Button ms-Button--icon root-131"
+                className="ms-Button ms-Button--icon root-74"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -1057,12 +1057,12 @@ exports[`object fields with title and description from both additionalProperties
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer flexContainer-124"
+                  className="ms-Button-flexContainer flexContainer-67"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-105 css-134 ms-Button-icon icon-126"
+                    className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
                     data-icon-name="Delete"
                     style={
                       Object {
@@ -1086,7 +1086,7 @@ exports[`object fields with title and description from both additionalProperties
         }
       >
         <button
-          className="ms-Button ms-Button--commandBar object-property-expand root-135"
+          className="ms-Button ms-Button--commandBar object-property-expand root-77"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -1102,12 +1102,12 @@ exports[`object fields with title and description from both additionalProperties
           type="button"
         >
           <span
-            className="ms-Button-flexContainer flexContainer-124"
+            className="ms-Button-flexContainer flexContainer-67"
             data-automationid="splitbuttonprimary"
           >
             <i
               aria-hidden={true}
-              className="ms-Icon root-105 css-134 ms-Button-icon icon-136"
+              className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
               data-icon-name="Add"
               style={
                 Object {
@@ -1118,11 +1118,11 @@ exports[`object fields with title and description from both additionalProperties
               
             </i>
             <span
-              className="ms-Button-textContainer textContainer-125"
+              className="ms-Button-textContainer textContainer-68"
             >
               <span
-                className="ms-Button-label label-137"
-                id="id__179"
+                className="ms-Button-label label-79"
+                id="id__135"
               >
                 Add Item
               </span>
@@ -1138,7 +1138,7 @@ exports[`object fields with title and description from both additionalProperties
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-123"
+        className="ms-Button ms-Button--primary root-66"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1149,15 +1149,15 @@ exports[`object fields with title and description from both additionalProperties
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-124"
+          className="ms-Button-flexContainer flexContainer-67"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-125"
+            className="ms-Button-textContainer textContainer-68"
           >
             <span
-              className="ms-Button-label label-127"
-              id="id__182"
+              className="ms-Button-label label-70"
+              id="id__138"
             >
               Submit
             </span>
@@ -1184,13 +1184,13 @@ exports[`object fields with title and description from both object 1`] = `
     }
   >
     <label
-      className="ms-Label root-139"
+      className="ms-Label root-81"
       id="root__title"
     >
       My Field
     </label>
     <span
-      className="css-140"
+      className="css-82"
       id="root__description"
     >
       a fancier description
@@ -1211,27 +1211,27 @@ exports[`object fields with title and description from both object 1`] = `
           }
         >
           <div
-            className="ms-TextField root-111"
+            className="ms-TextField root-54"
           >
             <div
               className="ms-TextField-wrapper"
             >
               <label
-                className="ms-Label root-122"
+                className="ms-Label root-65"
                 htmlFor="root_a"
-                id="TextFieldLabel155"
+                id="TextFieldLabel119"
               >
                 My Item A
               </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-112"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
                 <input
                   aria-describedby="root_a__error root_a__description root_a__help"
                   aria-invalid={false}
-                  aria-labelledby="TextFieldLabel155"
+                  aria-labelledby="TextFieldLabel119"
                   autoFocus={false}
-                  className="ms-TextField-field field-113"
+                  className="ms-TextField-field field-56"
                   disabled={false}
                   id="root_a"
                   name="root_a"
@@ -1249,7 +1249,7 @@ exports[`object fields with title and description from both object 1`] = `
             </div>
           </div>
           <span
-            className="css-140"
+            className="css-82"
           >
             a fancier item A description
           </span>
@@ -1263,27 +1263,27 @@ exports[`object fields with title and description from both object 1`] = `
           }
         >
           <div
-            className="ms-TextField root-111"
+            className="ms-TextField root-54"
           >
             <div
               className="ms-TextField-wrapper"
             >
               <label
-                className="ms-Label root-122"
+                className="ms-Label root-65"
                 htmlFor="root_b"
-                id="TextFieldLabel160"
+                id="TextFieldLabel122"
               >
                 My Item B
               </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-112"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
                 <input
                   aria-describedby="root_b__error root_b__description root_b__help"
                   aria-invalid={false}
-                  aria-labelledby="TextFieldLabel160"
+                  aria-labelledby="TextFieldLabel122"
                   autoFocus={false}
-                  className="ms-TextField-field field-113"
+                  className="ms-TextField-field field-56"
                   disabled={false}
                   id="root_b"
                   name="root_b"
@@ -1302,7 +1302,7 @@ exports[`object fields with title and description from both object 1`] = `
             </div>
           </div>
           <span
-            className="css-140"
+            className="css-82"
           >
             a fancier item B description
           </span>
@@ -1316,7 +1316,7 @@ exports[`object fields with title and description from both object 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-123"
+        className="ms-Button ms-Button--primary root-66"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1327,15 +1327,15 @@ exports[`object fields with title and description from both object 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-124"
+          className="ms-Button-flexContainer flexContainer-67"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-125"
+            className="ms-Button-textContainer textContainer-68"
           >
             <span
-              className="ms-Button-label label-127"
-              id="id__163"
+              className="ms-Button-label label-70"
+              id="id__123"
             >
               Submit
             </span>
@@ -1362,13 +1362,13 @@ exports[`object fields with title and description from uiSchema additionalProper
     }
   >
     <label
-      className="ms-Label root-139"
+      className="ms-Label root-81"
       id="root__title"
     >
       My Field
     </label>
     <span
-      className="css-140"
+      className="css-82"
       id="root__description"
     >
       a fancier description
@@ -1396,25 +1396,25 @@ exports[`object fields with title and description from uiSchema additionalProper
               className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
               <div
-                className="ms-TextField root-111"
+                className="ms-TextField root-54"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-122"
+                    className="ms-Label root-65"
                     htmlFor="root_foo-key"
-                    id="TextFieldLabel117"
+                    id="TextFieldLabel89"
                   >
                     foo Key
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-112"
+                    className="ms-TextField-fieldGroup fieldGroup-55"
                   >
                     <input
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel117"
-                      className="ms-TextField-field field-113"
+                      aria-labelledby="TextFieldLabel89"
+                      className="ms-TextField-field field-56"
                       disabled={false}
                       id="root_foo-key"
                       name="root_foo-key"
@@ -1434,27 +1434,27 @@ exports[`object fields with title and description from uiSchema additionalProper
               className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
               <div
-                className="ms-TextField root-111"
+                className="ms-TextField root-54"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-122"
+                    className="ms-Label root-65"
                     htmlFor="root_foo"
-                    id="TextFieldLabel122"
+                    id="TextFieldLabel92"
                   >
                     foo
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-112"
+                    className="ms-TextField-fieldGroup fieldGroup-55"
                   >
                     <input
                       aria-describedby="root_foo__error root_foo__description root_foo__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel122"
+                      aria-labelledby="TextFieldLabel92"
                       autoFocus={false}
-                      className="ms-TextField-field field-113"
+                      className="ms-TextField-field field-56"
                       disabled={false}
                       id="root_foo"
                       name="root_foo"
@@ -1482,7 +1482,7 @@ exports[`object fields with title and description from uiSchema additionalProper
               }
             >
               <button
-                className="ms-Button ms-Button--icon root-131"
+                className="ms-Button ms-Button--icon root-74"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -1493,12 +1493,12 @@ exports[`object fields with title and description from uiSchema additionalProper
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer flexContainer-124"
+                  className="ms-Button-flexContainer flexContainer-67"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-105 css-134 ms-Button-icon icon-126"
+                    className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
                     data-icon-name="Delete"
                     style={
                       Object {
@@ -1522,7 +1522,7 @@ exports[`object fields with title and description from uiSchema additionalProper
         }
       >
         <button
-          className="ms-Button ms-Button--commandBar object-property-expand root-135"
+          className="ms-Button ms-Button--commandBar object-property-expand root-77"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -1538,12 +1538,12 @@ exports[`object fields with title and description from uiSchema additionalProper
           type="button"
         >
           <span
-            className="ms-Button-flexContainer flexContainer-124"
+            className="ms-Button-flexContainer flexContainer-67"
             data-automationid="splitbuttonprimary"
           >
             <i
               aria-hidden={true}
-              className="ms-Icon root-105 css-134 ms-Button-icon icon-136"
+              className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
               data-icon-name="Add"
               style={
                 Object {
@@ -1554,11 +1554,11 @@ exports[`object fields with title and description from uiSchema additionalProper
               
             </i>
             <span
-              className="ms-Button-textContainer textContainer-125"
+              className="ms-Button-textContainer textContainer-68"
             >
               <span
-                className="ms-Button-label label-137"
-                id="id__128"
+                className="ms-Button-label label-79"
+                id="id__96"
               >
                 Add Item
               </span>
@@ -1574,7 +1574,7 @@ exports[`object fields with title and description from uiSchema additionalProper
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-123"
+        className="ms-Button ms-Button--primary root-66"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1585,15 +1585,15 @@ exports[`object fields with title and description from uiSchema additionalProper
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-124"
+          className="ms-Button-flexContainer flexContainer-67"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-125"
+            className="ms-Button-textContainer textContainer-68"
           >
             <span
-              className="ms-Button-label label-127"
-              id="id__131"
+              className="ms-Button-label label-70"
+              id="id__99"
             >
               Submit
             </span>
@@ -1620,13 +1620,13 @@ exports[`object fields with title and description from uiSchema object 1`] = `
     }
   >
     <label
-      className="ms-Label root-139"
+      className="ms-Label root-81"
       id="root__title"
     >
       My Field
     </label>
     <span
-      className="css-140"
+      className="css-82"
       id="root__description"
     >
       a fancier description
@@ -1647,27 +1647,27 @@ exports[`object fields with title and description from uiSchema object 1`] = `
           }
         >
           <div
-            className="ms-TextField root-111"
+            className="ms-TextField root-54"
           >
             <div
               className="ms-TextField-wrapper"
             >
               <label
-                className="ms-Label root-122"
+                className="ms-Label root-65"
                 htmlFor="root_a"
-                id="TextFieldLabel104"
+                id="TextFieldLabel80"
               >
                 My Item A
               </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-112"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
                 <input
                   aria-describedby="root_a__error root_a__description root_a__help"
                   aria-invalid={false}
-                  aria-labelledby="TextFieldLabel104"
+                  aria-labelledby="TextFieldLabel80"
                   autoFocus={false}
-                  className="ms-TextField-field field-113"
+                  className="ms-TextField-field field-56"
                   disabled={false}
                   id="root_a"
                   name="root_a"
@@ -1685,7 +1685,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
             </div>
           </div>
           <span
-            className="css-140"
+            className="css-82"
           >
             a fancier item A description
           </span>
@@ -1699,27 +1699,27 @@ exports[`object fields with title and description from uiSchema object 1`] = `
           }
         >
           <div
-            className="ms-TextField root-111"
+            className="ms-TextField root-54"
           >
             <div
               className="ms-TextField-wrapper"
             >
               <label
-                className="ms-Label root-122"
+                className="ms-Label root-65"
                 htmlFor="root_b"
-                id="TextFieldLabel109"
+                id="TextFieldLabel83"
               >
                 My Item B
               </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-112"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
                 <input
                   aria-describedby="root_b__error root_b__description root_b__help"
                   aria-invalid={false}
-                  aria-labelledby="TextFieldLabel109"
+                  aria-labelledby="TextFieldLabel83"
                   autoFocus={false}
-                  className="ms-TextField-field field-113"
+                  className="ms-TextField-field field-56"
                   disabled={false}
                   id="root_b"
                   name="root_b"
@@ -1738,7 +1738,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
             </div>
           </div>
           <span
-            className="css-140"
+            className="css-82"
           >
             a fancier item B description
           </span>
@@ -1752,7 +1752,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-123"
+        className="ms-Button ms-Button--primary root-66"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -1763,15 +1763,15 @@ exports[`object fields with title and description from uiSchema object 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-124"
+          className="ms-Button-flexContainer flexContainer-67"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-125"
+            className="ms-Button-textContainer textContainer-68"
           >
             <span
-              className="ms-Button-label label-127"
-              id="id__112"
+              className="ms-Button-label label-70"
+              id="id__84"
             >
               Submit
             </span>
@@ -1798,13 +1798,13 @@ exports[`object fields with title and description from uiSchema show add button 
     }
   >
     <label
-      className="ms-Label root-139"
+      className="ms-Label root-81"
       id="root__title"
     >
       My Field
     </label>
     <span
-      className="css-140"
+      className="css-82"
       id="root__description"
     >
       a fancier description
@@ -1832,25 +1832,25 @@ exports[`object fields with title and description from uiSchema show add button 
               className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
               <div
-                className="ms-TextField root-111"
+                className="ms-TextField root-54"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-122"
+                    className="ms-Label root-65"
                     htmlFor="root_additionalProperty-key"
-                    id="TextFieldLabel136"
+                    id="TextFieldLabel104"
                   >
                     additionalProperty Key
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-112"
+                    className="ms-TextField-fieldGroup fieldGroup-55"
                   >
                     <input
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel136"
-                      className="ms-TextField-field field-113"
+                      aria-labelledby="TextFieldLabel104"
+                      className="ms-TextField-field field-56"
                       disabled={false}
                       id="root_additionalProperty-key"
                       name="root_additionalProperty-key"
@@ -1870,27 +1870,27 @@ exports[`object fields with title and description from uiSchema show add button 
               className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
               <div
-                className="ms-TextField root-111"
+                className="ms-TextField root-54"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-122"
+                    className="ms-Label root-65"
                     htmlFor="root_additionalProperty"
-                    id="TextFieldLabel141"
+                    id="TextFieldLabel107"
                   >
                     additionalProperty
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-112"
+                    className="ms-TextField-fieldGroup fieldGroup-55"
                   >
                     <input
                       aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel141"
+                      aria-labelledby="TextFieldLabel107"
                       autoFocus={false}
-                      className="ms-TextField-field field-113"
+                      className="ms-TextField-field field-56"
                       disabled={false}
                       id="root_additionalProperty"
                       name="root_additionalProperty"
@@ -1918,7 +1918,7 @@ exports[`object fields with title and description from uiSchema show add button 
               }
             >
               <button
-                className="ms-Button ms-Button--icon root-131"
+                className="ms-Button ms-Button--icon root-74"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -1929,12 +1929,12 @@ exports[`object fields with title and description from uiSchema show add button 
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer flexContainer-124"
+                  className="ms-Button-flexContainer flexContainer-67"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-105 css-134 ms-Button-icon icon-126"
+                    className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
                     data-icon-name="Delete"
                     style={
                       Object {
@@ -1958,7 +1958,7 @@ exports[`object fields with title and description from uiSchema show add button 
         }
       >
         <button
-          className="ms-Button ms-Button--commandBar object-property-expand root-135"
+          className="ms-Button ms-Button--commandBar object-property-expand root-77"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -1974,12 +1974,12 @@ exports[`object fields with title and description from uiSchema show add button 
           type="button"
         >
           <span
-            className="ms-Button-flexContainer flexContainer-124"
+            className="ms-Button-flexContainer flexContainer-67"
             data-automationid="splitbuttonprimary"
           >
             <i
               aria-hidden={true}
-              className="ms-Icon root-105 css-134 ms-Button-icon icon-136"
+              className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
               data-icon-name="Add"
               style={
                 Object {
@@ -1990,11 +1990,11 @@ exports[`object fields with title and description from uiSchema show add button 
               
             </i>
             <span
-              className="ms-Button-textContainer textContainer-125"
+              className="ms-Button-textContainer textContainer-68"
             >
               <span
-                className="ms-Button-label label-137"
-                id="id__147"
+                className="ms-Button-label label-79"
+                id="id__111"
               >
                 Add Item
               </span>
@@ -2010,7 +2010,7 @@ exports[`object fields with title and description from uiSchema show add button 
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-123"
+        className="ms-Button ms-Button--primary root-66"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2021,15 +2021,15 @@ exports[`object fields with title and description from uiSchema show add button 
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-124"
+          className="ms-Button-flexContainer flexContainer-67"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-125"
+            className="ms-Button-textContainer textContainer-68"
           >
             <span
-              className="ms-Button-label label-127"
-              id="id__150"
+              className="ms-Button-label label-70"
+              id="id__114"
             >
               Submit
             </span>
@@ -2056,13 +2056,13 @@ exports[`object fields with title and description object 1`] = `
     }
   >
     <label
-      className="ms-Label root-139"
+      className="ms-Label root-81"
       id="root__title"
     >
       Test field
     </label>
     <span
-      className="css-140"
+      className="css-82"
       id="root__description"
     >
       a test description
@@ -2083,27 +2083,27 @@ exports[`object fields with title and description object 1`] = `
           }
         >
           <div
-            className="ms-TextField root-111"
+            className="ms-TextField root-54"
           >
             <div
               className="ms-TextField-wrapper"
             >
               <label
-                className="ms-Label root-122"
+                className="ms-Label root-65"
                 htmlFor="root_a"
-                id="TextFieldLabel53"
+                id="TextFieldLabel41"
               >
                 A
               </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-112"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
                 <input
                   aria-describedby="root_a__error root_a__description root_a__help"
                   aria-invalid={false}
-                  aria-labelledby="TextFieldLabel53"
+                  aria-labelledby="TextFieldLabel41"
                   autoFocus={false}
-                  className="ms-TextField-field field-113"
+                  className="ms-TextField-field field-56"
                   disabled={false}
                   id="root_a"
                   name="root_a"
@@ -2121,7 +2121,7 @@ exports[`object fields with title and description object 1`] = `
             </div>
           </div>
           <span
-            className="css-140"
+            className="css-82"
           >
             A description
           </span>
@@ -2135,27 +2135,27 @@ exports[`object fields with title and description object 1`] = `
           }
         >
           <div
-            className="ms-TextField root-111"
+            className="ms-TextField root-54"
           >
             <div
               className="ms-TextField-wrapper"
             >
               <label
-                className="ms-Label root-122"
+                className="ms-Label root-65"
                 htmlFor="root_b"
-                id="TextFieldLabel58"
+                id="TextFieldLabel44"
               >
                 B
               </label>
               <div
-                className="ms-TextField-fieldGroup fieldGroup-112"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
                 <input
                   aria-describedby="root_b__error root_b__description root_b__help"
                   aria-invalid={false}
-                  aria-labelledby="TextFieldLabel58"
+                  aria-labelledby="TextFieldLabel44"
                   autoFocus={false}
-                  className="ms-TextField-field field-113"
+                  className="ms-TextField-field field-56"
                   disabled={false}
                   id="root_b"
                   name="root_b"
@@ -2174,7 +2174,7 @@ exports[`object fields with title and description object 1`] = `
             </div>
           </div>
           <span
-            className="css-140"
+            className="css-82"
           >
             B description
           </span>
@@ -2188,7 +2188,7 @@ exports[`object fields with title and description object 1`] = `
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-123"
+        className="ms-Button ms-Button--primary root-66"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2199,15 +2199,15 @@ exports[`object fields with title and description object 1`] = `
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-124"
+          className="ms-Button-flexContainer flexContainer-67"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-125"
+            className="ms-Button-textContainer textContainer-68"
           >
             <span
-              className="ms-Button-label label-127"
-              id="id__61"
+              className="ms-Button-label label-70"
+              id="id__45"
             >
               Submit
             </span>
@@ -2234,13 +2234,13 @@ exports[`object fields with title and description show add button and fields if 
     }
   >
     <label
-      className="ms-Label root-139"
+      className="ms-Label root-81"
       id="root__title"
     >
       Test field
     </label>
     <span
-      className="css-140"
+      className="css-82"
       id="root__description"
     >
       a test description
@@ -2268,25 +2268,25 @@ exports[`object fields with title and description show add button and fields if 
               className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
               <div
-                className="ms-TextField root-111"
+                className="ms-TextField root-54"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-122"
+                    className="ms-Label root-65"
                     htmlFor="root_additionalProperty-key"
-                    id="TextFieldLabel85"
+                    id="TextFieldLabel65"
                   >
                     additionalProperty Key
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-112"
+                    className="ms-TextField-fieldGroup fieldGroup-55"
                   >
                     <input
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel85"
-                      className="ms-TextField-field field-113"
+                      aria-labelledby="TextFieldLabel65"
+                      className="ms-TextField-field field-56"
                       disabled={false}
                       id="root_additionalProperty-key"
                       name="root_additionalProperty-key"
@@ -2306,27 +2306,27 @@ exports[`object fields with title and description show add button and fields if 
               className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
               <div
-                className="ms-TextField root-111"
+                className="ms-TextField root-54"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-122"
+                    className="ms-Label root-65"
                     htmlFor="root_additionalProperty"
-                    id="TextFieldLabel90"
+                    id="TextFieldLabel68"
                   >
                     additionalProperty
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-112"
+                    className="ms-TextField-fieldGroup fieldGroup-55"
                   >
                     <input
                       aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel90"
+                      aria-labelledby="TextFieldLabel68"
                       autoFocus={false}
-                      className="ms-TextField-field field-113"
+                      className="ms-TextField-field field-56"
                       disabled={false}
                       id="root_additionalProperty"
                       name="root_additionalProperty"
@@ -2354,7 +2354,7 @@ exports[`object fields with title and description show add button and fields if 
               }
             >
               <button
-                className="ms-Button ms-Button--icon root-131"
+                className="ms-Button ms-Button--icon root-74"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -2365,12 +2365,12 @@ exports[`object fields with title and description show add button and fields if 
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer flexContainer-124"
+                  className="ms-Button-flexContainer flexContainer-67"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-105 css-134 ms-Button-icon icon-126"
+                    className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
                     data-icon-name="Delete"
                     style={
                       Object {
@@ -2394,7 +2394,7 @@ exports[`object fields with title and description show add button and fields if 
         }
       >
         <button
-          className="ms-Button ms-Button--commandBar object-property-expand root-135"
+          className="ms-Button ms-Button--commandBar object-property-expand root-77"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -2410,12 +2410,12 @@ exports[`object fields with title and description show add button and fields if 
           type="button"
         >
           <span
-            className="ms-Button-flexContainer flexContainer-124"
+            className="ms-Button-flexContainer flexContainer-67"
             data-automationid="splitbuttonprimary"
           >
             <i
               aria-hidden={true}
-              className="ms-Icon root-105 css-134 ms-Button-icon icon-136"
+              className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
               data-icon-name="Add"
               style={
                 Object {
@@ -2426,11 +2426,11 @@ exports[`object fields with title and description show add button and fields if 
               
             </i>
             <span
-              className="ms-Button-textContainer textContainer-125"
+              className="ms-Button-textContainer textContainer-68"
             >
               <span
-                className="ms-Button-label label-137"
-                id="id__96"
+                className="ms-Button-label label-79"
+                id="id__72"
               >
                 Add Item
               </span>
@@ -2446,7 +2446,7 @@ exports[`object fields with title and description show add button and fields if 
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-123"
+        className="ms-Button ms-Button--primary root-66"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2457,15 +2457,15 @@ exports[`object fields with title and description show add button and fields if 
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-124"
+          className="ms-Button-flexContainer flexContainer-67"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-125"
+            className="ms-Button-textContainer textContainer-68"
           >
             <span
-              className="ms-Button-label label-127"
-              id="id__99"
+              className="ms-Button-label label-70"
+              id="id__75"
             >
               Submit
             </span>
@@ -2515,25 +2515,25 @@ exports[`object fields with title and description with global label off addition
               className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
               <div
-                className="ms-TextField root-111"
+                className="ms-TextField root-54"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-122"
+                    className="ms-Label root-65"
                     htmlFor="root_foo-key"
-                    id="TextFieldLabel200"
+                    id="TextFieldLabel152"
                   >
                     foo Key
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-112"
+                    className="ms-TextField-fieldGroup fieldGroup-55"
                   >
                     <input
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel200"
-                      className="ms-TextField-field field-113"
+                      aria-labelledby="TextFieldLabel152"
+                      className="ms-TextField-field field-56"
                       disabled={false}
                       id="root_foo-key"
                       name="root_foo-key"
@@ -2553,19 +2553,19 @@ exports[`object fields with title and description with global label off addition
               className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
               <div
-                className="ms-TextField root-111"
+                className="ms-TextField root-54"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-112"
+                    className="ms-TextField-fieldGroup fieldGroup-55"
                   >
                     <input
                       aria-describedby="root_foo__error root_foo__description root_foo__help"
                       aria-invalid={false}
                       autoFocus={false}
-                      className="ms-TextField-field field-113"
+                      className="ms-TextField-field field-56"
                       disabled={false}
                       id="root_foo"
                       name="root_foo"
@@ -2592,7 +2592,7 @@ exports[`object fields with title and description with global label off addition
               }
             >
               <button
-                className="ms-Button ms-Button--icon root-131"
+                className="ms-Button ms-Button--icon root-74"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -2603,12 +2603,12 @@ exports[`object fields with title and description with global label off addition
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer flexContainer-124"
+                  className="ms-Button-flexContainer flexContainer-67"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-105 css-134 ms-Button-icon icon-126"
+                    className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
                     data-icon-name="Delete"
                     style={
                       Object {
@@ -2632,7 +2632,7 @@ exports[`object fields with title and description with global label off addition
         }
       >
         <button
-          className="ms-Button ms-Button--commandBar object-property-expand root-135"
+          className="ms-Button ms-Button--commandBar object-property-expand root-77"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -2648,12 +2648,12 @@ exports[`object fields with title and description with global label off addition
           type="button"
         >
           <span
-            className="ms-Button-flexContainer flexContainer-124"
+            className="ms-Button-flexContainer flexContainer-67"
             data-automationid="splitbuttonprimary"
           >
             <i
               aria-hidden={true}
-              className="ms-Icon root-105 css-134 ms-Button-icon icon-136"
+              className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
               data-icon-name="Add"
               style={
                 Object {
@@ -2664,11 +2664,11 @@ exports[`object fields with title and description with global label off addition
               
             </i>
             <span
-              className="ms-Button-textContainer textContainer-125"
+              className="ms-Button-textContainer textContainer-68"
             >
               <span
-                className="ms-Button-label label-137"
-                id="id__211"
+                className="ms-Button-label label-79"
+                id="id__159"
               >
                 Add Item
               </span>
@@ -2684,7 +2684,7 @@ exports[`object fields with title and description with global label off addition
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-123"
+        className="ms-Button ms-Button--primary root-66"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2695,15 +2695,15 @@ exports[`object fields with title and description with global label off addition
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-124"
+          className="ms-Button-flexContainer flexContainer-67"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-125"
+            className="ms-Button-textContainer textContainer-68"
           >
             <span
-              className="ms-Button-label label-127"
-              id="id__214"
+              className="ms-Button-label label-70"
+              id="id__162"
             >
               Submit
             </span>
@@ -2746,19 +2746,19 @@ exports[`object fields with title and description with global label off object 1
           }
         >
           <div
-            className="ms-TextField root-111"
+            className="ms-TextField root-54"
           >
             <div
               className="ms-TextField-wrapper"
             >
               <div
-                className="ms-TextField-fieldGroup fieldGroup-112"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
                 <input
                   aria-describedby="root_a__error root_a__description root_a__help"
                   aria-invalid={false}
                   autoFocus={false}
-                  className="ms-TextField-field field-113"
+                  className="ms-TextField-field field-56"
                   disabled={false}
                   id="root_a"
                   name="root_a"
@@ -2785,19 +2785,19 @@ exports[`object fields with title and description with global label off object 1
           }
         >
           <div
-            className="ms-TextField root-111"
+            className="ms-TextField root-54"
           >
             <div
               className="ms-TextField-wrapper"
             >
               <div
-                className="ms-TextField-fieldGroup fieldGroup-112"
+                className="ms-TextField-fieldGroup fieldGroup-55"
               >
                 <input
                   aria-describedby="root_b__error root_b__description root_b__help"
                   aria-invalid={false}
                   autoFocus={false}
-                  className="ms-TextField-field field-113"
+                  className="ms-TextField-field field-56"
                   disabled={false}
                   id="root_b"
                   name="root_b"
@@ -2825,7 +2825,7 @@ exports[`object fields with title and description with global label off object 1
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-123"
+        className="ms-Button ms-Button--primary root-66"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -2836,15 +2836,15 @@ exports[`object fields with title and description with global label off object 1
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-124"
+          className="ms-Button-flexContainer flexContainer-67"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-125"
+            className="ms-Button-textContainer textContainer-68"
           >
             <span
-              className="ms-Button-label label-127"
-              id="id__195"
+              className="ms-Button-label label-70"
+              id="id__147"
             >
               Submit
             </span>
@@ -2894,25 +2894,25 @@ exports[`object fields with title and description with global label off show add
               className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
               <div
-                className="ms-TextField root-111"
+                className="ms-TextField root-54"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <label
-                    className="ms-Label root-122"
+                    className="ms-Label root-65"
                     htmlFor="root_additionalProperty-key"
-                    id="TextFieldLabel219"
+                    id="TextFieldLabel167"
                   >
                     additionalProperty Key
                   </label>
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-112"
+                    className="ms-TextField-fieldGroup fieldGroup-55"
                   >
                     <input
                       aria-invalid={false}
-                      aria-labelledby="TextFieldLabel219"
-                      className="ms-TextField-field field-113"
+                      aria-labelledby="TextFieldLabel167"
+                      className="ms-TextField-field field-56"
                       disabled={false}
                       id="root_additionalProperty-key"
                       name="root_additionalProperty-key"
@@ -2932,19 +2932,19 @@ exports[`object fields with title and description with global label off show add
               className="ms-Grid-col ms-sm4 ms-md4 ms-lg5"
             >
               <div
-                className="ms-TextField root-111"
+                className="ms-TextField root-54"
               >
                 <div
                   className="ms-TextField-wrapper"
                 >
                   <div
-                    className="ms-TextField-fieldGroup fieldGroup-112"
+                    className="ms-TextField-fieldGroup fieldGroup-55"
                   >
                     <input
                       aria-describedby="root_additionalProperty__error root_additionalProperty__description root_additionalProperty__help"
                       aria-invalid={false}
                       autoFocus={false}
-                      className="ms-TextField-field field-113"
+                      className="ms-TextField-field field-56"
                       disabled={false}
                       id="root_additionalProperty"
                       name="root_additionalProperty"
@@ -2971,7 +2971,7 @@ exports[`object fields with title and description with global label off show add
               }
             >
               <button
-                className="ms-Button ms-Button--icon root-131"
+                className="ms-Button ms-Button--icon root-74"
                 data-is-focusable={true}
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -2982,12 +2982,12 @@ exports[`object fields with title and description with global label off show add
                 type="button"
               >
                 <span
-                  className="ms-Button-flexContainer flexContainer-124"
+                  className="ms-Button-flexContainer flexContainer-67"
                   data-automationid="splitbuttonprimary"
                 >
                   <i
                     aria-hidden={true}
-                    className="ms-Icon root-105 css-134 ms-Button-icon icon-126"
+                    className="ms-Icon root-37 css-76 ms-Button-icon icon-69"
                     data-icon-name="Delete"
                     style={
                       Object {
@@ -3011,7 +3011,7 @@ exports[`object fields with title and description with global label off show add
         }
       >
         <button
-          className="ms-Button ms-Button--commandBar object-property-expand root-135"
+          className="ms-Button ms-Button--commandBar object-property-expand root-77"
           data-is-focusable={true}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -3027,12 +3027,12 @@ exports[`object fields with title and description with global label off show add
           type="button"
         >
           <span
-            className="ms-Button-flexContainer flexContainer-124"
+            className="ms-Button-flexContainer flexContainer-67"
             data-automationid="splitbuttonprimary"
           >
             <i
               aria-hidden={true}
-              className="ms-Icon root-105 css-134 ms-Button-icon icon-136"
+              className="ms-Icon root-37 css-76 ms-Button-icon icon-78"
               data-icon-name="Add"
               style={
                 Object {
@@ -3043,11 +3043,11 @@ exports[`object fields with title and description with global label off show add
               
             </i>
             <span
-              className="ms-Button-textContainer textContainer-125"
+              className="ms-Button-textContainer textContainer-68"
             >
               <span
-                className="ms-Button-label label-137"
-                id="id__230"
+                className="ms-Button-label label-79"
+                id="id__174"
               >
                 Add Item
               </span>
@@ -3063,7 +3063,7 @@ exports[`object fields with title and description with global label off show add
       className="ms-Grid-col ms-sm12"
     >
       <button
-        className="ms-Button ms-Button--primary root-123"
+        className="ms-Button ms-Button--primary root-66"
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}
@@ -3074,15 +3074,15 @@ exports[`object fields with title and description with global label off show add
         type="submit"
       >
         <span
-          className="ms-Button-flexContainer flexContainer-124"
+          className="ms-Button-flexContainer flexContainer-67"
           data-automationid="splitbuttonprimary"
         >
           <span
-            className="ms-Button-textContainer textContainer-125"
+            className="ms-Button-textContainer textContainer-68"
           >
             <span
-              className="ms-Button-label label-127"
-              id="id__233"
+              className="ms-Button-label label-70"
+              id="id__177"
             >
               Submit
             </span>


### PR DESCRIPTION
### Reasons for making this change

If for some reason the element to focus cannot be found when the validation fails and the `focusOnFirstError` prop is set, then it will throw an error.

### Checklist

- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
