### PR TITLE
Fix data type in `FieldTemplateProps['onChange']`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,16 +16,13 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
-## @rjsf/utils
-- Fix data type in `FieldTemplateProps['onChange']`
-
-
 # 5.13.1
 
 ## @rjsf/utils
 
 - Added `getOptionMatchingSimpleDiscriminator()` function
 - `getMatchingOption` and `getClosestMatchingOption` now bypass `validator.isValid()` calls when simple discriminator is provided, fixing [#3692](https://github.com/rjsf-team/react-jsonschema-form/issues/3692)
+- Fix data type in `FieldTemplateProps['onChange']`
 
 
 # 5.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+
+## @rjsf/utils
+- Fix data type in `FieldTemplateProps['onChange']`
+
+
 # 5.13.0
 
 ## @rjsf/antd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
-
 # 5.13.1
 
 ## @rjsf/utils

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -440,7 +440,7 @@ export type FieldTemplateProps<T = any, S extends StrictRJSFSchema = RJSFSchema,
   /** The formData for this field */
   formData?: T;
   /** The value change event handler; Can be called with a new value to change the value for this field */
-  onChange: FieldProps['onChange'];
+  onChange: FieldProps<T>['onChange'];
   /** The key change event handler; Called when the key associated with a field is changed for an additionalProperty */
   onKeyChange: (value: string) => () => void;
   /** The property drop/removal event handler; Called when a field is removed in an additionalProperty context */

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -440,7 +440,7 @@ export type FieldTemplateProps<T = any, S extends StrictRJSFSchema = RJSFSchema,
   /** The formData for this field */
   formData?: T;
   /** The value change event handler; Can be called with a new value to change the value for this field */
-  onChange: FieldProps<T>['onChange'];
+  onChange: FieldProps<T, S, F>['onChange'];
   /** The key change event handler; Called when the key associated with a field is changed for an additionalProperty */
   onKeyChange: (value: string) => () => void;
   /** The property drop/removal event handler; Called when a field is removed in an additionalProperty context */


### PR DESCRIPTION
### Reasons for making this change

Typing is not passed on, so even if we have a type (`<T>`) on `FieldTemplateProps`, its `onChange` method is typed to have `any` as first argument, which is incorrect. This fixes it.
### Checklist

- [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR