### PR TITLE
[DRAFT] Custom widgets for arrays

### DIFF
--- a/packages/core/src/components/fields/ObjectField.tsx
+++ b/packages/core/src/components/fields/ObjectField.tsx
@@ -276,7 +276,7 @@ class ObjectField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
       description: uiOptions.label === false ? undefined : description,
       properties: orderedProperties.map((name) => {
         const addedByAdditionalProperties = has(schema, [PROPERTIES_KEY, name, ADDITIONAL_PROPERTY_FLAG]);
-        const fieldUiSchema = addedByAdditionalProperties ? uiSchema.additionalProperties : uiSchema[name];
+        const fieldUiSchema = addedByAdditionalProperties ? uiSchema.additionalProperties || get(uiSchema, [name], {}) : uiSchema[name];
         const hidden = getUiOptions<T, S, F>(fieldUiSchema).widget === 'hidden';
         const fieldIdSchema: IdSchema<T> = get(idSchema, [name], {});
 


### PR DESCRIPTION
### Reasons for making this change

Allows to have custom Widgets for arrays. I have not tested it apart from my own implementations. It worked for me without any issues currently. I'll make sure to check back in in case I notice some issues.

I would like to mark this as a DRAFT, since I'm not sure of any issues. I also didn't have time to check the tests yet. Any help testing this would be appreciated which is why I'm already making the pull request.

Here are some logical tests I did:
- `addedByAdditionalProperties` is `true`, since the `name` is something like root_[number].
- `uiSchema.additionalProperties` must be empty, but like this it still won't break
- `get(uiSchema, [name], {})` works if the name doesn't match anything but falls back to default behaviour 

fixes #573 

### Checklist

- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
