### PR TITLE
Make fields with `const` pre-fiiled and readonly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 
 - Updated `MultiSchemaField` to merge all top level fields except properties for anyOf/oneOf options, fixing [#3808](https://github.com/rjsf-team/react-jsonschema-form/issues/3808) and [#3787](https://github.com/rjsf-team/react-jsonschema-form/issues/3787)
+- Updated `SchemaField` to make fields readonly when they have `const` defined, fixing [#2600](https://github.com/rjsf-team/react-jsonschema-form/issues/2600)
 
 ## @rjsf/antd
 
@@ -32,6 +33,11 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/utils
 
 - Updated `retrieveSchemaInternal` allOf logic for precompiled schemas to resolve top level properties fixing [#3817](https://github.com/rjsf-team/react-jsonschema-form/issues/3817)
+- Updated `getDefaultFormState` to extract default value when fields have `const` definition, fixing [#2600](https://github.com/rjsf-team/react-jsonschema-form/issues/2600)
+
+## Dev / docs / playground
+
+- Updated the `playground` to add sample for `const` use cases
 
 # 5.12.0
 

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -151,7 +151,14 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
 
   const FieldComponent = getFieldComponent<T, S, F>(schema, uiOptions, idSchema, registry);
   const disabled = Boolean(props.disabled || uiOptions.disabled);
-  const readonly = Boolean(props.readonly || uiOptions.readonly || props.schema.readOnly || schema.readOnly);
+  const readonly = Boolean(
+    props.readonly ||
+      uiOptions.readonly ||
+      props.schema.readOnly ||
+      schema.readOnly ||
+      props.schema.const ||
+      schema.const
+  );
   const uiSchemaHideError = uiOptions.hideError;
   // Set hideError to the value provided in the uiSchema, otherwise stick with the prop to propagate to children
   const hideError = uiSchemaHideError === undefined ? props.hideError : Boolean(uiSchemaHideError);

--- a/packages/playground/src/samples/constField.ts
+++ b/packages/playground/src/samples/constField.ts
@@ -1,0 +1,53 @@
+export default {
+  schema: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string',
+        const: 'John',
+      },
+      address: {
+        type: 'object',
+        properties: {
+          city: {
+            type: 'string',
+          },
+          detail: {
+            type: 'object',
+            properties: {
+              street: {
+                type: 'string',
+              },
+              zip: {
+                type: 'integer',
+              },
+            },
+          },
+        },
+        const: {
+          city: 'New York',
+          detail: {
+            street: 'First Street',
+            zip: 12345,
+          },
+        },
+      },
+      tags: {
+        type: 'array',
+        items: {
+          type: 'string',
+        },
+        const: ['red', 'green', 'blue'],
+      },
+      isVerified: {
+        type: 'boolean',
+        const: true,
+      },
+      age: {
+        type: 'number',
+        const: 30,
+      },
+    },
+  },
+  formData: {},
+};

--- a/packages/playground/src/samples/index.ts
+++ b/packages/playground/src/samples/index.ts
@@ -31,6 +31,7 @@ import defaults from './defaults';
 import options from './options';
 import ifThenElse from './ifThenElse';
 import customField from './customField';
+import constField from './constField';
 
 export const samples = Object.freeze({
   Blank: { schema: {}, uiSchema: {}, formData: {} },
@@ -67,6 +68,7 @@ export const samples = Object.freeze({
   ErrorSchema: errorSchema,
   Defaults: defaults,
   'Custom Field': customField,
+  'Const Field': constField,
 } as const);
 
 export type Sample = keyof typeof samples;

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -1,7 +1,15 @@
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 
-import { ANY_OF_KEY, DEFAULT_KEY, DEPENDENCIES_KEY, PROPERTIES_KEY, ONE_OF_KEY, REF_KEY } from '../constants';
+import {
+  ANY_OF_KEY,
+  CONST_KEY,
+  DEFAULT_KEY,
+  DEPENDENCIES_KEY,
+  PROPERTIES_KEY,
+  ONE_OF_KEY,
+  REF_KEY,
+} from '../constants';
 import findSchemaDefinition from '../findSchemaDefinition';
 import getClosestMatchingOption from './getClosestMatchingOption';
 import getDiscriminatorFieldFromSchema from '../getDiscriminatorFieldFromSchema';
@@ -177,6 +185,8 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
     defaults = mergeObjects(defaults!, schema.default as GenericObjectType) as T;
   } else if (DEFAULT_KEY in schema) {
     defaults = schema.default as unknown as T;
+  } else if (CONST_KEY in schema) {
+    defaults = schema.const as unknown as T;
   } else if (REF_KEY in schema) {
     const refName = schema[REF_KEY];
     // Use referenced schema defaults for this node.

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -314,6 +314,39 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         const schema: RJSFSchema = { type: 'string' };
         expect(computeDefaults(testValidator, schema)).toBe(undefined);
       });
+      it('test const value will populate as field defaults', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            foo: {
+              type: 'string',
+              const: 'bar',
+            },
+            foo2: {
+              type: 'object',
+              properties: {
+                attr1: {
+                  type: 'number',
+                },
+                attr2: {
+                  type: 'boolean',
+                },
+              },
+              const: {
+                attr1: 1,
+                attr2: true,
+              },
+            },
+          },
+        };
+        expect(computeDefaults(testValidator, schema, { rootSchema: schema })).toEqual({
+          foo: 'bar',
+          foo2: {
+            attr1: 1,
+            attr2: true,
+          },
+        });
+      });
     });
     describe('default form state behavior: ignore min items unless required', () => {
       it('should return empty data for an optional array property with minItems', () => {


### PR DESCRIPTION
### Reasons for making this change

fixes #2600 

If fields have `const` definition, make the value as pre-filled default and also make the fields readonly. (current logic will just ignore the `const` value and leave blank input for users.

<img width="1667" alt="image" src="https://github.com/rjsf-team/react-jsonschema-form/assets/1276391/f9c760fe-648b-4163-919f-419a3c3a2d41">

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
