### PR TITLE
fix: precompiled schemas now properly resolve same $ref used in `anyOf/oneOf` branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.13.2
+
+## @rjsf/utils
+
+- Updated `resolveAnyOrOneOfSchemas()` to not take a `recurseList` anymore, and instead always pass an empty array down to `resolveAllReferences()`, fixing [#3902](https://github.com/rjsf-team/react-jsonschema-form/issues/3902)
+  - Also updated `parseSchema()` and `resolveDependencies()` to no longer pass `recurseList` to `resolveAnyOrOneOfSchemas()`
+
+## @rjsf/validator-ajv8
+
+- Updated `AJV8PrecompiledValidator` to add a new `ensureSameRootSchema()` function that is called in both `rawValidation()` and `isValid()`
+  - This function adds an optimization to avoid resolving the root schema unless necessary
+
 # 5.13.1
 
 ## @rjsf/core

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -25,7 +25,7 @@
     "lint": "eslint src test",
     "precommit": "lint-staged",
     "test": "jest",
-    "test:debug": "node --inspect-brk node_modules/.bin/jest"
+    "test:debug": "node --inspect-brk ../../node_modules/.bin/jest"
   },
   "lint-staged": {
     "{src,test}/**/*.ts?(x)": [

--- a/packages/utils/src/parser/schemaParser.ts
+++ b/packages/utils/src/parser/schemaParser.ts
@@ -22,13 +22,12 @@ function parseSchema<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends
   rootSchema: S,
   schema: S
 ) {
-  const recurseRefs: string[] = [];
-  const schemas = retrieveSchemaInternal<T, S, F>(validator, schema, rootSchema, undefined, true, recurseRefs);
+  const schemas = retrieveSchemaInternal<T, S, F>(validator, schema, rootSchema, undefined, true);
   schemas.forEach((schema) => {
     const sameSchemaIndex = recurseList.findIndex((item) => isEqual(item, schema));
     if (sameSchemaIndex === -1) {
       recurseList.push(schema);
-      const allOptions = resolveAnyOrOneOfSchemas<T, S, F>(validator, schema, rootSchema, true, recurseRefs);
+      const allOptions = resolveAnyOrOneOfSchemas<T, S, F>(validator, schema, rootSchema, true);
       allOptions.forEach((s) => {
         if (PROPERTIES_KEY in s && s[PROPERTIES_KEY]) {
           forEach(schema[PROPERTIES_KEY], (value) => {

--- a/packages/utils/test/parser/__snapshots__/schemaParser.test.ts.snap
+++ b/packages/utils/test/parser/__snapshots__/schemaParser.test.ts.snap
@@ -923,8 +923,71 @@ exports[`schemaParser() parses superSchema properly 1`] = `
     },
     "type": "object",
   },
+  "-7df52035": {
+    "$id": "-7df52035",
+    "anyOf": [
+      {
+        "required": [
+          "firstName",
+        ],
+      },
+      {
+        "required": [
+          "lastName",
+        ],
+      },
+    ],
+    "properties": {
+      "firstName": {
+        "title": "First name",
+        "type": "string",
+      },
+      "lastName": {
+        "type": "string",
+      },
+    },
+    "title": "First method of identification",
+  },
+  "587c7f18": {
+    "$id": "587c7f18",
+    "anyOf": [
+      {
+        "required": [
+          "idCode",
+        ],
+      },
+    ],
+    "properties": {
+      "idCode": {
+        "type": "string",
+      },
+    },
+    "title": "Second method of identification",
+  },
   "super-schema": {
     "$id": "super-schema",
+    "anyOf": [
+      {
+        "properties": {
+          "firstName": {
+            "title": "First name",
+            "type": "string",
+          },
+          "lastName": {
+            "$ref": "#/definitions/test",
+          },
+        },
+        "title": "First method of identification",
+      },
+      {
+        "properties": {
+          "idCode": {
+            "$ref": "#/definitions/test",
+          },
+        },
+        "title": "Second method of identification",
+      },
+    ],
     "definitions": {
       "choice1": {
         "properties": {
@@ -987,6 +1050,9 @@ exports[`schemaParser() parses superSchema properly 1`] = `
         "multipleOf": 0.03,
         "title": "Price per task ($)",
         "type": "number",
+      },
+      "test": {
+        "type": "string",
       },
     },
     "properties": {

--- a/packages/utils/test/testUtils/testData.ts
+++ b/packages/utils/test/testUtils/testData.ts
@@ -409,6 +409,9 @@ export const TEST_ERROR_LIST_OUTPUT: RJSFValidationError[] = reduce(
 export const SUPER_SCHEMA: RJSFSchema = deepFreeze({
   [ID_KEY]: 'super-schema',
   definitions: {
+    test: {
+      type: 'string',
+    },
     foo: {
       type: 'object',
       properties: {
@@ -481,6 +484,28 @@ export const SUPER_SCHEMA: RJSFSchema = deepFreeze({
       },
     },
   },
+  anyOf: [
+    {
+      title: 'First method of identification',
+      properties: {
+        firstName: {
+          type: 'string',
+          title: 'First name',
+        },
+        lastName: {
+          $ref: '#/definitions/test',
+        },
+      },
+    },
+    {
+      title: 'Second method of identification',
+      properties: {
+        idCode: {
+          $ref: '#/definitions/test',
+        },
+      },
+    },
+  ],
 });
 
 export const PROPERTY_DEPENDENCIES: RJSFSchema = deepFreeze({

--- a/packages/validator-ajv8/test/harness/superSchema.json
+++ b/packages/validator-ajv8/test/harness/superSchema.json
@@ -1,5 +1,8 @@
 {
   "definitions": {
+    "test": {
+      "type": "string"
+    },
     "foo": {
       "type": "object",
       "properties": {
@@ -72,5 +75,27 @@
         "type": "string"
       }
     }
-  }
+  },
+  "anyOf": [
+    {
+      "title": "First method of identification",
+      "properties": {
+        "firstName": {
+          "type": "string",
+          "title": "First name"
+        },
+        "lastName": {
+          "$ref": "#/definitions/test"
+        }
+      }
+    },
+    {
+      "title": "Second method of identification",
+      "properties": {
+        "idCode": {
+          "$ref": "#/definitions/test"
+        }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
### Reasons for making this change

Fixes #3902 by fixing the recursive `$ref` resolution when resolving `anyOf/oneOf` branches
- In `@rjsf/utils`, fixed #3902 as follows:
  - Updated the `package.json` to fix the path to `jest` within the `test:debug` script after NPM workspaces were used
  - Updated the `resolveAnyOrOneOfSchemas()` to no longer take a `recurseList` array and to have each branch of the `anyOf`/`oneOf` pass an empty array to the `resolveAllReferences()` function
  - Updated `parseSchema()` and `resolveDependencies()` to no longer pass `recurseList` to `resolveAnyOrOneOfSchemas()`
  - Updated the `SUPER_SCHEMA` to add the use case provided in #3902 to verify the issue is fixed
    - Updated the snapshot for the `schemaParser` test with the updated parsed schema
- In `@rjsf/validator-ajv8`, added an optimization to the `AJV8PrecompiledSchema` class
  - Added a new `ensureSameRootSchema()` function that only resolves the `rootSchema` with the `formData` when it does not match the given `schema` before throwing an error
  - Used this new function in `rawValidation()` and `isValid()`, replacing the duplicate existing code
  - Updated the tests to add unit tests for the new function as well as removing the need to use a resolved `rootSchema` in the tests
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
