### PR TITLE
fix: bug fix and new feature for experimental_defaultFormStateBehavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
-# 5.8.3
+# 5.9.0
 
 ## @rjsf/utils
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,23 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.8.3
+
+## @rjsf/utils
+
+- Updated `getDefaultFormState()` to fix a bug where `experimental_defaultFormStateBehavior: { emptyObjectFields: 'populateRequiredDefaults' }` wasn't working for object properties with `$ref`s
+- Experimental feature **breaking change**:
+  - Updated the `experimental_defaultFormStateBehavior.arrayMinItems` from simple flag to an object containing two optional fields, `populate` and `mergeExtraDefaults`
+    - The new `arrayMinItems.mergeExtraDefaults` flag, when "true", allows users to merge defaults onto the end of `formData` arrays when `minItems` is specified
+  - If you were previously passing `experimental_defaultFormStateBehavior` as `{ arrayMinItems = 'requiredOnly }` on the `Form`, now you would pass `{ arrayMinItems: { populate: 'requiredOnly' } }`
+- Added a new, optional `mergeExtraArrayDefaults=false` flag to the `mergeDefaultWithFormData()` utility function to support the new `arrayMinItems.mergeExtraDefaults` experimental feature
+
+## Dev / docs / playground
+
+- Updated the `utility-functions` documentation to add the new `mergeExtraArrayDefaults` flag for the `mergeDefaultWithFormData()` function
+- Updated the `form-props` documentation to update the `arrayMinItems` documentation for the new object behavior
+- Updated the `playground` to add a checkbox for the new `arrayMinItems.mergeExtraDefaults` flag 
+
 # 5.8.2
 
 ## @rjsf/validator-ajv8

