### PR TITLE
fix: errorSchema is not correctly updated when inserting or copying array items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # 5.13.1
 
+## @rjsf/core
+
+- Updated `ArrayField` to move errors in the errorSchema when the position of array items changes for the insert and copy cases.
+
 ## @rjsf/mui
 
 - Removed an unnecessary `Grid` container component in the `ArrayFieldTemplate` component that wrapped the `ArrayFieldItemTemplate`, fixing [#3863](https://github.com/rjsf-team/react-jsonschema-form/issues/3863)

--- a/packages/core/src/components/fields/ArrayField.tsx
+++ b/packages/core/src/components/fields/ArrayField.tsx
@@ -198,8 +198,22 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
       event.preventDefault();
     }
 
-    const { onChange } = this.props;
+    const { onChange, errorSchema } = this.props;
     const { keyedFormData } = this.state;
+    // refs #195: revalidate to ensure properly reindexing errors
+    let newErrorSchema: ErrorSchema<T>;
+    if (errorSchema) {
+      newErrorSchema = {};
+      for (const idx in errorSchema) {
+        const i = parseInt(idx);
+        if (index === undefined || i < index) {
+          set(newErrorSchema, [i], errorSchema[idx]);
+        } else if (i >= index) {
+          set(newErrorSchema, [i + 1], errorSchema[idx]);
+        }
+      }
+    }
+
     const newKeyedFormDataRow: KeyedFormDataType<T> = {
       key: generateRowId(),
       item: this._getNewFormDataRow(),
@@ -215,7 +229,7 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
         keyedFormData: newKeyedFormData,
         updatedKeyedFormData: true,
       },
-      () => onChange(keyedToPlainFormData(newKeyedFormData))
+      () => onChange(keyedToPlainFormData(newKeyedFormData), newErrorSchema as ErrorSchema<T[]>)
     );
   }
 
@@ -253,8 +267,22 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
         event.preventDefault();
       }
 
-      const { onChange } = this.props;
+      const { onChange, errorSchema } = this.props;
       const { keyedFormData } = this.state;
+      // refs #195: revalidate to ensure properly reindexing errors
+      let newErrorSchema: ErrorSchema<T>;
+      if (errorSchema) {
+        newErrorSchema = {};
+        for (const idx in errorSchema) {
+          const i = parseInt(idx);
+          if (i <= index) {
+            set(newErrorSchema, [i], errorSchema[idx]);
+          } else if (i > index) {
+            set(newErrorSchema, [i + 1], errorSchema[idx]);
+          }
+        }
+      }
+
       const newKeyedFormDataRow: KeyedFormDataType<T> = {
         key: generateRowId(),
         item: cloneDeep(keyedFormData[index].item),
@@ -270,7 +298,7 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
           keyedFormData: newKeyedFormData,
           updatedKeyedFormData: true,
         },
-        () => onChange(keyedToPlainFormData(newKeyedFormData))
+        () => onChange(keyedToPlainFormData(newKeyedFormData), newErrorSchema as ErrorSchema<T[]>)
       );
     };
   };


### PR DESCRIPTION
### Reasons for making this change

When swapping or removing array items, the existing errorSchema is correctly updated. However this was not the case when inserting or copying array elements. Inserting array elements is not implementedby the default ArrayItemTemplate, but it is still possible from custom templates.

To test the "insert" functionality I added a custom ArrayItemTemplate to the ArrayField tests. If this is not the way, or if there is a better way to test this please let me know and I can update them.

### Checklist

- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR

