### PR TITLE
Add hide error prop to string field and boolean field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.13.5
+
+## @rjsf/core
+
+- Updated `StringField` and `BooleanField` to pass `hideError` prop to `Widget` so that all fields are consistent
+
 # 5.13.4
 
 ## @rjsf/core

--- a/packages/core/src/components/fields/BooleanField.tsx
+++ b/packages/core/src/components/fields/BooleanField.tsx
@@ -29,6 +29,7 @@ function BooleanField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
     required,
     disabled,
     readonly,
+    hideError,
     autofocus,
     onChange,
     onFocus,
@@ -103,6 +104,7 @@ function BooleanField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
       required={required}
       disabled={disabled}
       readonly={readonly}
+      hideError={hideError}
       registry={registry}
       formContext={formContext}
       autofocus={autofocus}

--- a/packages/core/test/BooleanField.test.jsx
+++ b/packages/core/test/BooleanField.test.jsx
@@ -247,7 +247,7 @@ describe('BooleanField', () => {
     });
   });
 
-  it('should focus on required radio missing data when focusOnFirstField', () => {
+  it('should focus on required radio missing data when focusOnFirstField and shows error', () => {
     const { node, onError } = createFormComponent({
       schema: {
         type: 'object',
@@ -264,6 +264,8 @@ describe('BooleanField', () => {
     const focusSpys = [sinon.spy(), sinon.spy()];
     const inputs = node.querySelectorAll('input[id^=root_bool]');
     expect(inputs.length).eql(2);
+    let errorInputs = node.querySelectorAll('.form-group.field-error input[id^=root_bool]');
+    expect(errorInputs).to.have.length.of(0);
     // Since programmatically triggering focus does not call onFocus, change the focus method to a spy
     inputs[0].focus = focusSpys[0];
     inputs[1].focus = focusSpys[1];
@@ -273,6 +275,40 @@ describe('BooleanField', () => {
     });
     sinon.assert.calledOnce(focusSpys[0]);
     sinon.assert.notCalled(focusSpys[1]);
+    errorInputs = node.querySelectorAll('.form-group.field-error input[id^=root_bool]');
+    expect(errorInputs).to.have.length.of(2);
+  });
+
+  it('should focus on required radio missing data when focusOnFirstField and hides error', () => {
+    const { node, onError } = createFormComponent({
+      schema: {
+        type: 'object',
+        properties: {
+          bool: {
+            type: 'boolean',
+          },
+        },
+        required: ['bool'],
+      },
+      focusOnFirstError: true,
+      uiSchema: { bool: { 'ui:widget': 'radio', 'ui:hideError': true } },
+    });
+    const focusSpys = [sinon.spy(), sinon.spy()];
+    const inputs = node.querySelectorAll('input[id^=root_bool]');
+    expect(inputs.length).eql(2);
+    let errorInputs = node.querySelectorAll('.form-group.field-error input[id^=root_bool]');
+    expect(errorInputs).to.have.length.of(0);
+    // Since programmatically triggering focus does not call onFocus, change the focus method to a spy
+    inputs[0].focus = focusSpys[0];
+    inputs[1].focus = focusSpys[1];
+    submitForm(node);
+    sinon.assert.calledWithMatch(onError.lastCall, {
+      formData: undefined,
+    });
+    sinon.assert.calledOnce(focusSpys[0]);
+    sinon.assert.notCalled(focusSpys[1]);
+    errorInputs = node.querySelectorAll('.form-group.field-error input[id^=root_bool]');
+    expect(errorInputs).to.have.length.of(0);
   });
 
   it('should handle a change event', () => {

--- a/packages/core/test/StringField.test.jsx
+++ b/packages/core/test/StringField.test.jsx
@@ -648,7 +648,7 @@ describe('StringField', () => {
       expect(node.querySelector('[type=datetime-local]').id).eql('root');
     });
 
-    it('should reject an invalid entered datetime', () => {
+    it('should reject an invalid entered datetime and shows error', () => {
       const { node, onChange } = createFormComponent({
         schema: {
           type: 'string',
@@ -656,11 +656,11 @@ describe('StringField', () => {
         },
         liveValidate: true,
       });
-
+      let inputs = node.querySelectorAll('.form-group.field-error input[type=datetime-local]');
+      expect(inputs).to.have.length.of(0);
       Simulate.change(node.querySelector('[type=datetime-local]'), {
         target: { value: 'invalid' },
       });
-
       sinon.assert.calledWithMatch(onChange.lastCall, {
         errorSchema: { __errors: ['must be string'] },
         errors: [
@@ -674,6 +674,41 @@ describe('StringField', () => {
           },
         ],
       });
+      inputs = node.querySelectorAll('.form-group.field-error input[type=datetime-local]');
+      expect(inputs).to.have.length.of(1);
+    });
+    it('should reject an invalid entered datetime and hides error', () => {
+      const { node, onChange } = createFormComponent({
+        schema: {
+          type: 'string',
+          format: 'date-time',
+        },
+        uiSchema: {
+          'ui:hideError': true,
+        },
+        liveValidate: true,
+      });
+      let inputs = node.querySelectorAll('.form-group.field-error input[type=datetime-local]');
+
+      expect(inputs).to.have.length.of(0);
+      Simulate.change(node.querySelector('[type=datetime-local]'), {
+        target: { value: 'invalid' },
+      });
+      sinon.assert.calledWithMatch(onChange.lastCall, {
+        errorSchema: { __errors: ['must be string'] },
+        errors: [
+          {
+            message: 'must be string',
+            name: 'type',
+            params: { type: 'string' },
+            property: '',
+            schemaPath: '#/type',
+            stack: 'must be string',
+          },
+        ],
+      });
+      inputs = node.querySelectorAll('.form-group.field-error input[type=datetime-local]');
+      expect(inputs).to.have.length.of(0);
     });
 
     it('should render customized DateTimeWidget', () => {


### PR DESCRIPTION
### Reasons for making this change

Add `hideError` prop support to `StringField` and `BooleanField` to keep all fields consistent

### Checklist

- [ ] **I'm updating documentation** <-- No documentation needed
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed .
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed <-- No documentation needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
