### PR TITLE
fix #3700 - Compiling Schema mergeAllOf errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 5.8.0
 
+## @rjsf/utils
+
+- Updated `retrieveSchemaInternal` to return failed merged allOf sub schemas for expandAllBranches flag, fixing [#3689](https://github.com/rjsf-team/react-jsonschema-form/issues/3700)
+- Updated `hashForSchema` to short schema fields in consistent order before stringify to prevent different hash ids for the same schema
+
 ## @rjsf/bootstrap-4
 
 - Updated FieldTemplate Component to display description from SchemaField and make it consistent for all the available themes

--- a/packages/utils/src/hashForSchema.ts
+++ b/packages/utils/src/hashForSchema.ts
@@ -25,6 +25,7 @@ function hashString(string: string): string {
  */
 export default function hashForSchema<S extends StrictRJSFSchema = RJSFSchema>(schema: S) {
   const allKeys = new Set<string>();
+  // solution source: https://stackoverflow.com/questions/16167581/sort-object-properties-and-json-stringify/53593328#53593328
   JSON.stringify(schema, (key, value) => (allKeys.add(key), value));
   return hashString(JSON.stringify(schema, Array.from(allKeys).sort()));
 }

--- a/packages/utils/src/hashForSchema.ts
+++ b/packages/utils/src/hashForSchema.ts
@@ -17,11 +17,14 @@ function hashString(string: string): string {
   return hash.toString(16);
 }
 
-/** Stringifies the schema and returns the hash of the resulting string.
+/** Stringifies the schema and returns the hash of the resulting string. Sorts schema fields
+ * in consistent order before stringify to prevent different hash ids for the same schema.
  *
  * @param schema - The schema for which the hash is desired
  * @returns - The string obtained from the hash of the stringified schema
  */
 export default function hashForSchema<S extends StrictRJSFSchema = RJSFSchema>(schema: S) {
-  return hashString(JSON.stringify(schema));
+  const allKeys = new Set<string>();
+  JSON.stringify(schema, (key, value) => (allKeys.add(key), value));
+  return hashString(JSON.stringify(schema, Array.from(allKeys).sort()));
 }

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -287,6 +287,9 @@ export function retrieveSchemaInternal<
       } catch (e) {
         console.warn('could not merge subschemas in allOf:\n', e);
         const { allOf, ...resolvedSchemaWithoutAllOf } = resolvedSchema;
+        if (expandAllBranches && allOf) {
+          return [resolvedSchemaWithoutAllOf as S, ...(allOf as S[])];
+        }
         return resolvedSchemaWithoutAllOf as S;
       }
     }

--- a/packages/utils/test/__snapshots__/hashFromSchema.test.ts.snap
+++ b/packages/utils/test/__snapshots__/hashFromSchema.test.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`hashForSchema returns a hash for a more complex schema 1`] = `"-6bbb062a"`;
+exports[`hashForSchema returns a hash for a more complex schema 1`] = `"7cf4cd8a"`;
 
-exports[`hashForSchema returns a hash for a tiny schema 1`] = `"5b2fed3d"`;
+exports[`hashForSchema returns a hash for a tiny schema 1`] = `"2faae26f"`;

--- a/packages/utils/test/hashFromSchema.test.ts
+++ b/packages/utils/test/hashFromSchema.test.ts
@@ -13,4 +13,9 @@ describe('hashForSchema', () => {
   it('returns a hash for a more complex schema', () => {
     expect(hashForSchema(RECURSIVE_REF)).toMatchSnapshot();
   });
+  it('returns same hash for two schemas but fields are different order', () => {
+    const schema1: RJSFSchema = { type: 'string', title: 'order' };
+    const schema2: RJSFSchema = { title: 'order', type: 'string' };
+    expect(hashForSchema(schema1)).toBe(hashForSchema(schema2));
+  });
 });

