### PR TITLE
[fix] Fix #3792, handle null case in `withIdRefPrefix`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Created new `resolveAllReferences()` function to resolve all references within a schema's properties and array items.
 - Updated `getClosestMatchingOption()` to use `resolveAllReferences()` for all oneOf/anyOf schemas
 - Updated `resolveAnyOrOneOfSchemas()` to use `resolveAllReferences()` for all oneOf/anyOf schemas
+- Better handle the `null` case in `withIdRefPrefix`, fixing [#3792](https://github.com/rjsf-team/react-jsonschema-form/pull/3792)
 
 # 5.11.0
 

--- a/packages/utils/src/withIdRefPrefix.ts
+++ b/packages/utils/src/withIdRefPrefix.ts
@@ -1,5 +1,6 @@
 import { REF_KEY, ROOT_SCHEMA_PREFIX } from './constants';
 import { RJSFSchema, StrictRJSFSchema } from './types';
+import isObject from 'lodash/isObject';
 
 /** Takes a `node` object and transforms any contained `$ref` node variables with a prefix, recursively calling
  * `withIdRefPrefix` for any other elements.
@@ -38,11 +39,11 @@ function withIdRefPrefixArray<S extends StrictRJSFSchema = RJSFSchema>(node: S[]
  * @returns - A copy of the `schemaNode` with updated `$ref`s
  */
 export default function withIdRefPrefix<S extends StrictRJSFSchema = RJSFSchema>(schemaNode: S): S | S[] {
-  if (schemaNode.constructor === Object) {
-    return withIdRefPrefixObject<S>({ ...schemaNode });
-  }
   if (Array.isArray(schemaNode)) {
     return withIdRefPrefixArray<S>([...schemaNode]);
+  }
+  if (isObject(schemaNode)) {
+    return withIdRefPrefixObject<S>({ ...schemaNode });
   }
   return schemaNode;
 }

--- a/packages/utils/test/withIdRef.test.ts
+++ b/packages/utils/test/withIdRef.test.ts
@@ -34,4 +34,8 @@ describe('withIdRefPrefix()', () => {
 
     expect(withIdRefPrefix(schema)).toEqual(schema);
   });
+  it('should handle null schema', () => {
+    const schema: RJSFSchema = null;
+    expect(withIdRefPrefix(schema)).toEqual(schema);
+  });
 });


### PR DESCRIPTION
### Reasons for making this change

Fixes #3792

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
