### PR TITLE
fix: #3924 fixed array with additional formData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.13.4
+
+## @rjsf/core
+
+- Fix render fixed Array with addditional formData in this array. Fixing [#3924](https://github.com/rjsf-team/react-jsonschema-form/issues/3924)
+
 # 5.13.3
 
 ## @rjsf/core

--- a/packages/core/test/ArrayField.test.jsx
+++ b/packages/core/test/ArrayField.test.jsx
@@ -1862,6 +1862,15 @@ describe('ArrayField', () => {
       );
     });
 
+    it('should render fieldset with additional formData', () => {
+      const form = createFormComponent({
+        schema,
+        formData: [null, null, null],
+      });
+
+      expect(form.node.querySelectorAll('fieldset')).to.have.length.of(1);
+    });
+
     it('should generate additional fields and fill data', () => {
       const { node } = createFormComponent({
         schema: schemaAdditional,


### PR DESCRIPTION
### Reasons for making this change

Fixes https://github.com/rjsf-team/react-jsonschema-form/issues/3924 - when rendering fixed array with additional formData, render only fields from schema

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
