### PR TITLE
[docs] remove ErrorList from FormProps docs, fix bad theme imports

### DIFF
--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -163,10 +163,6 @@ The value of this prop will be passed to the `enctype` [HTML attribute on the fo
 
 This prop allows passing in custom errors that are augmented with the existing JSON Schema errors on the form; it can be used to implement asynchronous validation. See [Validation](../usage/validation.md) for more information.
 
-## ErrorList
-
-You can pass a React component to this prop to customize how form errors are displayed. See [Validation](../usage/validation.md) for more information.
-
 ## fields
 
 Dictionary of registered fields in the form. See [Custom Widgets and Fields](../advanced-customization/custom-widgets-fields.md) for more information.

--- a/packages/docs/docs/migration-guides/v5.x upgrade guide.md
+++ b/packages/docs/docs/migration-guides/v5.x upgrade guide.md
@@ -542,7 +542,7 @@ or
 
 ```tsx
 import { withTheme } from '@rjsf/core';
-import Theme from '@rjsf/material-ui/v5';
+import { Theme } from '@rjsf/material-ui/v5';
 // Make modifications to the theme with your own fields and widgets
 const Form = withTheme(Theme);
 ```
@@ -551,7 +551,7 @@ or
 
 ```tsx
 import { withTheme } from '@rjsf/core';
-import Theme5 from '@rjsf/material-ui';
+import { Theme as Theme5 } from '@rjsf/material-ui';
 // Make modifications to the theme with your own fields and widgets
 const Form = withTheme(Theme5);
 ```
@@ -566,7 +566,7 @@ or
 
 ```tsx
 import { withTheme } from '@rjsf/core';
-import Theme from '@rjsf/mui';
+import { Theme } from '@rjsf/mui';
 // Make modifications to the theme with your own fields and widgets
 const Form = withTheme(Theme);
 ```


### PR DESCRIPTION
### Reasons for making this change

Fixes #3758 - ErrorList prop should have been removed when v5 was released

Fixes #3760


If your PR is non-trivial and you'd like to schedule a synchronous review, please add it to the weekly meeting agenda: https://docs.google.com/document/d/12PjTvv21k6LIky6bNQVnsplMLLnmEuypTLQF8a-8Wss/edit

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
