### PR TITLE
feature #3796 arrayMinItems.populate = never

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,31 +15,26 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
-# 5.13.0
+# 5.12.0
 
 ## @rjsf/utils
 
 - Experimental feature:
   - Added `experimental_defaultFormStateBehavior = { arrayMinItems: { populate: 'never' } }` (feature [#3796](https://github.com/rjsf-team/react-jsonschema-form/issues/3796))
 
+## @rjsf/validator-ajv8
+
+- Exposing new function `compileSchemaValidatorsCode` to allow creating precompiled validator without a file. This is useful in case when precompiled validator is to be created dynamically. [#3793](https://github.com/rjsf-team/react-jsonschema-form/pull/3793)
+
 ## Dev / docs / playground
-
-- Updated the `form-props` documentation `arrayMinItems`, added description for `never`.
-- Updated the `playground` to add the option for the new `arrayMinItems.populate = 'never'`.
-
-# 5.12.0
-
-## Dev / playground
 
 - update playground vite config to use sources directly, allowing to reload changes in it without additional build step
 - moving from `dts-cli` to use individual dev tools directly, updating package publish config
   - tsc for generating type definitions and esm modules
   - esbuild for CJS bundle
   - rollup for UMD bundle
-
-## @rjsf/validator-ajv8
-
-- Exposing new function `compileSchemaValidatorsCode` to allow creating precompiled validator without a file. This is useful in case when precompiled validator is to be created dynamically. [#3793](https://github.com/rjsf-team/react-jsonschema-form/pull/3793)
+- Updated the `form-props` documentation `arrayMinItems`, added description for `never`.
+- Updated the `playground` to add the option for the new `arrayMinItems.populate = 'never'`.
 
 # 5.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.13.0
+
+## @rjsf/utils
+
+- Experimental feature:
+  - Added `experimental_defaultFormStateBehavior = { arrayMinItems: { populate: 'never' } }` (feature [#3796](https://github.com/rjsf-team/react-jsonschema-form/issues/3796))
+
+## Dev / docs / playground
+
+- Updated the `form-props` documentation `arrayMinItems`, added description for `never`.
+- Updated the `playground` to add the option for the new `arrayMinItems.populate = 'never'`.
+
 # 5.12.0
 
 ## Dev / playground
@@ -105,7 +117,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Updated the `utility-functions` documentation to add the new `mergeExtraArrayDefaults` flag for the `mergeDefaultWithFormData()` function
 - Updated the `form-props` documentation to update the `arrayMinItems` documentation for the new object behavior
-- Updated the `playground` to add a checkbox for the new `arrayMinItems.mergeExtraDefaults` flag 
+- Updated the `playground` to add a checkbox for the new `arrayMinItems.mergeExtraDefaults` flag
 
 # 5.8.2
 

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -77,10 +77,11 @@ When not specified, it defaults to `{ populate: 'all', mergeExtraDefaults: false
 
 Optional enumerated flag controlling how array minItems are populated, defaulting to `all`:
 
-| Flag Value     | Description                                                                                                                         |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `all`          | Legacy behavior - populate minItems entries with default values initially and include empty array when no values have been defined. |
-| `requiredOnly` | Ignore `minItems` on a field when calculating defaults unless the field is required.                                                |
+| Flag Value     | Description                                                                                                                                        |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `all`          | Legacy behavior - populate minItems entries with default values initially and include empty array when no values have been defined.                |
+| `requiredOnly` | Ignore `minItems` on a field when calculating defaults unless the field is required.                                                               |
+| `never`        | Ignore `minItems` on a field when calculating defaults for required and non-required. Value will set only if defined `default` and from `formData` |
 
 #### `arrayMinItems.mergeExtraDefaults`
 

--- a/packages/playground/src/components/Header.tsx
+++ b/packages/playground/src/components/Header.tsx
@@ -93,12 +93,12 @@ const liveSettingsSelectSchema: RJSFSchema = {
                 },
                 {
                   type: 'string',
-                  title: 'Ignore minItems unless field is required',
+                  title: 'Only populate minItems with default values when field is required',
                   enum: ['requiredOnly'],
                 },
                 {
                   type: 'string',
-                  title: 'Ignore populating arrays even if settled minItems',
+                  title: 'Never populate minItems with default values',
                   enum: ['never'],
                 },
               ],

--- a/packages/playground/src/components/Header.tsx
+++ b/packages/playground/src/components/Header.tsx
@@ -96,6 +96,11 @@ const liveSettingsSelectSchema: RJSFSchema = {
                   title: 'Ignore minItems unless field is required',
                   enum: ['requiredOnly'],
                 },
+                {
+                  type: 'string',
+                  title: 'Ignore populating arrays even if settled minItems',
+                  enum: ['never'],
+                },
               ],
             },
             mergeExtraDefaults: {

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -38,8 +38,9 @@ export type Experimental_ArrayMinItems = {
    * - `all`: Legacy behavior, populate minItems entries with default values initially and include an empty array when
    *        no values have been defined.
    * - `requiredOnly`: Ignore `minItems` on a field when calculating defaults unless the field is required.
+   * - `never`: Ignore `minItems` on a field even the field is required.
    */
-  populate?: 'all' | 'requiredOnly';
+  populate?: 'all' | 'requiredOnly' | 'never';
   /** When `formData` is provided and does not contain `minItems` worth of data, this flag (`false` by default) controls
    * whether the extra data provided by the defaults is appended onto the existing `formData` items to ensure the
    * `minItems` condition is met. When false (legacy behavior), only the `formData` provided is merged into the default

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -508,10 +508,10 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         expect(
           computeDefaults(testValidator, schema, {
             rootSchema: schema,
-            rawFormData: { nonRequiredArray: ['raw0'] },
+            rawFormData: { nonRequiredArray: ['raw1'] },
             experimental_defaultFormStateBehavior: { arrayMinItems: { populate: 'never' } },
           })
-        ).toStrictEqual({ nonRequiredArray: ['raw0'] });
+        ).toStrictEqual({ nonRequiredArray: ['raw1'] });
       });
 
       it('should not add items to formData', () => {


### PR DESCRIPTION
### Reasons for making this change

Hi team! I've already described the problem in the issue below:
[#3796](https://github.com/rjsf-team/react-jsonschema-form/issues/3796)

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