--- a/packages/utils/test/parser/__snapshots__/schemaParser.test.ts.snap
+++ b/packages/utils/test/parser/__snapshots__/schemaParser.test.ts.snap
@@ -1,5 +1,100 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`schemaParser() parse schema with allof not able to merge 1`] = `
+Object {
+  "-44c06f09": Object {
+    "$id": "-44c06f09",
+    "allOf": Array [
+      Object {
+        "if": Object {
+          "properties": Object {
+            "animal": Object {
+              "const": "Cat",
+            },
+          },
+        },
+        "then": Object {
+          "properties": Object {
+            "food": Object {
+              "enum": Array [
+                "meat",
+                "grass",
+                "fish",
+              ],
+              "type": "string",
+            },
+          },
+          "required": Array [
+            "food",
+          ],
+        },
+      },
+      Object {
+        "if": Object {
+          "properties": Object {
+            "animal": Object {
+              "const": "Fish",
+            },
+          },
+        },
+        "then": Object {
+          "properties": Object {
+            "food": Object {
+              "enum": Array [
+                "insect",
+                "worms",
+              ],
+              "type": "string",
+            },
+            "water": Object {
+              "enum": Array [
+                "lake",
+                "sea",
+              ],
+              "type": "string",
+            },
+          },
+          "required": Array [
+            "food",
+            "water",
+          ],
+        },
+      },
+      Object {
+        "required": Array [
+          "animal",
+        ],
+      },
+    ],
+    "properties": Object {
+      "animal": Object {
+        "enum": Array [
+          "Cat",
+          "Fish",
+        ],
+      },
+    },
+    "type": "object",
+  },
+  "59fefb6e": Object {
+    "$id": "59fefb6e",
+    "properties": Object {
+      "animal": Object {
+        "const": "Fish",
+      },
+    },
+  },
+  "6f438756": Object {
+    "$id": "6f438756",
+    "properties": Object {
+      "animal": Object {
+        "const": "Cat",
+      },
+    },
+  },
+}
+`;
+
 exports[`schemaParser() parse schema with array condition 1`] = `
 Object {
   "-33d8d73c": Object {
@@ -10,8 +105,8 @@ Object {
       },
     },
   },
-  "240a61a6": Object {
-    "$id": "240a61a6",
+  "f254d0a": Object {
+    "$id": "f254d0a",
     "properties": Object {
       "list": Object {
         "items": Object {
@@ -57,8 +152,8 @@ Object {
 
 exports[`schemaParser() parses property dependencies properly 1`] = `
 Object {
-  "2c34081c": Object {
-    "$id": "2c34081c",
+  "-4e612676": Object {
+    "$id": "-4e612676",
     "dependencies": Object {
       "a": Array [
         "b",
@@ -82,8 +177,8 @@ Object {
 
 exports[`schemaParser() parses recursive refs in allOf properly 1`] = `
 Object {
-  "3d2b22a": Object {
-    "$id": "3d2b22a",
+  "2b3d97f8": Object {
+    "$id": "2b3d97f8",
     "definitions": Object {
       "@enum": Object {
         "properties": Object {
@@ -131,8 +226,8 @@ Object {
 
 exports[`schemaParser() parses recursive refs properly 1`] = `
 Object {
-  "-6bbb062a": Object {
-    "$id": "-6bbb062a",
+  "7cf4cd8a": Object {
+    "$id": "7cf4cd8a",
     "$ref": "#/definitions/@enum",
     "definitions": Object {
       "@enum": Object {
@@ -155,8 +250,8 @@ Object {
 
 exports[`schemaParser() parses schema and required dependencies properly 1`] = `
 Object {
-  "-a54479e": Object {
-    "$id": "-a54479e",
+  "-738b34fc": Object {
+    "$id": "-738b34fc",
     "dependencies": Object {
       "a": Object {
         "properties": Object {
@@ -187,8 +282,8 @@ Object {
 
 exports[`schemaParser() parses schema dependencies properly 1`] = `
 Object {
-  "-77e20f4b": Object {
-    "$id": "-77e20f4b",
+  "75f1f611": Object {
+    "$id": "75f1f611",
     "dependencies": Object {
       "a": Object {
         "properties": Object {
@@ -210,8 +305,30 @@ Object {
 
 exports[`schemaParser() parses schema dependencies with one of and refs properly 1`] = `
 Object {
-  "-6ae1f7c2": Object {
-    "$id": "-6ae1f7c2",
+  "-29b1244f": Object {
+    "$id": "-29b1244f",
+    "properties": Object {
+      "a": Object {
+        "enum": Array [
+          "int",
+        ],
+      },
+    },
+    "type": "object",
+  },
+  "71dd1668": Object {
+    "$id": "71dd1668",
+    "properties": Object {
+      "a": Object {
+        "enum": Array [
+          "bool",
+        ],
+      },
+    },
+    "type": "object",
+  },
+  "7de97d9a": Object {
+    "$id": "7de97d9a",
     "definitions": Object {
       "needsA": Object {
         "properties": Object {
@@ -261,28 +378,6 @@ Object {
     },
     "type": "object",
   },
-  "-72b37ea6": Object {
-    "$id": "-72b37ea6",
-    "properties": Object {
-      "a": Object {
-        "enum": Array [
-          "bool",
-        ],
-      },
-    },
-    "type": "object",
-  },
-  "-a4bd7cf": Object {
-    "$id": "-a4bd7cf",
-    "properties": Object {
-      "a": Object {
-        "enum": Array [
-          "int",
-        ],
-      },
-    },
-    "type": "object",
-  },
 }
 `;
 
@@ -296,8 +391,8 @@ Object {
       },
     },
   },
-  "76bba80f": Object {
-    "$id": "76bba80f",
+  "7a88ed97": Object {
+    "$id": "7a88ed97",
     "else": Object {
       "properties": Object {
         "postal_code": Object {
@@ -335,30 +430,8 @@ Object {
 
 exports[`schemaParser() parses schema with multiple conditions 1`] = `
 Object {
-  "-36b03e42": Object {
-    "$id": "-36b03e42",
-    "properties": Object {
-      "BreedName": Object {
-        "const": "Alsatian",
-      },
-    },
-    "required": Array [
-      "BreedName",
-    ],
-  },
-  "-d94a755": Object {
-    "$id": "-d94a755",
-    "properties": Object {
-      "Animal": Object {
-        "const": "Cat",
-      },
-    },
-    "required": Array [
-      "Animal",
-    ],
-  },
-  "3e7e3b11": Object {
-    "$id": "3e7e3b11",
+  "-269ce7ef": Object {
+    "$id": "-269ce7ef",
     "properties": Object {
       "Animal": Object {
         "const": "Dog",
@@ -368,8 +441,8 @@ Object {
       "Animal",
     ],
   },
-  "5b44d8ca": Object {
-    "$id": "5b44d8ca",
+  "-5e82ba72": Object {
+    "$id": "-5e82ba72",
     "properties": Object {
       "BreedName": Object {
         "const": "Dalmation",
@@ -379,8 +452,8 @@ Object {
       "BreedName",
     ],
   },
-  "7f2647ff": Object {
-    "$id": "7f2647ff",
+  "-61d82723": Object {
+    "$id": "-61d82723",
     "allOf": Array [
       Object {
         "if": Object {
@@ -519,6 +592,28 @@ Object {
     ],
     "type": "object",
   },
+  "-7b9d5dae": Object {
+    "$id": "-7b9d5dae",
+    "properties": Object {
+      "BreedName": Object {
+        "const": "Alsatian",
+      },
+    },
+    "required": Array [
+      "BreedName",
+    ],
+  },
+  "6dc2a62b": Object {
+    "$id": "6dc2a62b",
+    "properties": Object {
+      "Animal": Object {
+        "const": "Cat",
+      },
+    },
+    "required": Array [
+      "Animal",
+    ],
+  },
 }
 `;
 
@@ -546,8 +641,19 @@ Object {
       "country",
     ],
   },
-  "2d21fc3e": Object {
-    "$id": "2d21fc3e",
+  "5ad8e931": Object {
+    "$id": "5ad8e931",
+    "properties": Object {
+      "state": Object {
+        "const": "California",
+      },
+    },
+    "required": Array [
+      "state",
+    ],
+  },
+  "767ff7c6": Object {
+    "$id": "767ff7c6",
     "if": Object {
       "properties": Object {
         "country": Object {
@@ -630,33 +736,13 @@ Object {
     },
     "type": "object",
   },
-  "5ad8e931": Object {
-    "$id": "5ad8e931",
-    "properties": Object {
-      "state": Object {
-        "const": "California",
-      },
-    },
-    "required": Array [
-      "state",
-    ],
-  },
 }
 `;
 
 exports[`schemaParser() parses schema with oneof and nested dependencies 1`] = `
 Object {
-  "-1b756c98": Object {
-    "$id": "-1b756c98",
-    "properties": Object {
-      "employee_accounts": Object {
-        "const": true,
-      },
-    },
-    "type": "object",
-  },
-  "-29fab89": Object {
-    "$id": "-29fab89",
+  "-37c29d49": Object {
+    "$id": "-37c29d49",
     "properties": Object {
       "update_absences": Object {
         "const": "NON_MEDICAL_ONLY",
@@ -664,31 +750,8 @@ Object {
     },
     "type": "object",
   },
-  "-5773f6db": Object {
-    "$id": "-5773f6db",
-    "properties": Object {
-      "update_absences": Object {
-        "const": "MEDICAL_ONLY",
-      },
-    },
-    "type": "object",
-  },
-  "2638e86c": Object {
-    "$id": "2638e86c",
-    "properties": Object {
-      "update_absences": Object {
-        "const": "BOTH",
-      },
-    },
-    "type": "object",
-  },
-  "2ef9c4e1": Object {
-    "$id": "2ef9c4e1",
-    "const": "BOTH",
-    "title": "Both",
-  },
-  "5269a07e": Object {
-    "$id": "5269a07e",
+  "-406a5a54": Object {
+    "$id": "-406a5a54",
     "dependencies": Object {
       "employee_accounts": Object {
         "oneOf": Array [
@@ -757,13 +820,45 @@ Object {
     },
     "type": "object",
   },
+  "-7a6dd81b": Object {
+    "$id": "-7a6dd81b",
+    "properties": Object {
+      "update_absences": Object {
+        "const": "MEDICAL_ONLY",
+      },
+    },
+    "type": "object",
+  },
+  "-7c3c9229": Object {
+    "$id": "-7c3c9229",
+    "const": "BOTH",
+    "title": "Both",
+  },
+  "3a28e528": Object {
+    "$id": "3a28e528",
+    "properties": Object {
+      "employee_accounts": Object {
+        "const": true,
+      },
+    },
+    "type": "object",
+  },
+  "934b22c": Object {
+    "$id": "934b22c",
+    "properties": Object {
+      "update_absences": Object {
+        "const": "BOTH",
+      },
+    },
+    "type": "object",
+  },
 }
 `;
 
 exports[`schemaParser() parses superSchema properly 1`] = `
 Object {
-  "-1a32fe51": Object {
-    "$id": "-1a32fe51",
+  "-130bae51": Object {
+    "$id": "-130bae51",
     "anyOf": Array [
       Object {
         "required": Array [
@@ -778,8 +873,8 @@ Object {
     },
     "type": "object",
   },
-  "-48288a90": Object {
-    "$id": "-48288a90",
+  "-1e3c57ec": Object {
+    "$id": "-1e3c57ec",
     "anyOf": Array [
       Object {
         "required": Array [
@@ -803,8 +898,8 @@ Object {
     },
     "type": "object",
   },
-  "4aa7be7e": Object {
-    "$id": "4aa7be7e",
+  "-42566fe2": Object {
+    "$id": "-42566fe2",
     "anyOf": Array [
       Object {
         "required": Array [

--- a/packages/utils/test/parser/schemaParser.test.ts
+++ b/packages/utils/test/parser/schemaParser.test.ts
@@ -4,6 +4,7 @@ import {
   RECURSIVE_REF,
   RECURSIVE_REF_ALLOF,
   SCHEMA_DEPENDENCIES,
+  SCHEMA_WITH_ALLOF_CANNOT_MERGE,
   SCHEMA_AND_ONEOF_REF_DEPENDENCIES,
   SCHEMA_AND_REQUIRED_DEPENDENCIES,
   SCHEMA_WITH_ARRAY_CONDITION,
@@ -61,6 +62,10 @@ describe('schemaParser()', () => {
   });
   it('parse schema with array condition', () => {
     const schemaMap = schemaParser(SCHEMA_WITH_ARRAY_CONDITION);
+    expect(schemaMap).toMatchSnapshot();
+  });
+  it('parse schema with allof not able to merge', () => {
+    const schemaMap = schemaParser(SCHEMA_WITH_ALLOF_CANNOT_MERGE);
     expect(schemaMap).toMatchSnapshot();
   });
 });

--- a/packages/utils/test/testUtils/testData.ts
+++ b/packages/utils/test/testUtils/testData.ts
@@ -795,3 +795,57 @@ export const SCHEMA_WITH_ARRAY_CONDITION: RJSFSchema = {
     },
   },
 };
+
+export const SCHEMA_WITH_ALLOF_CANNOT_MERGE: RJSFSchema = {
+  type: 'object',
+  properties: {
+    animal: {
+      enum: ['Cat', 'Fish'],
+    },
+  },
+  allOf: [
+    {
+      if: {
+        properties: {
+          animal: {
+            const: 'Cat',
+          },
+        },
+      },
+      then: {
+        properties: {
+          food: {
+            type: 'string',
+            enum: ['meat', 'grass', 'fish'],
+          },
+        },
+        required: ['food'],
+      },
+    },
+    {
+      if: {
+        properties: {
+          animal: {
+            const: 'Fish',
+          },
+        },
+      },
+      then: {
+        properties: {
+          food: {
+            type: 'string',
+            enum: ['insect', 'worms'],
+          },
+          water: {
+            type: 'string',
+            enum: ['lake', 'sea'],
+          },
+        },
+        required: ['food', 'water'],
+      },
+    },
+    {
+      required: ['animal'],
+    },
+  ],
+};


### PR DESCRIPTION
### Reasons for making this change

fixes #3700 when mergeAllOf fails for compiled schema still return all of the sub schemas to be resolved.

This also fixes issue where `hashForSchema` is not consistent for the same schema but fields are in a different order.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
