### PR TITLE
fix #3696 - Playground fixes and light improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.x.x
+
+## Dev / docs / playground
+
+- Fixed broken playground examples ([#3696](https://github.com/rjsf-team/react-jsonschema-form/issues/3696))
+- Added experimental_defaultFormStateBehavior.emptyObjectFields control to Playground
+- Fixed bug where subthemes would not appear in Playground
+
 # 5.8.0
 
 ## @rjsf/utils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,6 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
-# 5.x.x
-
-## Dev / docs / playground
-
-- Fixed broken playground examples ([#3696](https://github.com/rjsf-team/react-jsonschema-form/issues/3696))
-- Added experimental_defaultFormStateBehavior.emptyObjectFields control to Playground
-- Fixed bug where subthemes would not appear in Playground
-
 # 5.8.0
 
 ## @rjsf/utils
@@ -63,6 +55,9 @@ should change the heading of the (upcoming) version to include a major version b
 ## Dev / docs / playground
 
 - Updated sample data and documentation about the markdown in `RJSFSchema` description
+- Fixed broken playground examples ([#3696](https://github.com/rjsf-team/react-jsonschema-form/issues/3696))
+- Added experimental_defaultFormStateBehavior.emptyObjectFields control to Playground
+- Fixed bug where subthemes would not appear in Playground
 
 # 5.7.3
 

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -72,7 +72,7 @@ The following sub-sections represent the different keys in this object, with the
 | `populate`     | Legacy behavior - populate minItems entries with default values initially and include empty array when no values have been defined |
 | `requiredOnly` | Ignore `minItems` on a field when calculating defaults unless the field is required                                                |
 
-### `emptyObjectFields
+### `emptyObjectFields`
 
 | Flag Value                 | Description                                                                                                                |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------------------- |

--- a/packages/docs/docs/usage/validation.md
+++ b/packages/docs/docs/usage/validation.md
@@ -71,7 +71,7 @@ node compileYourSchema.js
 
 > NOTE: You must have your schema provided within a file that can be parsed and turned into the set of precompiled validator functions.
 
-> Additional Note: If you are using Webpack or NextJS and are encountering an issue resolving `fs` during development, consult this [blog post](https://bobbyhadz.com/blog/module-not-found-cant-resolve-fs) for how to solve the issue. 
+> Additional Note: If you are using Webpack or NextJS and are encountering an issue resolving `fs` during development, consult this [blog post](https://bobbyhadz.com/blog/module-not-found-cant-resolve-fs) for how to solve the issue.
 
 ### Using the precompiled validator
 
@@ -435,7 +435,7 @@ An important note is that these errors are "display only" and will not block the
 
 ### ajvOptionsOverrides
 
-In version 5, with the advent of the decoupling of the validation implementation from the `Form`, it is now possible to provide additional options to the `ajv6` instance used within `@rjsf/validator-ajv8`.
+In version 5, with the advent of the decoupling of the validation implementation from the `Form`, it is now possible to provide additional options to the `ajv` instance used within `@rjsf/validator-ajv8`.
 For instance, if you need more information from `ajv` about errors via the `verbose` option, now you can turn it on!
 
 ```tsx

--- a/packages/playground/src/components/Header.tsx
+++ b/packages/playground/src/components/Header.tsx
@@ -86,6 +86,30 @@ const liveSettingsSchema: RJSFSchema = {
             },
           ],
         },
+        emptyObjectFields: {
+          type: 'string',
+          title: 'Object fields default behavior',
+          default: 'populateAllDefaults',
+          oneOf: [
+            {
+              type: 'string',
+              title:
+                'Assign value to formData when default is primitive, non-empty object field, or is required (legacy behavior)',
+              enum: ['populateAllDefaults'],
+            },
+            {
+              type: 'string',
+              title:
+                'Assign value to formData when default is an object and parent is required, or default is primitive and is required',
+              enum: ['populateRequiredDefaults'],
+            },
+            {
+              type: 'string',
+              title: 'Does not set defaults',
+              enum: ['skipDefaults'],
+            },
+          ],
+        },
       },
     },
   },
@@ -213,7 +237,7 @@ export default function Header({
         </div>
         <div className='col-sm-2'>
           <ThemeSelector themes={themes} theme={theme} select={onThemeSelected} />
-          {themes[theme] && themes[theme].subthemes && subtheme && (
+          {themes[theme] && themes[theme].subthemes && (
             <SubthemeSelector subthemes={themes[theme].subthemes!} subtheme={subtheme} select={onSubthemeSelected} />
           )}
           <ValidatorSelector validators={validators} validator={validator} select={onValidatorSelected} />

--- a/packages/playground/src/components/Playground.tsx
+++ b/packages/playground/src/components/Playground.tsx
@@ -1,15 +1,6 @@
 import { useCallback, useState, useRef, useEffect, ComponentType, FormEvent } from 'react';
 import { withTheme, IChangeEvent, FormProps } from '@rjsf/core';
-import {
-  ErrorSchema,
-  ArrayFieldTemplateProps,
-  ObjectFieldTemplateProps,
-  RJSFSchema,
-  RJSFValidationError,
-  TemplatesType,
-  UiSchema,
-  ValidatorType,
-} from '@rjsf/utils';
+import { ErrorSchema, RJSFSchema, RJSFValidationError, TemplatesType, UiSchema, ValidatorType } from '@rjsf/utils';
 
 import { samples } from '../samples';
 import Header, { LiveSettings } from './Header';
@@ -44,11 +35,10 @@ export default function Playground({ themes, validators }: PlaygroundProps) {
     readonly: false,
     omitExtraData: false,
     liveOmit: false,
-    experimental_defaultFormStateBehavior: { arrayMinItems: 'populate' },
+    experimental_defaultFormStateBehavior: { arrayMinItems: 'populate', emptyObjectFields: 'populateAllDefaults' },
   });
   const [FormComponent, setFormComponent] = useState<ComponentType<FormProps>>(withTheme({}));
-  const [ArrayFieldTemplate, setArrayFieldTemplate] = useState<ComponentType<ArrayFieldTemplateProps>>();
-  const [ObjectFieldTemplate, setObjectFieldTemplate] = useState<ComponentType<ObjectFieldTemplateProps>>();
+  const [templates, setTemplates] = useState<Partial<TemplatesType>>();
 
   const playGroundFormRef = useRef<any>(null);
 
@@ -65,7 +55,7 @@ export default function Playground({ themes, validators }: PlaygroundProps) {
   const load = useCallback(
     (data: any) => {
       // Reset the ArrayFieldTemplate whenever you load new data
-      const { ArrayFieldTemplate, ObjectFieldTemplate, extraErrors, liveSettings } = data;
+      const { templates = {}, extraErrors, liveSettings } = data;
       // uiSchema is missing on some examples. Provide a default to
       // clear the field in all cases.
       const { schema, uiSchema = {}, formData, theme: dataTheme = theme } = data;
@@ -79,9 +69,7 @@ export default function Playground({ themes, validators }: PlaygroundProps) {
       setFormData(formData);
       setExtraErrors(extraErrors);
       setTheme(dataTheme);
-      setArrayFieldTemplate(ArrayFieldTemplate);
-      setObjectFieldTemplate(ObjectFieldTemplate);
-      setLiveSettings(liveSettings);
+      setTemplates(templates);
       setShowForm(true);
       setLiveSettings(liveSettings);
     },
@@ -126,14 +114,6 @@ export default function Playground({ themes, validators }: PlaygroundProps) {
     console.log('submit event', event);
     window.alert('Form submitted');
   }, []);
-
-  const templates: Partial<TemplatesType> = {};
-  if (ArrayFieldTemplate) {
-    templates.ArrayFieldTemplate = ArrayFieldTemplate;
-  }
-  if (ObjectFieldTemplate) {
-    templates.ObjectFieldTemplate = ObjectFieldTemplate;
-  }
 
   return (
     <>

--- a/packages/playground/src/components/SubthemeSelector.tsx
+++ b/packages/playground/src/components/SubthemeSelector.tsx
@@ -16,7 +16,7 @@ export interface SubthemesType {
 }
 
 interface SubthemeSelectorProps {
-  subtheme: string;
+  subtheme: string | null;
   subthemes: SubthemesType;
   select: (subthemeName: string, subtheme: SubthemeType) => void;
 }
@@ -25,6 +25,7 @@ export default function SubthemeSelector({ subtheme, subthemes, select }: Subthe
   const schema: RJSFSchema = useMemo(
     () => ({
       type: 'string',
+      title: 'Subtheme',
       enum: Object.keys(subthemes),
     }),
     [subthemes]

--- a/packages/playground/src/components/ThemeSelector.tsx
+++ b/packages/playground/src/components/ThemeSelector.tsx
@@ -18,6 +18,7 @@ interface ThemeSelectorProps {
 export default function ThemeSelector({ theme, themes, select }: ThemeSelectorProps) {
   const schema: RJSFSchema = {
     type: 'string',
+    title: 'Theme',
     enum: Object.keys(themes),
   };
 

--- a/packages/playground/src/components/ValidatorSelector.tsx
+++ b/packages/playground/src/components/ValidatorSelector.tsx
@@ -11,6 +11,7 @@ interface ValidatorSelectorProps {
 export default function ValidatorSelector({ validator, validators, select }: ValidatorSelectorProps) {
   const schema: RJSFSchema = {
     type: 'string',
+    title: 'Validator',
     enum: Object.keys(validators),
   };
 

--- a/packages/playground/src/samples/customArray.tsx
+++ b/packages/playground/src/samples/customArray.tsx
@@ -43,5 +43,5 @@ export default {
     },
   },
   formData: ['react', 'jsonschema', 'form'],
-  ArrayFieldTemplate,
+  templates: { ArrayFieldTemplate },
 };

--- a/packages/playground/src/samples/customObject.tsx
+++ b/packages/playground/src/samples/customObject.tsx
@@ -1,29 +1,48 @@
-const ObjectFieldTemplate: React.FC<{
-  TitleField: React.FC<{ title: string }>;
-  title: string;
-  properties: any[];
-  description: string;
-}> = ({ TitleField, properties, title, description }) => {
+import {
+  getTemplate,
+  getUiOptions,
+  titleId,
+  StrictRJSFSchema,
+  RJSFSchema,
+  FormContextType,
+  ObjectFieldTemplateProps,
+} from '@rjsf/utils';
+
+function ObjectFieldTemplate<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  props: ObjectFieldTemplateProps<T, S, F>
+) {
+  const { registry, properties, title, description, uiSchema, required, schema, idSchema } = props;
+  const options = getUiOptions<T, S, F>(uiSchema);
+  const TitleFieldTemplate = getTemplate<'TitleFieldTemplate', T, S, F>('TitleFieldTemplate', registry, options);
   return (
     <div>
-      <TitleField title={title} />
+      {title && (
+        <TitleFieldTemplate
+          id={titleId<T>(idSchema)}
+          title={title}
+          required={required}
+          schema={schema}
+          uiSchema={uiSchema}
+          registry={registry}
+        />
+      )}{' '}
+      {description}
       <div className='row'>
         {properties.map((prop) => (
-          <div className='col-lg-2 col-md-4 col-sm-6 col-xs-12' key={prop.content.key}>
+          <div className='col-lg-1 col-md-2 col-sm-4 col-xs-6' key={prop.content.key}>
             {prop.content}
           </div>
         ))}
       </div>
-      {description}
     </div>
   );
-};
+}
 
 export default {
   schema: {
     title: 'A registration form',
     description:
-      'This is the same as the simple form, but it is rendered as a bootstrap grid. Try shrinking the browser window to see it in action.',
+      'This is the same as the simple form, but with an altered bootstrap grid. Set the theme to default, and try shrinking the browser window to see it in action.',
     type: 'object',
     required: ['firstName', 'lastName'],
     properties: {
@@ -62,5 +81,7 @@ export default {
     bio: 'Roundhouse kicking asses since 1940',
     password: 'noneed',
   },
-  ObjectFieldTemplate,
+  templates: {
+    ObjectFieldTemplate,
+  },
 };


### PR DESCRIPTION
Fixes #3696 
- Fixed broken playground examples
- Added experimental_defaultFormStateBehavior.emptyObjectFields control to Playground
- Fixed bug where subthemes would not appear in Playground

- [X] **I'm updating documentation**
  - [X] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