--- a/packages/core/test/Form.test.jsx
+++ b/packages/core/test/Form.test.jsx
@@ -1416,7 +1416,7 @@ describeRepeated('Form common', (createFormComponent) => {
         formData: {
           albums: ['Until We Have Faces'],
         },
-        experimental_defaultFormStateBehavior: { arrayMinItems: 'requiredOnly' },
+        experimental_defaultFormStateBehavior: { arrayMinItems: { populate: 'requiredOnly' } },
       });
       submitForm(node);
       sinon.assert.calledWithMatch(onError.lastCall, [
@@ -1434,7 +1434,7 @@ describeRepeated('Form common', (createFormComponent) => {
       const { node, onSubmit } = createFormComponent({
         schema,
         formData: {},
-        experimental_defaultFormStateBehavior: { arrayMinItems: 'requiredOnly' },
+        experimental_defaultFormStateBehavior: { arrayMinItems: { populate: 'requiredOnly' } },
       });
       submitForm(node);
       sinon.assert.calledWithMatch(onSubmit.lastCall, { formData: {} });

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -61,24 +61,41 @@ See [Validation](../usage/validation.md) for more information.
 
 ## experimental_defaultFormStateBehavior
 
-Experimental features to specify different form state behavior. Currently, this only affects the handling of optional array fields where `minItems` is set.
+Experimental features to specify different form state behavior.
+Currently, this only affects the handling of optional array fields where `minItems` is set and handling of setting defaults based on the value of `emptyObjectFields`.
 
-The following sub-sections represent the different keys in this object, with the tables explaining the values and their meanings.
+The following subsections represent the different keys in this object, with the tables explaining the values and their meanings.
 
 ### `arrayMinItems`
 
-| Flag Value     | Description                                                                                                                        |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `populate`     | Legacy behavior - populate minItems entries with default values initially and include empty array when no values have been defined |
-| `requiredOnly` | Ignore `minItems` on a field when calculating defaults unless the field is required                                                |
+This optional subsection is an object with two optional fields, `populate` and `mergeExtraDefaults`.
+When not specified, it defaults to `{ populate: 'all', mergeExtraDefaults: false }`.
+
+#### `arrayMinItems.populate`
+
+Optional enumerated flag controlling how array minItems are populated, defaulting to `all`:
+
+| Flag Value     | Description                                                                                                                         |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `all`          | Legacy behavior - populate minItems entries with default values initially and include empty array when no values have been defined. |
+| `requiredOnly` | Ignore `minItems` on a field when calculating defaults unless the field is required.                                                |
+
+#### `arrayMinItems.mergeExtraDefaults`
+
+Optional boolean flag, defaulting to `false` when not specified.
+When `formData` is provided and does not contain `minItems` worth of data, this flag controls whether the extra data provided by the defaults is appended onto the existing `formData` items to ensure the `minItems` condition is met.
+When `false`, only the `formData` provided is merged into the default form state, even if there are fewer than the `minItems`.
+When `true`, the defaults are appended onto the end of the `formData` until the `minItems` condition is met.
 
 ### `emptyObjectFields`
 
-| Flag Value                 | Description                                                                                                                |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `populateAllDefaults`      | Legacy behavior - set default when there is a primitive value, an non-empty object field, or the field itself is required  |
-| `populateRequiredDefaults` | Only sets default when a value is an object and its parent field is required or it is a primitive value and it is required |
-| `skipDefaults`             | Does not set defaults                                                                                                      |
+Optional enumerated flag controlling how empty object fields are populated, defaulting to `populateAllDefaults`:
+
+| Flag Value                 | Description                                                                                                                 |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `populateAllDefaults`      | Legacy behavior - set default when there is a primitive value, an non-empty object field, or the field itself is required   |
+| `populateRequiredDefaults` | Only sets default when a value is an object and its parent field is required, or it is a primitive value and it is required |
+| `skipDefaults`             | Does not set defaults                                                                                                       |
 
 ```tsx
 import { RJSFSchema } from '@rjsf/utils';
@@ -95,7 +112,7 @@ render(
     schema={schema}
     validator={validator}
     experimental_defaultFormStateBehavior={{
-      arrayMinItems: 'requiredOnly',
+      arrayMinItems: { populate: 'requiredOnly' },
     }}
   />,
   document.getElementById('app')

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -84,7 +84,7 @@ Optional enumerated flag controlling how array minItems are populated, defaultin
 
 Optional boolean flag, defaulting to `false` when not specified.
 When `formData` is provided and does not contain `minItems` worth of data, this flag controls whether the extra data provided by the defaults is appended onto the existing `formData` items to ensure the `minItems` condition is met.
-When `false`, only the `formData` provided is merged into the default form state, even if there are fewer than the `minItems`.
+When `false` (legacy behavior), only the `formData` provided is merged into the default form state, even if there are fewer than the `minItems`.
 When `true`, the defaults are appended onto the end of the `formData` until the `minItems` condition is met.
 
 ### `emptyObjectFields`

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -64,6 +64,8 @@ See [Validation](../usage/validation.md) for more information.
 Experimental features to specify different form state behavior.
 Currently, this only affects the handling of optional array fields where `minItems` is set and handling of setting defaults based on the value of `emptyObjectFields`.
 
+> **Warning:** This API is experimental and unstable, therefore breaking changes may be shipped in minor or patch releases. If you want to use this feature, we recommend pinning exact versions of `@rjsf/\*` packages in your package.json file or be ready to update your use of it when necessary.
+
 The following subsections represent the different keys in this object, with the tables explaining the values and their meanings.
 
 ### `arrayMinItems`

--- a/packages/docs/docs/api-reference/utility-functions.md
+++ b/packages/docs/docs/api-reference/utility-functions.md
@@ -516,7 +516,7 @@ When merging defaults and form data, we want to merge in this specific way:
 
 - objects are deeply merged
 - arrays are merged in such a way that:
-  - when the array is set in form data, only array entries set in form data are deeply merged; additional entries from the defaults are ignored
+  - when the array is set in form data, only array entries set in form data are deeply merged; additional entries from the defaults are ignored unless `mergeExtraArrayDefaults` is true, in which case the extras are appended onto the end of the form data
   - when the array is not set in form data, the default is copied over
 - scalars are overwritten/set by form data
 
@@ -524,6 +524,7 @@ When merging defaults and form data, we want to merge in this specific way:
 
 - [defaults]: T | undefined - The defaults to merge
 - [formData]: T | undefined - The form data into which the defaults will be merged
+- [mergeExtraArrayDefaults=false]: boolean - If true, any additional default array entries are appended onto the formData
 
 #### Returns
 

--- a/packages/playground/src/components/Header.tsx
+++ b/packages/playground/src/components/Header.tsx
@@ -79,21 +79,31 @@ const liveSettingsSelectSchema: RJSFSchema = {
       type: 'object',
       properties: {
         arrayMinItems: {
-          type: 'string',
-          title: 'minItems behavior for array field',
-          default: 'populate',
-          oneOf: [
-            {
+          type: 'object',
+          properties: {
+            populate: {
               type: 'string',
-              title: 'Populate remaining minItems with default values (legacy behavior)',
-              enum: ['populate'],
+              default: 'populate',
+              title: 'Populate minItems in arrays',
+              oneOf: [
+                {
+                  type: 'string',
+                  title: 'Populate remaining minItems with default values (legacy behavior)',
+                  enum: ['all'],
+                },
+                {
+                  type: 'string',
+                  title: 'Ignore minItems unless field is required',
+                  enum: ['requiredOnly'],
+                },
+              ],
             },
-            {
-              type: 'string',
-              title: 'Ignore minItems unless field is required',
-              enum: ['requiredOnly'],
+            mergeExtraDefaults: {
+              title: 'Merge array defaults with formData',
+              type: 'boolean',
+              default: false,
             },
-          ],
+          },
         },
         emptyObjectFields: {
           type: 'string',
@@ -128,6 +138,11 @@ const liveSettingsSelectUiSchema: UiSchema = {
   experimental_defaultFormStateBehavior: {
     'ui:options': {
       label: false,
+    },
+    arrayMinItems: {
+      'ui:options': {
+        label: false,
+      },
     },
   },
 };

--- a/packages/utils/src/mergeDefaultsWithFormData.ts
+++ b/packages/utils/src/mergeDefaultsWithFormData.ts
@@ -9,29 +9,43 @@ import { GenericObjectType } from '../src';
  * - objects are deeply merged
  * - arrays are merged in such a way that:
  *   - when the array is set in form data, only array entries set in form data
- *     are deeply merged; additional entries from the defaults are ignored
+ *     are deeply merged; additional entries from the defaults are ignored unless `mergeExtraArrayDefaults` is true, in
+ *     which case the extras are appended onto the end of the form data
  *   - when the array is not set in form data, the default is copied over
  * - scalars are overwritten/set by form data
  *
  * @param [defaults] - The defaults to merge
  * @param [formData] - The form data into which the defaults will be merged
+ * @param [mergeExtraArrayDefaults=false] - If true, any additional default array entries are appended onto the formData
  * @returns - The resulting merged form data with defaults
  */
-export default function mergeDefaultsWithFormData<T = any>(defaults?: T, formData?: T): T | undefined {
+export default function mergeDefaultsWithFormData<T = any>(
+  defaults?: T,
+  formData?: T,
+  mergeExtraArrayDefaults = false
+): T | undefined {
   if (Array.isArray(formData)) {
     const defaultsArray = Array.isArray(defaults) ? defaults : [];
     const mapped = formData.map((value, idx) => {
       if (defaultsArray[idx]) {
-        return mergeDefaultsWithFormData<any>(defaultsArray[idx], value);
+        return mergeDefaultsWithFormData<any>(defaultsArray[idx], value, mergeExtraArrayDefaults);
       }
       return value;
     });
+    // Merge any extra defaults when mergeExtraArrayDefaults is true
+    if (mergeExtraArrayDefaults && mapped.length < defaultsArray.length) {
+      mapped.push(...defaultsArray.slice(mapped.length));
+    }
     return mapped as unknown as T;
   }
   if (isObject(formData)) {
     const acc: { [key in keyof T]: any } = Object.assign({}, defaults); // Prevent mutation of source object.
     return Object.keys(formData as GenericObjectType).reduce((acc, key) => {
-      acc[key as keyof T] = mergeDefaultsWithFormData<T>(defaults ? get(defaults, key) : {}, get(formData, key));
+      acc[key as keyof T] = mergeDefaultsWithFormData<T>(
+        defaults ? get(defaults, key) : {},
+        get(formData, key),
+        mergeExtraArrayDefaults
+      );
       return acc;
     }, acc);
   }

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -31,12 +31,40 @@ export type RJSFSchema = StrictRJSFSchema & GenericObjectType;
  */
 export type FormContextType = GenericObjectType;
 
-/** Experimental features to specify different form state behavior. Currently, this affects the
+/** Experimental feature that specifies the Array `minItems` default form state behavior
+ */
+export type Experimental_ArrayMinItems = {
+  /** Optional enumerated flag controlling how array minItems are populated, defaulting to `all`:
+   * - `all`: Legacy behavior, populate minItems entries with default values initially and include an empty array when
+   *        no values have been defined.
+   * - `requiredOnly`: Ignore `minItems` on a field when calculating defaults unless the field is required.
+   */
+  populate?: 'all' | 'requiredOnly';
+  /** When `formData` is provided and does not contain `minItems` worth of data, this flag (`false` by default) controls
+   * whether the extra data provided by the defaults is appended onto the existing `formData` items to ensure the
+   * `minItems` condition is met. When false, only the `formData` provided is merged into the default form state, even
+   * if there are fewer than the `minItems`. When true, the defaults are appended onto the end of the `formData` until
+   * the `minItems` condition is met.
+   */
+  mergeExtraDefaults?: boolean;
+};
+
+/** Experimental features to specify different default form state behaviors. Currently, this affects the
  * handling of optional array fields where `minItems` is set and handling of setting defaults based on the
- * value of `emptyObjectFields`
+ * value of `emptyObjectFields`.
  */
 export type Experimental_DefaultFormStateBehavior = {
-  arrayMinItems?: 'populate' | 'requiredOnly';
+  /** Optional object, that controls how the default form state for arrays with `minItems` is handled. When not provided
+   * it defaults to `{ populate: 'all' }`.
+   */
+  arrayMinItems?: Experimental_ArrayMinItems;
+  /** Optional enumerated flag controlling how empty object fields are populated, defaulting to `populateAllDefaults`:
+   * - `populateAllDefaults`: Legacy behavior - set default when there is a primitive value, an non-empty object field,
+   *        or the field itself is required  |
+   * - `populateRequiredDefaults`: Only sets default when a value is an object and its parent field is required, or it
+   *        is a primitive value and it is required |
+   * - `skipDefaults`: Does not set defaults                                                                                                      |
+   */
   emptyObjectFields?: 'populateAllDefaults' | 'populateRequiredDefaults' | 'skipDefaults';
 };
 

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -42,9 +42,9 @@ export type Experimental_ArrayMinItems = {
   populate?: 'all' | 'requiredOnly';
   /** When `formData` is provided and does not contain `minItems` worth of data, this flag (`false` by default) controls
    * whether the extra data provided by the defaults is appended onto the existing `formData` items to ensure the
-   * `minItems` condition is met. When false, only the `formData` provided is merged into the default form state, even
-   * if there are fewer than the `minItems`. When true, the defaults are appended onto the end of the `formData` until
-   * the `minItems` condition is met.
+   * `minItems` condition is met. When false (legacy behavior), only the `formData` provided is merged into the default
+   * form state, even if there are fewer than the `minItems`. When true, the defaults are appended onto the end of the
+   * `formData` until the `minItems` condition is met.
    */
   mergeExtraDefaults?: boolean;
 };

--- a/packages/utils/test/createSchemaUtils.test.ts
+++ b/packages/utils/test/createSchemaUtils.test.ts
@@ -10,7 +10,9 @@ import getTestValidator from './testUtils/getTestValidator';
 describe('createSchemaUtils()', () => {
   const testValidator: ValidatorType = getTestValidator({});
   const rootSchema: RJSFSchema = { type: 'object' };
-  const defaultFormStateBehavior: Experimental_DefaultFormStateBehavior = { arrayMinItems: 'requiredOnly' };
+  const defaultFormStateBehavior: Experimental_DefaultFormStateBehavior = {
+    arrayMinItems: { populate: 'requiredOnly' },
+  };
   const schemaUtils: SchemaUtilsType = createSchemaUtils(testValidator, rootSchema, defaultFormStateBehavior);
 
   it('getValidator()', () => {
@@ -25,9 +27,9 @@ describe('createSchemaUtils()', () => {
         expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema)).toBe(false);
       });
       it('returns true when passing different defaultFormStateBehavior', () => {
-        expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema, { arrayMinItems: 'requiredOnly' })).toBe(
-          true
-        );
+        expect(
+          schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema, { arrayMinItems: { populate: 'requiredOnly' } })
+        ).toBe(true);
       });
     });
 
@@ -52,7 +54,9 @@ describe('createSchemaUtils()', () => {
         expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, {}, defaultFormStateBehavior)).toBe(true);
       });
       it('returns true when passing different defaultFormStateBehavior', () => {
-        expect(schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema, { arrayMinItems: 'populate' })).toBe(true);
+        expect(
+          schemaUtils.doesSchemaUtilsDiffer(testValidator, rootSchema, { arrayMinItems: { populate: 'all' } })
+        ).toBe(true);
       });
     });
   });

--- a/packages/utils/test/mergeDefaultsWithFormData.test.ts
+++ b/packages/utils/test/mergeDefaultsWithFormData.test.ts
@@ -36,6 +36,10 @@ describe('mergeDefaultsWithFormData()', () => {
     expect(mergeDefaultsWithFormData([1, 2, 3], [4, 5])).toEqual([4, 5]);
   });
 
+  it('should merge arrays using entries from second and extra from the first', () => {
+    expect(mergeDefaultsWithFormData([1, 2, 3], [4, 5], true)).toEqual([4, 5, 3]);
+  });
+
   it('should deeply merge arrays with overlapping entries', () => {
     expect(mergeDefaultsWithFormData([{ a: 1 }], [{ b: 2 }, { c: 3 }])).toEqual([{ a: 1, b: 2 }, { c: 3 }]);
   });
@@ -73,6 +77,41 @@ describe('mergeDefaultsWithFormData()', () => {
       c: 3,
     };
     expect(mergeDefaultsWithFormData<any>(obj1, obj2)).toEqual(expected);
+  });
+
+  it('should recursively merge deeply nested objects, including extra array data', () => {
+    const obj1 = {
+      a: 1,
+      b: {
+        c: 3,
+        d: [1, 2, 3],
+        e: { f: { g: 1 } },
+        h: [{ i: 1 }, { i: 2 }],
+      },
+      c: 2,
+    };
+    const obj2 = {
+      a: 1,
+      b: {
+        d: [3],
+        e: { f: { h: 2 } },
+        g: 1,
+        h: [{ i: 3 }],
+      },
+      c: 3,
+    };
+    const expected = {
+      a: 1,
+      b: {
+        c: 3,
+        d: [3, 2, 3],
+        e: { f: { g: 1, h: 2 } },
+        g: 1,
+        h: [{ i: 3 }, { i: 2 }],
+      },
+      c: 3,
+    };
+    expect(mergeDefaultsWithFormData<any>(obj1, obj2, true)).toEqual(expected);
   });
 
   it('should recursively merge File objects', () => {

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -390,7 +390,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           })
         ).toEqual({ requiredArray: ['default0', 'default1'] });
       });
-      it('should combine defaults with raw form data for a required array property with minItems', () => {
+      it('should not combine defaults with raw form data for a required array property with minItems', () => {
         const schema: RJSFSchema = {
           type: 'object',
           properties: {
@@ -402,6 +402,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           },
           required: ['requiredArray'],
         };
+        // merging defaults with formData does not happen in computeDefaults, regardless of parameters
         expect(
           computeDefaults(testValidator, schema, {
             rootSchema: schema,

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -329,7 +329,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         expect(
           computeDefaults(testValidator, schema, {
             rootSchema: schema,
-            experimental_defaultFormStateBehavior: { arrayMinItems: 'requiredOnly' },
+            experimental_defaultFormStateBehavior: { arrayMinItems: { populate: 'requiredOnly' } },
           })
         ).toEqual({});
       });
@@ -347,7 +347,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           computeDefaults(testValidator, schema, {
             rootSchema: schema,
             rawFormData: { optionalArray: [] },
-            experimental_defaultFormStateBehavior: { arrayMinItems: 'requiredOnly' },
+            experimental_defaultFormStateBehavior: { arrayMinItems: { populate: 'requiredOnly' } },
           })
         ).toEqual({ optionalArray: [] });
       });
@@ -366,7 +366,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         expect(
           computeDefaults(testValidator, schema, {
             rootSchema: schema,
-            experimental_defaultFormStateBehavior: { arrayMinItems: 'requiredOnly' },
+            experimental_defaultFormStateBehavior: { arrayMinItems: { populate: 'requiredOnly' } },
           })
         ).toEqual({ requiredArray: [undefined, undefined] });
       });
@@ -386,12 +386,11 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         expect(
           computeDefaults(testValidator, schema, {
             rootSchema: schema,
-            experimental_defaultFormStateBehavior: { arrayMinItems: 'requiredOnly' },
+            experimental_defaultFormStateBehavior: { arrayMinItems: { populate: 'requiredOnly' } },
           })
         ).toEqual({ requiredArray: ['default0', 'default1'] });
       });
-      // BUG: https://github.com/rjsf-team/react-jsonschema-form/issues/3602
-      it.skip('should combine defaults with raw form data for a required array property with minItems', () => {
+      it('should combine defaults with raw form data for a required array property with minItems', () => {
         const schema: RJSFSchema = {
           type: 'object',
           properties: {
@@ -407,9 +406,9 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           computeDefaults(testValidator, schema, {
             rootSchema: schema,
             rawFormData: { requiredArray: ['raw0'] },
-            experimental_defaultFormStateBehavior: { arrayMinItems: 'requiredOnly' },
+            experimental_defaultFormStateBehavior: { arrayMinItems: { populate: 'requiredOnly' } },
           })
-        ).toEqual({ requiredArray: ['raw0', 'default0'] });
+        ).toEqual({ requiredArray: ['default0', 'default0'] });
       });
     });
     describe('default form state behavior: emptyObjectFields = "populateRequiredDefaults"', () => {
@@ -439,6 +438,69 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
             experimental_defaultFormStateBehavior: { emptyObjectFields: 'populateRequiredDefaults' },
           })
         ).toEqual({ requiredProperty: 'foo' });
+      });
+      it('test an object with a nested required property in a ref', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          definitions: {
+            nestedRequired: {
+              properties: {
+                nested: {
+                  type: 'string',
+                  default: 'foo',
+                },
+              },
+              required: ['nested'],
+            },
+          },
+          properties: {
+            nestedRequiredProperty: {
+              $ref: '#/definitions/nestedRequired',
+            },
+            requiredProperty: {
+              type: 'string',
+              default: 'foo',
+            },
+          },
+          required: ['requiredProperty', 'nestedRequiredProperty'],
+        };
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            experimental_defaultFormStateBehavior: { emptyObjectFields: 'populateRequiredDefaults' },
+          })
+        ).toEqual({ requiredProperty: 'foo', nestedRequiredProperty: { nested: 'foo' } });
+      });
+      it('test an object with a nested optional property in a ref', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          definitions: {
+            nestedOptional: {
+              properties: {
+                nested: {
+                  type: 'string',
+                  default: 'foo',
+                },
+              },
+            },
+          },
+          properties: {
+            nestedOptionalProperty: {
+              $ref: '#/definitions/nestedOptional',
+            },
+            requiredProperty: {
+              type: 'string',
+              default: 'foo',
+            },
+          },
+          required: ['requiredProperty', 'nestedOptionalProperty'],
+        };
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            experimental_defaultFormStateBehavior: { emptyObjectFields: 'populateRequiredDefaults' },
+          })
+        ).toEqual({ requiredProperty: 'foo', nestedOptionalProperty: {} });
       });
       it('test an object with an optional property that has a nested required property with default', () => {
         const schema: RJSFSchema = {
@@ -1911,6 +1973,109 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         };
         expect(getDefaultFormState(testValidator, schema, formData)).toEqual(result);
       });
+    });
+    it('should return undefined defaults for a required array property with minItems', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          requiredArray: {
+            type: 'array',
+            items: { type: 'string' },
+            minItems: 2,
+          },
+        },
+      };
+      expect(getDefaultFormState(testValidator, schema, undefined, schema, false)).toEqual({
+        requiredArray: [undefined, undefined],
+      });
+    });
+    it('should not combine defaults with raw form data for a required array property with minItems', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          requiredArray: {
+            type: 'array',
+            items: { type: 'string' },
+            minItems: 2,
+          },
+        },
+      };
+      expect(getDefaultFormState(testValidator, schema, { requiredArray: ['raw0'] }, schema, false)).toEqual({
+        requiredArray: ['raw0'],
+      });
+    });
+    it('should combine ALL defaults with raw form data for a required array property with minItems', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          requiredArray: {
+            type: 'array',
+            items: { type: 'string' },
+            minItems: 2,
+          },
+        },
+      };
+      expect(
+        getDefaultFormState(testValidator, schema, { requiredArray: ['raw0'] }, schema, false, {
+          arrayMinItems: { mergeExtraDefaults: true },
+        })
+      ).toEqual({
+        requiredArray: ['raw0', undefined],
+      });
+    });
+    it('should return given defaults for a required array property with minItems', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          requiredArray: {
+            type: 'array',
+            items: { type: 'string', default: 'default0' },
+            minItems: 2,
+          },
+        },
+        required: ['requiredArray'],
+      };
+      expect(
+        getDefaultFormState(testValidator, schema, undefined, schema, false, {
+          arrayMinItems: { populate: 'requiredOnly' },
+        })
+      ).toEqual({ requiredArray: ['default0', 'default0'] });
+    });
+    it('should not combine defaults with raw form data for a required array property with minItems', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          requiredArray: {
+            type: 'array',
+            items: { type: 'string', default: 'default0' },
+            minItems: 2,
+          },
+        },
+        required: ['requiredArray'],
+      };
+      expect(
+        getDefaultFormState(testValidator, schema, { requiredArray: ['raw0'] }, schema, false, {
+          arrayMinItems: { populate: 'requiredOnly' },
+        })
+      ).toEqual({ requiredArray: ['raw0'] });
+    });
+    it('should combine ALL defaults with raw form data for a required array property with minItems', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          requiredArray: {
+            type: 'array',
+            items: { type: 'string', default: 'default0' },
+            minItems: 2,
+          },
+        },
+        required: ['requiredArray'],
+      };
+      expect(
+        getDefaultFormState(testValidator, schema, { requiredArray: ['raw0'] }, schema, false, {
+          arrayMinItems: { populate: 'requiredOnly', mergeExtraDefaults: true },
+        })
+      ).toEqual({ requiredArray: ['raw0', 'default0'] });
     });
   });
 }


### PR DESCRIPTION
### Reasons for making this change

Fixed a bug with `experimental_defaultFormStateBehavior.emptyObjectFields='populateRequiredDefaults'` and added new feature for merging `minItems` array defaults into `formData`
- In `@rjsf/utils`, fixed the bug and added the new feature as follows:
  - Updated the `mergeDefaultsWithFormData()` function to take a new optional `mergeExtraArrayDefaults=false` parameter that causes array defaults to append onto `formData` values when true
  - Added a new `Experimental_ArrayMinItems` type containing `populate` and `mergeExtraDefaults`
  - Updated the `Experimental_DefaultFormStateBehavior` to switch `arrayMinItems` to be of the `Experimental_ArrayMinItems` type
    - Updated all tests to switch to use this new object structure
  - Updated the `computeDefaults()` function to not default `required` and to pass it to all of the recursive calls to itself where it was missing
  - Updated the `maybeAddDefaultToObject()` function to use the required state of the field itself when the (now optional) `isParentRequired` is not specified
  - Updated the `getDefaultFormState()` function to pass the value of `experimental_defaultFormStateBehavior.arrayMinItems.mergeExtraDefaults` to `mergeDefaultsWithFormData()`
    - Added additional tests that verify the bug fix and new behavior, while uncommenting a skipped test after fixing the expected result
- Updated the documentation for the new features in `mergeDefaultsWithFormData()` and `experimental_defaultFormStateBehavior.arrayMinItems`
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature

<img width="315" alt="Screenshot 2023-06-27 at 11 57 57 AM" src="https://github.com/rjsf-team/react-jsonschema-form/assets/51679588/f654988b-3d52-4914-ab20-346da8449544">
