### PR TITLE
fix: remove mui/material-ui ArrayFieldTemplate grid wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # 5.13.1
 
+## @rjsf/mui
+
+- Removed an unnecessary `Grid` container component in the `ArrayFieldTemplate` component that wrapped the `ArrayFieldItemTemplate`, fixing [#3863](https://github.com/rjsf-team/react-jsonschema-form/issues/3863)
+
+## @rjsf/material-ui
+
+- Removed an unnecessary `Grid` container component in the `ArrayFieldTemplate` component that wrapped the `ArrayFieldItemTemplate`, fixing [#3863](https://github.com/rjsf-team/react-jsonschema-form/issues/3863)
+
 ## @rjsf/utils
 
 - Added `getOptionMatchingSimpleDiscriminator()` function

--- a/packages/material-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/material-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -60,27 +60,25 @@ export default function ArrayFieldTemplate<
           uiSchema={uiSchema}
           registry={registry}
         />
-        <Grid container={true} key={`array-item-list-${idSchema.$id}`}>
-          {items &&
-            items.map(({ key, ...itemProps }: ArrayFieldTemplateItemType<T, S, F>) => (
-              <ArrayFieldItemTemplate key={key} {...itemProps} />
-            ))}
-          {canAdd && (
-            <Grid container justifyContent='flex-end'>
-              <Grid item={true}>
-                <Box mt={2}>
-                  <AddButton
-                    className='array-item-add'
-                    onClick={onAddClick}
-                    disabled={disabled || readonly}
-                    uiSchema={uiSchema}
-                    registry={registry}
-                  />
-                </Box>
-              </Grid>
+        {items &&
+          items.map(({ key, ...itemProps }: ArrayFieldTemplateItemType<T, S, F>) => (
+            <ArrayFieldItemTemplate key={key} {...itemProps} />
+          ))}
+        {canAdd && (
+          <Grid container justifyContent='flex-end'>
+            <Grid item={true}>
+              <Box mt={2}>
+                <AddButton
+                  className='array-item-add'
+                  onClick={onAddClick}
+                  disabled={disabled || readonly}
+                  uiSchema={uiSchema}
+                  registry={registry}
+                />
+              </Box>
             </Grid>
-          )}
-        </Grid>
+          </Grid>
+        )}
       </Box>
     </Paper>
   );

--- a/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Array.test.tsx.snap
@@ -19,52 +19,48 @@ exports[`array fields array 1`] = `
           className="MuiBox-root MuiBox-root-1"
         >
           <div
-            className="MuiGrid-root MuiGrid-container"
+            className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
           >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
+              className="MuiGrid-root MuiGrid-item"
             >
               <div
-                className="MuiGrid-root MuiGrid-item"
+                className="MuiBox-root MuiBox-root-2"
               >
-                <div
-                  className="MuiBox-root MuiBox-root-2"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <span
+                    className="MuiIconButton-label"
                   >
-                    <span
-                      className="MuiIconButton-label"
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
                     >
-                      <svg
-                        aria-hidden={true}
-                        className="MuiSvgIcon-root"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </div>
+                      <path
+                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                      />
+                    </svg>
+                  </span>
+                </button>
               </div>
             </div>
           </div>
@@ -121,59 +117,55 @@ exports[`array fields array icons 1`] = `
           className="MuiBox-root MuiBox-root-11"
         >
           <div
-            className="MuiGrid-root MuiGrid-container"
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
           >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root MuiBox-root-12"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-12"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-13"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-13"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
                           <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="a"
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="a"
+                            />
                           </div>
                         </div>
                       </div>
@@ -181,483 +173,483 @@ exports[`array fields array icons 1`] = `
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item"
-              >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move up"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move down"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    className="MuiTouchRipple-root"
-                  />
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    className="MuiTouchRipple-root"
-                  />
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13H5v-2h14v2z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    className="MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item"
             >
-              <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              <button
+                className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
                 style={
                   {
-                    "overflow": "auto",
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
                   }
                 }
+                tabIndex={-1}
+                title="Move up"
+                type="button"
               >
-                <div
-                  className="MuiBox-root MuiBox-root-14"
+                <span
+                  className="MuiIconButton-label"
                 >
-                  <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <div
-                      className="MuiBox-root MuiBox-root-15"
-                    >
-                      <div
-                        className="form-group field field-string"
-                      >
-                        <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
-                        >
-                          <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root"
-                          >
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="b"
-                              />
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="MuiGrid-root MuiGrid-item"
-              >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move up"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    className="MuiTouchRipple-root"
-                  />
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move down"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    className="MuiTouchRipple-root"
-                  />
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13H5v-2h14v2z"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    className="MuiTouchRipple-root"
-                  />
-                </button>
-              </div>
-            </div>
-            <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
-            >
-              <div
-                className="MuiGrid-root MuiGrid-item"
-              >
-                <div
-                  className="MuiBox-root MuiBox-root-16"
-                >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
-                  >
-                    <span
-                      className="MuiIconButton-label"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        className="MuiSvgIcon-root"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="MuiTouchRipple-root"
+                    <path
+                      d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
                     />
-                  </button>
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move down"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  className="MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  className="MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13H5v-2h14v2z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  className="MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
+            >
+              <div
+                className="MuiBox-root MuiBox-root-14"
+              >
+                <div
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                >
+                  <div
+                    className="MuiBox-root MuiBox-root-15"
+                  >
+                    <div
+                      className="form-group field field-string"
+                    >
+                      <div
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
+                      >
+                        <div
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root"
+                        >
+                          <div
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
+                          >
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="b"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                 </div>
+              </div>
+            </div>
+            <div
+              className="MuiGrid-root MuiGrid-item"
+            >
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move up"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  className="MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={-1}
+                title="Move down"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  className="MuiTouchRipple-root"
+                />
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13H5v-2h14v2z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  className="MuiTouchRipple-root"
+                />
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item"
+            >
+              <div
+                className="MuiBox-root MuiBox-root-16"
+              >
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
+                >
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
+                  />
+                </button>
               </div>
             </div>
           </div>
@@ -917,59 +909,55 @@ exports[`array fields fixed array 1`] = `
           className="MuiBox-root MuiBox-root-4"
         >
           <div
-            className="MuiGrid-root MuiGrid-container"
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
           >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root MuiBox-root-5"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-5"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-6"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-6"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
                           <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value=""
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value=""
+                            />
                           </div>
                         </div>
                       </div>
@@ -978,58 +966,58 @@ exports[`array fields fixed array 1`] = `
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+          >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root MuiBox-root-7"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-7"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-8"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-8"
+                      className="form-group field field-number"
                     >
                       <div
-                        className="form-group field field-number"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
                           <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                step="any"
-                                type="number"
-                                value=""
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              step="any"
+                              type="number"
+                              value=""
+                            />
                           </div>
                         </div>
                       </div>
@@ -1392,55 +1380,51 @@ exports[`with title and description array 1`] = `
             a test description
           </h6>
           <div
-            className="MuiGrid-root MuiGrid-container"
+            className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
           >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
+              className="MuiGrid-root MuiGrid-item"
             >
               <div
-                className="MuiGrid-root MuiGrid-item"
+                className="MuiBox-root MuiBox-root-24"
               >
-                <div
-                  className="MuiBox-root MuiBox-root-24"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <span
+                    className="MuiIconButton-label"
                   >
-                    <span
-                      className="MuiIconButton-label"
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
                     >
-                      <svg
-                        aria-hidden={true}
-                        className="MuiSvgIcon-root"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
+                      <path
+                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
+                  />
+                </button>
               </div>
             </div>
           </div>
@@ -1524,582 +1508,578 @@ exports[`with title and description array icons 1`] = `
             a test description
           </h6>
           <div
-            className="MuiGrid-root MuiGrid-container"
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
           >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root MuiBox-root-36"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-36"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-37"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-37"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled Mui-required Mui-required"
+                            data-shrink={true}
+                            htmlFor="root_0"
+                            id="root_0-label"
+                          >
+                            Test item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled Mui-required Mui-required"
-                              data-shrink={true}
-                              htmlFor="root_0"
-                              id="root_0-label"
-                            >
-                              Test item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
-                              >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="a"
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="a"
+                            />
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2"
-                              id="root_0__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a test item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2"
+                            id="root_0__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a test item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item"
-              >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move up"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move down"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13H5v-2h14v2z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item"
             >
-              <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              <button
+                className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
                 style={
                   {
-                    "overflow": "auto",
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
                   }
                 }
+                tabIndex={-1}
+                title="Move up"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move down"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13H5v-2h14v2z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
+            >
+              <div
+                className="MuiBox-root MuiBox-root-38"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-38"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-39"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-39"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled Mui-required Mui-required"
+                            data-shrink={true}
+                            htmlFor="root_1"
+                            id="root_1-label"
+                          >
+                            Test item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled Mui-required Mui-required"
-                              data-shrink={true}
-                              htmlFor="root_1"
-                              id="root_1-label"
-                            >
-                              Test item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
-                              >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="b"
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="b"
+                            />
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2"
-                              id="root_1__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a test item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2"
+                            id="root_1__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a test item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item"
-              >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move up"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move down"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13H5v-2h14v2z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
+              className="MuiGrid-root MuiGrid-item"
+            >
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move up"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={-1}
+                title="Move down"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13H5v-2h14v2z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item"
             >
               <div
-                className="MuiGrid-root MuiGrid-item"
+                className="MuiBox-root MuiBox-root-40"
               >
-                <div
-                  className="MuiBox-root MuiBox-root-40"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <span
+                    className="MuiIconButton-label"
                   >
-                    <span
-                      className="MuiIconButton-label"
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
                     >
-                      <svg
-                        aria-hidden={true}
-                        className="MuiSvgIcon-root"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </div>
+                      <path
+                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                      />
+                    </svg>
+                  </span>
+                </button>
               </div>
             </div>
           </div>
@@ -2301,181 +2281,177 @@ exports[`with title and description fixed array 1`] = `
             a test description
           </h6>
           <div
-            className="MuiGrid-root MuiGrid-container"
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
           >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root MuiBox-root-28"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-28"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-29"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-29"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-required Mui-required"
+                            data-shrink={false}
+                            htmlFor="root_0"
+                            id="root_0-label"
+                          >
+                            Test item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-required Mui-required"
-                              data-shrink={false}
-                              htmlFor="root_0"
-                              id="root_0-label"
-                            >
-                              Test item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
-                              >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value=""
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value=""
+                            />
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2"
-                              id="root_0__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a test item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2"
+                            id="root_0__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a test item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+          >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root MuiBox-root-30"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-30"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-31"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-31"
+                      className="form-group field field-number"
                     >
                       <div
-                        className="form-group field field-number"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-required Mui-required"
+                            data-shrink={false}
+                            htmlFor="root_1"
+                            id="root_1-label"
+                          >
+                            Test item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-required Mui-required"
-                              data-shrink={false}
-                              htmlFor="root_1"
-                              id="root_1-label"
-                            >
-                              Test item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
-                              >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                step="any"
-                                type="number"
-                                value=""
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              step="any"
+                              type="number"
+                              value=""
+                            />
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2"
-                              id="root_1__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a test item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2"
+                            id="root_1__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a test item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
@@ -2560,55 +2536,51 @@ exports[`with title and description from both array 1`] = `
             a fancier description
           </h6>
           <div
-            className="MuiGrid-root MuiGrid-container"
+            className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
           >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
+              className="MuiGrid-root MuiGrid-item"
             >
               <div
-                className="MuiGrid-root MuiGrid-item"
+                className="MuiBox-root MuiBox-root-64"
               >
-                <div
-                  className="MuiBox-root MuiBox-root-64"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <span
+                    className="MuiIconButton-label"
                   >
-                    <span
-                      className="MuiIconButton-label"
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
                     >
-                      <svg
-                        aria-hidden={true}
-                        className="MuiSvgIcon-root"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
+                      <path
+                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
+                  />
+                </button>
               </div>
             </div>
           </div>
@@ -2692,582 +2664,578 @@ exports[`with title and description from both array icons 1`] = `
             a fancier description
           </h6>
           <div
-            className="MuiGrid-root MuiGrid-container"
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
           >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root MuiBox-root-76"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-76"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-77"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-77"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled Mui-required Mui-required"
+                            data-shrink={true}
+                            htmlFor="root_0"
+                            id="root_0-label"
+                          >
+                            My Item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled Mui-required Mui-required"
-                              data-shrink={true}
-                              htmlFor="root_0"
-                              id="root_0-label"
-                            >
-                              My Item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
-                              >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="a"
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="a"
+                            />
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2"
-                              id="root_0__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a fancier item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2"
+                            id="root_0__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a fancier item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item"
-              >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move up"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move down"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13H5v-2h14v2z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item"
             >
-              <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              <button
+                className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
                 style={
                   {
-                    "overflow": "auto",
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
                   }
                 }
+                tabIndex={-1}
+                title="Move up"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move down"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13H5v-2h14v2z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
+            >
+              <div
+                className="MuiBox-root MuiBox-root-78"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-78"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-79"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-79"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled Mui-required Mui-required"
+                            data-shrink={true}
+                            htmlFor="root_1"
+                            id="root_1-label"
+                          >
+                            My Item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled Mui-required Mui-required"
-                              data-shrink={true}
-                              htmlFor="root_1"
-                              id="root_1-label"
-                            >
-                              My Item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
-                              >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="b"
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="b"
+                            />
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2"
-                              id="root_1__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a fancier item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2"
+                            id="root_1__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a fancier item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item"
-              >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move up"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move down"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13H5v-2h14v2z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
+              className="MuiGrid-root MuiGrid-item"
+            >
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move up"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={-1}
+                title="Move down"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13H5v-2h14v2z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item"
             >
               <div
-                className="MuiGrid-root MuiGrid-item"
+                className="MuiBox-root MuiBox-root-80"
               >
-                <div
-                  className="MuiBox-root MuiBox-root-80"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <span
+                    className="MuiIconButton-label"
                   >
-                    <span
-                      className="MuiIconButton-label"
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
                     >
-                      <svg
-                        aria-hidden={true}
-                        className="MuiSvgIcon-root"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </div>
+                      <path
+                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                      />
+                    </svg>
+                  </span>
+                </button>
               </div>
             </div>
           </div>
@@ -3469,181 +3437,177 @@ exports[`with title and description from both fixed array 1`] = `
             a fancier description
           </h6>
           <div
-            className="MuiGrid-root MuiGrid-container"
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
           >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root MuiBox-root-68"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-68"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-69"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-69"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-required Mui-required"
+                            data-shrink={false}
+                            htmlFor="root_0"
+                            id="root_0-label"
+                          >
+                            My Item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-required Mui-required"
-                              data-shrink={false}
-                              htmlFor="root_0"
-                              id="root_0-label"
-                            >
-                              My Item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
-                              >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value=""
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value=""
+                            />
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2"
-                              id="root_0__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a fancier item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2"
+                            id="root_0__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a fancier item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+          >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root MuiBox-root-70"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-70"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-71"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-71"
+                      className="form-group field field-number"
                     >
                       <div
-                        className="form-group field field-number"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-required Mui-required"
+                            data-shrink={false}
+                            htmlFor="root_1"
+                            id="root_1-label"
+                          >
+                            My Item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-required Mui-required"
-                              data-shrink={false}
-                              htmlFor="root_1"
-                              id="root_1-label"
-                            >
-                              My Item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
-                              >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                step="any"
-                                type="number"
-                                value=""
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              step="any"
+                              type="number"
+                              value=""
+                            />
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2"
-                              id="root_1__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a fancier item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2"
+                            id="root_1__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a fancier item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
@@ -3728,55 +3692,51 @@ exports[`with title and description from uiSchema array 1`] = `
             a fancier description
           </h6>
           <div
-            className="MuiGrid-root MuiGrid-container"
+            className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
           >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
+              className="MuiGrid-root MuiGrid-item"
             >
               <div
-                className="MuiGrid-root MuiGrid-item"
+                className="MuiBox-root MuiBox-root-44"
               >
-                <div
-                  className="MuiBox-root MuiBox-root-44"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <span
+                    className="MuiIconButton-label"
                   >
-                    <span
-                      className="MuiIconButton-label"
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
                     >
-                      <svg
-                        aria-hidden={true}
-                        className="MuiSvgIcon-root"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
+                      <path
+                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
+                  />
+                </button>
               </div>
             </div>
           </div>
@@ -3860,582 +3820,578 @@ exports[`with title and description from uiSchema array icons 1`] = `
             a fancier description
           </h6>
           <div
-            className="MuiGrid-root MuiGrid-container"
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
           >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root MuiBox-root-56"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-56"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-57"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-57"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled Mui-required Mui-required"
+                            data-shrink={true}
+                            htmlFor="root_0"
+                            id="root_0-label"
+                          >
+                            My Item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled Mui-required Mui-required"
-                              data-shrink={true}
-                              htmlFor="root_0"
-                              id="root_0-label"
-                            >
-                              My Item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
-                              >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="a"
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="a"
+                            />
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2"
-                              id="root_0__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a fancier item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2"
+                            id="root_0__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a fancier item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item"
-              >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move up"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move down"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13H5v-2h14v2z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item"
             >
-              <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              <button
+                className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
                 style={
                   {
-                    "overflow": "auto",
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
                   }
                 }
+                tabIndex={-1}
+                title="Move up"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move down"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13H5v-2h14v2z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
+            >
+              <div
+                className="MuiBox-root MuiBox-root-58"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-58"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-59"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-59"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled Mui-required Mui-required"
+                            data-shrink={true}
+                            htmlFor="root_1"
+                            id="root_1-label"
+                          >
+                            My Item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled Mui-required Mui-required"
-                              data-shrink={true}
-                              htmlFor="root_1"
-                              id="root_1-label"
-                            >
-                              My Item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
-                              >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="b"
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="b"
+                            />
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2"
-                              id="root_1__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a fancier item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2"
+                            id="root_1__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a fancier item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item"
-              >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move up"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move down"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13H5v-2h14v2z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
+              className="MuiGrid-root MuiGrid-item"
+            >
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move up"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={-1}
+                title="Move down"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13H5v-2h14v2z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item"
             >
               <div
-                className="MuiGrid-root MuiGrid-item"
+                className="MuiBox-root MuiBox-root-60"
               >
-                <div
-                  className="MuiBox-root MuiBox-root-60"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <span
+                    className="MuiIconButton-label"
                   >
-                    <span
-                      className="MuiIconButton-label"
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
                     >
-                      <svg
-                        aria-hidden={true}
-                        className="MuiSvgIcon-root"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </div>
+                      <path
+                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                      />
+                    </svg>
+                  </span>
+                </button>
               </div>
             </div>
           </div>
@@ -4637,181 +4593,177 @@ exports[`with title and description from uiSchema fixed array 1`] = `
             a fancier description
           </h6>
           <div
-            className="MuiGrid-root MuiGrid-container"
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
           >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root MuiBox-root-48"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-48"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-49"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-49"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-required Mui-required"
+                            data-shrink={false}
+                            htmlFor="root_0"
+                            id="root_0-label"
+                          >
+                            My Item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-required Mui-required"
-                              data-shrink={false}
-                              htmlFor="root_0"
-                              id="root_0-label"
-                            >
-                              My Item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
-                              >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value=""
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value=""
+                            />
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2"
-                              id="root_0__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a fancier item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2"
+                            id="root_0__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a fancier item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+          >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root MuiBox-root-50"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-50"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-51"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-51"
+                      className="form-group field field-number"
                     >
                       <div
-                        className="form-group field field-number"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-required Mui-required"
+                            data-shrink={false}
+                            htmlFor="root_1"
+                            id="root_1-label"
+                          >
+                            My Item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated Mui-required Mui-required"
-                              data-shrink={false}
-                              htmlFor="root_1"
-                              id="root_1-label"
-                            >
-                              My Item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk"
-                              >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                step="any"
-                                type="number"
-                                value=""
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              step="any"
+                              type="number"
+                              value=""
+                            />
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2"
-                              id="root_1__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a fancier item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2"
+                            id="root_1__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a fancier item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
@@ -4872,55 +4824,51 @@ exports[`with title and description with global label off array 1`] = `
           className="MuiBox-root MuiBox-root-82"
         >
           <div
-            className="MuiGrid-root MuiGrid-container"
+            className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
           >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
+              className="MuiGrid-root MuiGrid-item"
             >
               <div
-                className="MuiGrid-root MuiGrid-item"
+                className="MuiBox-root MuiBox-root-83"
               >
-                <div
-                  className="MuiBox-root MuiBox-root-83"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <span
+                    className="MuiIconButton-label"
                   >
-                    <span
-                      className="MuiIconButton-label"
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
                     >
-                      <svg
-                        aria-hidden={true}
-                        className="MuiSvgIcon-root"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      className="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
+                      <path
+                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
+                  />
+                </button>
               </div>
             </div>
           </div>
@@ -4980,59 +4928,55 @@ exports[`with title and description with global label off array icons 1`] = `
           className="MuiBox-root MuiBox-root-92"
         >
           <div
-            className="MuiGrid-root MuiGrid-container"
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
           >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root MuiBox-root-93"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-93"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-94"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-94"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
                           <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="a"
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="a"
+                            />
                           </div>
                         </div>
                       </div>
@@ -5040,234 +4984,234 @@ exports[`with title and description with global label off array icons 1`] = `
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item"
-              >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move up"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move down"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13H5v-2h14v2z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item"
             >
-              <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              <button
+                className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
                 style={
                   {
-                    "overflow": "auto",
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
                   }
                 }
+                tabIndex={-1}
+                title="Move up"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move down"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13H5v-2h14v2z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
+            >
+              <div
+                className="MuiBox-root MuiBox-root-95"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-95"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-96"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-96"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
                           <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="b"
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="b"
+                            />
                           </div>
                         </div>
                       </div>
@@ -5275,227 +5219,227 @@ exports[`with title and description with global label off array icons 1`] = `
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item"
-              >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move up"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move down"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <span
-                    className="MuiIconButton-label"
-                  >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13H5v-2h14v2z"
-                      />
-                    </svg>
-                  </span>
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
+              className="MuiGrid-root MuiGrid-item"
+            >
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move up"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall Mui-disabled"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={-1}
+                title="Move down"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 12l-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm-1 4l6 6v10c0 1.1-.9 2-2 2H7.99C6.89 23 6 22.1 6 21l.01-14c0-1.1.89-2 1.99-2h7zm-1 7h5.5L14 6.5V12z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSecondary MuiIconButton-sizeSmall"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <span
+                  className="MuiIconButton-label"
+                >
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 13H5v-2h14v2z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container MuiGrid-justify-content-xs-flex-end"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item"
             >
               <div
-                className="MuiGrid-root MuiGrid-item"
+                className="MuiBox-root MuiBox-root-97"
               >
-                <div
-                  className="MuiBox-root MuiBox-root-97"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root array-item-add MuiIconButton-colorPrimary"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <span
+                    className="MuiIconButton-label"
                   >
-                    <span
-                      className="MuiIconButton-label"
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root"
+                      focusable="false"
+                      viewBox="0 0 24 24"
                     >
-                      <svg
-                        aria-hidden={true}
-                        className="MuiSvgIcon-root"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </div>
+                      <path
+                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                      />
+                    </svg>
+                  </span>
+                </button>
               </div>
             </div>
           </div>
@@ -5673,59 +5617,55 @@ exports[`with title and description with global label off fixed array 1`] = `
           className="MuiBox-root MuiBox-root-85"
         >
           <div
-            className="MuiGrid-root MuiGrid-container"
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
           >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root MuiBox-root-86"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-86"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-87"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-87"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
                           <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value=""
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value=""
+                            />
                           </div>
                         </div>
                       </div>
@@ -5734,58 +5674,58 @@ exports[`with title and description with global label off fixed array 1`] = `
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+          >
             <div
-              className="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root MuiBox-root-88"
               >
                 <div
-                  className="MuiBox-root MuiBox-root-88"
+                  className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
+                    className="MuiBox-root MuiBox-root-89"
                   >
                     <div
-                      className="MuiBox-root MuiBox-root-89"
+                      className="form-group field field-number"
                     >
                       <div
-                        className="form-group field field-number"
+                        className="MuiFormControl-root MuiFormControl-fullWidth"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root"
                         >
                           <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root"
+                            className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+                            onClick={[Function]}
                           >
-                            <div
-                              className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiInput-input"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                step="any"
-                                type="number"
-                                value=""
-                              />
-                            </div>
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiInput-input"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              step="any"
+                              type="number"
+                              value=""
+                            />
                           </div>
                         </div>
                       </div>

--- a/packages/mui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/mui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -60,27 +60,25 @@ export default function ArrayFieldTemplate<
           uiSchema={uiSchema}
           registry={registry}
         />
-        <Grid container={true} key={`array-item-list-${idSchema.$id}`}>
-          {items &&
-            items.map(({ key, ...itemProps }: ArrayFieldTemplateItemType<T, S, F>) => (
-              <ArrayFieldItemTemplate key={key} {...itemProps} />
-            ))}
-          {canAdd && (
-            <Grid container justifyContent='flex-end'>
-              <Grid item={true}>
-                <Box mt={2}>
-                  <AddButton
-                    className='array-item-add'
-                    onClick={onAddClick}
-                    disabled={disabled || readonly}
-                    uiSchema={uiSchema}
-                    registry={registry}
-                  />
-                </Box>
-              </Grid>
+        {items &&
+          items.map(({ key, ...itemProps }: ArrayFieldTemplateItemType<T, S, F>) => (
+            <ArrayFieldItemTemplate key={key} {...itemProps} />
+          ))}
+        {canAdd && (
+          <Grid container justifyContent='flex-end'>
+            <Grid item={true}>
+              <Box mt={2}>
+                <AddButton
+                  className='array-item-add'
+                  onClick={onAddClick}
+                  disabled={disabled || readonly}
+                  uiSchema={uiSchema}
+                  registry={registry}
+                />
+              </Box>
             </Grid>
-          )}
-        </Grid>
+          </Grid>
+        )}
       </Box>
     </Paper>
   );

