### PR TITLE
Fix #3716

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated `resolveCondition` to default formData as empty object when evaluating if expression, fixing [#3706](https://github.com/rjsf-team/react-jsonschema-form/issues/3706)
 - Updated `retrieveSchemaInternal` to return failed merged allOf sub schemas for expandAllBranches flag, fixing [#3689](https://github.com/rjsf-team/react-jsonschema-form/issues/3700)
 - Updated `hashForSchema` to sort schema fields in consistent order before stringify to prevent different hash ids for the same schema
+- Updated `enumOptionsSelectValue` to allow picking falsy enumOptions, fixing [#3716](https://github.com/rjsf-team/react-jsonschema-form/issues/3716)
 
 ## @rjsf/bootstrap-4
 

--- a/packages/utils/src/enumOptionsSelectValue.ts
+++ b/packages/utils/src/enumOptionsSelectValue.ts
@@ -1,5 +1,6 @@
 import { EnumOptionsType, RJSFSchema, StrictRJSFSchema } from './types';
 import enumOptionsValueForIndex from './enumOptionsValueForIndex';
+import { isNil } from 'lodash';
 
 /** Add the enum option value at the `valueIndex` to the list of `selected` values in the proper order as defined by
  * `allEnumOptions`
@@ -15,7 +16,7 @@ export default function enumOptionsSelectValue<S extends StrictRJSFSchema = RJSF
   allEnumOptions: EnumOptionsType<S>[] = []
 ) {
   const value = enumOptionsValueForIndex<S>(valueIndex, allEnumOptions);
-  if (value) {
+  if (!isNil(value)) {
     const index = allEnumOptions.findIndex((opt) => value === opt.value);
     const all = allEnumOptions.map(({ value: val }) => val);
     const updated = selected.slice(0, index).concat(value, selected.slice(index));

--- a/packages/utils/test/enumOptionsSelectValue.test.ts
+++ b/packages/utils/test/enumOptionsSelectValue.test.ts
@@ -1,5 +1,5 @@
 import { enumOptionsSelectValue, EnumOptionsType } from '../src';
-import { ALL_OPTIONS } from './testUtils/testData';
+import { ALL_OPTIONS, FALSY_OPTIONS } from './testUtils/testData';
 
 describe('enumOptionsSelectValue()', () => {
   let selected: EnumOptionsType['value'][];
@@ -32,5 +32,14 @@ describe('enumOptionsSelectValue()', () => {
   });
   it('returns the selected array unchanged when options are missing', () => {
     expect(enumOptionsSelectValue(0, selected)).toBe(selected);
+  });
+  it('handles falsy values', () => {
+    selected = [];
+    const expected: any[] = [];
+    FALSY_OPTIONS.forEach((option, index) => {
+      expected.push(option.value);
+      selected = enumOptionsSelectValue(index, selected, FALSY_OPTIONS);
+      expect(selected).toStrictEqual(expected);
+    });
   });
 });

--- a/packages/utils/test/testUtils/testData.ts
+++ b/packages/utils/test/testUtils/testData.ts
@@ -285,6 +285,11 @@ export const ALL_OPTIONS: EnumOptionsType[] = [
   { value: 'boo', label: 'Boo' },
 ];
 
+export const FALSY_OPTIONS: EnumOptionsType[] = [
+  { value: '', label: 'Empty String' },
+  { value: 0, label: 'Zero' },
+];
+
 export const RECURSIVE_REF_ALLOF: RJSFSchema = {
   definitions: {
     '@enum': {


### PR DESCRIPTION
Fix #3716
- Non-null falsy enum options should still be selectable

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

If your PR is non-trivial and you'd like to schedule a synchronous review, please add it to the weekly meeting agenda: https://docs.google.com/document/d/12PjTvv21k6LIky6bNQVnsplMLLnmEuypTLQF8a-8Wss/edit

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
