### PR TITLE
fix: Fixes #3808 Duplciate AnyOf/OneOf Description

### DIFF
--- a/packages/core/src/components/fields/MultiSchemaField.tsx
+++ b/packages/core/src/components/fields/MultiSchemaField.tsx
@@ -2,9 +2,7 @@ import { Component } from 'react';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import omit from 'lodash/omit';
-import unset from 'lodash/unset';
 import {
-  ADDITIONAL_PROPERTY_FLAG,
   deepEquals,
   ERRORS_KEY,
   FieldProps,
@@ -172,11 +170,10 @@ class AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
     let optionSchema: S;
 
     if (option) {
-      // merge all top level fields except properties
-      const { oneOf, anyOf, properties, ...remaining } = schema;
+      // merge top level required field
+      const { required } = schema;
       // Merge in all the non-oneOf/anyOf properties and also skip the special ADDITIONAL_PROPERTY_FLAG property
-      unset(remaining, ADDITIONAL_PROPERTY_FLAG);
-      optionSchema = !isEmpty(remaining) ? (mergeSchemas(remaining, option) as S) : option;
+      optionSchema = required ? (mergeSchemas({ required }, option) as S) : option;
     }
 
     const translateEnum: TranslatableString = title


### PR DESCRIPTION
### Reasons for making this change

Adding on to this [fix](https://github.com/rjsf-team/react-jsonschema-form/pull/3821), the description of the top level schema still shows in the oneOf/allOf fields.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