--- a/packages/mui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Array.test.tsx.snap
@@ -45,29 +45,13 @@ exports[`array fields array 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-}
-
-.emotion-4 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
   justify-content: flex-end;
 }
 
-.emotion-5 {
+.emotion-4 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -75,11 +59,11 @@ exports[`array fields array 1`] = `
   flex-direction: row;
 }
 
-.emotion-6 {
+.emotion-5 {
   margin-top: 16px;
 }
 
-.emotion-7 {
+.emotion-6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -126,48 +110,48 @@ exports[`array fields array 1`] = `
   color: #1976d2;
 }
 
-.emotion-7::-moz-focus-inner {
+.emotion-6::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-7.Mui-disabled {
+.emotion-6.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-7 {
+  .emotion-6 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-7:hover {
+.emotion-6:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-7:hover {
+  .emotion-6:hover {
     background-color: transparent;
   }
 }
 
-.emotion-7:hover {
+.emotion-6:hover {
   background-color: rgba(25, 118, 210, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-7:hover {
+  .emotion-6:hover {
     background-color: transparent;
   }
 }
 
-.emotion-7.Mui-disabled {
+.emotion-6.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-8 {
+.emotion-7 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -184,11 +168,11 @@ exports[`array fields array 1`] = `
   font-size: 1.5rem;
 }
 
-.emotion-9 {
+.emotion-8 {
   margin-top: 24px;
 }
 
-.emotion-10 {
+.emotion-9 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -237,23 +221,23 @@ exports[`array fields array 1`] = `
   box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-10::-moz-focus-inner {
+.emotion-9::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-10.Mui-disabled {
+.emotion-9.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-10 {
+  .emotion-9 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-10:hover {
+.emotion-9:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: #1565c0;
@@ -261,20 +245,20 @@ exports[`array fields array 1`] = `
 }
 
 @media (hover: none) {
-  .emotion-10:hover {
+  .emotion-9:hover {
     background-color: #1976d2;
   }
 }
 
-.emotion-10:active {
+.emotion-9:active {
   box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
 }
 
-.emotion-10.Mui-focusVisible {
+.emotion-9.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-10.Mui-disabled {
+.emotion-9.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
@@ -301,47 +285,43 @@ exports[`array fields array 1`] = `
             className="MuiGrid-root MuiGrid-container emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-4"
+              className="MuiGrid-root MuiGrid-item emotion-4"
             >
               <div
-                className="MuiGrid-root MuiGrid-item emotion-5"
+                className="MuiBox-root emotion-5"
               >
-                <div
-                  className="MuiBox-root emotion-6"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-6"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-7"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onContextMenu={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-7"
+                    data-testid="AddIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-8"
-                      data-testid="AddIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                      />
-                    </svg>
-                  </button>
-                </div>
+                    <path
+                      d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                    />
+                  </svg>
+                </button>
               </div>
             </div>
           </div>
@@ -350,10 +330,10 @@ exports[`array fields array 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root emotion-9"
+    className="MuiBox-root emotion-8"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-10"
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-9"
       disabled={false}
       onBlur={[Function]}
       onContextMenu={[Function]}
@@ -421,29 +401,13 @@ exports[`array fields array icons 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-}
-
-.emotion-4 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-5 {
+.emotion-4 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -460,7 +424,7 @@ exports[`array fields array icons 1`] = `
 }
 
 @media (min-width:600px) {
-  .emotion-5 {
+  .emotion-4 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -473,7 +437,7 @@ exports[`array fields array icons 1`] = `
 }
 
 @media (min-width:900px) {
-  .emotion-5 {
+  .emotion-4 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -486,7 +450,7 @@ exports[`array fields array icons 1`] = `
 }
 
 @media (min-width:1200px) {
-  .emotion-5 {
+  .emotion-4 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -499,7 +463,7 @@ exports[`array fields array icons 1`] = `
 }
 
 @media (min-width:1536px) {
-  .emotion-5 {
+  .emotion-4 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -511,11 +475,11 @@ exports[`array fields array icons 1`] = `
   }
 }
 
-.emotion-6 {
+.emotion-5 {
   margin-bottom: 16px;
 }
 
-.emotion-10 {
+.emotion-9 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -531,7 +495,7 @@ exports[`array fields array icons 1`] = `
   vertical-align: top;
 }
 
-.emotion-11 {
+.emotion-10 {
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -553,35 +517,35 @@ exports[`array fields array icons 1`] = `
   border-radius: 4px;
 }
 
-.emotion-11.Mui-disabled {
+.emotion-10.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
   cursor: default;
 }
 
-.emotion-11:hover .MuiOutlinedInput-notchedOutline {
+.emotion-10:hover .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.87);
 }
 
 @media (hover: none) {
-  .emotion-11:hover .MuiOutlinedInput-notchedOutline {
+  .emotion-10:hover .MuiOutlinedInput-notchedOutline {
     border-color: rgba(0, 0, 0, 0.23);
   }
 }
 
-.emotion-11.Mui-focused .MuiOutlinedInput-notchedOutline {
+.emotion-10.Mui-focused .MuiOutlinedInput-notchedOutline {
   border-color: #1976d2;
   border-width: 2px;
 }
 
-.emotion-11.Mui-error .MuiOutlinedInput-notchedOutline {
+.emotion-10.Mui-error .MuiOutlinedInput-notchedOutline {
   border-color: #d32f2f;
 }
 
-.emotion-11.Mui-disabled .MuiOutlinedInput-notchedOutline {
+.emotion-10.Mui-disabled .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-12 {
+.emotion-11 {
   font: inherit;
   letter-spacing: inherit;
   color: currentColor;
@@ -602,95 +566,95 @@ exports[`array fields array icons 1`] = `
   padding: 16.5px 14px;
 }
 
-.emotion-12::-webkit-input-placeholder {
+.emotion-11::-webkit-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-12::-moz-placeholder {
+.emotion-11::-moz-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-12:-ms-input-placeholder {
+.emotion-11:-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-12::-ms-input-placeholder {
+.emotion-11::-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-12:focus {
+.emotion-11:focus {
   outline: 0;
 }
 
-.emotion-12:invalid {
+.emotion-11:invalid {
   box-shadow: none;
 }
 
-.emotion-12::-webkit-search-decoration {
+.emotion-11::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-12::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-11::-webkit-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-12::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-11::-moz-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-12::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-11::-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-webkit-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-moz-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus:-ms-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-placeholder {
   opacity: 0.42;
 }
 
-.emotion-12.Mui-disabled {
+.emotion-11.Mui-disabled {
   opacity: 1;
   -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-12:-webkit-autofill {
+.emotion-11:-webkit-autofill {
   -webkit-animation-duration: 5000s;
   animation-duration: 5000s;
   -webkit-animation-name: mui-auto-fill;
   animation-name: mui-auto-fill;
 }
 
-.emotion-12:-webkit-autofill {
+.emotion-11:-webkit-autofill {
   border-radius: inherit;
 }
 
-.emotion-13 {
+.emotion-12 {
   text-align: left;
   position: absolute;
   bottom: 0;
@@ -708,7 +672,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   border-color: rgba(0, 0, 0, 0.23);
 }
 
-.emotion-14 {
+.emotion-13 {
   float: unset;
   width: auto;
   overflow: hidden;
@@ -718,7 +682,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
 }
 
-.emotion-15 {
+.emotion-14 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -726,7 +690,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   flex-direction: row;
 }
 
-.emotion-16 {
+.emotion-15 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -774,38 +738,38 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   font-size: 1.125rem;
 }
 
-.emotion-16::-moz-focus-inner {
+.emotion-15::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-16.Mui-disabled {
+.emotion-15.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-16 {
+  .emotion-15 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-16:hover {
+.emotion-15:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-16:hover {
+  .emotion-15:hover {
     background-color: transparent;
   }
 }
 
-.emotion-16.Mui-disabled {
+.emotion-15.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-17 {
+.emotion-16 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -822,7 +786,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   font-size: 1.25rem;
 }
 
-.emotion-20 {
+.emotion-19 {
   overflow: hidden;
   pointer-events: none;
   position: absolute;
@@ -834,7 +798,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   border-radius: inherit;
 }
 
-.emotion-24 {
+.emotion-23 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -883,48 +847,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   font-size: 1.125rem;
 }
 
-.emotion-24::-moz-focus-inner {
+.emotion-23::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-24.Mui-disabled {
+.emotion-23.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-24 {
+  .emotion-23 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-24:hover {
+.emotion-23:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-24:hover {
+  .emotion-23:hover {
     background-color: transparent;
   }
 }
 
-.emotion-24:hover {
+.emotion-23:hover {
   background-color: rgba(211, 47, 47, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-24:hover {
+  .emotion-23:hover {
     background-color: transparent;
   }
 }
 
-.emotion-24.Mui-disabled {
+.emotion-23.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-50 {
+.emotion-49 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -944,11 +908,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   justify-content: flex-end;
 }
 
-.emotion-52 {
+.emotion-51 {
   margin-top: 16px;
 }
 
-.emotion-53 {
+.emotion-52 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -995,48 +959,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   color: #1976d2;
 }
 
-.emotion-53::-moz-focus-inner {
+.emotion-52::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-53.Mui-disabled {
+.emotion-52.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-53 {
+  .emotion-52 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-53:hover {
+.emotion-52:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-53:hover {
+  .emotion-52:hover {
     background-color: transparent;
   }
 }
 
-.emotion-53:hover {
+.emotion-52:hover {
   background-color: rgba(25, 118, 210, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-53:hover {
+  .emotion-52:hover {
     background-color: transparent;
   }
 }
 
-.emotion-53.Mui-disabled {
+.emotion-52.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-54 {
+.emotion-53 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -1053,11 +1017,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   font-size: 1.5rem;
 }
 
-.emotion-56 {
+.emotion-55 {
   margin-top: 24px;
 }
 
-.emotion-57 {
+.emotion-56 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1106,23 +1070,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-57::-moz-focus-inner {
+.emotion-56::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-57.Mui-disabled {
+.emotion-56.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-57 {
+  .emotion-56 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-57:hover {
+.emotion-56:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: #1565c0;
@@ -1130,20 +1094,20 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
 }
 
 @media (hover: none) {
-  .emotion-57:hover {
+  .emotion-56:hover {
     background-color: #1976d2;
   }
 }
 
-.emotion-57:active {
+.emotion-56:active {
   box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
 }
 
-.emotion-57.Mui-focusVisible {
+.emotion-56.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-57.Mui-disabled {
+.emotion-56.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
@@ -1170,70 +1134,66 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
             className="MuiGrid-root MuiGrid-container emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-4"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-5"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root emotion-5"
               >
                 <div
-                  className="MuiBox-root emotion-6"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-9"
                         >
                           <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-10"
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-10"
+                            onClick={[Function]}
                           >
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-11"
-                              onClick={[Function]}
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-11"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="a"
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-12"
                             >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-12"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="a"
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-13"
+                              <legend
+                                className="emotion-13"
                               >
-                                <legend
-                                  className="emotion-14"
+                                <span
+                                  className="notranslate"
                                 >
-                                  <span
-                                    className="notranslate"
-                                  >
-                                    ​
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                  ​
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
                         </div>
                       </div>
@@ -1241,249 +1201,249 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item emotion-15"
-              >
-                <button
-                  className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-16"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move up"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
-                    data-testid="ArrowUpwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-16"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move down"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
-                    data-testid="ArrowDownwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                    />
-                  </svg>
-                  <span
-                    className="MuiTouchRipple-root emotion-20"
-                  />
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-16"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
-                    data-testid="ContentCopyIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
-                    />
-                  </svg>
-                  <span
-                    className="MuiTouchRipple-root emotion-20"
-                  />
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-24"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
-                    data-testid="RemoveIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M19 13H5v-2h14v2z"
-                    />
-                  </svg>
-                  <span
-                    className="MuiTouchRipple-root emotion-20"
-                  />
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container emotion-4"
+              className="MuiGrid-root MuiGrid-item emotion-14"
             >
-              <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-5"
+              <button
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-15"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
                 style={
                   {
-                    "overflow": "auto",
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
                   }
                 }
+                tabIndex={-1}
+                title="Move up"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-16"
+                  data-testid="ArrowUpwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-15"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move down"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-16"
+                  data-testid="ArrowDownwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                  />
+                </svg>
+                <span
+                  className="MuiTouchRipple-root emotion-19"
+                />
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-15"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-16"
+                  data-testid="ContentCopyIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                  />
+                </svg>
+                <span
+                  className="MuiTouchRipple-root emotion-19"
+                />
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-23"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-16"
+                  data-testid="RemoveIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 13H5v-2h14v2z"
+                  />
+                </svg>
+                <span
+                  className="MuiTouchRipple-root emotion-19"
+                />
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container emotion-3"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
+            >
+              <div
+                className="MuiBox-root emotion-5"
               >
                 <div
-                  className="MuiBox-root emotion-6"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-9"
                         >
                           <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-10"
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-10"
+                            onClick={[Function]}
                           >
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-11"
-                              onClick={[Function]}
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-11"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="b"
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-12"
                             >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-12"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="b"
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-13"
+                              <legend
+                                className="emotion-13"
                               >
-                                <legend
-                                  className="emotion-14"
+                                <span
+                                  className="notranslate"
                                 >
-                                  <span
-                                    className="notranslate"
-                                  >
-                                    ​
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                  ​
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
                         </div>
                       </div>
@@ -1491,229 +1451,229 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item emotion-15"
-              >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-16"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move up"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
-                    data-testid="ArrowUpwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                    />
-                  </svg>
-                  <span
-                    className="MuiTouchRipple-root emotion-20"
-                  />
-                </button>
-                <button
-                  className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-16"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move down"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
-                    data-testid="ArrowDownwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-16"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
-                    data-testid="ContentCopyIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
-                    />
-                  </svg>
-                  <span
-                    className="MuiTouchRipple-root emotion-20"
-                  />
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-24"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-17"
-                    data-testid="RemoveIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M19 13H5v-2h14v2z"
-                    />
-                  </svg>
-                  <span
-                    className="MuiTouchRipple-root emotion-20"
-                  />
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container emotion-50"
+              className="MuiGrid-root MuiGrid-item emotion-14"
+            >
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-15"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move up"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-16"
+                  data-testid="ArrowUpwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                  />
+                </svg>
+                <span
+                  className="MuiTouchRipple-root emotion-19"
+                />
+              </button>
+              <button
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-15"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={-1}
+                title="Move down"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-16"
+                  data-testid="ArrowDownwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-15"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-16"
+                  data-testid="ContentCopyIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                  />
+                </svg>
+                <span
+                  className="MuiTouchRipple-root emotion-19"
+                />
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-23"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-16"
+                  data-testid="RemoveIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 13H5v-2h14v2z"
+                  />
+                </svg>
+                <span
+                  className="MuiTouchRipple-root emotion-19"
+                />
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container emotion-49"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item emotion-14"
             >
               <div
-                className="MuiGrid-root MuiGrid-item emotion-15"
+                className="MuiBox-root emotion-51"
               >
-                <div
-                  className="MuiBox-root emotion-52"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-52"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-53"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onContextMenu={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-53"
+                    data-testid="AddIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-54"
-                      data-testid="AddIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                      />
-                    </svg>
-                    <span
-                      className="MuiTouchRipple-root emotion-20"
+                    <path
+                      d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
                     />
-                  </button>
-                </div>
+                  </svg>
+                  <span
+                    className="MuiTouchRipple-root emotion-19"
+                  />
+                </button>
               </div>
             </div>
           </div>
@@ -1722,10 +1682,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
     </div>
   </div>
   <div
-    className="MuiBox-root emotion-56"
+    className="MuiBox-root emotion-55"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-57"
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-56"
       disabled={false}
       onBlur={[Function]}
       onContextMenu={[Function]}
@@ -1744,7 +1704,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
     >
       Submit
       <span
-        className="MuiTouchRipple-root emotion-20"
+        className="MuiTouchRipple-root emotion-19"
       />
     </button>
   </div>
@@ -2875,29 +2835,13 @@ exports[`array fields fixed array 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-}
-
-.emotion-4 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-5 {
+.emotion-4 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -2914,7 +2858,7 @@ exports[`array fields fixed array 1`] = `
 }
 
 @media (min-width:600px) {
-  .emotion-5 {
+  .emotion-4 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -2927,7 +2871,7 @@ exports[`array fields fixed array 1`] = `
 }
 
 @media (min-width:900px) {
-  .emotion-5 {
+  .emotion-4 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -2940,7 +2884,7 @@ exports[`array fields fixed array 1`] = `
 }
 
 @media (min-width:1200px) {
-  .emotion-5 {
+  .emotion-4 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -2953,7 +2897,7 @@ exports[`array fields fixed array 1`] = `
 }
 
 @media (min-width:1536px) {
-  .emotion-5 {
+  .emotion-4 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -2965,11 +2909,11 @@ exports[`array fields fixed array 1`] = `
   }
 }
 
-.emotion-6 {
+.emotion-5 {
   margin-bottom: 16px;
 }
 
-.emotion-10 {
+.emotion-9 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2985,7 +2929,7 @@ exports[`array fields fixed array 1`] = `
   vertical-align: top;
 }
 
-.emotion-11 {
+.emotion-10 {
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -3007,35 +2951,35 @@ exports[`array fields fixed array 1`] = `
   border-radius: 4px;
 }
 
-.emotion-11.Mui-disabled {
+.emotion-10.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
   cursor: default;
 }
 
-.emotion-11:hover .MuiOutlinedInput-notchedOutline {
+.emotion-10:hover .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.87);
 }
 
 @media (hover: none) {
-  .emotion-11:hover .MuiOutlinedInput-notchedOutline {
+  .emotion-10:hover .MuiOutlinedInput-notchedOutline {
     border-color: rgba(0, 0, 0, 0.23);
   }
 }
 
-.emotion-11.Mui-focused .MuiOutlinedInput-notchedOutline {
+.emotion-10.Mui-focused .MuiOutlinedInput-notchedOutline {
   border-color: #1976d2;
   border-width: 2px;
 }
 
-.emotion-11.Mui-error .MuiOutlinedInput-notchedOutline {
+.emotion-10.Mui-error .MuiOutlinedInput-notchedOutline {
   border-color: #d32f2f;
 }
 
-.emotion-11.Mui-disabled .MuiOutlinedInput-notchedOutline {
+.emotion-10.Mui-disabled .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-12 {
+.emotion-11 {
   font: inherit;
   letter-spacing: inherit;
   color: currentColor;
@@ -3056,95 +3000,95 @@ exports[`array fields fixed array 1`] = `
   padding: 16.5px 14px;
 }
 
-.emotion-12::-webkit-input-placeholder {
+.emotion-11::-webkit-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-12::-moz-placeholder {
+.emotion-11::-moz-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-12:-ms-input-placeholder {
+.emotion-11:-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-12::-ms-input-placeholder {
+.emotion-11::-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-12:focus {
+.emotion-11:focus {
   outline: 0;
 }
 
-.emotion-12:invalid {
+.emotion-11:invalid {
   box-shadow: none;
 }
 
-.emotion-12::-webkit-search-decoration {
+.emotion-11::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-12::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-11::-webkit-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-12::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-11::-moz-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-12::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-11::-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-webkit-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-moz-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus:-ms-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-placeholder {
   opacity: 0.42;
 }
 
-.emotion-12.Mui-disabled {
+.emotion-11.Mui-disabled {
   opacity: 1;
   -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-12:-webkit-autofill {
+.emotion-11:-webkit-autofill {
   -webkit-animation-duration: 5000s;
   animation-duration: 5000s;
   -webkit-animation-name: mui-auto-fill;
   animation-name: mui-auto-fill;
 }
 
-.emotion-12:-webkit-autofill {
+.emotion-11:-webkit-autofill {
   border-radius: inherit;
 }
 
-.emotion-13 {
+.emotion-12 {
   text-align: left;
   position: absolute;
   bottom: 0;
@@ -3162,7 +3106,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   border-color: rgba(0, 0, 0, 0.23);
 }
 
-.emotion-14 {
+.emotion-13 {
   float: unset;
   width: auto;
   overflow: hidden;
@@ -3172,11 +3116,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   transition: width 150ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
 }
 
-.emotion-26 {
+.emotion-25 {
   margin-top: 24px;
 }
 
-.emotion-27 {
+.emotion-26 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -3225,23 +3169,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-27::-moz-focus-inner {
+.emotion-26::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-27.Mui-disabled {
+.emotion-26.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-27 {
+  .emotion-26 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-27:hover {
+.emotion-26:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: #1565c0;
@@ -3249,26 +3193,26 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
 }
 
 @media (hover: none) {
-  .emotion-27:hover {
+  .emotion-26:hover {
     background-color: #1976d2;
   }
 }
 
-.emotion-27:active {
+.emotion-26:active {
   box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
 }
 
-.emotion-27.Mui-focusVisible {
+.emotion-26.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-27.Mui-disabled {
+.emotion-26.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
 }
 
-.emotion-28 {
+.emotion-27 {
   overflow: hidden;
   pointer-events: none;
   position: absolute;
@@ -3301,70 +3245,66 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
             className="MuiGrid-root MuiGrid-container emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-4"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-5"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root emotion-5"
               >
                 <div
-                  className="MuiBox-root emotion-6"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-9"
                         >
                           <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-10"
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-10"
+                            onClick={[Function]}
                           >
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-11"
-                              onClick={[Function]}
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-11"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value=""
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-12"
                             >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-12"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value=""
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-13"
+                              <legend
+                                className="emotion-13"
                               >
-                                <legend
-                                  className="emotion-14"
+                                <span
+                                  className="notranslate"
                                 >
-                                  <span
-                                    className="notranslate"
-                                  >
-                                    ​
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                  ​
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
                         </div>
                       </div>
@@ -3373,72 +3313,72 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container emotion-3"
+          >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-4"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-5"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root emotion-5"
               >
                 <div
-                  className="MuiBox-root emotion-6"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-number"
                     >
                       <div
-                        className="form-group field field-number"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-9"
                         >
                           <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-10"
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-10"
+                            onClick={[Function]}
                           >
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-11"
-                              onClick={[Function]}
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-11"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              step="any"
+                              type="number"
+                              value=""
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-12"
                             >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-12"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                step="any"
-                                type="number"
-                                value=""
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-13"
+                              <legend
+                                className="emotion-13"
                               >
-                                <legend
-                                  className="emotion-14"
+                                <span
+                                  className="notranslate"
                                 >
-                                  <span
-                                    className="notranslate"
-                                  >
-                                    ​
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                  ​
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
                         </div>
                       </div>
@@ -3453,10 +3393,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
     </div>
   </div>
   <div
-    className="MuiBox-root emotion-26"
+    className="MuiBox-root emotion-25"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-27"
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-26"
       disabled={false}
       onBlur={[Function]}
       onContextMenu={[Function]}
@@ -3475,7 +3415,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
     >
       Submit
       <span
-        className="MuiTouchRipple-root emotion-28"
+        className="MuiTouchRipple-root emotion-27"
       />
     </button>
   </div>
@@ -4983,29 +4923,13 @@ exports[`with title and description array 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-}
-
-.emotion-8 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
   justify-content: flex-end;
 }
 
-.emotion-9 {
+.emotion-8 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -5013,11 +4937,11 @@ exports[`with title and description array 1`] = `
   flex-direction: row;
 }
 
-.emotion-10 {
+.emotion-9 {
   margin-top: 16px;
 }
 
-.emotion-11 {
+.emotion-10 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -5064,48 +4988,48 @@ exports[`with title and description array 1`] = `
   color: #1976d2;
 }
 
-.emotion-11::-moz-focus-inner {
+.emotion-10::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-11.Mui-disabled {
+.emotion-10.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-11 {
+  .emotion-10 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-11:hover {
+.emotion-10:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-11:hover {
+  .emotion-10:hover {
     background-color: transparent;
   }
 }
 
-.emotion-11:hover {
+.emotion-10:hover {
   background-color: rgba(25, 118, 210, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-11:hover {
+  .emotion-10:hover {
     background-color: transparent;
   }
 }
 
-.emotion-11.Mui-disabled {
+.emotion-10.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-12 {
+.emotion-11 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -5122,7 +5046,7 @@ exports[`with title and description array 1`] = `
   font-size: 1.5rem;
 }
 
-.emotion-13 {
+.emotion-12 {
   overflow: hidden;
   pointer-events: none;
   position: absolute;
@@ -5134,11 +5058,11 @@ exports[`with title and description array 1`] = `
   border-radius: inherit;
 }
 
-.emotion-14 {
+.emotion-13 {
   margin-top: 24px;
 }
 
-.emotion-15 {
+.emotion-14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -5187,23 +5111,23 @@ exports[`with title and description array 1`] = `
   box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-15::-moz-focus-inner {
+.emotion-14::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-15.Mui-disabled {
+.emotion-14.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-15 {
+  .emotion-14 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-15:hover {
+.emotion-14:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: #1565c0;
@@ -5211,20 +5135,20 @@ exports[`with title and description array 1`] = `
 }
 
 @media (hover: none) {
-  .emotion-15:hover {
+  .emotion-14:hover {
     background-color: #1976d2;
   }
 }
 
-.emotion-15:active {
+.emotion-14:active {
   box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
 }
 
-.emotion-15.Mui-focusVisible {
+.emotion-14.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-15.Mui-disabled {
+.emotion-14.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
@@ -5275,50 +5199,46 @@ exports[`with title and description array 1`] = `
             className="MuiGrid-root MuiGrid-container emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-8"
+              className="MuiGrid-root MuiGrid-item emotion-8"
             >
               <div
-                className="MuiGrid-root MuiGrid-item emotion-9"
+                className="MuiBox-root emotion-9"
               >
-                <div
-                  className="MuiBox-root emotion-10"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-10"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-11"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onContextMenu={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-11"
+                    data-testid="AddIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-12"
-                      data-testid="AddIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                      />
-                    </svg>
-                    <span
-                      className="MuiTouchRipple-root emotion-13"
+                    <path
+                      d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
                     />
-                  </button>
-                </div>
+                  </svg>
+                  <span
+                    className="MuiTouchRipple-root emotion-12"
+                  />
+                </button>
               </div>
             </div>
           </div>
@@ -5327,10 +5247,10 @@ exports[`with title and description array 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root emotion-14"
+    className="MuiBox-root emotion-13"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-15"
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-14"
       disabled={false}
       onBlur={[Function]}
       onContextMenu={[Function]}
@@ -5349,7 +5269,7 @@ exports[`with title and description array 1`] = `
     >
       Submit
       <span
-        className="MuiTouchRipple-root emotion-13"
+        className="MuiTouchRipple-root emotion-12"
       />
     </button>
   </div>
@@ -5435,29 +5355,13 @@ exports[`with title and description array icons 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-}
-
-.emotion-8 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-9 {
+.emotion-8 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -5474,7 +5378,7 @@ exports[`with title and description array icons 1`] = `
 }
 
 @media (min-width:600px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -5487,7 +5391,7 @@ exports[`with title and description array icons 1`] = `
 }
 
 @media (min-width:900px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -5500,7 +5404,7 @@ exports[`with title and description array icons 1`] = `
 }
 
 @media (min-width:1200px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -5513,7 +5417,7 @@ exports[`with title and description array icons 1`] = `
 }
 
 @media (min-width:1536px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -5525,11 +5429,11 @@ exports[`with title and description array icons 1`] = `
   }
 }
 
-.emotion-10 {
+.emotion-9 {
   margin-bottom: 16px;
 }
 
-.emotion-14 {
+.emotion-13 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -5545,7 +5449,7 @@ exports[`with title and description array icons 1`] = `
   vertical-align: top;
 }
 
-.emotion-15 {
+.emotion-14 {
   color: rgba(0, 0, 0, 0.6);
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
@@ -5577,23 +5481,23 @@ exports[`with title and description array icons 1`] = `
   user-select: none;
 }
 
-.emotion-15.Mui-focused {
+.emotion-14.Mui-focused {
   color: #1976d2;
 }
 
-.emotion-15.Mui-disabled {
+.emotion-14.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-14.Mui-error {
+  color: #d32f2f;
 }
 
 .emotion-15.Mui-error {
   color: #d32f2f;
 }
 
-.emotion-16.Mui-error {
-  color: #d32f2f;
-}
-
-.emotion-17 {
+.emotion-16 {
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -5615,35 +5519,35 @@ exports[`with title and description array icons 1`] = `
   border-radius: 4px;
 }
 
-.emotion-17.Mui-disabled {
+.emotion-16.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
   cursor: default;
 }
 
-.emotion-17:hover .MuiOutlinedInput-notchedOutline {
+.emotion-16:hover .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.87);
 }
 
 @media (hover: none) {
-  .emotion-17:hover .MuiOutlinedInput-notchedOutline {
+  .emotion-16:hover .MuiOutlinedInput-notchedOutline {
     border-color: rgba(0, 0, 0, 0.23);
   }
 }
 
-.emotion-17.Mui-focused .MuiOutlinedInput-notchedOutline {
+.emotion-16.Mui-focused .MuiOutlinedInput-notchedOutline {
   border-color: #1976d2;
   border-width: 2px;
 }
 
-.emotion-17.Mui-error .MuiOutlinedInput-notchedOutline {
+.emotion-16.Mui-error .MuiOutlinedInput-notchedOutline {
   border-color: #d32f2f;
 }
 
-.emotion-17.Mui-disabled .MuiOutlinedInput-notchedOutline {
+.emotion-16.Mui-disabled .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-18 {
+.emotion-17 {
   font: inherit;
   letter-spacing: inherit;
   color: currentColor;
@@ -5664,95 +5568,95 @@ exports[`with title and description array icons 1`] = `
   padding: 16.5px 14px;
 }
 
-.emotion-18::-webkit-input-placeholder {
+.emotion-17::-webkit-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18::-moz-placeholder {
+.emotion-17::-moz-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18:-ms-input-placeholder {
+.emotion-17:-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18::-ms-input-placeholder {
+.emotion-17::-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18:focus {
+.emotion-17:focus {
   outline: 0;
 }
 
-.emotion-18:invalid {
+.emotion-17:invalid {
   box-shadow: none;
 }
 
-.emotion-18::-webkit-search-decoration {
+.emotion-17::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17::-webkit-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17::-moz-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17::-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-webkit-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-moz-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus:-ms-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-placeholder {
   opacity: 0.42;
 }
 
-.emotion-18.Mui-disabled {
+.emotion-17.Mui-disabled {
   opacity: 1;
   -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-18:-webkit-autofill {
+.emotion-17:-webkit-autofill {
   -webkit-animation-duration: 5000s;
   animation-duration: 5000s;
   -webkit-animation-name: mui-auto-fill;
   animation-name: mui-auto-fill;
 }
 
-.emotion-18:-webkit-autofill {
+.emotion-17:-webkit-autofill {
   border-radius: inherit;
 }
 
-.emotion-19 {
+.emotion-18 {
   text-align: left;
   position: absolute;
   bottom: 0;
@@ -5770,7 +5674,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   border-color: rgba(0, 0, 0, 0.23);
 }
 
-.emotion-20 {
+.emotion-19 {
   float: unset;
   width: auto;
   overflow: hidden;
@@ -5785,7 +5689,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   white-space: nowrap;
 }
 
-.emotion-20>span {
+.emotion-19>span {
   padding-left: 5px;
   padding-right: 5px;
   display: inline-block;
@@ -5793,7 +5697,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   visibility: visible;
 }
 
-.emotion-21 {
+.emotion-20 {
   margin: 0;
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
@@ -5803,7 +5707,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   color: rgba(0, 0, 0, 0.6);
 }
 
-.emotion-23 {
+.emotion-22 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -5811,7 +5715,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   flex-direction: row;
 }
 
-.emotion-24 {
+.emotion-23 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -5859,38 +5763,38 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   font-size: 1.125rem;
 }
 
-.emotion-24::-moz-focus-inner {
+.emotion-23::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-24.Mui-disabled {
+.emotion-23.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-24 {
+  .emotion-23 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-24:hover {
+.emotion-23:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-24:hover {
+  .emotion-23:hover {
     background-color: transparent;
   }
 }
 
-.emotion-24.Mui-disabled {
+.emotion-23.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-25 {
+.emotion-24 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -5907,7 +5811,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   font-size: 1.25rem;
 }
 
-.emotion-30 {
+.emotion-29 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -5956,48 +5860,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   font-size: 1.125rem;
 }
 
-.emotion-30::-moz-focus-inner {
+.emotion-29::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-30.Mui-disabled {
+.emotion-29.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-30 {
+  .emotion-29 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-30:hover {
+.emotion-29:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-30:hover {
+  .emotion-29:hover {
     background-color: transparent;
   }
 }
 
-.emotion-30:hover {
+.emotion-29:hover {
   background-color: rgba(211, 47, 47, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-30:hover {
+  .emotion-29:hover {
     background-color: transparent;
   }
 }
 
-.emotion-30.Mui-disabled {
+.emotion-29.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-56 {
+.emotion-55 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -6017,11 +5921,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   justify-content: flex-end;
 }
 
-.emotion-58 {
+.emotion-57 {
   margin-top: 16px;
 }
 
-.emotion-59 {
+.emotion-58 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -6068,48 +5972,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   color: #1976d2;
 }
 
-.emotion-59::-moz-focus-inner {
+.emotion-58::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-59.Mui-disabled {
+.emotion-58.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-59 {
+  .emotion-58 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-59:hover {
+.emotion-58:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-59:hover {
+  .emotion-58:hover {
     background-color: transparent;
   }
 }
 
-.emotion-59:hover {
+.emotion-58:hover {
   background-color: rgba(25, 118, 210, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-59:hover {
+  .emotion-58:hover {
     background-color: transparent;
   }
 }
 
-.emotion-59.Mui-disabled {
+.emotion-58.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-60 {
+.emotion-59 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -6126,11 +6030,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   font-size: 1.5rem;
 }
 
-.emotion-61 {
+.emotion-60 {
   margin-top: 24px;
 }
 
-.emotion-62 {
+.emotion-61 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -6179,23 +6083,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-62::-moz-focus-inner {
+.emotion-61::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-62.Mui-disabled {
+.emotion-61.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-62 {
+  .emotion-61 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-62:hover {
+.emotion-61:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: #1565c0;
@@ -6203,20 +6107,20 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
 }
 
 @media (hover: none) {
-  .emotion-62:hover {
+  .emotion-61:hover {
     background-color: #1976d2;
   }
 }
 
-.emotion-62:active {
+.emotion-61:active {
   box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
 }
 
-.emotion-62.Mui-focusVisible {
+.emotion-61.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-62.Mui-disabled {
+.emotion-61.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
@@ -6267,589 +6171,585 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
             className="MuiGrid-root MuiGrid-container emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-8"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-9"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root emotion-9"
               >
                 <div
-                  className="MuiBox-root emotion-10"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-13"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-14"
+                            data-shrink={true}
+                            htmlFor="root_0"
+                            id="root_0-label"
+                          >
+                            Test item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-15"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-14"
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
-                              data-shrink={true}
-                              htmlFor="root_0"
-                              id="root_0-label"
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-17"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="a"
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-18"
                             >
-                              Test item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-16"
+                              <legend
+                                className="emotion-19"
                               >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-18"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="a"
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-19"
-                              >
-                                <legend
-                                  className="emotion-20"
-                                >
-                                  <span>
-                                    Test item
-                                     
-                                    *
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                <span>
+                                  Test item
+                                   
+                                  *
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption emotion-21"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
-                              id="root_0__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a test item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption emotion-20"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
+                            id="root_0__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a test item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item emotion-23"
-              >
-                <button
-                  className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-24"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move up"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="ArrowUpwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-24"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move down"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="ArrowDownwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-24"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="ContentCopyIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-30"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="RemoveIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M19 13H5v-2h14v2z"
-                    />
-                  </svg>
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container emotion-8"
+              className="MuiGrid-root MuiGrid-item emotion-22"
             >
-              <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-9"
+              <button
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-23"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
                 style={
                   {
-                    "overflow": "auto",
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
                   }
                 }
+                tabIndex={-1}
+                title="Move up"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="ArrowUpwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-23"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move down"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="ArrowDownwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-23"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="ContentCopyIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-29"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="RemoveIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 13H5v-2h14v2z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container emotion-7"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
+            >
+              <div
+                className="MuiBox-root emotion-9"
               >
                 <div
-                  className="MuiBox-root emotion-10"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-13"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-14"
+                            data-shrink={true}
+                            htmlFor="root_1"
+                            id="root_1-label"
+                          >
+                            Test item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-15"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-14"
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
-                              data-shrink={true}
-                              htmlFor="root_1"
-                              id="root_1-label"
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-17"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="b"
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-18"
                             >
-                              Test item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-16"
+                              <legend
+                                className="emotion-19"
                               >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-18"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="b"
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-19"
-                              >
-                                <legend
-                                  className="emotion-20"
-                                >
-                                  <span>
-                                    Test item
-                                     
-                                    *
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                <span>
+                                  Test item
+                                   
+                                  *
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption emotion-21"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
-                              id="root_1__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a test item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption emotion-20"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
+                            id="root_1__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a test item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item emotion-23"
-              >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-24"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move up"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="ArrowUpwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-24"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move down"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="ArrowDownwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-24"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="ContentCopyIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-30"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="RemoveIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M19 13H5v-2h14v2z"
-                    />
-                  </svg>
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container emotion-56"
+              className="MuiGrid-root MuiGrid-item emotion-22"
+            >
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-23"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move up"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="ArrowUpwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-23"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={-1}
+                title="Move down"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="ArrowDownwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-23"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="ContentCopyIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-29"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="RemoveIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 13H5v-2h14v2z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container emotion-55"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item emotion-22"
             >
               <div
-                className="MuiGrid-root MuiGrid-item emotion-23"
+                className="MuiBox-root emotion-57"
               >
-                <div
-                  className="MuiBox-root emotion-58"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-58"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-59"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onContextMenu={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-59"
+                    data-testid="AddIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-60"
-                      data-testid="AddIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                      />
-                    </svg>
-                  </button>
-                </div>
+                    <path
+                      d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                    />
+                  </svg>
+                </button>
               </div>
             </div>
           </div>
@@ -6858,10 +6758,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
     </div>
   </div>
   <div
-    className="MuiBox-root emotion-61"
+    className="MuiBox-root emotion-60"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-62"
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-61"
       disabled={false}
       onBlur={[Function]}
       onContextMenu={[Function]}
@@ -7572,29 +7472,13 @@ exports[`with title and description fixed array 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-}
-
-.emotion-8 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-9 {
+.emotion-8 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -7611,7 +7495,7 @@ exports[`with title and description fixed array 1`] = `
 }
 
 @media (min-width:600px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -7624,7 +7508,7 @@ exports[`with title and description fixed array 1`] = `
 }
 
 @media (min-width:900px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -7637,7 +7521,7 @@ exports[`with title and description fixed array 1`] = `
 }
 
 @media (min-width:1200px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -7650,7 +7534,7 @@ exports[`with title and description fixed array 1`] = `
 }
 
 @media (min-width:1536px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -7662,11 +7546,11 @@ exports[`with title and description fixed array 1`] = `
   }
 }
 
-.emotion-10 {
+.emotion-9 {
   margin-bottom: 16px;
 }
 
-.emotion-14 {
+.emotion-13 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -7682,7 +7566,7 @@ exports[`with title and description fixed array 1`] = `
   vertical-align: top;
 }
 
-.emotion-15 {
+.emotion-14 {
   color: rgba(0, 0, 0, 0.6);
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
@@ -7710,23 +7594,23 @@ exports[`with title and description fixed array 1`] = `
   pointer-events: none;
 }
 
-.emotion-15.Mui-focused {
+.emotion-14.Mui-focused {
   color: #1976d2;
 }
 
-.emotion-15.Mui-disabled {
+.emotion-14.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-14.Mui-error {
+  color: #d32f2f;
 }
 
 .emotion-15.Mui-error {
   color: #d32f2f;
 }
 
-.emotion-16.Mui-error {
-  color: #d32f2f;
-}
-
-.emotion-17 {
+.emotion-16 {
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -7748,35 +7632,35 @@ exports[`with title and description fixed array 1`] = `
   border-radius: 4px;
 }
 
-.emotion-17.Mui-disabled {
+.emotion-16.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
   cursor: default;
 }
 
-.emotion-17:hover .MuiOutlinedInput-notchedOutline {
+.emotion-16:hover .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.87);
 }
 
 @media (hover: none) {
-  .emotion-17:hover .MuiOutlinedInput-notchedOutline {
+  .emotion-16:hover .MuiOutlinedInput-notchedOutline {
     border-color: rgba(0, 0, 0, 0.23);
   }
 }
 
-.emotion-17.Mui-focused .MuiOutlinedInput-notchedOutline {
+.emotion-16.Mui-focused .MuiOutlinedInput-notchedOutline {
   border-color: #1976d2;
   border-width: 2px;
 }
 
-.emotion-17.Mui-error .MuiOutlinedInput-notchedOutline {
+.emotion-16.Mui-error .MuiOutlinedInput-notchedOutline {
   border-color: #d32f2f;
 }
 
-.emotion-17.Mui-disabled .MuiOutlinedInput-notchedOutline {
+.emotion-16.Mui-disabled .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-18 {
+.emotion-17 {
   font: inherit;
   letter-spacing: inherit;
   color: currentColor;
@@ -7797,95 +7681,95 @@ exports[`with title and description fixed array 1`] = `
   padding: 16.5px 14px;
 }
 
-.emotion-18::-webkit-input-placeholder {
+.emotion-17::-webkit-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18::-moz-placeholder {
+.emotion-17::-moz-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18:-ms-input-placeholder {
+.emotion-17:-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18::-ms-input-placeholder {
+.emotion-17::-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18:focus {
+.emotion-17:focus {
   outline: 0;
 }
 
-.emotion-18:invalid {
+.emotion-17:invalid {
   box-shadow: none;
 }
 
-.emotion-18::-webkit-search-decoration {
+.emotion-17::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17::-webkit-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17::-moz-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17::-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-webkit-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-moz-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus:-ms-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-placeholder {
   opacity: 0.42;
 }
 
-.emotion-18.Mui-disabled {
+.emotion-17.Mui-disabled {
   opacity: 1;
   -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-18:-webkit-autofill {
+.emotion-17:-webkit-autofill {
   -webkit-animation-duration: 5000s;
   animation-duration: 5000s;
   -webkit-animation-name: mui-auto-fill;
   animation-name: mui-auto-fill;
 }
 
-.emotion-18:-webkit-autofill {
+.emotion-17:-webkit-autofill {
   border-radius: inherit;
 }
 
-.emotion-19 {
+.emotion-18 {
   text-align: left;
   position: absolute;
   bottom: 0;
@@ -7903,7 +7787,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   border-color: rgba(0, 0, 0, 0.23);
 }
 
-.emotion-20 {
+.emotion-19 {
   float: unset;
   width: auto;
   overflow: hidden;
@@ -7918,7 +7802,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   white-space: nowrap;
 }
 
-.emotion-20>span {
+.emotion-19>span {
   padding-left: 5px;
   padding-right: 5px;
   display: inline-block;
@@ -7926,7 +7810,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   visibility: visible;
 }
 
-.emotion-21 {
+.emotion-20 {
   margin: 0;
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
@@ -7936,11 +7820,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   color: rgba(0, 0, 0, 0.6);
 }
 
-.emotion-38 {
+.emotion-37 {
   margin-top: 24px;
 }
 
-.emotion-39 {
+.emotion-38 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -7989,23 +7873,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-39::-moz-focus-inner {
+.emotion-38::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-39.Mui-disabled {
+.emotion-38.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-39 {
+  .emotion-38 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-39:hover {
+.emotion-38:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: #1565c0;
@@ -8013,20 +7897,20 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
 }
 
 @media (hover: none) {
-  .emotion-39:hover {
+  .emotion-38:hover {
     background-color: #1976d2;
   }
 }
 
-.emotion-39:active {
+.emotion-38:active {
   box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
 }
 
-.emotion-39.Mui-focusVisible {
+.emotion-38.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-39.Mui-disabled {
+.emotion-38.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
@@ -8077,206 +7961,202 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
             className="MuiGrid-root MuiGrid-container emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-8"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-9"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root emotion-9"
               >
                 <div
-                  className="MuiBox-root emotion-10"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-13"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-14"
+                            data-shrink={false}
+                            htmlFor="root_0"
+                            id="root_0-label"
+                          >
+                            Test item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-15"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-14"
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
-                              data-shrink={false}
-                              htmlFor="root_0"
-                              id="root_0-label"
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-17"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value=""
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-18"
                             >
-                              Test item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-16"
+                              <legend
+                                className="emotion-19"
                               >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-18"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value=""
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-19"
-                              >
-                                <legend
-                                  className="emotion-20"
-                                >
-                                  <span>
-                                    Test item
-                                     
-                                    *
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                <span>
+                                  Test item
+                                   
+                                  *
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption emotion-21"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
-                              id="root_0__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a test item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption emotion-20"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
+                            id="root_0__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a test item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container emotion-7"
+          >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-8"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-9"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root emotion-9"
               >
                 <div
-                  className="MuiBox-root emotion-10"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-number"
                     >
                       <div
-                        className="form-group field field-number"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-13"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-14"
+                            data-shrink={false}
+                            htmlFor="root_1"
+                            id="root_1-label"
+                          >
+                            Test item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-15"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-14"
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
-                              data-shrink={false}
-                              htmlFor="root_1"
-                              id="root_1-label"
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-17"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              step="any"
+                              type="number"
+                              value=""
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-18"
                             >
-                              Test item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-16"
+                              <legend
+                                className="emotion-19"
                               >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-18"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                step="any"
-                                type="number"
-                                value=""
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-19"
-                              >
-                                <legend
-                                  className="emotion-20"
-                                >
-                                  <span>
-                                    Test item
-                                     
-                                    *
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                <span>
+                                  Test item
+                                   
+                                  *
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption emotion-21"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
-                              id="root_1__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a test item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption emotion-20"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
+                            id="root_1__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a test item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
@@ -8289,10 +8169,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
     </div>
   </div>
   <div
-    className="MuiBox-root emotion-38"
+    className="MuiBox-root emotion-37"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-39"
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-38"
       disabled={false}
       onBlur={[Function]}
       onContextMenu={[Function]}
@@ -8394,29 +8274,13 @@ exports[`with title and description from both array 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-}
-
-.emotion-8 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
   justify-content: flex-end;
 }
 
-.emotion-9 {
+.emotion-8 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -8424,11 +8288,11 @@ exports[`with title and description from both array 1`] = `
   flex-direction: row;
 }
 
-.emotion-10 {
+.emotion-9 {
   margin-top: 16px;
 }
 
-.emotion-11 {
+.emotion-10 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -8475,48 +8339,48 @@ exports[`with title and description from both array 1`] = `
   color: #1976d2;
 }
 
-.emotion-11::-moz-focus-inner {
+.emotion-10::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-11.Mui-disabled {
+.emotion-10.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-11 {
+  .emotion-10 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-11:hover {
+.emotion-10:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-11:hover {
+  .emotion-10:hover {
     background-color: transparent;
   }
 }
 
-.emotion-11:hover {
+.emotion-10:hover {
   background-color: rgba(25, 118, 210, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-11:hover {
+  .emotion-10:hover {
     background-color: transparent;
   }
 }
 
-.emotion-11.Mui-disabled {
+.emotion-10.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-12 {
+.emotion-11 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -8533,7 +8397,7 @@ exports[`with title and description from both array 1`] = `
   font-size: 1.5rem;
 }
 
-.emotion-13 {
+.emotion-12 {
   overflow: hidden;
   pointer-events: none;
   position: absolute;
@@ -8545,11 +8409,11 @@ exports[`with title and description from both array 1`] = `
   border-radius: inherit;
 }
 
-.emotion-14 {
+.emotion-13 {
   margin-top: 24px;
 }
 
-.emotion-15 {
+.emotion-14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -8598,23 +8462,23 @@ exports[`with title and description from both array 1`] = `
   box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-15::-moz-focus-inner {
+.emotion-14::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-15.Mui-disabled {
+.emotion-14.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-15 {
+  .emotion-14 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-15:hover {
+.emotion-14:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: #1565c0;
@@ -8622,20 +8486,20 @@ exports[`with title and description from both array 1`] = `
 }
 
 @media (hover: none) {
-  .emotion-15:hover {
+  .emotion-14:hover {
     background-color: #1976d2;
   }
 }
 
-.emotion-15:active {
+.emotion-14:active {
   box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
 }
 
-.emotion-15.Mui-focusVisible {
+.emotion-14.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-15.Mui-disabled {
+.emotion-14.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
@@ -8686,50 +8550,46 @@ exports[`with title and description from both array 1`] = `
             className="MuiGrid-root MuiGrid-container emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-8"
+              className="MuiGrid-root MuiGrid-item emotion-8"
             >
               <div
-                className="MuiGrid-root MuiGrid-item emotion-9"
+                className="MuiBox-root emotion-9"
               >
-                <div
-                  className="MuiBox-root emotion-10"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-10"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-11"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onContextMenu={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-11"
+                    data-testid="AddIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-12"
-                      data-testid="AddIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                      />
-                    </svg>
-                    <span
-                      className="MuiTouchRipple-root emotion-13"
+                    <path
+                      d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
                     />
-                  </button>
-                </div>
+                  </svg>
+                  <span
+                    className="MuiTouchRipple-root emotion-12"
+                  />
+                </button>
               </div>
             </div>
           </div>
@@ -8738,10 +8598,10 @@ exports[`with title and description from both array 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root emotion-14"
+    className="MuiBox-root emotion-13"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-15"
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-14"
       disabled={false}
       onBlur={[Function]}
       onContextMenu={[Function]}
@@ -8760,7 +8620,7 @@ exports[`with title and description from both array 1`] = `
     >
       Submit
       <span
-        className="MuiTouchRipple-root emotion-13"
+        className="MuiTouchRipple-root emotion-12"
       />
     </button>
   </div>
@@ -8846,29 +8706,13 @@ exports[`with title and description from both array icons 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-}
-
-.emotion-8 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-9 {
+.emotion-8 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -8885,7 +8729,7 @@ exports[`with title and description from both array icons 1`] = `
 }
 
 @media (min-width:600px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -8898,7 +8742,7 @@ exports[`with title and description from both array icons 1`] = `
 }
 
 @media (min-width:900px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -8911,7 +8755,7 @@ exports[`with title and description from both array icons 1`] = `
 }
 
 @media (min-width:1200px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -8924,7 +8768,7 @@ exports[`with title and description from both array icons 1`] = `
 }
 
 @media (min-width:1536px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -8936,11 +8780,11 @@ exports[`with title and description from both array icons 1`] = `
   }
 }
 
-.emotion-10 {
+.emotion-9 {
   margin-bottom: 16px;
 }
 
-.emotion-14 {
+.emotion-13 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -8956,7 +8800,7 @@ exports[`with title and description from both array icons 1`] = `
   vertical-align: top;
 }
 
-.emotion-15 {
+.emotion-14 {
   color: rgba(0, 0, 0, 0.6);
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
@@ -8988,23 +8832,23 @@ exports[`with title and description from both array icons 1`] = `
   user-select: none;
 }
 
-.emotion-15.Mui-focused {
+.emotion-14.Mui-focused {
   color: #1976d2;
 }
 
-.emotion-15.Mui-disabled {
+.emotion-14.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-14.Mui-error {
+  color: #d32f2f;
 }
 
 .emotion-15.Mui-error {
   color: #d32f2f;
 }
 
-.emotion-16.Mui-error {
-  color: #d32f2f;
-}
-
-.emotion-17 {
+.emotion-16 {
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -9026,35 +8870,35 @@ exports[`with title and description from both array icons 1`] = `
   border-radius: 4px;
 }
 
-.emotion-17.Mui-disabled {
+.emotion-16.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
   cursor: default;
 }
 
-.emotion-17:hover .MuiOutlinedInput-notchedOutline {
+.emotion-16:hover .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.87);
 }
 
 @media (hover: none) {
-  .emotion-17:hover .MuiOutlinedInput-notchedOutline {
+  .emotion-16:hover .MuiOutlinedInput-notchedOutline {
     border-color: rgba(0, 0, 0, 0.23);
   }
 }
 
-.emotion-17.Mui-focused .MuiOutlinedInput-notchedOutline {
+.emotion-16.Mui-focused .MuiOutlinedInput-notchedOutline {
   border-color: #1976d2;
   border-width: 2px;
 }
 
-.emotion-17.Mui-error .MuiOutlinedInput-notchedOutline {
+.emotion-16.Mui-error .MuiOutlinedInput-notchedOutline {
   border-color: #d32f2f;
 }
 
-.emotion-17.Mui-disabled .MuiOutlinedInput-notchedOutline {
+.emotion-16.Mui-disabled .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-18 {
+.emotion-17 {
   font: inherit;
   letter-spacing: inherit;
   color: currentColor;
@@ -9075,95 +8919,95 @@ exports[`with title and description from both array icons 1`] = `
   padding: 16.5px 14px;
 }
 
-.emotion-18::-webkit-input-placeholder {
+.emotion-17::-webkit-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18::-moz-placeholder {
+.emotion-17::-moz-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18:-ms-input-placeholder {
+.emotion-17:-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18::-ms-input-placeholder {
+.emotion-17::-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18:focus {
+.emotion-17:focus {
   outline: 0;
 }
 
-.emotion-18:invalid {
+.emotion-17:invalid {
   box-shadow: none;
 }
 
-.emotion-18::-webkit-search-decoration {
+.emotion-17::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17::-webkit-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17::-moz-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17::-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-webkit-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-moz-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus:-ms-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-placeholder {
   opacity: 0.42;
 }
 
-.emotion-18.Mui-disabled {
+.emotion-17.Mui-disabled {
   opacity: 1;
   -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-18:-webkit-autofill {
+.emotion-17:-webkit-autofill {
   -webkit-animation-duration: 5000s;
   animation-duration: 5000s;
   -webkit-animation-name: mui-auto-fill;
   animation-name: mui-auto-fill;
 }
 
-.emotion-18:-webkit-autofill {
+.emotion-17:-webkit-autofill {
   border-radius: inherit;
 }
 
-.emotion-19 {
+.emotion-18 {
   text-align: left;
   position: absolute;
   bottom: 0;
@@ -9181,7 +9025,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   border-color: rgba(0, 0, 0, 0.23);
 }
 
-.emotion-20 {
+.emotion-19 {
   float: unset;
   width: auto;
   overflow: hidden;
@@ -9196,7 +9040,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   white-space: nowrap;
 }
 
-.emotion-20>span {
+.emotion-19>span {
   padding-left: 5px;
   padding-right: 5px;
   display: inline-block;
@@ -9204,7 +9048,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   visibility: visible;
 }
 
-.emotion-21 {
+.emotion-20 {
   margin: 0;
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
@@ -9214,7 +9058,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   color: rgba(0, 0, 0, 0.6);
 }
 
-.emotion-23 {
+.emotion-22 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -9222,7 +9066,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   flex-direction: row;
 }
 
-.emotion-24 {
+.emotion-23 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -9270,38 +9114,38 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   font-size: 1.125rem;
 }
 
-.emotion-24::-moz-focus-inner {
+.emotion-23::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-24.Mui-disabled {
+.emotion-23.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-24 {
+  .emotion-23 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-24:hover {
+.emotion-23:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-24:hover {
+  .emotion-23:hover {
     background-color: transparent;
   }
 }
 
-.emotion-24.Mui-disabled {
+.emotion-23.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-25 {
+.emotion-24 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -9318,7 +9162,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   font-size: 1.25rem;
 }
 
-.emotion-30 {
+.emotion-29 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -9367,48 +9211,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   font-size: 1.125rem;
 }
 
-.emotion-30::-moz-focus-inner {
+.emotion-29::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-30.Mui-disabled {
+.emotion-29.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-30 {
+  .emotion-29 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-30:hover {
+.emotion-29:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-30:hover {
+  .emotion-29:hover {
     background-color: transparent;
   }
 }
 
-.emotion-30:hover {
+.emotion-29:hover {
   background-color: rgba(211, 47, 47, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-30:hover {
+  .emotion-29:hover {
     background-color: transparent;
   }
 }
 
-.emotion-30.Mui-disabled {
+.emotion-29.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-56 {
+.emotion-55 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -9428,11 +9272,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   justify-content: flex-end;
 }
 
-.emotion-58 {
+.emotion-57 {
   margin-top: 16px;
 }
 
-.emotion-59 {
+.emotion-58 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -9479,48 +9323,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   color: #1976d2;
 }
 
-.emotion-59::-moz-focus-inner {
+.emotion-58::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-59.Mui-disabled {
+.emotion-58.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-59 {
+  .emotion-58 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-59:hover {
+.emotion-58:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-59:hover {
+  .emotion-58:hover {
     background-color: transparent;
   }
 }
 
-.emotion-59:hover {
+.emotion-58:hover {
   background-color: rgba(25, 118, 210, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-59:hover {
+  .emotion-58:hover {
     background-color: transparent;
   }
 }
 
-.emotion-59.Mui-disabled {
+.emotion-58.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-60 {
+.emotion-59 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -9537,11 +9381,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   font-size: 1.5rem;
 }
 
-.emotion-61 {
+.emotion-60 {
   margin-top: 24px;
 }
 
-.emotion-62 {
+.emotion-61 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -9590,23 +9434,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-62::-moz-focus-inner {
+.emotion-61::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-62.Mui-disabled {
+.emotion-61.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-62 {
+  .emotion-61 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-62:hover {
+.emotion-61:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: #1565c0;
@@ -9614,20 +9458,20 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
 }
 
 @media (hover: none) {
-  .emotion-62:hover {
+  .emotion-61:hover {
     background-color: #1976d2;
   }
 }
 
-.emotion-62:active {
+.emotion-61:active {
   box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
 }
 
-.emotion-62.Mui-focusVisible {
+.emotion-61.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-62.Mui-disabled {
+.emotion-61.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
@@ -9678,589 +9522,585 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
             className="MuiGrid-root MuiGrid-container emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-8"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-9"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root emotion-9"
               >
                 <div
-                  className="MuiBox-root emotion-10"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-13"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-14"
+                            data-shrink={true}
+                            htmlFor="root_0"
+                            id="root_0-label"
+                          >
+                            My Item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-15"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-14"
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
-                              data-shrink={true}
-                              htmlFor="root_0"
-                              id="root_0-label"
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-17"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="a"
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-18"
                             >
-                              My Item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-16"
+                              <legend
+                                className="emotion-19"
                               >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-18"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="a"
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-19"
-                              >
-                                <legend
-                                  className="emotion-20"
-                                >
-                                  <span>
-                                    My Item
-                                     
-                                    *
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                <span>
+                                  My Item
+                                   
+                                  *
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption emotion-21"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
-                              id="root_0__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a fancier item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption emotion-20"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
+                            id="root_0__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a fancier item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item emotion-23"
-              >
-                <button
-                  className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-24"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move up"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="ArrowUpwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-24"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move down"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="ArrowDownwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-24"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="ContentCopyIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-30"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="RemoveIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M19 13H5v-2h14v2z"
-                    />
-                  </svg>
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container emotion-8"
+              className="MuiGrid-root MuiGrid-item emotion-22"
             >
-              <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-9"
+              <button
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-23"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
                 style={
                   {
-                    "overflow": "auto",
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
                   }
                 }
+                tabIndex={-1}
+                title="Move up"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="ArrowUpwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-23"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move down"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="ArrowDownwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-23"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="ContentCopyIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-29"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="RemoveIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 13H5v-2h14v2z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container emotion-7"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
+            >
+              <div
+                className="MuiBox-root emotion-9"
               >
                 <div
-                  className="MuiBox-root emotion-10"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-13"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-14"
+                            data-shrink={true}
+                            htmlFor="root_1"
+                            id="root_1-label"
+                          >
+                            My Item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-15"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-14"
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
-                              data-shrink={true}
-                              htmlFor="root_1"
-                              id="root_1-label"
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-17"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="b"
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-18"
                             >
-                              My Item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-16"
+                              <legend
+                                className="emotion-19"
                               >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-18"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="b"
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-19"
-                              >
-                                <legend
-                                  className="emotion-20"
-                                >
-                                  <span>
-                                    My Item
-                                     
-                                    *
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                <span>
+                                  My Item
+                                   
+                                  *
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption emotion-21"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
-                              id="root_1__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a fancier item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption emotion-20"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
+                            id="root_1__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a fancier item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item emotion-23"
-              >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-24"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move up"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="ArrowUpwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-24"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move down"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="ArrowDownwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-24"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="ContentCopyIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-30"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="RemoveIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M19 13H5v-2h14v2z"
-                    />
-                  </svg>
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container emotion-56"
+              className="MuiGrid-root MuiGrid-item emotion-22"
+            >
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-23"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move up"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="ArrowUpwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-23"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={-1}
+                title="Move down"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="ArrowDownwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-23"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="ContentCopyIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-29"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="RemoveIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 13H5v-2h14v2z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container emotion-55"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item emotion-22"
             >
               <div
-                className="MuiGrid-root MuiGrid-item emotion-23"
+                className="MuiBox-root emotion-57"
               >
-                <div
-                  className="MuiBox-root emotion-58"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-58"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-59"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onContextMenu={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-59"
+                    data-testid="AddIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-60"
-                      data-testid="AddIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                      />
-                    </svg>
-                  </button>
-                </div>
+                    <path
+                      d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                    />
+                  </svg>
+                </button>
               </div>
             </div>
           </div>
@@ -10269,10 +10109,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
     </div>
   </div>
   <div
-    className="MuiBox-root emotion-61"
+    className="MuiBox-root emotion-60"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-62"
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-61"
       disabled={false}
       onBlur={[Function]}
       onContextMenu={[Function]}
@@ -10983,29 +10823,13 @@ exports[`with title and description from both fixed array 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-}
-
-.emotion-8 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-9 {
+.emotion-8 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -11022,7 +10846,7 @@ exports[`with title and description from both fixed array 1`] = `
 }
 
 @media (min-width:600px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -11035,7 +10859,7 @@ exports[`with title and description from both fixed array 1`] = `
 }
 
 @media (min-width:900px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -11048,7 +10872,7 @@ exports[`with title and description from both fixed array 1`] = `
 }
 
 @media (min-width:1200px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -11061,7 +10885,7 @@ exports[`with title and description from both fixed array 1`] = `
 }
 
 @media (min-width:1536px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -11073,11 +10897,11 @@ exports[`with title and description from both fixed array 1`] = `
   }
 }
 
-.emotion-10 {
+.emotion-9 {
   margin-bottom: 16px;
 }
 
-.emotion-14 {
+.emotion-13 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -11093,7 +10917,7 @@ exports[`with title and description from both fixed array 1`] = `
   vertical-align: top;
 }
 
-.emotion-15 {
+.emotion-14 {
   color: rgba(0, 0, 0, 0.6);
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
@@ -11121,23 +10945,23 @@ exports[`with title and description from both fixed array 1`] = `
   pointer-events: none;
 }
 
-.emotion-15.Mui-focused {
+.emotion-14.Mui-focused {
   color: #1976d2;
 }
 
-.emotion-15.Mui-disabled {
+.emotion-14.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-14.Mui-error {
+  color: #d32f2f;
 }
 
 .emotion-15.Mui-error {
   color: #d32f2f;
 }
 
-.emotion-16.Mui-error {
-  color: #d32f2f;
-}
-
-.emotion-17 {
+.emotion-16 {
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -11159,35 +10983,35 @@ exports[`with title and description from both fixed array 1`] = `
   border-radius: 4px;
 }
 
-.emotion-17.Mui-disabled {
+.emotion-16.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
   cursor: default;
 }
 
-.emotion-17:hover .MuiOutlinedInput-notchedOutline {
+.emotion-16:hover .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.87);
 }
 
 @media (hover: none) {
-  .emotion-17:hover .MuiOutlinedInput-notchedOutline {
+  .emotion-16:hover .MuiOutlinedInput-notchedOutline {
     border-color: rgba(0, 0, 0, 0.23);
   }
 }
 
-.emotion-17.Mui-focused .MuiOutlinedInput-notchedOutline {
+.emotion-16.Mui-focused .MuiOutlinedInput-notchedOutline {
   border-color: #1976d2;
   border-width: 2px;
 }
 
-.emotion-17.Mui-error .MuiOutlinedInput-notchedOutline {
+.emotion-16.Mui-error .MuiOutlinedInput-notchedOutline {
   border-color: #d32f2f;
 }
 
-.emotion-17.Mui-disabled .MuiOutlinedInput-notchedOutline {
+.emotion-16.Mui-disabled .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-18 {
+.emotion-17 {
   font: inherit;
   letter-spacing: inherit;
   color: currentColor;
@@ -11208,95 +11032,95 @@ exports[`with title and description from both fixed array 1`] = `
   padding: 16.5px 14px;
 }
 
-.emotion-18::-webkit-input-placeholder {
+.emotion-17::-webkit-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18::-moz-placeholder {
+.emotion-17::-moz-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18:-ms-input-placeholder {
+.emotion-17:-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18::-ms-input-placeholder {
+.emotion-17::-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18:focus {
+.emotion-17:focus {
   outline: 0;
 }
 
-.emotion-18:invalid {
+.emotion-17:invalid {
   box-shadow: none;
 }
 
-.emotion-18::-webkit-search-decoration {
+.emotion-17::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17::-webkit-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17::-moz-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17::-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-webkit-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-moz-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus:-ms-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-placeholder {
   opacity: 0.42;
 }
 
-.emotion-18.Mui-disabled {
+.emotion-17.Mui-disabled {
   opacity: 1;
   -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-18:-webkit-autofill {
+.emotion-17:-webkit-autofill {
   -webkit-animation-duration: 5000s;
   animation-duration: 5000s;
   -webkit-animation-name: mui-auto-fill;
   animation-name: mui-auto-fill;
 }
 
-.emotion-18:-webkit-autofill {
+.emotion-17:-webkit-autofill {
   border-radius: inherit;
 }
 
-.emotion-19 {
+.emotion-18 {
   text-align: left;
   position: absolute;
   bottom: 0;
@@ -11314,7 +11138,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   border-color: rgba(0, 0, 0, 0.23);
 }
 
-.emotion-20 {
+.emotion-19 {
   float: unset;
   width: auto;
   overflow: hidden;
@@ -11329,7 +11153,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   white-space: nowrap;
 }
 
-.emotion-20>span {
+.emotion-19>span {
   padding-left: 5px;
   padding-right: 5px;
   display: inline-block;
@@ -11337,7 +11161,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   visibility: visible;
 }
 
-.emotion-21 {
+.emotion-20 {
   margin: 0;
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
@@ -11347,11 +11171,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   color: rgba(0, 0, 0, 0.6);
 }
 
-.emotion-38 {
+.emotion-37 {
   margin-top: 24px;
 }
 
-.emotion-39 {
+.emotion-38 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -11400,23 +11224,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-39::-moz-focus-inner {
+.emotion-38::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-39.Mui-disabled {
+.emotion-38.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-39 {
+  .emotion-38 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-39:hover {
+.emotion-38:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: #1565c0;
@@ -11424,20 +11248,20 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
 }
 
 @media (hover: none) {
-  .emotion-39:hover {
+  .emotion-38:hover {
     background-color: #1976d2;
   }
 }
 
-.emotion-39:active {
+.emotion-38:active {
   box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
 }
 
-.emotion-39.Mui-focusVisible {
+.emotion-38.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-39.Mui-disabled {
+.emotion-38.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
@@ -11488,206 +11312,202 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
             className="MuiGrid-root MuiGrid-container emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-8"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-9"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root emotion-9"
               >
                 <div
-                  className="MuiBox-root emotion-10"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-13"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-14"
+                            data-shrink={false}
+                            htmlFor="root_0"
+                            id="root_0-label"
+                          >
+                            My Item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-15"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-14"
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
-                              data-shrink={false}
-                              htmlFor="root_0"
-                              id="root_0-label"
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-17"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value=""
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-18"
                             >
-                              My Item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-16"
+                              <legend
+                                className="emotion-19"
                               >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-18"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value=""
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-19"
-                              >
-                                <legend
-                                  className="emotion-20"
-                                >
-                                  <span>
-                                    My Item
-                                     
-                                    *
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                <span>
+                                  My Item
+                                   
+                                  *
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption emotion-21"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
-                              id="root_0__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a fancier item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption emotion-20"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
+                            id="root_0__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a fancier item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container emotion-7"
+          >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-8"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-9"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root emotion-9"
               >
                 <div
-                  className="MuiBox-root emotion-10"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-number"
                     >
                       <div
-                        className="form-group field field-number"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-13"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-14"
+                            data-shrink={false}
+                            htmlFor="root_1"
+                            id="root_1-label"
+                          >
+                            My Item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-15"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-14"
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
-                              data-shrink={false}
-                              htmlFor="root_1"
-                              id="root_1-label"
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-17"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              step="any"
+                              type="number"
+                              value=""
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-18"
                             >
-                              My Item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-16"
+                              <legend
+                                className="emotion-19"
                               >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-18"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                step="any"
-                                type="number"
-                                value=""
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-19"
-                              >
-                                <legend
-                                  className="emotion-20"
-                                >
-                                  <span>
-                                    My Item
-                                     
-                                    *
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                <span>
+                                  My Item
+                                   
+                                  *
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption emotion-21"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
-                              id="root_1__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a fancier item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption emotion-20"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
+                            id="root_1__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a fancier item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
@@ -11700,10 +11520,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
     </div>
   </div>
   <div
-    className="MuiBox-root emotion-38"
+    className="MuiBox-root emotion-37"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-39"
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-38"
       disabled={false}
       onBlur={[Function]}
       onContextMenu={[Function]}
@@ -11805,29 +11625,13 @@ exports[`with title and description from uiSchema array 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-}
-
-.emotion-8 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
   justify-content: flex-end;
 }
 
-.emotion-9 {
+.emotion-8 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -11835,11 +11639,11 @@ exports[`with title and description from uiSchema array 1`] = `
   flex-direction: row;
 }
 
-.emotion-10 {
+.emotion-9 {
   margin-top: 16px;
 }
 
-.emotion-11 {
+.emotion-10 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -11886,48 +11690,48 @@ exports[`with title and description from uiSchema array 1`] = `
   color: #1976d2;
 }
 
-.emotion-11::-moz-focus-inner {
+.emotion-10::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-11.Mui-disabled {
+.emotion-10.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-11 {
+  .emotion-10 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-11:hover {
+.emotion-10:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-11:hover {
+  .emotion-10:hover {
     background-color: transparent;
   }
 }
 
-.emotion-11:hover {
+.emotion-10:hover {
   background-color: rgba(25, 118, 210, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-11:hover {
+  .emotion-10:hover {
     background-color: transparent;
   }
 }
 
-.emotion-11.Mui-disabled {
+.emotion-10.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-12 {
+.emotion-11 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -11944,7 +11748,7 @@ exports[`with title and description from uiSchema array 1`] = `
   font-size: 1.5rem;
 }
 
-.emotion-13 {
+.emotion-12 {
   overflow: hidden;
   pointer-events: none;
   position: absolute;
@@ -11956,11 +11760,11 @@ exports[`with title and description from uiSchema array 1`] = `
   border-radius: inherit;
 }
 
-.emotion-14 {
+.emotion-13 {
   margin-top: 24px;
 }
 
-.emotion-15 {
+.emotion-14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -12009,23 +11813,23 @@ exports[`with title and description from uiSchema array 1`] = `
   box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-15::-moz-focus-inner {
+.emotion-14::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-15.Mui-disabled {
+.emotion-14.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-15 {
+  .emotion-14 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-15:hover {
+.emotion-14:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: #1565c0;
@@ -12033,20 +11837,20 @@ exports[`with title and description from uiSchema array 1`] = `
 }
 
 @media (hover: none) {
-  .emotion-15:hover {
+  .emotion-14:hover {
     background-color: #1976d2;
   }
 }
 
-.emotion-15:active {
+.emotion-14:active {
   box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
 }
 
-.emotion-15.Mui-focusVisible {
+.emotion-14.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-15.Mui-disabled {
+.emotion-14.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
@@ -12097,50 +11901,46 @@ exports[`with title and description from uiSchema array 1`] = `
             className="MuiGrid-root MuiGrid-container emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-8"
+              className="MuiGrid-root MuiGrid-item emotion-8"
             >
               <div
-                className="MuiGrid-root MuiGrid-item emotion-9"
+                className="MuiBox-root emotion-9"
               >
-                <div
-                  className="MuiBox-root emotion-10"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-10"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-11"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onContextMenu={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-11"
+                    data-testid="AddIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-12"
-                      data-testid="AddIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                      />
-                    </svg>
-                    <span
-                      className="MuiTouchRipple-root emotion-13"
+                    <path
+                      d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
                     />
-                  </button>
-                </div>
+                  </svg>
+                  <span
+                    className="MuiTouchRipple-root emotion-12"
+                  />
+                </button>
               </div>
             </div>
           </div>
@@ -12149,10 +11949,10 @@ exports[`with title and description from uiSchema array 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root emotion-14"
+    className="MuiBox-root emotion-13"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-15"
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-14"
       disabled={false}
       onBlur={[Function]}
       onContextMenu={[Function]}
@@ -12171,7 +11971,7 @@ exports[`with title and description from uiSchema array 1`] = `
     >
       Submit
       <span
-        className="MuiTouchRipple-root emotion-13"
+        className="MuiTouchRipple-root emotion-12"
       />
     </button>
   </div>
@@ -12257,29 +12057,13 @@ exports[`with title and description from uiSchema array icons 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-}
-
-.emotion-8 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-9 {
+.emotion-8 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -12296,7 +12080,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
 }
 
 @media (min-width:600px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -12309,7 +12093,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
 }
 
 @media (min-width:900px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -12322,7 +12106,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
 }
 
 @media (min-width:1200px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -12335,7 +12119,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
 }
 
 @media (min-width:1536px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -12347,11 +12131,11 @@ exports[`with title and description from uiSchema array icons 1`] = `
   }
 }
 
-.emotion-10 {
+.emotion-9 {
   margin-bottom: 16px;
 }
 
-.emotion-14 {
+.emotion-13 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -12367,7 +12151,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
   vertical-align: top;
 }
 
-.emotion-15 {
+.emotion-14 {
   color: rgba(0, 0, 0, 0.6);
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
@@ -12399,23 +12183,23 @@ exports[`with title and description from uiSchema array icons 1`] = `
   user-select: none;
 }
 
-.emotion-15.Mui-focused {
+.emotion-14.Mui-focused {
   color: #1976d2;
 }
 
-.emotion-15.Mui-disabled {
+.emotion-14.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-14.Mui-error {
+  color: #d32f2f;
 }
 
 .emotion-15.Mui-error {
   color: #d32f2f;
 }
 
-.emotion-16.Mui-error {
-  color: #d32f2f;
-}
-
-.emotion-17 {
+.emotion-16 {
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -12437,35 +12221,35 @@ exports[`with title and description from uiSchema array icons 1`] = `
   border-radius: 4px;
 }
 
-.emotion-17.Mui-disabled {
+.emotion-16.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
   cursor: default;
 }
 
-.emotion-17:hover .MuiOutlinedInput-notchedOutline {
+.emotion-16:hover .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.87);
 }
 
 @media (hover: none) {
-  .emotion-17:hover .MuiOutlinedInput-notchedOutline {
+  .emotion-16:hover .MuiOutlinedInput-notchedOutline {
     border-color: rgba(0, 0, 0, 0.23);
   }
 }
 
-.emotion-17.Mui-focused .MuiOutlinedInput-notchedOutline {
+.emotion-16.Mui-focused .MuiOutlinedInput-notchedOutline {
   border-color: #1976d2;
   border-width: 2px;
 }
 
-.emotion-17.Mui-error .MuiOutlinedInput-notchedOutline {
+.emotion-16.Mui-error .MuiOutlinedInput-notchedOutline {
   border-color: #d32f2f;
 }
 
-.emotion-17.Mui-disabled .MuiOutlinedInput-notchedOutline {
+.emotion-16.Mui-disabled .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-18 {
+.emotion-17 {
   font: inherit;
   letter-spacing: inherit;
   color: currentColor;
@@ -12486,95 +12270,95 @@ exports[`with title and description from uiSchema array icons 1`] = `
   padding: 16.5px 14px;
 }
 
-.emotion-18::-webkit-input-placeholder {
+.emotion-17::-webkit-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18::-moz-placeholder {
+.emotion-17::-moz-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18:-ms-input-placeholder {
+.emotion-17:-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18::-ms-input-placeholder {
+.emotion-17::-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18:focus {
+.emotion-17:focus {
   outline: 0;
 }
 
-.emotion-18:invalid {
+.emotion-17:invalid {
   box-shadow: none;
 }
 
-.emotion-18::-webkit-search-decoration {
+.emotion-17::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17::-webkit-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17::-moz-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17::-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-webkit-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-moz-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus:-ms-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-placeholder {
   opacity: 0.42;
 }
 
-.emotion-18.Mui-disabled {
+.emotion-17.Mui-disabled {
   opacity: 1;
   -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-18:-webkit-autofill {
+.emotion-17:-webkit-autofill {
   -webkit-animation-duration: 5000s;
   animation-duration: 5000s;
   -webkit-animation-name: mui-auto-fill;
   animation-name: mui-auto-fill;
 }
 
-.emotion-18:-webkit-autofill {
+.emotion-17:-webkit-autofill {
   border-radius: inherit;
 }
 
-.emotion-19 {
+.emotion-18 {
   text-align: left;
   position: absolute;
   bottom: 0;
@@ -12592,7 +12376,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   border-color: rgba(0, 0, 0, 0.23);
 }
 
-.emotion-20 {
+.emotion-19 {
   float: unset;
   width: auto;
   overflow: hidden;
@@ -12607,7 +12391,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   white-space: nowrap;
 }
 
-.emotion-20>span {
+.emotion-19>span {
   padding-left: 5px;
   padding-right: 5px;
   display: inline-block;
@@ -12615,7 +12399,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   visibility: visible;
 }
 
-.emotion-21 {
+.emotion-20 {
   margin: 0;
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
@@ -12625,7 +12409,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   color: rgba(0, 0, 0, 0.6);
 }
 
-.emotion-23 {
+.emotion-22 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -12633,7 +12417,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   flex-direction: row;
 }
 
-.emotion-24 {
+.emotion-23 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -12681,38 +12465,38 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   font-size: 1.125rem;
 }
 
-.emotion-24::-moz-focus-inner {
+.emotion-23::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-24.Mui-disabled {
+.emotion-23.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-24 {
+  .emotion-23 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-24:hover {
+.emotion-23:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-24:hover {
+  .emotion-23:hover {
     background-color: transparent;
   }
 }
 
-.emotion-24.Mui-disabled {
+.emotion-23.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-25 {
+.emotion-24 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -12729,7 +12513,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   font-size: 1.25rem;
 }
 
-.emotion-30 {
+.emotion-29 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -12778,48 +12562,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   font-size: 1.125rem;
 }
 
-.emotion-30::-moz-focus-inner {
+.emotion-29::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-30.Mui-disabled {
+.emotion-29.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-30 {
+  .emotion-29 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-30:hover {
+.emotion-29:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-30:hover {
+  .emotion-29:hover {
     background-color: transparent;
   }
 }
 
-.emotion-30:hover {
+.emotion-29:hover {
   background-color: rgba(211, 47, 47, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-30:hover {
+  .emotion-29:hover {
     background-color: transparent;
   }
 }
 
-.emotion-30.Mui-disabled {
+.emotion-29.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-56 {
+.emotion-55 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -12839,11 +12623,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   justify-content: flex-end;
 }
 
-.emotion-58 {
+.emotion-57 {
   margin-top: 16px;
 }
 
-.emotion-59 {
+.emotion-58 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -12890,48 +12674,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   color: #1976d2;
 }
 
-.emotion-59::-moz-focus-inner {
+.emotion-58::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-59.Mui-disabled {
+.emotion-58.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-59 {
+  .emotion-58 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-59:hover {
+.emotion-58:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-59:hover {
+  .emotion-58:hover {
     background-color: transparent;
   }
 }
 
-.emotion-59:hover {
+.emotion-58:hover {
   background-color: rgba(25, 118, 210, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-59:hover {
+  .emotion-58:hover {
     background-color: transparent;
   }
 }
 
-.emotion-59.Mui-disabled {
+.emotion-58.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-60 {
+.emotion-59 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -12948,11 +12732,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   font-size: 1.5rem;
 }
 
-.emotion-61 {
+.emotion-60 {
   margin-top: 24px;
 }
 
-.emotion-62 {
+.emotion-61 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -13001,23 +12785,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-62::-moz-focus-inner {
+.emotion-61::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-62.Mui-disabled {
+.emotion-61.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-62 {
+  .emotion-61 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-62:hover {
+.emotion-61:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: #1565c0;
@@ -13025,20 +12809,20 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
 }
 
 @media (hover: none) {
-  .emotion-62:hover {
+  .emotion-61:hover {
     background-color: #1976d2;
   }
 }
 
-.emotion-62:active {
+.emotion-61:active {
   box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
 }
 
-.emotion-62.Mui-focusVisible {
+.emotion-61.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-62.Mui-disabled {
+.emotion-61.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
@@ -13089,589 +12873,585 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
             className="MuiGrid-root MuiGrid-container emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-8"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-9"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root emotion-9"
               >
                 <div
-                  className="MuiBox-root emotion-10"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-13"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-14"
+                            data-shrink={true}
+                            htmlFor="root_0"
+                            id="root_0-label"
+                          >
+                            My Item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-15"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-14"
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
-                              data-shrink={true}
-                              htmlFor="root_0"
-                              id="root_0-label"
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-17"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="a"
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-18"
                             >
-                              My Item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-16"
+                              <legend
+                                className="emotion-19"
                               >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-18"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="a"
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-19"
-                              >
-                                <legend
-                                  className="emotion-20"
-                                >
-                                  <span>
-                                    My Item
-                                     
-                                    *
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                <span>
+                                  My Item
+                                   
+                                  *
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption emotion-21"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
-                              id="root_0__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a fancier item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption emotion-20"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
+                            id="root_0__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a fancier item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item emotion-23"
-              >
-                <button
-                  className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-24"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move up"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="ArrowUpwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-24"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move down"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="ArrowDownwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-24"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="ContentCopyIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-30"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="RemoveIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M19 13H5v-2h14v2z"
-                    />
-                  </svg>
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container emotion-8"
+              className="MuiGrid-root MuiGrid-item emotion-22"
             >
-              <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-9"
+              <button
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-23"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
                 style={
                   {
-                    "overflow": "auto",
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
                   }
                 }
+                tabIndex={-1}
+                title="Move up"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="ArrowUpwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-23"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move down"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="ArrowDownwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-23"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="ContentCopyIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-29"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="RemoveIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 13H5v-2h14v2z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container emotion-7"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
+            >
+              <div
+                className="MuiBox-root emotion-9"
               >
                 <div
-                  className="MuiBox-root emotion-10"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-13"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-14"
+                            data-shrink={true}
+                            htmlFor="root_1"
+                            id="root_1-label"
+                          >
+                            My Item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-15"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-14"
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
-                              data-shrink={true}
-                              htmlFor="root_1"
-                              id="root_1-label"
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-17"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="b"
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-18"
                             >
-                              My Item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-16"
+                              <legend
+                                className="emotion-19"
                               >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-18"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="b"
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-19"
-                              >
-                                <legend
-                                  className="emotion-20"
-                                >
-                                  <span>
-                                    My Item
-                                     
-                                    *
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                <span>
+                                  My Item
+                                   
+                                  *
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption emotion-21"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
-                              id="root_1__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a fancier item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption emotion-20"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
+                            id="root_1__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a fancier item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item emotion-23"
-              >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-24"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move up"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="ArrowUpwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-24"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move down"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="ArrowDownwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-24"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="ContentCopyIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-30"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-25"
-                    data-testid="RemoveIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M19 13H5v-2h14v2z"
-                    />
-                  </svg>
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container emotion-56"
+              className="MuiGrid-root MuiGrid-item emotion-22"
+            >
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-23"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move up"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="ArrowUpwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-23"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={-1}
+                title="Move down"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="ArrowDownwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-23"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="ContentCopyIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-29"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-24"
+                  data-testid="RemoveIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 13H5v-2h14v2z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container emotion-55"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item emotion-22"
             >
               <div
-                className="MuiGrid-root MuiGrid-item emotion-23"
+                className="MuiBox-root emotion-57"
               >
-                <div
-                  className="MuiBox-root emotion-58"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-58"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-59"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onContextMenu={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-59"
+                    data-testid="AddIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-60"
-                      data-testid="AddIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                      />
-                    </svg>
-                  </button>
-                </div>
+                    <path
+                      d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                    />
+                  </svg>
+                </button>
               </div>
             </div>
           </div>
@@ -13680,10 +13460,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
     </div>
   </div>
   <div
-    className="MuiBox-root emotion-61"
+    className="MuiBox-root emotion-60"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-62"
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-61"
       disabled={false}
       onBlur={[Function]}
       onContextMenu={[Function]}
@@ -14394,29 +14174,13 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-}
-
-.emotion-8 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-9 {
+.emotion-8 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -14433,7 +14197,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
 }
 
 @media (min-width:600px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -14446,7 +14210,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
 }
 
 @media (min-width:900px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -14459,7 +14223,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
 }
 
 @media (min-width:1200px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -14472,7 +14236,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
 }
 
 @media (min-width:1536px) {
-  .emotion-9 {
+  .emotion-8 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -14484,11 +14248,11 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   }
 }
 
-.emotion-10 {
+.emotion-9 {
   margin-bottom: 16px;
 }
 
-.emotion-14 {
+.emotion-13 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -14504,7 +14268,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   vertical-align: top;
 }
 
-.emotion-15 {
+.emotion-14 {
   color: rgba(0, 0, 0, 0.6);
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
@@ -14532,23 +14296,23 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   pointer-events: none;
 }
 
-.emotion-15.Mui-focused {
+.emotion-14.Mui-focused {
   color: #1976d2;
 }
 
-.emotion-15.Mui-disabled {
+.emotion-14.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-14.Mui-error {
+  color: #d32f2f;
 }
 
 .emotion-15.Mui-error {
   color: #d32f2f;
 }
 
-.emotion-16.Mui-error {
-  color: #d32f2f;
-}
-
-.emotion-17 {
+.emotion-16 {
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -14570,35 +14334,35 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   border-radius: 4px;
 }
 
-.emotion-17.Mui-disabled {
+.emotion-16.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
   cursor: default;
 }
 
-.emotion-17:hover .MuiOutlinedInput-notchedOutline {
+.emotion-16:hover .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.87);
 }
 
 @media (hover: none) {
-  .emotion-17:hover .MuiOutlinedInput-notchedOutline {
+  .emotion-16:hover .MuiOutlinedInput-notchedOutline {
     border-color: rgba(0, 0, 0, 0.23);
   }
 }
 
-.emotion-17.Mui-focused .MuiOutlinedInput-notchedOutline {
+.emotion-16.Mui-focused .MuiOutlinedInput-notchedOutline {
   border-color: #1976d2;
   border-width: 2px;
 }
 
-.emotion-17.Mui-error .MuiOutlinedInput-notchedOutline {
+.emotion-16.Mui-error .MuiOutlinedInput-notchedOutline {
   border-color: #d32f2f;
 }
 
-.emotion-17.Mui-disabled .MuiOutlinedInput-notchedOutline {
+.emotion-16.Mui-disabled .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-18 {
+.emotion-17 {
   font: inherit;
   letter-spacing: inherit;
   color: currentColor;
@@ -14619,95 +14383,95 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   padding: 16.5px 14px;
 }
 
-.emotion-18::-webkit-input-placeholder {
+.emotion-17::-webkit-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18::-moz-placeholder {
+.emotion-17::-moz-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18:-ms-input-placeholder {
+.emotion-17:-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18::-ms-input-placeholder {
+.emotion-17::-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-18:focus {
+.emotion-17:focus {
   outline: 0;
 }
 
-.emotion-18:invalid {
+.emotion-17:invalid {
   box-shadow: none;
 }
 
-.emotion-18::-webkit-search-decoration {
+.emotion-17::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17::-webkit-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17::-moz-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17::-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-webkit-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-moz-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus:-ms-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-placeholder {
   opacity: 0.42;
 }
 
-.emotion-18.Mui-disabled {
+.emotion-17.Mui-disabled {
   opacity: 1;
   -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-18:-webkit-autofill {
+.emotion-17:-webkit-autofill {
   -webkit-animation-duration: 5000s;
   animation-duration: 5000s;
   -webkit-animation-name: mui-auto-fill;
   animation-name: mui-auto-fill;
 }
 
-.emotion-18:-webkit-autofill {
+.emotion-17:-webkit-autofill {
   border-radius: inherit;
 }
 
-.emotion-19 {
+.emotion-18 {
   text-align: left;
   position: absolute;
   bottom: 0;
@@ -14725,7 +14489,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   border-color: rgba(0, 0, 0, 0.23);
 }
 
-.emotion-20 {
+.emotion-19 {
   float: unset;
   width: auto;
   overflow: hidden;
@@ -14740,7 +14504,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   white-space: nowrap;
 }
 
-.emotion-20>span {
+.emotion-19>span {
   padding-left: 5px;
   padding-right: 5px;
   display: inline-block;
@@ -14748,7 +14512,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   visibility: visible;
 }
 
-.emotion-21 {
+.emotion-20 {
   margin: 0;
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
@@ -14758,11 +14522,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   color: rgba(0, 0, 0, 0.6);
 }
 
-.emotion-38 {
+.emotion-37 {
   margin-top: 24px;
 }
 
-.emotion-39 {
+.emotion-38 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -14811,23 +14575,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
   box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-39::-moz-focus-inner {
+.emotion-38::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-39.Mui-disabled {
+.emotion-38.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-39 {
+  .emotion-38 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-39:hover {
+.emotion-38:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: #1565c0;
@@ -14835,20 +14599,20 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
 }
 
 @media (hover: none) {
-  .emotion-39:hover {
+  .emotion-38:hover {
     background-color: #1976d2;
   }
 }
 
-.emotion-39:active {
+.emotion-38:active {
   box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
 }
 
-.emotion-39.Mui-focusVisible {
+.emotion-38.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-39.Mui-disabled {
+.emotion-38.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
@@ -14899,206 +14663,202 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
             className="MuiGrid-root MuiGrid-container emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-8"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-9"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root emotion-9"
               >
                 <div
-                  className="MuiBox-root emotion-10"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-13"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-14"
+                            data-shrink={false}
+                            htmlFor="root_0"
+                            id="root_0-label"
+                          >
+                            My Item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-15"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-14"
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
-                              data-shrink={false}
-                              htmlFor="root_0"
-                              id="root_0-label"
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-17"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value=""
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-18"
                             >
-                              My Item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-16"
+                              <legend
+                                className="emotion-19"
                               >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-18"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value=""
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-19"
-                              >
-                                <legend
-                                  className="emotion-20"
-                                >
-                                  <span>
-                                    My Item
-                                     
-                                    *
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                <span>
+                                  My Item
+                                   
+                                  *
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption emotion-21"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
-                              id="root_0__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a fancier item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption emotion-20"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
+                            id="root_0__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a fancier item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container emotion-7"
+          >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-8"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-9"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root emotion-9"
               >
                 <div
-                  className="MuiBox-root emotion-10"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-number"
                     >
                       <div
-                        className="form-group field field-number"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-13"
                         >
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-14"
+                            data-shrink={false}
+                            htmlFor="root_1"
+                            id="root_1-label"
+                          >
+                            My Item
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-15"
+                            >
+                               
+                              *
+                            </span>
+                          </label>
                           <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-14"
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-16"
+                            onClick={[Function]}
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-15"
-                              data-shrink={false}
-                              htmlFor="root_1"
-                              id="root_1-label"
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-17"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              step="any"
+                              type="number"
+                              value=""
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-18"
                             >
-                              My Item
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-16"
+                              <legend
+                                className="emotion-19"
                               >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-17"
-                              onClick={[Function]}
-                            >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-18"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                step="any"
-                                type="number"
-                                value=""
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-19"
-                              >
-                                <legend
-                                  className="emotion-20"
-                                >
-                                  <span>
-                                    My Item
-                                     
-                                    *
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                <span>
+                                  My Item
+                                   
+                                  *
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
-                          <span
-                            className="MuiTypography-root MuiTypography-caption emotion-21"
-                          >
-                            <h6
-                              className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
-                              id="root_1__description"
-                              style={
-                                {
-                                  "marginTop": "5px",
-                                }
-                              }
-                            >
-                              a fancier item description
-                            </h6>
-                          </span>
                         </div>
+                        <span
+                          className="MuiTypography-root MuiTypography-caption emotion-20"
+                        >
+                          <h6
+                            className="MuiTypography-root MuiTypography-subtitle2 emotion-6"
+                            id="root_1__description"
+                            style={
+                              {
+                                "marginTop": "5px",
+                              }
+                            }
+                          >
+                            a fancier item description
+                          </h6>
+                        </span>
                       </div>
                     </div>
                   </div>
@@ -15111,10 +14871,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-18:focus::-ms-input-
     </div>
   </div>
   <div
-    className="MuiBox-root emotion-38"
+    className="MuiBox-root emotion-37"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-39"
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-38"
       disabled={false}
       onBlur={[Function]}
       onContextMenu={[Function]}
@@ -15182,29 +14942,13 @@ exports[`with title and description with global label off array 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-}
-
-.emotion-4 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
   justify-content: flex-end;
 }
 
-.emotion-5 {
+.emotion-4 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -15212,11 +14956,11 @@ exports[`with title and description with global label off array 1`] = `
   flex-direction: row;
 }
 
-.emotion-6 {
+.emotion-5 {
   margin-top: 16px;
 }
 
-.emotion-7 {
+.emotion-6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -15263,48 +15007,48 @@ exports[`with title and description with global label off array 1`] = `
   color: #1976d2;
 }
 
-.emotion-7::-moz-focus-inner {
+.emotion-6::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-7.Mui-disabled {
+.emotion-6.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-7 {
+  .emotion-6 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-7:hover {
+.emotion-6:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-7:hover {
+  .emotion-6:hover {
     background-color: transparent;
   }
 }
 
-.emotion-7:hover {
+.emotion-6:hover {
   background-color: rgba(25, 118, 210, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-7:hover {
+  .emotion-6:hover {
     background-color: transparent;
   }
 }
 
-.emotion-7.Mui-disabled {
+.emotion-6.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-8 {
+.emotion-7 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -15321,7 +15065,7 @@ exports[`with title and description with global label off array 1`] = `
   font-size: 1.5rem;
 }
 
-.emotion-9 {
+.emotion-8 {
   overflow: hidden;
   pointer-events: none;
   position: absolute;
@@ -15333,11 +15077,11 @@ exports[`with title and description with global label off array 1`] = `
   border-radius: inherit;
 }
 
-.emotion-10 {
+.emotion-9 {
   margin-top: 24px;
 }
 
-.emotion-11 {
+.emotion-10 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -15386,23 +15130,23 @@ exports[`with title and description with global label off array 1`] = `
   box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-11::-moz-focus-inner {
+.emotion-10::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-11.Mui-disabled {
+.emotion-10.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-11 {
+  .emotion-10 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-11:hover {
+.emotion-10:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: #1565c0;
@@ -15410,20 +15154,20 @@ exports[`with title and description with global label off array 1`] = `
 }
 
 @media (hover: none) {
-  .emotion-11:hover {
+  .emotion-10:hover {
     background-color: #1976d2;
   }
 }
 
-.emotion-11:active {
+.emotion-10:active {
   box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
 }
 
-.emotion-11.Mui-focusVisible {
+.emotion-10.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-11.Mui-disabled {
+.emotion-10.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
@@ -15450,50 +15194,46 @@ exports[`with title and description with global label off array 1`] = `
             className="MuiGrid-root MuiGrid-container emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-4"
+              className="MuiGrid-root MuiGrid-item emotion-4"
             >
               <div
-                className="MuiGrid-root MuiGrid-item emotion-5"
+                className="MuiBox-root emotion-5"
               >
-                <div
-                  className="MuiBox-root emotion-6"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-6"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-7"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onContextMenu={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-7"
+                    data-testid="AddIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-8"
-                      data-testid="AddIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                      />
-                    </svg>
-                    <span
-                      className="MuiTouchRipple-root emotion-9"
+                    <path
+                      d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
                     />
-                  </button>
-                </div>
+                  </svg>
+                  <span
+                    className="MuiTouchRipple-root emotion-8"
+                  />
+                </button>
               </div>
             </div>
           </div>
@@ -15502,10 +15242,10 @@ exports[`with title and description with global label off array 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root emotion-10"
+    className="MuiBox-root emotion-9"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-11"
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-10"
       disabled={false}
       onBlur={[Function]}
       onContextMenu={[Function]}
@@ -15524,7 +15264,7 @@ exports[`with title and description with global label off array 1`] = `
     >
       Submit
       <span
-        className="MuiTouchRipple-root emotion-9"
+        className="MuiTouchRipple-root emotion-8"
       />
     </button>
   </div>
@@ -15576,29 +15316,13 @@ exports[`with title and description with global label off array icons 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-}
-
-.emotion-4 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-5 {
+.emotion-4 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -15615,7 +15339,7 @@ exports[`with title and description with global label off array icons 1`] = `
 }
 
 @media (min-width:600px) {
-  .emotion-5 {
+  .emotion-4 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -15628,7 +15352,7 @@ exports[`with title and description with global label off array icons 1`] = `
 }
 
 @media (min-width:900px) {
-  .emotion-5 {
+  .emotion-4 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -15641,7 +15365,7 @@ exports[`with title and description with global label off array icons 1`] = `
 }
 
 @media (min-width:1200px) {
-  .emotion-5 {
+  .emotion-4 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -15654,7 +15378,7 @@ exports[`with title and description with global label off array icons 1`] = `
 }
 
 @media (min-width:1536px) {
-  .emotion-5 {
+  .emotion-4 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -15666,11 +15390,11 @@ exports[`with title and description with global label off array icons 1`] = `
   }
 }
 
-.emotion-6 {
+.emotion-5 {
   margin-bottom: 16px;
 }
 
-.emotion-10 {
+.emotion-9 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -15686,7 +15410,7 @@ exports[`with title and description with global label off array icons 1`] = `
   vertical-align: top;
 }
 
-.emotion-11 {
+.emotion-10 {
   color: rgba(0, 0, 0, 0.6);
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
@@ -15718,23 +15442,23 @@ exports[`with title and description with global label off array icons 1`] = `
   user-select: none;
 }
 
-.emotion-11.Mui-focused {
+.emotion-10.Mui-focused {
   color: #1976d2;
 }
 
-.emotion-11.Mui-disabled {
+.emotion-10.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-10.Mui-error {
+  color: #d32f2f;
 }
 
 .emotion-11.Mui-error {
   color: #d32f2f;
 }
 
-.emotion-12.Mui-error {
-  color: #d32f2f;
-}
-
-.emotion-13 {
+.emotion-12 {
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -15756,35 +15480,35 @@ exports[`with title and description with global label off array icons 1`] = `
   border-radius: 4px;
 }
 
-.emotion-13.Mui-disabled {
+.emotion-12.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
   cursor: default;
 }
 
-.emotion-13:hover .MuiOutlinedInput-notchedOutline {
+.emotion-12:hover .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.87);
 }
 
 @media (hover: none) {
-  .emotion-13:hover .MuiOutlinedInput-notchedOutline {
+  .emotion-12:hover .MuiOutlinedInput-notchedOutline {
     border-color: rgba(0, 0, 0, 0.23);
   }
 }
 
-.emotion-13.Mui-focused .MuiOutlinedInput-notchedOutline {
+.emotion-12.Mui-focused .MuiOutlinedInput-notchedOutline {
   border-color: #1976d2;
   border-width: 2px;
 }
 
-.emotion-13.Mui-error .MuiOutlinedInput-notchedOutline {
+.emotion-12.Mui-error .MuiOutlinedInput-notchedOutline {
   border-color: #d32f2f;
 }
 
-.emotion-13.Mui-disabled .MuiOutlinedInput-notchedOutline {
+.emotion-12.Mui-disabled .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-14 {
+.emotion-13 {
   font: inherit;
   letter-spacing: inherit;
   color: currentColor;
@@ -15805,95 +15529,95 @@ exports[`with title and description with global label off array icons 1`] = `
   padding: 16.5px 14px;
 }
 
-.emotion-14::-webkit-input-placeholder {
+.emotion-13::-webkit-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-14::-moz-placeholder {
+.emotion-13::-moz-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-14:-ms-input-placeholder {
+.emotion-13:-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-14::-ms-input-placeholder {
+.emotion-13::-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-14:focus {
+.emotion-13:focus {
   outline: 0;
 }
 
-.emotion-14:invalid {
+.emotion-13:invalid {
   box-shadow: none;
 }
 
-.emotion-14::-webkit-search-decoration {
+.emotion-13::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-14::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-13::-webkit-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-14::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-13::-moz-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-13:-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-14::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-13::-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-13:focus::-webkit-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-13:focus::-moz-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-13:focus:-ms-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-13:focus::-ms-input-placeholder {
   opacity: 0.42;
 }
 
-.emotion-14.Mui-disabled {
+.emotion-13.Mui-disabled {
   opacity: 1;
   -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-14:-webkit-autofill {
+.emotion-13:-webkit-autofill {
   -webkit-animation-duration: 5000s;
   animation-duration: 5000s;
   -webkit-animation-name: mui-auto-fill;
   animation-name: mui-auto-fill;
 }
 
-.emotion-14:-webkit-autofill {
+.emotion-13:-webkit-autofill {
   border-radius: inherit;
 }
 
-.emotion-15 {
+.emotion-14 {
   text-align: left;
   position: absolute;
   bottom: 0;
@@ -15911,7 +15635,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
   border-color: rgba(0, 0, 0, 0.23);
 }
 
-.emotion-16 {
+.emotion-15 {
   float: unset;
   width: auto;
   overflow: hidden;
@@ -15926,7 +15650,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
   white-space: nowrap;
 }
 
-.emotion-16>span {
+.emotion-15>span {
   padding-left: 5px;
   padding-right: 5px;
   display: inline-block;
@@ -15934,7 +15658,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
   visibility: visible;
 }
 
-.emotion-17 {
+.emotion-16 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -15942,7 +15666,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
   flex-direction: row;
 }
 
-.emotion-18 {
+.emotion-17 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -15990,38 +15714,38 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
   font-size: 1.125rem;
 }
 
-.emotion-18::-moz-focus-inner {
+.emotion-17::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-18.Mui-disabled {
+.emotion-17.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-18 {
+  .emotion-17 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-18:hover {
+.emotion-17:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-18:hover {
+  .emotion-17:hover {
     background-color: transparent;
   }
 }
 
-.emotion-18.Mui-disabled {
+.emotion-17.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-19 {
+.emotion-18 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -16038,7 +15762,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
   font-size: 1.25rem;
 }
 
-.emotion-24 {
+.emotion-23 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -16087,48 +15811,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
   font-size: 1.125rem;
 }
 
-.emotion-24::-moz-focus-inner {
+.emotion-23::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-24.Mui-disabled {
+.emotion-23.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-24 {
+  .emotion-23 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-24:hover {
+.emotion-23:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-24:hover {
+  .emotion-23:hover {
     background-color: transparent;
   }
 }
 
-.emotion-24:hover {
+.emotion-23:hover {
   background-color: rgba(211, 47, 47, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-24:hover {
+  .emotion-23:hover {
     background-color: transparent;
   }
 }
 
-.emotion-24.Mui-disabled {
+.emotion-23.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-48 {
+.emotion-47 {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -16148,11 +15872,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
   justify-content: flex-end;
 }
 
-.emotion-50 {
+.emotion-49 {
   margin-top: 16px;
 }
 
-.emotion-51 {
+.emotion-50 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -16199,48 +15923,48 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
   color: #1976d2;
 }
 
-.emotion-51::-moz-focus-inner {
+.emotion-50::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-51.Mui-disabled {
+.emotion-50.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-51 {
+  .emotion-50 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-51:hover {
+.emotion-50:hover {
   background-color: rgba(0, 0, 0, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-51:hover {
+  .emotion-50:hover {
     background-color: transparent;
   }
 }
 
-.emotion-51:hover {
+.emotion-50:hover {
   background-color: rgba(25, 118, 210, 0.04);
 }
 
 @media (hover: none) {
-  .emotion-51:hover {
+  .emotion-50:hover {
     background-color: transparent;
   }
 }
 
-.emotion-51.Mui-disabled {
+.emotion-50.Mui-disabled {
   background-color: transparent;
   color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-52 {
+.emotion-51 {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
@@ -16257,11 +15981,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
   font-size: 1.5rem;
 }
 
-.emotion-53 {
+.emotion-52 {
   margin-top: 24px;
 }
 
-.emotion-54 {
+.emotion-53 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -16310,23 +16034,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
   box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-54::-moz-focus-inner {
+.emotion-53::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-54.Mui-disabled {
+.emotion-53.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-54 {
+  .emotion-53 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-54:hover {
+.emotion-53:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: #1565c0;
@@ -16334,20 +16058,20 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
 }
 
 @media (hover: none) {
-  .emotion-54:hover {
+  .emotion-53:hover {
     background-color: #1976d2;
   }
 }
 
-.emotion-54:active {
+.emotion-53:active {
   box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
 }
 
-.emotion-54.Mui-focusVisible {
+.emotion-53.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-54.Mui-disabled {
+.emotion-53.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
@@ -16374,82 +16098,78 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
             className="MuiGrid-root MuiGrid-container emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-4"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-5"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root emotion-5"
               >
                 <div
-                  className="MuiBox-root emotion-6"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-9"
                         >
-                          <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-10"
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-10"
+                            data-shrink={true}
+                            htmlFor="root_0"
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-11"
-                              data-shrink={true}
-                              htmlFor="root_0"
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-11"
                             >
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-12"
-                              >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-13"
-                              onClick={[Function]}
+                               
+                              *
+                            </span>
+                          </label>
+                          <div
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-12"
+                            onClick={[Function]}
+                          >
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-13"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="a"
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-14"
                             >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-14"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="a"
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-15"
+                              <legend
+                                className="emotion-15"
                               >
-                                <legend
-                                  className="emotion-16"
-                                >
-                                  <span>
-                                     
-                                    *
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                <span>
+                                   
+                                  *
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
                         </div>
                       </div>
@@ -16457,252 +16177,252 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item emotion-17"
-              >
-                <button
-                  className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-18"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move up"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-19"
-                    data-testid="ArrowUpwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-18"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move down"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-19"
-                    data-testid="ArrowDownwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-18"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-19"
-                    data-testid="ContentCopyIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-24"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-19"
-                    data-testid="RemoveIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M19 13H5v-2h14v2z"
-                    />
-                  </svg>
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container emotion-4"
+              className="MuiGrid-root MuiGrid-item emotion-16"
             >
-              <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-5"
+              <button
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-17"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
                 style={
                   {
-                    "overflow": "auto",
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
                   }
                 }
+                tabIndex={-1}
+                title="Move up"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-18"
+                  data-testid="ArrowUpwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-17"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move down"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-18"
+                  data-testid="ArrowDownwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-17"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-18"
+                  data-testid="ContentCopyIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-23"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-18"
+                  data-testid="RemoveIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 13H5v-2h14v2z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container emotion-3"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
+            >
+              <div
+                className="MuiBox-root emotion-5"
               >
                 <div
-                  className="MuiBox-root emotion-6"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-9"
                         >
-                          <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-10"
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-10"
+                            data-shrink={true}
+                            htmlFor="root_1"
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiFormLabel-filled Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-11"
-                              data-shrink={true}
-                              htmlFor="root_1"
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-11"
                             >
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-12"
-                              >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-13"
-                              onClick={[Function]}
+                               
+                              *
+                            </span>
+                          </label>
+                          <div
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-12"
+                            onClick={[Function]}
+                          >
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-13"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value="b"
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-14"
                             >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-14"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value="b"
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-15"
+                              <legend
+                                className="emotion-15"
                               >
-                                <legend
-                                  className="emotion-16"
-                                >
-                                  <span>
-                                     
-                                    *
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                <span>
+                                   
+                                  *
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
                         </div>
                       </div>
@@ -16710,217 +16430,217 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
                   </div>
                 </div>
               </div>
-              <div
-                className="MuiGrid-root MuiGrid-item emotion-17"
-              >
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-18"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Move up"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-19"
-                    data-testid="ArrowUpwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-18"
-                  disabled={true}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={-1}
-                  title="Move down"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-19"
-                    data-testid="ArrowDownwardIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-18"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Copy"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-19"
-                    data-testid="ContentCopyIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
-                    />
-                  </svg>
-                </button>
-                <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-24"
-                  disabled={false}
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onContextMenu={[Function]}
-                  onDragLeave={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseLeave={[Function]}
-                  onMouseUp={[Function]}
-                  onTouchEnd={[Function]}
-                  onTouchMove={[Function]}
-                  onTouchStart={[Function]}
-                  style={
-                    {
-                      "flex": 1,
-                      "fontWeight": "bold",
-                      "minWidth": 0,
-                      "paddingLeft": 6,
-                      "paddingRight": 6,
-                    }
-                  }
-                  tabIndex={0}
-                  title="Remove"
-                  type="button"
-                >
-                  <svg
-                    aria-hidden={true}
-                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-19"
-                    data-testid="RemoveIcon"
-                    focusable="false"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M19 13H5v-2h14v2z"
-                    />
-                  </svg>
-                </button>
-              </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-container emotion-48"
+              className="MuiGrid-root MuiGrid-item emotion-16"
+            >
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-17"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Move up"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-18"
+                  data-testid="ArrowUpwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m4 12 1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall emotion-17"
+                disabled={true}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={-1}
+                title="Move down"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-18"
+                  data-testid="ArrowDownwardIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m20 12-1.41-1.41L13 16.17V4h-2v12.17l-5.58-5.59L4 12l8 8 8-8z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall emotion-17"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Copy"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-18"
+                  data-testid="ContentCopyIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+                  />
+                </svg>
+              </button>
+              <button
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall emotion-23"
+                disabled={false}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onContextMenu={[Function]}
+                onDragLeave={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "fontWeight": "bold",
+                    "minWidth": 0,
+                    "paddingLeft": 6,
+                    "paddingRight": 6,
+                  }
+                }
+                tabIndex={0}
+                title="Remove"
+                type="button"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall emotion-18"
+                  data-testid="RemoveIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M19 13H5v-2h14v2z"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container emotion-47"
+          >
+            <div
+              className="MuiGrid-root MuiGrid-item emotion-16"
             >
               <div
-                className="MuiGrid-root MuiGrid-item emotion-17"
+                className="MuiBox-root emotion-49"
               >
-                <div
-                  className="MuiBox-root emotion-50"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-50"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  title="Add Item"
+                  type="button"
                 >
-                  <button
-                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-51"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onContextMenu={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    title="Add Item"
-                    type="button"
+                  <svg
+                    aria-hidden={true}
+                    className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-51"
+                    data-testid="AddIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      aria-hidden={true}
-                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-52"
-                      data-testid="AddIcon"
-                      focusable="false"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-                      />
-                    </svg>
-                  </button>
-                </div>
+                    <path
+                      d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                    />
+                  </svg>
+                </button>
               </div>
             </div>
           </div>
@@ -16929,10 +16649,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
     </div>
   </div>
   <div
-    className="MuiBox-root emotion-53"
+    className="MuiBox-root emotion-52"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-54"
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-53"
       disabled={false}
       onBlur={[Function]}
       onContextMenu={[Function]}
@@ -17609,29 +17329,13 @@ exports[`with title and description with global label off fixed array 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-}
-
-.emotion-4 {
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-5 {
+.emotion-4 {
   box-sizing: border-box;
   margin: 0;
   -webkit-flex-direction: row;
@@ -17648,7 +17352,7 @@ exports[`with title and description with global label off fixed array 1`] = `
 }
 
 @media (min-width:600px) {
-  .emotion-5 {
+  .emotion-4 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -17661,7 +17365,7 @@ exports[`with title and description with global label off fixed array 1`] = `
 }
 
 @media (min-width:900px) {
-  .emotion-5 {
+  .emotion-4 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -17674,7 +17378,7 @@ exports[`with title and description with global label off fixed array 1`] = `
 }
 
 @media (min-width:1200px) {
-  .emotion-5 {
+  .emotion-4 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -17687,7 +17391,7 @@ exports[`with title and description with global label off fixed array 1`] = `
 }
 
 @media (min-width:1536px) {
-  .emotion-5 {
+  .emotion-4 {
     -webkit-flex-basis: 0;
     -ms-flex-preferred-size: 0;
     flex-basis: 0;
@@ -17699,11 +17403,11 @@ exports[`with title and description with global label off fixed array 1`] = `
   }
 }
 
-.emotion-6 {
+.emotion-5 {
   margin-bottom: 16px;
 }
 
-.emotion-10 {
+.emotion-9 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -17719,7 +17423,7 @@ exports[`with title and description with global label off fixed array 1`] = `
   vertical-align: top;
 }
 
-.emotion-11 {
+.emotion-10 {
   color: rgba(0, 0, 0, 0.6);
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
@@ -17747,23 +17451,23 @@ exports[`with title and description with global label off fixed array 1`] = `
   pointer-events: none;
 }
 
-.emotion-11.Mui-focused {
+.emotion-10.Mui-focused {
   color: #1976d2;
 }
 
-.emotion-11.Mui-disabled {
+.emotion-10.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-10.Mui-error {
+  color: #d32f2f;
 }
 
 .emotion-11.Mui-error {
   color: #d32f2f;
 }
 
-.emotion-12.Mui-error {
-  color: #d32f2f;
-}
-
-.emotion-13 {
+.emotion-12 {
   font-family: "Roboto","Helvetica","Arial",sans-serif;
   font-weight: 400;
   font-size: 1rem;
@@ -17785,35 +17489,35 @@ exports[`with title and description with global label off fixed array 1`] = `
   border-radius: 4px;
 }
 
-.emotion-13.Mui-disabled {
+.emotion-12.Mui-disabled {
   color: rgba(0, 0, 0, 0.38);
   cursor: default;
 }
 
-.emotion-13:hover .MuiOutlinedInput-notchedOutline {
+.emotion-12:hover .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.87);
 }
 
 @media (hover: none) {
-  .emotion-13:hover .MuiOutlinedInput-notchedOutline {
+  .emotion-12:hover .MuiOutlinedInput-notchedOutline {
     border-color: rgba(0, 0, 0, 0.23);
   }
 }
 
-.emotion-13.Mui-focused .MuiOutlinedInput-notchedOutline {
+.emotion-12.Mui-focused .MuiOutlinedInput-notchedOutline {
   border-color: #1976d2;
   border-width: 2px;
 }
 
-.emotion-13.Mui-error .MuiOutlinedInput-notchedOutline {
+.emotion-12.Mui-error .MuiOutlinedInput-notchedOutline {
   border-color: #d32f2f;
 }
 
-.emotion-13.Mui-disabled .MuiOutlinedInput-notchedOutline {
+.emotion-12.Mui-disabled .MuiOutlinedInput-notchedOutline {
   border-color: rgba(0, 0, 0, 0.26);
 }
 
-.emotion-14 {
+.emotion-13 {
   font: inherit;
   letter-spacing: inherit;
   color: currentColor;
@@ -17834,95 +17538,95 @@ exports[`with title and description with global label off fixed array 1`] = `
   padding: 16.5px 14px;
 }
 
-.emotion-14::-webkit-input-placeholder {
+.emotion-13::-webkit-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-14::-moz-placeholder {
+.emotion-13::-moz-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-14:-ms-input-placeholder {
+.emotion-13:-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-14::-ms-input-placeholder {
+.emotion-13::-ms-input-placeholder {
   color: currentColor;
   opacity: 0.42;
   -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 }
 
-.emotion-14:focus {
+.emotion-13:focus {
   outline: 0;
 }
 
-.emotion-14:invalid {
+.emotion-13:invalid {
   box-shadow: none;
 }
 
-.emotion-14::-webkit-search-decoration {
+.emotion-13::-webkit-search-decoration {
   -webkit-appearance: none;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-14::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-13::-webkit-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-14::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-13::-moz-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-13:-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-14::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-13::-ms-input-placeholder {
   opacity: 0!important;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-webkit-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-13:focus::-webkit-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-moz-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-13:focus::-moz-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus:-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-13:focus:-ms-input-placeholder {
   opacity: 0.42;
 }
 
-label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-placeholder {
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-13:focus::-ms-input-placeholder {
   opacity: 0.42;
 }
 
-.emotion-14.Mui-disabled {
+.emotion-13.Mui-disabled {
   opacity: 1;
   -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
 }
 
-.emotion-14:-webkit-autofill {
+.emotion-13:-webkit-autofill {
   -webkit-animation-duration: 5000s;
   animation-duration: 5000s;
   -webkit-animation-name: mui-auto-fill;
   animation-name: mui-auto-fill;
 }
 
-.emotion-14:-webkit-autofill {
+.emotion-13:-webkit-autofill {
   border-radius: inherit;
 }
 
-.emotion-15 {
+.emotion-14 {
   text-align: left;
   position: absolute;
   bottom: 0;
@@ -17940,7 +17644,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
   border-color: rgba(0, 0, 0, 0.23);
 }
 
-.emotion-16 {
+.emotion-15 {
   float: unset;
   width: auto;
   overflow: hidden;
@@ -17955,7 +17659,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
   white-space: nowrap;
 }
 
-.emotion-16>span {
+.emotion-15>span {
   padding-left: 5px;
   padding-right: 5px;
   display: inline-block;
@@ -17963,11 +17667,11 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
   visibility: visible;
 }
 
-.emotion-30 {
+.emotion-29 {
   margin-top: 24px;
 }
 
-.emotion-31 {
+.emotion-30 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -18016,23 +17720,23 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
   box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-31::-moz-focus-inner {
+.emotion-30::-moz-focus-inner {
   border-style: none;
 }
 
-.emotion-31.Mui-disabled {
+.emotion-30.Mui-disabled {
   pointer-events: none;
   cursor: default;
 }
 
 @media print {
-  .emotion-31 {
+  .emotion-30 {
     -webkit-print-color-adjust: exact;
     color-adjust: exact;
   }
 }
 
-.emotion-31:hover {
+.emotion-30:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background-color: #1565c0;
@@ -18040,20 +17744,20 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
 }
 
 @media (hover: none) {
-  .emotion-31:hover {
+  .emotion-30:hover {
     background-color: #1976d2;
   }
 }
 
-.emotion-31:active {
+.emotion-30:active {
   box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
 }
 
-.emotion-31.Mui-focusVisible {
+.emotion-30.Mui-focusVisible {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 
-.emotion-31.Mui-disabled {
+.emotion-30.Mui-disabled {
   color: rgba(0, 0, 0, 0.26);
   box-shadow: none;
   background-color: rgba(0, 0, 0, 0.12);
@@ -18080,82 +17784,78 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
             className="MuiGrid-root MuiGrid-container emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-4"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-5"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root emotion-5"
               >
                 <div
-                  className="MuiBox-root emotion-6"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-string"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_0__error root_0__description root_0__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-9"
                         >
-                          <div
-                            aria-describedby="root_0__error root_0__description root_0__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-10"
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-10"
+                            data-shrink={false}
+                            htmlFor="root_0"
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-11"
-                              data-shrink={false}
-                              htmlFor="root_0"
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-11"
                             >
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-12"
-                              >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-13"
-                              onClick={[Function]}
+                               
+                              *
+                            </span>
+                          </label>
+                          <div
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-12"
+                            onClick={[Function]}
+                          >
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-13"
+                              disabled={false}
+                              id="root_0"
+                              name="root_0"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              type="text"
+                              value=""
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-14"
                             >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-14"
-                                disabled={false}
-                                id="root_0"
-                                name="root_0"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                type="text"
-                                value=""
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-15"
+                              <legend
+                                className="emotion-15"
                               >
-                                <legend
-                                  className="emotion-16"
-                                >
-                                  <span>
-                                     
-                                    *
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                <span>
+                                   
+                                  *
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
                         </div>
                       </div>
@@ -18164,84 +17864,84 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
                 </div>
               </div>
             </div>
+          </div>
+          <div
+            className="MuiGrid-root MuiGrid-container emotion-3"
+          >
             <div
-              className="MuiGrid-root MuiGrid-container emotion-4"
+              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              style={
+                {
+                  "overflow": "auto",
+                }
+              }
             >
               <div
-                className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-5"
-                style={
-                  {
-                    "overflow": "auto",
-                  }
-                }
+                className="MuiBox-root emotion-5"
               >
                 <div
-                  className="MuiBox-root emotion-6"
+                  className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
                 >
                   <div
-                    className="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation2 emotion-1"
+                    className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="MuiBox-root emotion-2"
+                      className="form-group field field-number"
                     >
                       <div
-                        className="form-group field field-number"
+                        className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
                       >
                         <div
-                          className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+                          aria-describedby="root_1__error root_1__description root_1__help"
+                          className="MuiFormControl-root MuiTextField-root emotion-9"
                         >
-                          <div
-                            aria-describedby="root_1__error root_1__description root_1__help"
-                            className="MuiFormControl-root MuiTextField-root emotion-10"
+                          <label
+                            className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-10"
+                            data-shrink={false}
+                            htmlFor="root_1"
                           >
-                            <label
-                              className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-required MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-11"
-                              data-shrink={false}
-                              htmlFor="root_1"
+                            <span
+                              aria-hidden={true}
+                              className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-11"
                             >
-                              <span
-                                aria-hidden={true}
-                                className="MuiFormLabel-asterisk MuiInputLabel-asterisk emotion-12"
-                              >
-                                 
-                                *
-                              </span>
-                            </label>
-                            <div
-                              className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-13"
-                              onClick={[Function]}
+                               
+                              *
+                            </span>
+                          </label>
+                          <div
+                            className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-12"
+                            onClick={[Function]}
+                          >
+                            <input
+                              aria-invalid={false}
+                              autoFocus={false}
+                              className="MuiInputBase-input MuiOutlinedInput-input emotion-13"
+                              disabled={false}
+                              id="root_1"
+                              name="root_1"
+                              onAnimationStart={[Function]}
+                              onBlur={[Function]}
+                              onChange={[Function]}
+                              onFocus={[Function]}
+                              placeholder=""
+                              required={true}
+                              step="any"
+                              type="number"
+                              value=""
+                            />
+                            <fieldset
+                              aria-hidden={true}
+                              className="MuiOutlinedInput-notchedOutline emotion-14"
                             >
-                              <input
-                                aria-invalid={false}
-                                autoFocus={false}
-                                className="MuiInputBase-input MuiOutlinedInput-input emotion-14"
-                                disabled={false}
-                                id="root_1"
-                                name="root_1"
-                                onAnimationStart={[Function]}
-                                onBlur={[Function]}
-                                onChange={[Function]}
-                                onFocus={[Function]}
-                                placeholder=""
-                                required={true}
-                                step="any"
-                                type="number"
-                                value=""
-                              />
-                              <fieldset
-                                aria-hidden={true}
-                                className="MuiOutlinedInput-notchedOutline emotion-15"
+                              <legend
+                                className="emotion-15"
                               >
-                                <legend
-                                  className="emotion-16"
-                                >
-                                  <span>
-                                     
-                                    *
-                                  </span>
-                                </legend>
-                              </fieldset>
-                            </div>
+                                <span>
+                                   
+                                  *
+                                </span>
+                              </legend>
+                            </fieldset>
                           </div>
                         </div>
                       </div>
@@ -18256,10 +17956,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-14:focus::-ms-input-
     </div>
   </div>
   <div
-    className="MuiBox-root emotion-30"
+    className="MuiBox-root emotion-29"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-31"
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-30"
       disabled={false}
       onBlur={[Function]}
       onContextMenu={[Function]}


### PR DESCRIPTION
### Reasons for making this change

fixes #3863

Removes a wrapping Grid component in `ArrayFieldTemplate` that wraps `ArrayFieldItemTemplate`. This is for the [MUI](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/mui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx#L41) and [material-ui](https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/material-ui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx#L41) themes only.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
