### PR TITLE
correct antd SelectWidget filter option check. fix PR #3377

### DIFF
--- a/packages/antd/src/widgets/SelectWidget/index.tsx
+++ b/packages/antd/src/widgets/SelectWidget/index.tsx
@@ -81,17 +81,16 @@ export default function SelectWidget<
       {...extraProps}
       filterOption={filterOption}
       aria-describedby={ariaDescribedByIds<T>(id)}
-    >
-      {Array.isArray(enumOptions) &&
-        enumOptions.map(({ value: optionValue, label: optionLabel }, index) => (
-          <Select.Option
-            disabled={Array.isArray(enumDisabled) && enumDisabled.indexOf(optionValue) !== -1}
-            key={String(index)}
-            value={String(index)}
-          >
-            {optionLabel}
-          </Select.Option>
-        ))}
-    </Select>
+      options={
+        Array.isArray(enumOptions)
+          ? enumOptions.map(({ value: optionValue, label: optionLabel }, index) => ({
+              disabled: Array.isArray(enumDisabled) && enumDisabled.indexOf(optionValue) !== -1,
+              key: String(index),
+              value: String(index),
+              label: optionLabel,
+            }))
+          : undefined
+      }
+    />
   );
 }


### PR DESCRIPTION
Hello everyone

Filtering made in #3377 isn't working because `Select.Option` doesn't have `label` prop passed into.
So I fixed that