### PR TITLE
ignore changes from adding npm token in npmrc when publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
       - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: git update-index --assume-unchanged .npmrc
       - run: npx lerna publish from-package --yes
       - if: always()
         run: rm .npmrc


### PR DESCRIPTION
### Reasons for making this change

Updating release script to ignore `.npmrc` change when running `lerna publish`

#3785 
