### PR TITLE
fix: Fixed #3744 and another precompiled schema issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 
 - Updated `getFieldComponent()` to support rendering a custom component by given schema id ($id). [#3740](https://github.com/rjsf-team/react-jsonschema-form/pull/3740)
+- Updated `MultiSchemaField` to merge the selected `oneOf/anyOf` value into base `schema`, fixing [#3744](https://github.com/rjsf-team/react-jsonschema-form/issues/3744)
+
+## @rjsf/utils
+
+- Updated `getClosestMatchingOption()` to resolve refs in options before computing the closest matching option, fixing an issue with using precompiled validators
+  - Also, added support for nested `anyOf` and `discriminator` support in the recursive `calculateIndexScore()`
+- Updated `getDefaultFormState()` to merge the remaining schema into `anyOf/oneOf` schema selected during the computation of values, fixing [#3744](https://github.com/rjsf-team/react-jsonschema-form/issues/3744)
+- Updated `retrieveSchema()` to merge the remaining schema into the `anyOf/oneOf` schema selected during the resolving of dependencies, fixing [#3744](https://github.com/rjsf-team/react-jsonschema-form/issues/3744)
 
 ## Dev / docs / playground
 

--- a/packages/core/src/components/fields/MultiSchemaField.tsx
+++ b/packages/core/src/components/fields/MultiSchemaField.tsx
@@ -2,7 +2,9 @@ import { Component } from 'react';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import omit from 'lodash/omit';
+import unset from 'lodash/unset';
 import {
+  ADDITIONAL_PROPERTY_FLAG,
   deepEquals,
   ERRORS_KEY,
   FieldProps,
@@ -19,7 +21,7 @@ import {
 type AnyOfFieldState<S extends StrictRJSFSchema = RJSFSchema> = {
   /** The currently selected option */
   selectedOption: number;
-  /* The option schemas after retrieving all $refs */
+  /** The option schemas after retrieving all $refs */
   retrievedOptions: S[];
 };
 
@@ -139,7 +141,6 @@ class AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
   render() {
     const {
       name,
-      baseType,
       disabled = false,
       errorSchema = {},
       formContext,
@@ -170,9 +171,10 @@ class AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
     let optionSchema: S;
 
     if (option) {
-      // If the subschema doesn't declare a type, infer the type from the
-      // parent schema
-      optionSchema = option.type ? option : Object.assign({}, option, { type: baseType });
+      const { oneOf, anyOf, ...remaining } = schema;
+      // Merge in all the non-oneOf/anyOf properties and also skip the special ADDITIONAL_PROPERTY_FLAG property
+      unset(remaining, ADDITIONAL_PROPERTY_FLAG);
+      optionSchema = !isEmpty(remaining) ? { ...remaining, ...option } : option;
     }
 
     const translateEnum: TranslatableString = title

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -305,7 +305,6 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
             options={schema.anyOf.map((_schema) =>
               schemaUtils.retrieveSchema(isObject(_schema) ? (_schema as S) : ({} as S), formData)
             )}
-            baseType={schema.type}
             registry={registry}
             schema={schema}
             uiSchema={uiSchema}
@@ -329,7 +328,6 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
             options={schema.oneOf.map((_schema) =>
               schemaUtils.retrieveSchema(isObject(_schema) ? (_schema as S) : ({} as S), formData)
             )}
-            baseType={schema.type}
             registry={registry}
             schema={schema}
             uiSchema={uiSchema}

--- a/packages/core/test/anyOf.test.jsx
+++ b/packages/core/test/anyOf.test.jsx
@@ -34,6 +34,7 @@ describe('anyOf', () => {
   it('should render a select element if the anyOf keyword is present', () => {
     const schema = {
       type: 'object',
+      title: 'Merges into anyOf',
       anyOf: [
         {
           properties: {
@@ -52,6 +53,7 @@ describe('anyOf', () => {
       schema,
     });
 
+    expect(node.querySelector('legend#root__title').innerHTML).eql(schema.title);
     expect(node.querySelectorAll('select')).to.have.length.of(1);
     expect(node.querySelector('select').id).eql('root__anyof_select');
   });

--- a/packages/core/test/oneOf.test.jsx
+++ b/packages/core/test/oneOf.test.jsx
@@ -35,6 +35,7 @@ describe('oneOf', () => {
   it('should render a select element if the oneOf keyword is present', () => {
     const schema = {
       type: 'object',
+      title: 'Merges into oneOf',
       oneOf: [
         {
           properties: {
@@ -53,6 +54,7 @@ describe('oneOf', () => {
       schema,
     });
 
+    expect(node.querySelector('legend#root__title').innerHTML).eql(schema.title);
     expect(node.querySelectorAll('select')).to.have.length.of(1);
     expect(node.querySelector('select').id).eql('root__oneof_select');
   });

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -199,35 +199,39 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
       })
     ) as T[];
   } else if (ONE_OF_KEY in schema) {
-    if (schema.oneOf!.length === 0) {
+    const { oneOf, ...remaining } = schema;
+    if (oneOf!.length === 0) {
       return undefined;
     }
     const discriminator = getDiscriminatorFieldFromSchema<S>(schema);
-    schemaToCompute = schema.oneOf![
+    schemaToCompute = oneOf![
       getClosestMatchingOption<T, S, F>(
         validator,
         rootSchema,
         isEmpty(formData) ? undefined : formData,
-        schema.oneOf as S[],
+        oneOf as S[],
         0,
         discriminator
       )
     ] as S;
+    schemaToCompute = { ...remaining, ...schemaToCompute };
   } else if (ANY_OF_KEY in schema) {
-    if (schema.anyOf!.length === 0) {
+    const { anyOf, ...remaining } = schema;
+    if (anyOf!.length === 0) {
       return undefined;
     }
     const discriminator = getDiscriminatorFieldFromSchema<S>(schema);
-    schemaToCompute = schema.anyOf![
+    schemaToCompute = anyOf![
       getClosestMatchingOption<T, S, F>(
         validator,
         rootSchema,
         isEmpty(formData) ? undefined : formData,
-        schema.anyOf as S[],
+        anyOf as S[],
         0,
         discriminator
       )
     ] as S;
+    schemaToCompute = { ...remaining, ...schemaToCompute };
   }
 
   if (schemaToCompute) {

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -279,9 +279,9 @@ export function retrieveSchemaInternal<
     if (IF_KEY in resolvedSchema) {
       return resolveCondition<T, S, F>(validator, resolvedSchema, rootSchema, expandAllBranches, rawFormData as T);
     }
-    if (ALL_OF_KEY in schema) {
+    if (ALL_OF_KEY in resolvedSchema) {
       try {
-        resolvedSchema = mergeAllOf(s, {
+        resolvedSchema = mergeAllOf(resolvedSchema, {
           deep: false,
         } as Options) as S;
       } catch (e) {
@@ -321,10 +321,11 @@ export function resolveAnyOrOneOfSchemas<
   F extends FormContextType = any
 >(validator: ValidatorType<T, S, F>, schema: S, rootSchema: S, expandAllBranches: boolean, rawFormData?: T) {
   let anyOrOneOf: S[] | undefined;
-  if (Array.isArray(schema.oneOf)) {
-    anyOrOneOf = schema.oneOf as S[];
-  } else if (Array.isArray(schema.anyOf)) {
-    anyOrOneOf = schema.anyOf as S[];
+  const { oneOf, anyOf, ...remaining } = schema;
+  if (Array.isArray(oneOf)) {
+    anyOrOneOf = oneOf as S[];
+  } else if (Array.isArray(anyOf)) {
+    anyOrOneOf = anyOf as S[];
   }
   if (anyOrOneOf) {
     // Ensure that during expand all branches we pass an object rather than undefined so that all options are interrogated
@@ -340,9 +341,9 @@ export function resolveAnyOrOneOfSchemas<
     // Call this to trigger the set of isValid() calls that the schema parser will need
     const option = getFirstMatchingOption<T, S, F>(validator, formData, anyOrOneOf, rootSchema, discriminator);
     if (expandAllBranches) {
-      return anyOrOneOf;
+      return anyOrOneOf.map((item) => ({ ...remaining, ...item }));
     }
-    schema = anyOrOneOf[option] as S;
+    schema = { ...remaining, ...anyOrOneOf[option] } as S;
   }
   return [schema];
 }

--- a/packages/utils/test/parser/__snapshots__/schemaParser.test.ts.snap
+++ b/packages/utils/test/parser/__snapshots__/schemaParser.test.ts.snap
@@ -1009,6 +1009,7 @@ Object {
             "$ref": "#/definitions/foo",
           },
         ],
+        "title": "multi",
       },
       "passwords": Object {
         "$ref": "#/definitions/passwords",
@@ -1024,6 +1025,9 @@ Object {
           Object {
             "$ref": "#/definitions/choice2",
           },
+        ],
+        "required": Array [
+          "choice",
         ],
       },
     },

--- a/packages/utils/test/schema/getClosestMatchingOptionTest.ts
+++ b/packages/utils/test/schema/getClosestMatchingOptionTest.ts
@@ -120,7 +120,7 @@ export default function getClosestMatchingOptionTest(testValidator: TestValidato
         )
       ).toEqual(2);
     });
-    it('returns the second option when data matches', () => {
+    it('returns the second option when data matches for oneOf', () => {
       // From https://github.com/rjsf-team/react-jsonschema-form/issues/2944
       const schema: RJSFSchema = {
         type: 'array',
@@ -166,6 +166,52 @@ export default function getClosestMatchingOptionTest(testValidator: TestValidato
         isValid: [false, false, false, false, false, false, false, true],
       });
       expect(getClosestMatchingOption(testValidator, schema, formData, get(schema, 'items.oneOf'))).toEqual(1);
+    });
+    it('returns the second option when data matches for anyOf', () => {
+      const schema: RJSFSchema = {
+        type: 'array',
+        items: {
+          anyOf: [
+            {
+              properties: {
+                lorem: {
+                  type: 'string',
+                },
+              },
+              required: ['lorem'],
+            },
+            {
+              properties: {
+                ipsum: {
+                  anyOf: [
+                    {
+                      properties: {
+                        day: {
+                          type: 'string',
+                        },
+                      },
+                    },
+                    {
+                      properties: {
+                        night: {
+                          type: 'string',
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+              required: ['ipsum'],
+            },
+          ],
+        },
+      };
+      const formData = { ipsum: { night: 'nicht' } };
+      // Mock to return true for the last of the second one-ofs
+      testValidator.setReturnValues({
+        isValid: [false, false, false, false, false, false, false, true],
+      });
+      expect(getClosestMatchingOption(testValidator, schema, formData, get(schema, 'items.anyOf'))).toEqual(1);
     });
     it('should return 0 when schema has discriminator but no matching data', () => {
       // Mock isValid to fail both values

--- a/packages/utils/test/schema/getClosestMatchingOptionTest.ts
+++ b/packages/utils/test/schema/getClosestMatchingOptionTest.ts
@@ -207,7 +207,7 @@ export default function getClosestMatchingOptionTest(testValidator: TestValidato
         },
       };
       const formData = { ipsum: { night: 'nicht' } };
-      // Mock to return true for the last of the second one-ofs
+      // Mock to return true for the last of the second anyOfs
       testValidator.setReturnValues({
         isValid: [false, false, false, false, false, false, false, true],
       });

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -1469,6 +1469,66 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           },
         });
       });
+      it('should not populate nested default values for oneOf, when not required', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          required: ['name'],
+          properties: {
+            name: {
+              type: 'object',
+              oneOf: [
+                {
+                  type: 'object',
+                  properties: {
+                    first: { type: 'string', default: 'First Name' },
+                  },
+                },
+                { type: 'string', default: 'b' },
+              ],
+            },
+          },
+        };
+        expect(
+          getDefaultFormState(testValidator, schema, {}, undefined, undefined, {
+            emptyObjectFields: 'populateRequiredDefaults',
+          })
+        ).toEqual({ name: {} });
+      });
+      it('should populate nested default values for oneOf, when required is merged in', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          required: ['name'],
+          properties: {
+            name: {
+              type: 'object',
+              required: ['first'],
+              oneOf: [
+                {
+                  type: 'object',
+                  properties: {
+                    first: { type: 'string', default: 'First Name' },
+                  },
+                },
+                {
+                  type: 'object',
+                  properties: {
+                    first: { type: 'string', default: '1st Name' },
+                  },
+                },
+              ],
+            },
+          },
+        };
+        expect(
+          getDefaultFormState(testValidator, schema, {}, undefined, undefined, {
+            emptyObjectFields: 'populateRequiredDefaults',
+          })
+        ).toEqual({
+          name: {
+            first: 'First Name',
+          },
+        });
+      });
       it('should populate defaults for oneOf + dependencies', () => {
         const schema: RJSFSchema = {
           oneOf: [
@@ -1571,6 +1631,66 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           },
         };
         expect(getDefaultFormState(testValidator, schema, {})).toEqual({
+          name: {
+            first: 'First Name',
+          },
+        });
+      });
+      it('should not populate nested default values for anyOf, when not required', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          required: ['name'],
+          properties: {
+            name: {
+              type: 'object',
+              anyOf: [
+                {
+                  type: 'object',
+                  properties: {
+                    first: { type: 'string', default: 'First Name' },
+                  },
+                },
+                { type: 'string', default: 'b' },
+              ],
+            },
+          },
+        };
+        expect(
+          getDefaultFormState(testValidator, schema, {}, undefined, undefined, {
+            emptyObjectFields: 'populateRequiredDefaults',
+          })
+        ).toEqual({ name: {} });
+      });
+      it('should populate nested default values for anyOf, when required is merged in', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          required: ['name'],
+          properties: {
+            name: {
+              type: 'object',
+              required: ['first'],
+              anyOf: [
+                {
+                  type: 'object',
+                  properties: {
+                    first: { type: 'string', default: 'First Name' },
+                  },
+                },
+                {
+                  type: 'object',
+                  properties: {
+                    first: { type: 'string', default: '1st Name' },
+                  },
+                },
+              ],
+            },
+          },
+        };
+        expect(
+          getDefaultFormState(testValidator, schema, {}, undefined, undefined, {
+            emptyObjectFields: 'populateRequiredDefaults',
+          })
+        ).toEqual({
           name: {
             first: 'First Name',
           },

--- a/packages/utils/test/schema/retrieveSchemaTest.ts
+++ b/packages/utils/test/schema/retrieveSchemaTest.ts
@@ -1276,17 +1276,26 @@ export default function retrieveSchemaTest(testValidator: TestValidatorType) {
       });
     });
     describe('resolveAnyOrOneOfSchemas()', () => {
-      it('resolves anyOf with $ref for single element', () => {
+      it('resolves anyOf with $ref for single element, merging schemas', () => {
         const anyOfSchema: RJSFSchema = SUPER_SCHEMA.properties?.multi as RJSFSchema;
         expect(resolveAnyOrOneOfSchemas(testValidator, anyOfSchema, SUPER_SCHEMA, false)).toEqual([
-          SUPER_SCHEMA.definitions?.foo,
+          {
+            ...(SUPER_SCHEMA.definitions?.foo as RJSFSchema),
+            title: 'multi',
+          },
         ]);
       });
-      it('resolves oneOf with $ref for expandedAll elements', () => {
+      it('resolves oneOf with $ref for expandedAll elements, merging schemas', () => {
         const oneOfSchema: RJSFSchema = SUPER_SCHEMA.properties?.single as RJSFSchema;
         expect(resolveAnyOrOneOfSchemas(testValidator, oneOfSchema, SUPER_SCHEMA, true)).toEqual([
-          SUPER_SCHEMA.definitions?.choice1,
-          SUPER_SCHEMA.definitions?.choice2,
+          {
+            ...(SUPER_SCHEMA.definitions?.choice1 as RJSFSchema),
+            required: ['choice'],
+          },
+          {
+            ...(SUPER_SCHEMA.definitions?.choice2 as RJSFSchema),
+            required: ['choice'],
+          },
         ]);
       });
     });

--- a/packages/utils/test/testUtils/testData.ts
+++ b/packages/utils/test/testUtils/testData.ts
@@ -449,10 +449,12 @@ export const SUPER_SCHEMA: RJSFSchema = {
     passwords: { $ref: '#/definitions/passwords' },
     dataUrlWithName: { type: 'string', format: 'data-url' },
     multi: {
+      title: 'multi',
       anyOf: [{ $ref: '#/definitions/foo' }],
     },
     list: { $ref: '#/definitions/list' },
     single: {
+      required: ['choice'],
       oneOf: [{ $ref: '#/definitions/choice1' }, { $ref: '#/definitions/choice2' }],
     },
     anything: {


### PR DESCRIPTION
### Reasons for making this change

Fixes #3744 as well as an issue associated with anyOf/oneOf in precompiled schema
- In `@rjsf/util`, fixed part of #3744 and the precompiled schema issue as follows:
  - Updated `getClosestMatchingOption()` to resolve refs in the options before computing the correct index, as well as supporting `anyOf` and discriminators in `calculateIndexScore()`
  - Updated `getDefaultFormState()` to merge in the remaining schema into the selected anyOf/oneOf option prior to computing new defaults
  - Updated `retrieveSchema()` to merge in the remaining schema into the anyOf/oneOf options when resolving dependencies
  - Added/updated tests to verify all the fixes
- In `@rjsf/core`, fixed the rest of #3744 by updating `MultiSchemaField` to merge the remaining schema into the selected anyOf/oneOf selected option
  - Also updated `SchemaField` to no longer pass in `baseType` to `MultiSchemaField` since it is no longer used
### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
