### PR TITLE
fix 3693 and 3705 anyOf/oneOf select correct schema index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
+- Updated `getClosestMatchingOption` to return selected option if all options score the same, fixing [#3693](https://github.com/rjsf-team/react-jsonschema-form/issues/3693) and [#3705](https://github.com/rjsf-team/react-jsonschema-form/issues/3705)
 - Updated `resolveCondition` to default formData as empty object when evaluating if expression, fixing [#3706](https://github.com/rjsf-team/react-jsonschema-form/issues/3706)
 - Updated `retrieveSchemaInternal` to return failed merged allOf sub schemas for expandAllBranches flag, fixing [#3689](https://github.com/rjsf-team/react-jsonschema-form/issues/3700)
 - Updated `hashForSchema` to sort schema fields in consistent order before stringify to prevent different hash ids for the same schema
@@ -56,6 +57,8 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 
 - Updated SchemaField to be able to render markdown in the description field
+- Updated `MultiSchemaField.getMatchingOption` to use option index from `getClosestMatchingOption`, fixing [#3693](https://github.com/rjsf-team/react-jsonschema-form/issues/3693) and
+[#3705](https://github.com/rjsf-team/react-jsonschema-form/issues/3705)
 
 ## Dev / docs / playground
 

--- a/packages/core/src/components/fields/MultiSchemaField.tsx
+++ b/packages/core/src/components/fields/MultiSchemaField.tsx
@@ -98,12 +98,7 @@ class AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
 
     const discriminator = getDiscriminatorFieldFromSchema<S>(schema);
     const option = schemaUtils.getClosestMatchingOption(formData, options, selectedOption, discriminator);
-    if (option > 0) {
-      return option;
-    }
-    // If the form data matches none of the options, use the currently selected
-    // option, assuming it's available; otherwise use the first option
-    return selectedOption || 0;
+    return option;
   }
 
   /** Callback handler to remember what the currently selected option is. In addition to that the `formData` is updated

--- a/packages/utils/src/schema/getClosestMatchingOption.ts
+++ b/packages/utils/src/schema/getClosestMatchingOption.ts
@@ -152,6 +152,7 @@ export default function getClosestMatchingOption<
     times(options.length, (i) => allValidIndexes.push(i));
   }
   type BestType = { bestIndex: number; bestScore: number };
+  const scoreCount = new Set<number>();
   // Score all the options in the list of valid indexes and return the index with the best score
   const { bestIndex }: BestType = allValidIndexes.reduce(
     (scoreData: BestType, index: number) => {
@@ -161,6 +162,7 @@ export default function getClosestMatchingOption<
         option = retrieveSchema<T, S, F>(validator, option, rootSchema, formData);
       }
       const score = calculateIndexScore(validator, rootSchema, option, formData);
+      scoreCount.add(score);
       if (score > bestScore) {
         return { bestIndex: index, bestScore: score };
       }
@@ -168,5 +170,10 @@ export default function getClosestMatchingOption<
     },
     { bestIndex: selectedOption, bestScore: 0 }
   );
+  // if all scores are the same go with selectedOption
+  if (scoreCount.size === 1 && selectedOption >= 0) {
+    return selectedOption;
+  }
+
   return bestIndex;
 }


### PR DESCRIPTION
### Reasons for making this change

Fixes #3693 and #3705 - Update `MultiSchemaField.getMatchingOption` use option index from `getClosestMatchingOption` and then have `getClosestMatchingOption` return selected option if all options have same score.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
