### PR TITLE
fix: programmatic validation removes previous errors if all data is now valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 
 - Updated `MultiSchemaField` to only merge top level required field fixing duplicate field and description.
+- Fixed programmatic validation (`validateForm()`) removes previous errors if all data is now valid.
 
 ## @rjsf/chakra-ui
 

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -729,13 +729,14 @@ export default class Form<
    */
   validateForm() {
     const { extraErrors, extraErrorsBlockSubmit, focusOnFirstError, onError } = this.props;
-    const { formData } = this.state;
+    const { formData, errors: prevErrors } = this.state;
     const schemaValidation = this.validate(formData);
     let errors = schemaValidation.errors;
     let errorSchema = schemaValidation.errorSchema;
     const schemaValidationErrors = errors;
     const schemaValidationErrorSchema = errorSchema;
-    if (errors.length > 0 || (extraErrors && extraErrorsBlockSubmit)) {
+    const hasError = errors.length > 0 || (extraErrors && extraErrorsBlockSubmit);
+    if (hasError) {
       if (extraErrors) {
         const merged = validationDataMerge(schemaValidation, extraErrors);
         errorSchema = merged.errorSchema;
@@ -763,9 +764,15 @@ export default class Form<
           }
         }
       );
-      return false;
+    } else if (prevErrors.length > 0) {
+      this.setState({
+        errors: [],
+        errorSchema: {},
+        schemaValidationErrors: [],
+        schemaValidationErrorSchema: {},
+      });
     }
-    return true;
+    return !hasError;
   }
 
   /** Renders the `Form` fields inside the <form> | `tagName` or `_internalFormWrapper`, rendering any errors if

--- a/packages/core/test/Form.test.jsx
+++ b/packages/core/test/Form.test.jsx
@@ -4182,4 +4182,47 @@ describe('Form omitExtraData and liveOmit', () => {
       expect(checkbox.checked).to.eq(true);
     });
   });
+
+  describe('validateForm()', () => {
+    it('Should update state when data updated from invalid to valid', () => {
+      const ref = createRef();
+      const props = {
+        schema: {
+          type: 'object',
+          required: ['input'],
+          properties: {
+            input: {
+              type: 'string',
+            },
+          },
+        },
+        formData: {},
+        ref,
+      };
+      const { comp, node } = createFormComponent(props);
+
+      // trigger programmatic validation and make sure an error appears.
+      expect(ref.current.validateForm()).to.eql(false);
+      let errors = node.querySelectorAll('.error-detail');
+      expect(errors).to.have.lengthOf(1);
+      expect(errors[0].textContent).to.be.eql("must have required property 'input'");
+
+      // populate the input and simulate a re-render from the parent.
+      const textNode = node.querySelector('#root_input');
+      Simulate.change(textNode, {
+        target: { value: 'populated value' },
+      });
+      setProps(comp, { ...props, formData: { input: 'populated value' } });
+
+      // error should still be present.
+      errors = node.querySelectorAll('.error-detail');
+      expect(errors).to.have.lengthOf(1);
+      expect(errors[0].textContent).to.be.eql("must have required property 'input'");
+
+      // trigger programmatic validation again and make sure the error disappears.
+      expect(ref.current.validateForm()).to.eql(true);
+      errors = node.querySelectorAll('.error-detail');
+      expect(errors).to.have.lengthOf(0);
+    });
+  });
 });


### PR DESCRIPTION
### Reasons for making this change

Programatic validation doesn't clear the errors if the form has been changed from being invalid -> valid. This results in stale errors remaining.

Reproduction steps:

1. With the following example form: https://rjsf-team.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6e30sInNjaGVtYSI6eyJ0aXRsZSI6IkEgcmVnaXN0cmF0aW9uIGZvcm0iLCJkZXNjcmlwdGlvbiI6IkEgc2ltcGxlIGZvcm0gZXhhbXBsZS4iLCJ0eXBlIjoib2JqZWN0IiwicmVxdWlyZWQiOlsibmFtZSJdLCJwcm9wZXJ0aWVzIjp7Im5hbWUiOnsidHlwZSI6InN0cmluZyIsInRpdGxlIjoiTmFtZSJ9fX0sInVpU2NoZW1hIjp7fSwidGhlbWUiOiJkZWZhdWx0IiwibGl2ZVNldHRpbmdzIjp7Im5vSHRtbDVWYWxpZGF0ZSI6dHJ1ZSwic2hvd0Vycm9yTGlzdCI6InRvcCIsImV4cGVyaW1lbnRhbF9kZWZhdWx0Rm9ybVN0YXRlQmVoYXZpb3IiOnsiYXJyYXlNaW5JdGVtcyI6eyJwb3B1bGF0ZSI6InBvcHVsYXRlIiwibWVyZ2VFeHRyYURlZmF1bHRzIjpmYWxzZX0sImVtcHR5T2JqZWN0RmllbGRzIjoicG9wdWxhdGVBbGxEZWZhdWx0cyJ9fX0=
2. Click the Programmatic "Validate" button, an error indicating name is required should appear.
3. Fill in the name field.
4. Click the Programmatic "Validate" button again.

Expected: The error should disappear after clearing invalid data and re-validating.
Actual: The error remains after clearing invalid data and re-validating.

Workaround:

Pass additional props when rendering `Form` so the state will still be updated if there are no errors:
```
        extraErrors={{}}
        extraErrorsBlockSubmit={true}
```

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
