### PR TITLE
fix labelValue types, update fluent-rc tsconfig

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 packages/*/lib
+packages/*/lib-test
 packages/*/dist
 packages/docs/build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,15 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # 5.14.1
 
+## @rjsf/utils
+
+- update types for `labelValue` to have more granular return types, fixing [#3946](https://github.com/rjsf-team/react-jsonschema-form/issues/3946)
+
 ## Dev / playground
 
 - Added Fluent UI v9 (React Components) theme to playground
+- Update Fluent UI v9 and playground project references
+- Update eslint ignores to exclude new typescript build output folders 
 
 # 5.14.0
 

--- a/packages/fluent-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/fluent-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -91,7 +91,6 @@ export default function BaseInputTemplate<
         id={id}
         name={id}
         placeholder={placeholder}
-        // @ts-expect-error todo: TS2322: Type 'string | false | ReactElement<any, string | JSXElementConstructor<any>> | undefined' is not assignable to type 'string | undefined'.
         label={labelValue(label, hideLabel)}
         autoFocus={autofocus}
         required={required}

--- a/packages/fluent-ui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/fluent-ui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -92,7 +92,6 @@ export default function CheckboxWidget<
       <Checkbox
         id={id}
         name={id}
-        // @ts-expect-error todo: TS2322: Type 'string | false | ReactElement<any, string | JSXElementConstructor<any>> | undefined' is not assignable to type 'string | undefined'.
         label={labelValue(label || undefined, hideLabel)}
         disabled={disabled || readonly}
         inputProps={{

--- a/packages/fluent-ui/src/DateWidget/DateWidget.tsx
+++ b/packages/fluent-ui/src/DateWidget/DateWidget.tsx
@@ -116,7 +116,6 @@ export default function DateWidget<T = any, S extends StrictRJSFSchema = RJSFSch
       placeholder={placeholder}
       ariaLabel={translateString(TranslatableString.AriaDateLabel)}
       isRequired={required}
-      // @ts-expect-error todo: TS2322: Type 'string | false | ReactElement<any, string | JSXElementConstructor<any>> | undefined' is not assignable to type 'string | undefined'.
       label={labelValue(label, hideLabel)}
       onSelectDate={_onSelectDate}
       onBlur={_onBlur}

--- a/packages/fluent-ui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/fluent-ui/src/RadioWidget/RadioWidget.tsx
@@ -76,7 +76,6 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
       onChange={_onChange}
       onFocus={_onFocus}
       onBlur={_onBlur}
-      // @ts-expect-error todo: TS2322: Type 'string | false | ReactElement<any, string | JSXElementConstructor<any>> | undefined' is not assignable to type 'string | undefined'.
       label={labelValue(label, hideLabel || !label)}
       required={required}
       selectedKey={selectedIndex}

--- a/packages/fluent-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/fluent-ui/src/SelectWidget/SelectWidget.tsx
@@ -112,7 +112,6 @@ export default function SelectWidget<
   return (
     <Dropdown
       id={id}
-      // @ts-expect-error todo: TS2322: Type 'string | false | ReactElement<any, string | JSXElementConstructor<any>> | undefined' is not assignable to type 'string | undefined'.
       label={labelValue(label, hideLabel)}
       multiSelect={multiple}
       defaultSelectedKey={multiple ? undefined : selectedIndexes}

--- a/packages/fluentui-rc/src/SelectWidget/SelectWidget.tsx
+++ b/packages/fluentui-rc/src/SelectWidget/SelectWidget.tsx
@@ -63,8 +63,6 @@ function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
 
   return (
     <Field
-      // @ts-expect-error todo: TS2322: Type 'false' is not assignable to type 'WithSlotShorthandValue<WithSlotRenderFunction<Omit<ComponentProps<LabelSlots>, "required"> & ...
-      // See https://github.com/rjsf-team/react-jsonschema-form/issues/3946
       label={labelValue(label, hideLabel)}
       validationState={rawErrors.length ? 'error' : undefined}
       required={required}

--- a/packages/fluentui-rc/src/tsconfig.json
+++ b/packages/fluentui-rc/src/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": [
+    "./"
+  ],
+  "compilerOptions": {
+    "rootDir": "./",
+    "outDir": "../lib",
+    "baseUrl": "../",
+    "jsx": "react-jsx",
+    "skipLibCheck": true
+  },
+  "references": [
+    {
+      "path": "../../core"
+    },
+    {
+      "path": "../../utils"
+    },
+    {
+      "path": "../../validator-ajv8"
+    }
+  ]
+}

--- a/packages/fluentui-rc/test/tsconfig.json
+++ b/packages/fluentui-rc/test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["./"],
+  "compilerOptions": {
+    "rootDir": "./",
+    "baseUrl": "../",
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "references": [
+    {
+      "path": "../src"
+    },
+    {
+      "path": "../../snapshot-tests"
+    }
+  ]
+}

--- a/packages/fluentui-rc/tsconfig.json
+++ b/packages/fluentui-rc/tsconfig.json
@@ -1,22 +1,12 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./lib",
-    "baseUrl": "./",
-    "jsx": "react-jsx",
-    "skipLibCheck": true
-  },
+  "files": [],
   "references": [
     {
-      "path": "../core"
+      "path": "./src"
     },
     {
-      "path": "../utils"
-    },
-    {
-      "path": "../validator-ajv8"
+      "path": "./test"
     }
   ]
 }

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -27,6 +27,7 @@
     { "path": "../chakra-ui" },
     { "path": "../core" },
     { "path": "../fluent-ui" },
+    { "path": "../fluentui-rc" },
     { "path": "../material-ui" },
     { "path": "../mui" },
     { "path": "../semantic-ui" },

--- a/packages/utils/src/labelValue.ts
+++ b/packages/utils/src/labelValue.ts
@@ -10,16 +10,19 @@ import { ReactElement } from 'react';
  * @param [fallback] - One of 3 values, `undefined` (the default), `false` or an empty string
  * @returns - `fallback` if `hideLabel` is true, otherwise `label`
  */
