### PR TITLE
fixes: 3908 oneOf Error Helper Text for Select Control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.13.4
+
+## @rjsf/core
+
+- Updated `SchemaField` to show errors for `anyOf`/`oneOf` when being rendered as select control, fixing [3908](https://github.com/rjsf-team/react-jsonschema-form/issues/3908)
+
 # 5.13.3
 
 ## @rjsf/antd

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -231,9 +231,10 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
   );
   /*
    * AnyOf/OneOf errors handled by child schema
+   * unless it can be rendered as select control
    */
   const errorsComponent =
-    hideError || schema.anyOf || schema.oneOf ? undefined : (
+    hideError || ((schema.anyOf || schema.oneOf) && !schemaUtils.isSelect(schema)) ? undefined : (
       <FieldErrorTemplate
         errors={__errors}
         errorSchema={errorSchema}

--- a/packages/core/test/SchemaField.test.jsx
+++ b/packages/core/test/SchemaField.test.jsx
@@ -506,6 +506,42 @@ describe('SchemaField', () => {
       expect(matches[0].textContent).to.contain('test');
     });
 
+    it('should show errors for top level anyOf/oneOf when schema is select control', () => {
+      const testSchema = {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string',
+            title: 'Media Type',
+            oneOf: [
+              {
+                const: 'tv',
+                title: 'Television',
+              },
+              {
+                const: 'pc',
+                title: 'Computer',
+              },
+              {
+                const: 'console',
+                title: 'Console',
+              },
+            ],
+          },
+        },
+      };
+      const { node } = createFormComponent({
+        schema: testSchema,
+        uiSchema,
+        customValidate,
+      });
+      Simulate.submit(node);
+
+      const matches = node.querySelectorAll('form .form-group .form-group .text-danger');
+      expect(matches).to.have.length.of(1);
+      expect(matches[0].textContent).to.contain('test');
+    });
+
     it('should pass errors to custom FieldErrorTemplate', () => {
       const customFieldError = (props) => {
         return <div className='custom-field-error'>{props.errors}</div>;


### PR DESCRIPTION
### Reasons for making this change

Fixes #3908 adding error help text for oneOf/anyOf select control schema. Error schema was not being passed down to oneOf/anyOf component because the schema was being render as a `StringField`.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
