### PR TITLE
chore: Fix stale bot to add new tags to the exemptLabels

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,6 +8,8 @@ exemptLabels:
   - enhancement
   - feature
   - theme request
+  - help wanted
+  - p1
 # Label to use when marking an issue as stale
 staleLabel: possibly close
 # Comment to post when marking an issue as stale. Set to `false` to disable
@@ -16,4 +18,4 @@ markComment: >
   recent activity. It will be closed if no further activity occurs. Please
   leave a comment if this is still an issue for you. Thank you.
 # Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: This issue was closed because of lack of recent activity. Reoopen if you still need assistance.
+closeComment: This issue was closed because of lack of recent activity. Reopen if you still need assistance.


### PR DESCRIPTION
### Reasons for making this change

Updated stale bot to prevent stale from being added to `p1` and `help wanted` tags

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
