### PR TITLE
fix: Fixes #3825 Precompiled validator resolve root schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # 5.12.1
 
+## @rjsf/validator-ajv8
+
+- Updated `AJV8PrecompiledValidator.rawValidation()` to resolve root schema with formData when comparing input schema, fixing [#3825](https://github.com/rjsf-team/react-jsonschema-form/issues/3825)
+
 ## @rjsf/utils
 
 - Updated `retrieveSchemaInternal` allOf logic for precompiled schemas to resolve top level properties fixing [#3817](https://github.com/rjsf-team/react-jsonschema-form/issues/3817)

--- a/packages/validator-ajv8/src/precompiledValidator.ts
+++ b/packages/validator-ajv8/src/precompiledValidator.ts
@@ -36,12 +36,6 @@ export default class AJV8PrecompiledValidator<
    */
   readonly rootSchema: S;
 
-  /** The root schema resolved top level refs
-   *
-   * @private
-   */
-  readonly resolvedRootSchema: S;
-
   /** The `ValidatorFunctions` map used to construct this validator
    *
    * @private
@@ -72,7 +66,6 @@ export default class AJV8PrecompiledValidator<
     this.validateFns = validateFns;
     this.localizer = localizer;
     this.mainValidator = this.getValidator(rootSchema);
-    this.resolvedRootSchema = retrieveSchema(this, rootSchema, rootSchema);
   }
 
   /** Returns the precompiled validator associated with the given `schema` from the map of precompiled validator
@@ -109,7 +102,8 @@ export default class AJV8PrecompiledValidator<
    * @throws - Error when the schema provided does not match the base schema of the precompiled validator
    */
   rawValidation<Result = any>(schema: S, formData?: T): RawValidationErrorsType<Result> {
-    if (!isEqual(schema, this.resolvedRootSchema)) {
+    const resolvedRootSchema = retrieveSchema(this, this.rootSchema, this.rootSchema, formData);
+    if (!isEqual(schema, resolvedRootSchema)) {
       throw new Error(
         'The schema associated with the precompiled schema differs from the schema provided for validation'
       );


### PR DESCRIPTION
### Reasons for making this change

Fixes #3825 by updating `rawValidation ` resolving root schema with formData before comparing to incoming schema

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
