### PR TITLE
feat(templates): Allow customization per-field by using Registry string key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.14.0
+
+## @rjsf/utils
+- Updated `getTemplate()` to allow per-field customization using string key from `Registry`.
+
+## Dev / docs / playground
+- Updated `advanced-customization/custom-templates` with the new feature.
+
 # 5.13.0
 
 ## @rjsf/antd

--- a/packages/docs/docs/advanced-customization/custom-templates.md
+++ b/packages/docs/docs/advanced-customization/custom-templates.md
@@ -76,7 +76,7 @@ render(
 );
 ```
 
-You also can provide your own field template to a uiSchema by specifying a `ui:ArrayFieldTemplate` property.
+You also can provide your own field template to a uiSchema by specifying a `ui:ArrayFieldTemplate` property with your Component or a string value from the `Registry`.
 
 ```tsx
 import { UiSchema } from '@rjsf/utils';
@@ -162,7 +162,7 @@ render(
 );
 ```
 
-You also can provide your own template to a uiSchema by specifying a `ui:ArrayFieldDescriptionTemplate` property.
+You also can provide your own template to a uiSchema by specifying a `ui:ArrayFieldDescriptionTemplate` property with your Component or a string value from the `Registry`.
 
 ```tsx
 import { UiSchema } from '@rjsf/utils';
@@ -260,7 +260,7 @@ render(
 );
 ```
 
-You also can provide your own template to a uiSchema by specifying a `ui:ArrayFieldDescriptionTemplate` property.
+You also can provide your own template to a uiSchema by specifying a `ui:ArrayFieldDescriptionTemplate` property with your Component or a string value from the `Registry`.
 
 ```tsx
 import { UiSchema } from '@rjsf/utils';
@@ -612,7 +612,7 @@ render(
 );
 ```
 
-You also can provide your own field template to a uiSchema by specifying a `ui:FieldTemplate` property.
+You also can provide your own field template to a uiSchema by specifying a `ui:FieldTemplate` property with your Component or a string value from the `Registry`.
 
 ```tsx
 import { UiSchema } from '@rjsf/utils';
@@ -691,7 +691,7 @@ render(
 );
 ```
 
-You also can provide your own field template to a uiSchema by specifying a `ui:ObjectFieldTemplate` property.
+You also can provide your own field template to a uiSchema by specifying a `ui:ObjectFieldTemplate` property with your Component or a string value from the `Registry`.
 
 ```tsx
 import { UiSchema } from '@rjsf/utils';

--- a/packages/utils/src/getTemplate.ts
+++ b/packages/utils/src/getTemplate.ts
@@ -18,6 +18,10 @@ export default function getTemplate<
   if (name === 'ButtonTemplates') {
     return templates[name];
   }
+  // Allow templates to be customized per-field by using string keys from the registry
+  if (Object.hasOwn(uiOptions, name) && Object.hasOwn(templates, uiOptions[name])) {
+    return templates[uiOptions[name]]
+  }
   return (
     // Evaluating uiOptions[name] results in TS2590: Expression produces a union type that is too complex to represent
     // To avoid that, we cast uiOptions to `any` before accessing the name field

--- a/packages/utils/src/getTemplate.ts
+++ b/packages/utils/src/getTemplate.ts
@@ -24,10 +24,10 @@ export default function getTemplate<
     typeof uiOptions[name] === 'string' &&
     Object.hasOwn(templates, uiOptions[name] as string)
   ) {
-    const key = uiOptions[name]
+    const key = uiOptions[name];
     // Evaluating templates[key] results in TS2590: Expression produces a union type that is too complex to represent
     // To avoid that, we cast templates to `any` before accessing the key field
-    return (templates as any)[key]
+    return (templates as any)[key];
   }
   return (
     // Evaluating uiOptions[name] results in TS2590: Expression produces a union type that is too complex to represent

--- a/packages/utils/src/getTemplate.ts
+++ b/packages/utils/src/getTemplate.ts
@@ -19,7 +19,11 @@ export default function getTemplate<
     return templates[name];
   }
   // Allow templates to be customized per-field by using string keys from the registry
