### PR TITLE
fix: Fixed 3757 by supporting extraErrors that block the submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,12 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
-# 5.10.1
+# 5.11.0
 
 ## @rjsf/core
 
 - Updated `MultiSchemaField` to use `mergeSchema()` for merging in the remaining schema for `anyOf`/`oneOf`
+- Added new `extraErrorsBlockSubmit` prop to `Form` that allows the extra asynchronous errors to block a form submit, fixing [#3757](https://github.com/rjsf-team/react-jsonschema-form/issues/3757)
 
 ## @rjsf/utils
 

--- a/packages/core/test/Form.test.jsx
+++ b/packages/core/test/Form.test.jsx
@@ -2044,6 +2044,45 @@ describeRepeated('Form common', (createFormComponent) => {
         sinon.assert.calledOnce(focusOnFirstError);
       });
 
+      it('should call the onError handler and call the provided focusOnFirstError callback function', () => {
+        const onError = sandbox.spy();
+
+        const focusCallback = () => {
+          console.log('focusCallback called');
+        };
+        const extraErrors = {
+          __errors: ['foo'],
+        };
+
+        const focusOnFirstError = sandbox.spy(focusCallback);
+        const { node } = createFormComponent({
+          schema,
+          onError,
+          focusOnFirstError,
+          extraErrors,
+          extraErrorsBlockSubmit: true,
+        });
+
+        const input = node.querySelector('input[type=text]');
+        const focusSpy = sinon.spy();
+        // Since programmatically triggering focus does not call onFocus, change the focus method to a spy
+        input.focus = focusSpy;
+
+        Simulate.change(input, {
+          target: { value: 'valid string' },
+        });
+        Simulate.submit(node);
+
+        sinon.assert.calledWithMatch(
+          onError,
+          sinon.match((value) => {
+            return value.length === 1 && value[0].message === 'foo';
+          })
+        );
+        sinon.assert.notCalled(focusSpy);
+        sinon.assert.calledOnce(focusOnFirstError);
+      });
+
       it('should reset errors and errorSchema state to initial state after correction and resubmission', () => {
         const { node, onError, onSubmit } = createFormComponent({
           schema,

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -161,7 +161,13 @@ The value of this prop will be passed to the `enctype` [HTML attribute on the fo
 
 ## extraErrors
 
-This prop allows passing in custom errors that are augmented with the existing JSON Schema errors on the form; it can be used to implement asynchronous validation. See [Validation](../usage/validation.md) for more information.
+This prop allows passing in custom errors that are augmented with the existing JSON Schema errors on the form; it can be used to implement asynchronous validation.
+By default, these are non-blocking errors, meaning that you can still submit the form when these are the only errors displayed to the user.
+See [Validation](../usage/validation.md) for more information.
+
+## extraErrorsBlockSubmit
+
+If set to true, causes the `extraErrors` to become blocking when the form is submitted.
 
 ## fields
 


### PR DESCRIPTION
### Reasons for making this change

Fix #3757 by adding a new `extraErrorsBlockSubmit` prop on `Form`
- Updated the `FormProps` and `Form` for the new `extraErrorsBlockSubmit` flag
- Updated the validation code to detect when the flag is set and there are `extraErrors` and allow the extra error to be focused on
- Updated `form-props` documentation with additional details about `extraErrors` as well as the new prop
- Updated the `CHANGELOG.md` file accordingly switching from a patch to minor release due to the new feature

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
