### PR TITLE
Missed hide error in string field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.13.6
+
+## @rjsf/core
+
+- Updated `StringField` to pass `hideError` prop to `Widget` so that all fields are consistent. Missed this file in previous patch
+
+
 # 5.13.5
 
 ## @rjsf/core

--- a/packages/core/src/components/fields/StringField.tsx
+++ b/packages/core/src/components/fields/StringField.tsx
@@ -31,6 +31,7 @@ function StringField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends
     onFocus,
     registry,
     rawErrors,
+    hideError,
   } = props;
   const { title, format } = schema;
   const { widgets, formContext, schemaUtils, globalUiOptions } = registry;
@@ -52,6 +53,7 @@ function StringField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends
       name={name}
       label={label}
       hideLabel={!displayLabel}
+      hideError={hideError}
       value={formData}
       onChange={onChange}
       onBlur={onBlur}


### PR DESCRIPTION
### Reasons for making this change

Missed the passing of hideError in my previous PR.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
