### PR TITLE
fix: schemaParser resolve array items

### DIFF
--- a/packages/utils/src/parser/schemaParser.ts
+++ b/packages/utils/src/parser/schemaParser.ts
@@ -2,7 +2,7 @@ import forEach from 'lodash/forEach';
 import isEqual from 'lodash/isEqual';
 
 import { FormContextType, RJSFSchema, StrictRJSFSchema } from '../types';
-import { PROPERTIES_KEY } from '../constants';
+import { PROPERTIES_KEY, ITEMS_KEY } from '../constants';
 import ParserValidator, { SchemaMap } from './ParserValidator';
 import { retrieveSchemaInternal, resolveAnyOrOneOfSchemas } from '../schema/retrieveSchema';
 
@@ -35,6 +35,9 @@ function parseSchema<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends
           });
         }
       });
+      if (ITEMS_KEY in schema && !Array.isArray(schema.items) && typeof schema.items !== 'boolean') {
+        parseSchema<T, S, F>(validator, recurseList, rootSchema, schema.items as S);
+      }
     }
   });
 }

--- a/packages/utils/test/parser/__snapshots__/schemaParser.test.ts.snap
+++ b/packages/utils/test/parser/__snapshots__/schemaParser.test.ts.snap
@@ -1,5 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`schemaParser() parse schema with array condition 1`] = `
+Object {
+  "-33d8d73c": Object {
+    "$id": "-33d8d73c",
+    "properties": Object {
+      "country": Object {
+        "const": "United States of America",
+      },
+    },
+  },
+  "240a61a6": Object {
+    "$id": "240a61a6",
+    "properties": Object {
+      "list": Object {
+        "items": Object {
+          "else": Object {
+            "properties": Object {
+              "postal_code": Object {
+                "pattern": "[A-Z][0-9][A-Z] [0-9][A-Z][0-9]",
+              },
+            },
+          },
+          "if": Object {
+            "properties": Object {
+              "country": Object {
+                "const": "United States of America",
+              },
+            },
+          },
+          "properties": Object {
+            "country": Object {
+              "default": "United States of America",
+              "enum": Array [
+                "United States of America",
+                "Canada",
+              ],
+            },
+          },
+          "then": Object {
+            "properties": Object {
+              "postal_code": Object {
+                "pattern": "[0-9]{5}(-[0-9]{4})?",
+              },
+            },
+          },
+          "type": "object",
+        },
+        "type": "array",
+      },
+    },
+    "type": "object",
+  },
+}
+`;
+
 exports[`schemaParser() parses property dependencies properly 1`] = `
 Object {
   "2c34081c": Object {

--- a/packages/utils/test/parser/schemaParser.test.ts
+++ b/packages/utils/test/parser/schemaParser.test.ts
@@ -6,6 +6,7 @@ import {
   SCHEMA_DEPENDENCIES,
   SCHEMA_AND_ONEOF_REF_DEPENDENCIES,
   SCHEMA_AND_REQUIRED_DEPENDENCIES,
+  SCHEMA_WITH_ARRAY_CONDITION,
   SCHEMA_WITH_ONEOF_NESTED_DEPENDENCIES,
   SCHEMA_WITH_SINGLE_CONDITION,
   SCHEMA_WITH_MULTIPLE_CONDITIONS,
@@ -56,6 +57,10 @@ describe('schemaParser()', () => {
   });
   it('parses superSchema properly', () => {
     const schemaMap = schemaParser(SUPER_SCHEMA);
+    expect(schemaMap).toMatchSnapshot();
+  });
+  it('parse schema with array condition', () => {
+    const schemaMap = schemaParser(SCHEMA_WITH_ARRAY_CONDITION);
     expect(schemaMap).toMatchSnapshot();
   });
 });

--- a/packages/utils/test/testUtils/testData.ts
+++ b/packages/utils/test/testUtils/testData.ts
@@ -785,3 +785,13 @@ export const SCHEMA_WITH_NESTED_CONDITIONS: RJSFSchema = {
     },
   },
 };
+
+export const SCHEMA_WITH_ARRAY_CONDITION: RJSFSchema = {
+  type: 'object',
+  properties: {
+    list: {
+      type: 'array',
+      items: SCHEMA_WITH_SINGLE_CONDITION,
+    },
+  },
+};


### PR DESCRIPTION
### Reasons for making this change

fixes: #3689 updating schemaParser to resolve array items field. When resolving array schema without formData the `retrieveSchemaInternal` won't expand and resolve any references or conditions in the items field.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