-  if (Object.hasOwn(uiOptions, name) && Object.hasOwn(templates, uiOptions[name])) {
+  if (
+    Object.hasOwn(uiOptions, name) &&
+    typeof uiOptions[name] === 'string' &&
+    Object.hasOwn(templates, uiOptions[name])
+  ) {
     return templates[uiOptions[name]]
   }
   return (

--- a/packages/utils/src/getTemplate.ts
+++ b/packages/utils/src/getTemplate.ts
@@ -22,9 +22,12 @@ export default function getTemplate<
   if (
     Object.hasOwn(uiOptions, name) &&
     typeof uiOptions[name] === 'string' &&
-    Object.hasOwn(templates, uiOptions[name])
+    Object.hasOwn(templates, uiOptions[name] as string)
   ) {
-    return templates[uiOptions[name]]
+    const key = uiOptions[name]
+    // Evaluating uiOptions[name] results in TS2590: Expression produces a union type that is too complex to represent
+    // To avoid that, we cast templates to `any` before accessing the key field
+    return (templates as any)[key]
   }
   return (
     // Evaluating uiOptions[name] results in TS2590: Expression produces a union type that is too complex to represent

--- a/packages/utils/src/getTemplate.ts
+++ b/packages/utils/src/getTemplate.ts
@@ -25,7 +25,7 @@ export default function getTemplate<
     Object.hasOwn(templates, uiOptions[name] as string)
   ) {
     const key = uiOptions[name]
-    // Evaluating uiOptions[name] results in TS2590: Expression produces a union type that is too complex to represent
+    // Evaluating templates[key] results in TS2590: Expression produces a union type that is too complex to represent
     // To avoid that, we cast templates to `any` before accessing the key field
     return (templates as any)[key]
   }

--- a/packages/utils/test/getTemplate.test.ts
+++ b/packages/utils/test/getTemplate.test.ts
@@ -88,17 +88,17 @@ describe('getTemplate', () => {
   });
   it('returns the template from registry using uiOptions key when available', () => {
     KEYS.forEach(key => {
-      const name = key as keyof TemplatesType
+      const name = key as keyof TemplatesType;
       expect(
         getTemplate<typeof name>(
           name,
           registry,
           Object.keys(uiOptions).reduce((uiOptions, key) => {
-            uiOptions[key] = key
-            return uiOptions
+            uiOptions[key] = key;
+            return uiOptions;
           }, {})
         )
       ).toBe(FakeTemplate);
-    })
+    });
   });
 });

--- a/packages/utils/test/getTemplate.test.ts
+++ b/packages/utils/test/getTemplate.test.ts
@@ -86,4 +86,19 @@ describe('getTemplate', () => {
       expect(getTemplate<typeof name>(name, registry, uiOptions)).toBe(CustomTemplate);
     });
   });
+  it('returns the template from registry using uiOptions key when available', () => {
+    KEYS.forEach(key => {
+      const name = key as keyof TemplatesType
+      expect(
+        getTemplate<typeof name>(
+          name,
+          registry,
+          Object.keys(uiOptions).reduce((uiOptions, key) => {
+            uiOptions[key] = key
+            return uiOptions
+          }, {})
+        )
+      ).toBe(FakeTemplate);
+    })
+  });
 });


### PR DESCRIPTION
Fixes #3695

### Reasons for making this change

Currently, to per-field customize the template, it is necessary to send the `function`/`class` of the component in the uiSchema, breaking the JSON nature of the `uiSchema`. It's not possible to provide just the registration key.

This PR fixes this issue by allowing the consumer of the library (the one with access to changing only schema, uiSchema and formData) to choose a different template provided to the form by the developer.

@ahkhanjani, could you please review?

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
