### PR TITLE
fix: Fixes #3805 by copying schema props rather than directly updating them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.11.2
+
+## @rjsf/material-ui
+
+- Removed unnecessary import of old `@types/material-ui` which can cause typescript issues in some situations
+
+## @rjsf/utils
+
+- Updated the `resolveAllReferences()` function to use object spreading to update properties and items in a schema rather than directly modifying the schema to avoid issues with frozen object, fixing [#3805](https://github.com/rjsf-team/react-jsonschema-form/issues/3805)
+
 # 5.11.1
 
 ## @rjsf/core

--- a/package-lock.json
+++ b/package-lock.json
@@ -8896,15 +8896,6 @@
         "@types/lodash": "*"
       }
     },
-    "node_modules/@types/material-ui": {
-      "version": "0.21.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*",
-        "@types/react-addons-linked-state-mixin": "*"
-      }
-    },
     "node_modules/@types/mdast": {
       "version": "3.0.12",
       "license": "MIT",
@@ -8967,14 +8958,6 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-addons-linked-state-mixin": {
-      "version": "0.14.22",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*"
       }
     },
     "node_modules/@types/react-dom": {
@@ -40489,7 +40472,6 @@
         "@rjsf/core": "^5.11.1",
         "@rjsf/utils": "^5.11.1",
         "@rjsf/validator-ajv8": "^5.11.1",
-        "@types/material-ui": "^0.21.12",
         "@types/react": "^17.0.62",
         "@types/react-dom": "^17.0.20",
         "@types/react-test-renderer": "^17.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46049,6 +46049,7 @@
         "@types/react-is": "^17.0.4",
         "@types/react-test-renderer": "^17.0.2",
         "babel-jest": "^29.6.1",
+        "deep-freeze-es6": "^1.4.1",
         "dts-cli": "^1.6.3",
         "eslint": "^8.44.0",
         "jest": "^29.6.1",
@@ -46501,6 +46502,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "packages/utils/node_modules/deep-freeze-es6": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/deep-freeze-es6/-/deep-freeze-es6-1.4.1.tgz",
+      "integrity": "sha512-WnyM4ZCzpHtziy7LxnpQPGS+mfZDQvFpmH3LGqmyUfzwBLkvNTwbn+mTwSNTQoLQTHiN85qZqprRZdYwU3xN/Q==",
+      "dev": true
     },
     "packages/utils/node_modules/diff-sequences": {
       "version": "29.4.3",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -45,7 +45,6 @@
     "@rjsf/core": "^5.11.1",
     "@rjsf/utils": "^5.11.1",
     "@rjsf/validator-ajv8": "^5.11.1",
-    "@types/material-ui": "^0.21.12",
     "@types/react": "^17.0.62",
     "@types/react-dom": "^17.0.20",
     "@types/react-test-renderer": "^17.0.2",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -51,6 +51,7 @@
     "@types/react-is": "^17.0.4",
     "@types/react-test-renderer": "^17.0.2",
     "babel-jest": "^29.6.1",
+    "deep-freeze-es6": "^1.4.1",
     "dts-cli": "^1.6.3",
     "eslint": "^8.44.0",
     "jest": "^29.6.1",

--- a/packages/utils/test/testUtils/testData.ts
+++ b/packages/utils/test/testUtils/testData.ts
@@ -1,4 +1,5 @@
 import reduce from 'lodash/reduce';
+import deepFreeze from 'deep-freeze-es6';
 
 import {
   EnumOptionsType,
@@ -21,7 +22,7 @@ export const oneOfData = {
     },
   },
 };
-export const oneOfSchema: RJSFSchema = {
+export const oneOfSchema: RJSFSchema = deepFreeze({
   type: 'object',
   title: 'Testing OneOfs',
   definitions: {
@@ -201,11 +202,11 @@ export const oneOfSchema: RJSFSchema = {
       title: 'second option',
     },
   ],
-};
+});
 export const ONE_OF_SCHEMA_OPTIONS = oneOfSchema[ONE_OF_KEY]! as RJSFSchema[];
 export const FIRST_ONE_OF: RJSFSchema = ONE_OF_SCHEMA_OPTIONS[0];
 export const SECOND_ONE_OF: RJSFSchema = ONE_OF_SCHEMA_OPTIONS[1];
-export const OPTIONAL_ONE_OF_SCHEMA: RJSFSchema = {
+export const OPTIONAL_ONE_OF_SCHEMA: RJSFSchema = deepFreeze({
   oneOf: [
     {
       type: 'object',
@@ -257,7 +258,7 @@ export const OPTIONAL_ONE_OF_SCHEMA: RJSFSchema = {
       additionalProperties: false,
     },
   ],
-};
+});
 export const OPTIONAL_ONE_OF_SCHEMA_ONEOF = OPTIONAL_ONE_OF_SCHEMA[ONE_OF_KEY] as RJSFSchema[];
 export const OPTIONAL_ONE_OF_DATA = { flag: true, inner_obj: { foo: 'bar' } };
 export const SIMPLE_ONE_OF_SCHEMA = {
@@ -290,7 +291,7 @@ export const FALSY_OPTIONS: EnumOptionsType[] = [
   { value: 0, label: 'Zero' },
 ];
 
-export const RECURSIVE_REF_ALLOF: RJSFSchema = {
+export const RECURSIVE_REF_ALLOF: RJSFSchema = deepFreeze({
   definitions: {
     '@enum': {
       type: 'object',
@@ -332,9 +333,9 @@ export const RECURSIVE_REF_ALLOF: RJSFSchema = {
       minItems: 1,
     },
   },
-};
+});
 
-export const RECURSIVE_REF: RJSFSchema = {
+export const RECURSIVE_REF: RJSFSchema = deepFreeze({
   definitions: {
     '@enum': {
       type: 'object',
@@ -351,7 +352,7 @@ export const RECURSIVE_REF: RJSFSchema = {
     },
   },
   $ref: '#/definitions/@enum',
-};
+});
 
 export const ERROR_MAPPER = {
   '': 'root error',
@@ -390,7 +391,7 @@ export const TEST_ERROR_LIST: RJSFValidationError[] = reduce(
   []
 );
 
-export const SUPER_SCHEMA: RJSFSchema = {
+export const SUPER_SCHEMA: RJSFSchema = deepFreeze({
   [ID_KEY]: 'super-schema',
   definitions: {
     foo: {
@@ -465,9 +466,9 @@ export const SUPER_SCHEMA: RJSFSchema = {
       },
     },
   },
-};
+});
 
-export const PROPERTY_DEPENDENCIES: RJSFSchema = {
+export const PROPERTY_DEPENDENCIES: RJSFSchema = deepFreeze({
   type: 'object',
   properties: {
     a: { type: 'string' },
@@ -477,9 +478,9 @@ export const PROPERTY_DEPENDENCIES: RJSFSchema = {
   dependencies: {
     a: ['b'],
   },
-};
+});
 
-export const SCHEMA_DEPENDENCIES: RJSFSchema = {
+export const SCHEMA_DEPENDENCIES: RJSFSchema = deepFreeze({
   type: 'object',
   properties: {
     a: { type: 'string' },
@@ -491,9 +492,9 @@ export const SCHEMA_DEPENDENCIES: RJSFSchema = {
       },
     },
   },
-};
+});
 
-export const SCHEMA_AND_ONEOF_REF_DEPENDENCIES: RJSFSchema = {
+export const SCHEMA_AND_ONEOF_REF_DEPENDENCIES: RJSFSchema = deepFreeze({
   type: 'object',
   definitions: {
     needsA: {
@@ -517,9 +518,9 @@ export const SCHEMA_AND_ONEOF_REF_DEPENDENCIES: RJSFSchema = {
       oneOf: [{ $ref: '#/definitions/needsA' }, { $ref: '#/definitions/needsB' }],
     },
   },
-};
+});
 
-export const SCHEMA_AND_REQUIRED_DEPENDENCIES: RJSFSchema = {
+export const SCHEMA_AND_REQUIRED_DEPENDENCIES: RJSFSchema = deepFreeze({
   type: 'object',
   properties: {
     a: { type: 'string' },
@@ -534,9 +535,9 @@ export const SCHEMA_AND_REQUIRED_DEPENDENCIES: RJSFSchema = {
       required: ['b'],
     },
   },
-};
+});
 
-export const SCHEMA_WITH_ONEOF_NESTED_DEPENDENCIES: RJSFSchema = {
+export const SCHEMA_WITH_ONEOF_NESTED_DEPENDENCIES: RJSFSchema = deepFreeze({
   type: 'object',
   dependencies: {
     employee_accounts: {
@@ -604,9 +605,9 @@ export const SCHEMA_WITH_ONEOF_NESTED_DEPENDENCIES: RJSFSchema = {
       title: 'Employee Accounts',
     },
   },
-};
+});
 
-export const SCHEMA_WITH_SINGLE_CONDITION: RJSFSchema = {
+export const SCHEMA_WITH_SINGLE_CONDITION: RJSFSchema = deepFreeze({
   type: 'object',
   properties: {
     country: {
@@ -625,9 +626,9 @@ export const SCHEMA_WITH_SINGLE_CONDITION: RJSFSchema = {
       postal_code: { pattern: '[A-Z][0-9][A-Z] [0-9][A-Z][0-9]' },
     },
   },
-};
+});
 
-export const SCHEMA_WITH_MULTIPLE_CONDITIONS: RJSFSchema = {
+export const SCHEMA_WITH_MULTIPLE_CONDITIONS: RJSFSchema = deepFreeze({
   type: 'object',
   properties: {
     Animal: {
@@ -731,9 +732,9 @@ export const SCHEMA_WITH_MULTIPLE_CONDITIONS: RJSFSchema = {
     },
   ],
   required: ['Animal'],
-};
+});
 
-export const SCHEMA_WITH_NESTED_CONDITIONS: RJSFSchema = {
+export const SCHEMA_WITH_NESTED_CONDITIONS: RJSFSchema = deepFreeze({
   type: 'object',
   properties: {
     country: {
@@ -792,9 +793,9 @@ export const SCHEMA_WITH_NESTED_CONDITIONS: RJSFSchema = {
       },
     },
   },
-};
+});
 
-export const SCHEMA_WITH_ARRAY_CONDITION: RJSFSchema = {
+export const SCHEMA_WITH_ARRAY_CONDITION: RJSFSchema = deepFreeze({
   type: 'object',
   properties: {
     list: {
@@ -802,9 +803,9 @@ export const SCHEMA_WITH_ARRAY_CONDITION: RJSFSchema = {
       items: SCHEMA_WITH_SINGLE_CONDITION,
     },
   },
-};
+});
 
-export const SCHEMA_WITH_ALLOF_CANNOT_MERGE: RJSFSchema = {
+export const SCHEMA_WITH_ALLOF_CANNOT_MERGE: RJSFSchema = deepFreeze({
   type: 'object',
   properties: {
     animal: {
@@ -856,4 +857,4 @@ export const SCHEMA_WITH_ALLOF_CANNOT_MERGE: RJSFSchema = {
       required: ['animal'],
     },
   ],
-};
+});


### PR DESCRIPTION
### Reasons for making this change

Fixes #3805 by using object spread of schema changes rather than direct updating of schema properties

- In `@rjsf/utils`, updated `resolveAllReferences()` to copy updated schema properties rather than directly changing them to avoid issues with frozen schemas
- In `@rjsf/material-ui`, removed the unnecessary import of the `@types/material-ui` which was causing typescript issues in some situations

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