-export default function labelValue<T extends string | ReactElement = string | ReactElement>(
-  label?: T,
-  hideLabel?: boolean,
-  fallback?: ''
-): T | undefined;
-export default function labelValue<T extends string | ReactElement = string | ReactElement>(
-  label?: T,
+
+export default function labelValue(label?: string, hideLabel?: boolean, fallback?: ''): undefined | string;
+export default function labelValue(label?: string, hideLabel?: boolean, fallback?: false): undefined | false | string;
+export default function labelValue(label?: ReactElement, hideLabel?: boolean, fallback?: ''): undefined | ReactElement;
+export default function labelValue(
+  label?: ReactElement,
   hideLabel?: boolean,
   fallback?: false
-): T | undefined | false;
-export default function labelValue(label?: string | ReactElement, hideLabel?: boolean, fallback?: false | '') {
+): undefined | false | ReactElement;
+export default function labelValue(
+  label?: string | ReactElement,
+  hideLabel?: boolean,
+  fallback?: false | ''
+): undefined | false | string | ReactElement {
   return hideLabel ? fallback : label;
 }

--- a/packages/utils/src/labelValue.ts
+++ b/packages/utils/src/labelValue.ts
@@ -10,7 +10,16 @@ import { ReactElement } from 'react';
  * @param [fallback] - One of 3 values, `undefined` (the default), `false` or an empty string
  * @returns - `fallback` if `hideLabel` is true, otherwise `label`
  */
-export function labelValue(label?: string | ReactElement, hideLabel?: boolean, fallback?: ''): undefined | string;
+export default function labelValue<T extends string | ReactElement = string | ReactElement>(
+  label?: T,
+  hideLabel?: boolean,
+  fallback?: ''
+): T | undefined;
+export default function labelValue<T extends string | ReactElement = string | ReactElement>(
+  label?: T,
+  hideLabel?: boolean,
+  fallback?: false
+): T | undefined | false;
 export default function labelValue(label?: string | ReactElement, hideLabel?: boolean, fallback?: false | '') {
   return hideLabel ? fallback : label;
 }


### PR DESCRIPTION
### Reasons for making this change

Fixes type error for `labelValue` usages where it can not return `false`. Fixes #3946

Also updated tsconfig for `fluentui-rc`, to be the same as for other packages.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
