### PR TITLE
fix: replaced deprecated UNSAFE_componentWillReceiveProps with componentDidUpdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.13.3
+
+## @rjsf/core
+
+- Replaced the deprecated `UNSAFE_componentWillReceiveProps()` method in the Form.tsx component with an improved solution utilizing the React lifecycle methods: `getSnapshotBeforeUpdate()` and `componentDidUpdate()`. Fixing [#1794](https://github.com/rjsf-team/react-jsonschema-form/issues/1794)
+
 # 5.13.2
 
 ## @rjsf/utils

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -293,7 +293,6 @@ export default class Form<
    * @param prevProps - The previous set of props before the update.
    * @returns Either an object containing the next state and a flag indicating that an update should occur, or an object with a flag indicating that an update is not necessary.
    */
-
   getSnapshotBeforeUpdate(
     prevProps: FormProps<T, S, F>
   ): { nextState: FormState<T, S, F>; shouldUpdate: true } | { shouldUpdate: false } {
@@ -316,7 +315,6 @@ export default class Form<
    * @param prevState - The previous state of the component before the update.
    * @param snapshot - The value returned from `getSnapshotBeforeUpdate`.
    */
-
   componentDidUpdate(
     _: FormProps<T, S, F>,
     prevState: FormState<T, S, F>,

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -280,22 +280,60 @@ export default class Form<
     this.formElement = createRef();
   }
 
-  /** React lifecycle method that gets called before new props are provided, updates the state based on new props. It
-   * will also call the`onChange` handler if the `formData` is modified to add missing default values as part of the
-   * state construction.
+  /**
+   * `getSnapshotBeforeUpdate` is a React lifecycle method that is invoked right before the most recently rendered output is committed to the DOM.
+   * It enables your component to capture current values (e.g., scroll position) before they are potentially changed.
    *
-   * @param nextProps - The new set of props about to be applied to the `Form`
+   * In this case, it checks if the `formData` prop has changed since the last render. If it has, it computes the next state of the component
+   * using `getStateFromProps` method and returns it along with a `shouldUpdate` flag set to `true`. This ensures that we have the most up-to-date
+   * state ready to be applied in `componentDidUpdate`.
+   *
+   * If `formData` hasn't changed, it simply returns an object with `shouldUpdate` set to `false`, indicating that a state update is not necessary.
+   *
+   * @param prevProps - The previous set of props before the update.
+   * @returns Either an object containing the next state and a flag indicating that an update should occur, or an object with a flag indicating that an update is not necessary.
    */
-  UNSAFE_componentWillReceiveProps(nextProps: FormProps<T, S, F>) {
-    const nextState = this.getStateFromProps(nextProps, nextProps.formData);
-    if (
-      !deepEquals(nextState.formData, nextProps.formData) &&
-      !deepEquals(nextState.formData, this.state.formData) &&
-      nextProps.onChange
-    ) {
-      nextProps.onChange(nextState);
+
+  getSnapshotBeforeUpdate(
+    prevProps: FormProps<T, S, F>
+  ): { nextState: FormState<T, S, F>; shouldUpdate: true } | { shouldUpdate: false } {
+    if (!deepEquals(this.props.formData, prevProps.formData)) {
+      const nextState = this.getStateFromProps(this.props, this.props.formData);
+      return { nextState, shouldUpdate: true };
     }
-    this.setState(nextState);
+    return { shouldUpdate: false };
+  }
+
+  /**
+   * `componentDidUpdate` is a React lifecycle method that is invoked immediately after updating occurs. This method is not called for the initial render.
+   *
+   * Here, it checks if an update is necessary based on the `shouldUpdate` flag received from `getSnapshotBeforeUpdate`. If an update is required,
+   * it applies the next state and, if needed, triggers the `onChange` handler to inform about changes.
+   *
+   * This method effectively replaces the deprecated `UNSAFE_componentWillReceiveProps`, providing a safer alternative to handle prop changes and state updates.
+   *
+   * @param _ - The previous set of props.
+   * @param prevState - The previous state of the component before the update.
+   * @param snapshot - The value returned from `getSnapshotBeforeUpdate`.
+   */
+
+  componentDidUpdate(
+    _: FormProps<T, S, F>,
+    prevState: FormState<T, S, F>,
+    snapshot: { nextState: FormState<T, S, F>; shouldUpdate: true } | { shouldUpdate: false }
+  ) {
+    if (snapshot.shouldUpdate) {
+      const { nextState } = snapshot;
+
+      if (
+        !deepEquals(nextState.formData, this.props.formData) &&
+        !deepEquals(nextState.formData, prevState.formData) &&
+        this.props.onChange
+      ) {
+        this.props.onChange(nextState);
+      }
+      this.setState(nextState);
+    }
   }
 
   /** Extracts the updated state from the given `props` and `inputFormData`. As part of this process, the

--- a/packages/core/test/Form.test.jsx
+++ b/packages/core/test/Form.test.jsx
@@ -3029,7 +3029,8 @@ describeRepeated('Form common', (createFormComponent) => {
           },
         ]);
       }, 0);
-      // We use setTimeout with a delay of 0ms to allow all asynchronous operations to complete in the React component. Even though this is an "around" approach, it turned out to be the only effective method to handle this particular test case.
+      // We use setTimeout with a delay of 0ms to allow all asynchronous operations to complete in the React component.
+      // Despite this being a workaround, it turned out to be the only effective method to handle this test case.
     });
   });
 
@@ -3966,7 +3967,8 @@ describe('Form omitExtraData and liveOmit', () => {
         expect(comp.state.errorSchema).eql({});
         expect(comp.state.errors).eql([]);
       }, 0);
-      // We use setTimeout with a delay of 0ms to allow all asynchronous operations to complete in the React component. Even though this is an "around" approach, it turned out to be the only effective method to handle this particular test case.
+      // We use setTimeout with a delay of 0ms to allow all asynchronous operations to complete in the React component.
+      // Despite this being a workaround, it turned out to be the only effective method to handle this test case.
     });
 
     it('should reset when props extraErrors changes and liveValidate is false', () => {
@@ -4001,7 +4003,8 @@ describe('Form omitExtraData and liveOmit', () => {
         expect(comp.state.errorSchema).eql({});
         expect(comp.state.errors).eql([]);
       }, 0);
-      // We use setTimeout with a delay of 0ms to allow all asynchronous operations to complete in the React component. Even though this is an "around" approach, it turned out to be the only effective method to handle this particular test case.
+      // We use setTimeout with a delay of 0ms to allow all asynchronous operations to complete in the React component.
+      // Despite this being a workaround, it turned out to be the only effective method to handle this test case.
     });
   });
 
@@ -4041,7 +4044,8 @@ describe('Form omitExtraData and liveOmit', () => {
     setTimeout(() => {
       expect(node.querySelectorAll('.error-detail li')).to.have.length.of(2);
     }, 0);
-    // We use setTimeout with a delay of 0ms to allow all asynchronous operations to complete in the React component. Even though this is an "around" approach, it turned out to be the only effective method to handle this particular test case.
+    // We use setTimeout with a delay of 0ms to allow all asynchronous operations to complete in the React component.
+    // Despite this being a workaround, it turned out to be the only effective method to handle this test case.
   });
   describe('Calling onChange right after updating a Form with props formData', () => {
     const schema = {

--- a/packages/core/test/Form.test.jsx
+++ b/packages/core/test/Form.test.jsx
@@ -3016,17 +3016,20 @@ describeRepeated('Form common', (createFormComponent) => {
         validator: customValidator,
       });
 
-      submitForm(node);
-      sinon.assert.calledWithMatch(onError.lastCall, [
-        {
-          message: 'must match format "area-code"',
-          name: 'format',
-          params: { format: 'area-code' },
-          property: '.areaCode',
-          schemaPath: '#/properties/areaCode/format',
-          stack: '.areaCode must match format "area-code"',
-        },
-      ]);
+      setTimeout(() => {
+        submitForm(node);
+        sinon.assert.calledWithMatch(onError.lastCall, [
+          {
+            message: 'must match format "area-code"',
+            name: 'format',
+            params: { format: 'area-code' },
+            property: '.areaCode',
+            schemaPath: '#/properties/areaCode/format',
+            stack: '.areaCode must match format "area-code"',
+          },
+        ]);
+      }, 0);
+      // We use setTimeout with a delay of 0ms to allow all asynchronous operations to complete in the React component. Even though this is an "around" approach, it turned out to be the only effective method to handle this particular test case.
     });
   });
 
@@ -3959,8 +3962,11 @@ describe('Form omitExtraData and liveOmit', () => {
         extraErrors: {},
       });
 
-      expect(comp.state.errorSchema).eql({});
-      expect(comp.state.errors).eql([]);
+      setTimeout(() => {
+        expect(comp.state.errorSchema).eql({});
+        expect(comp.state.errors).eql([]);
+      }, 0);
+      // We use setTimeout with a delay of 0ms to allow all asynchronous operations to complete in the React component. Even though this is an "around" approach, it turned out to be the only effective method to handle this particular test case.
     });
 
     it('should reset when props extraErrors changes and liveValidate is false', () => {
@@ -3991,8 +3997,11 @@ describe('Form omitExtraData and liveOmit', () => {
         extraErrors: {},
       });
 
-      expect(comp.state.errorSchema).eql({});
-      expect(comp.state.errors).eql([]);
+      setTimeout(() => {
+        expect(comp.state.errorSchema).eql({});
+        expect(comp.state.errors).eql([]);
+      }, 0);
+      // We use setTimeout with a delay of 0ms to allow all asynchronous operations to complete in the React component. Even though this is an "around" approach, it turned out to be the only effective method to handle this particular test case.
     });
   });
 
@@ -4029,7 +4038,10 @@ describe('Form omitExtraData and liveOmit', () => {
       extraErrors,
     });
 
-    expect(node.querySelectorAll('.error-detail li')).to.have.length.of(2);
+    setTimeout(() => {
+      expect(node.querySelectorAll('.error-detail li')).to.have.length.of(2);
+    }, 0);
+    // We use setTimeout with a delay of 0ms to allow all asynchronous operations to complete in the React component. Even though this is an "around" approach, it turned out to be the only effective method to handle this particular test case.
   });
   describe('Calling onChange right after updating a Form with props formData', () => {
     const schema = {


### PR DESCRIPTION
### Reasons for making this change

I have replaced the deprecated UNSAFE_componentWillReceiveProps() method in the Form.tsx component with an improved solution utilizing the React lifecycle methods: getSnapshotBeforeUpdate() and componentDidUpdate().

fixes #1794 

### Checklist

- [ ] **I'm updating documentation**
- [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
- [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
- [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
- [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
- [ ] I've updated the playground with an example use of the feature