### PR TITLE
fix 3711 anyOf/oneOf remove old fields from previous schema

### DIFF
--- a/packages/core/test/oneOf.test.jsx
+++ b/packages/core/test/oneOf.test.jsx
@@ -1228,7 +1228,7 @@ describe('oneOf', () => {
 
     sinon.assert.calledWithMatch(onChange.lastCall, {
       formData: {
-        craftTypes: [{ keywords: [undefined], title: undefined, daysOfYear: undefined }],
+        craftTypes: [{ keywords: [undefined], title: undefined }],
       },
     });
   });

--- a/packages/utils/src/schema/sanitizeDataForNewSchema.ts
+++ b/packages/utils/src/schema/sanitizeDataForNewSchema.ts
@@ -1,5 +1,7 @@
 import get from 'lodash/get';
 import has from 'lodash/has';
+import omitBy from 'lodash/omitBy';
+import isUndefined from 'lodash/isUndefined';
 
 import { FormContextType, GenericObjectType, RJSFSchema, StrictRJSFSchema, ValidatorType } from '../types';
 import { PROPERTIES_KEY, REF_KEY } from '../constants';
@@ -137,8 +139,14 @@ export default function sanitizeDataForNewSchema<
     });
 
     newFormData = {
-      ...data,
-      ...removeOldSchemaData,
+      // remove fields from old schema and then sanitize undefined
+      ...omitBy(
+        {
+          ...data,
+          ...removeOldSchemaData,
+        },
+        isUndefined
+      ),
       ...nestedData,
     };
     // First apply removing the old schema data, then apply the nested data, then apply the old data keys to keep


### PR DESCRIPTION
### Reasons for making this change

Fixes #3711 - removing old undefined fields when switching to different oneOf/anyOf schema

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
