### PR TITLE
Cache schemas by explicit ID in AJV8Validator.isValid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.8.2
+
+## @rjsf/validator-ajv8
+
+- Explicitly cache schemas by their hash when checking data is valid to avoid multiple compilations for schemas without IDs leading to poor performance [#3721](https://github.com/rjsf-team/react-jsonschema-form/pull/3721)
 
 # 5.8.1
 

--- a/packages/validator-ajv8/src/validator.ts
+++ b/packages/validator-ajv8/src/validator.ts
@@ -138,16 +138,15 @@ export default class AJV8Validator<T = any, S extends StrictRJSFSchema = RJSFSch
         this.ajv.addSchema(rootSchema, rootSchemaId);
       }
       const schemaWithIdRefPrefix = withIdRefPrefix<S>(schema) as S;
-      const schemaHash = hashForSchema(schemaWithIdRefPrefix);
+      const schemaId = schemaWithIdRefPrefix[ID_KEY] ?? hashForSchema(schemaWithIdRefPrefix);
       let compiledValidator: ValidateFunction | undefined;
-      if (schemaWithIdRefPrefix[ID_KEY]) {
-        compiledValidator = this.ajv.getSchema(schemaWithIdRefPrefix[ID_KEY]);
-      } else {
-        compiledValidator = this.ajv.getSchema(schemaHash);
-      }
+      compiledValidator = this.ajv.getSchema(schemaId);
       if (compiledValidator === undefined) {
+        // Add schema by an explicit ID so it can be fetched later
+        // Fall back to using compile if necessary
+        // https://ajv.js.org/guide/managing-schemas.html#pre-adding-all-schemas-vs-adding-on-demand
         compiledValidator =
-          this.ajv.addSchema(schemaWithIdRefPrefix, schemaHash).getSchema(schemaHash) ||
+          this.ajv.addSchema(schemaWithIdRefPrefix, schemaId).getSchema(schemaId) ||
           this.ajv.compile(schemaWithIdRefPrefix);
       }
       const result = compiledValidator(formData);

--- a/packages/validator-ajv8/src/validator.ts
+++ b/packages/validator-ajv8/src/validator.ts
@@ -13,6 +13,7 @@ import {
   ValidationData,
   ValidatorType,
   withIdRefPrefix,
+  hashForSchema,
 } from '@rjsf/utils';
 
 import { CustomValidatorOptionsType, Localizer } from './types';
@@ -137,12 +138,17 @@ export default class AJV8Validator<T = any, S extends StrictRJSFSchema = RJSFSch
         this.ajv.addSchema(rootSchema, rootSchemaId);
       }
       const schemaWithIdRefPrefix = withIdRefPrefix<S>(schema) as S;
+      const schemaHash = hashForSchema(schemaWithIdRefPrefix);
       let compiledValidator: ValidateFunction | undefined;
       if (schemaWithIdRefPrefix[ID_KEY]) {
         compiledValidator = this.ajv.getSchema(schemaWithIdRefPrefix[ID_KEY]);
+      } else {
+        compiledValidator = this.ajv.getSchema(schemaHash);
       }
       if (compiledValidator === undefined) {
-        compiledValidator = this.ajv.compile(schemaWithIdRefPrefix);
+        compiledValidator =
+          this.ajv.addSchema(schemaWithIdRefPrefix, schemaHash).getSchema(schemaHash) ||
+          this.ajv.compile(schemaWithIdRefPrefix);
       }
       const result = compiledValidator(formData);
       return result as boolean;


### PR DESCRIPTION
### Reasons for making this change

fixes #3692

For allOf/anyOf schemas, subschemas are compiled each time they are encountered if they lack an $id field. This can create poor performance for large lists or recursive refs. Leveraging the ajv cache to cache subschemas that have been encountered before greatly improves performance.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
