### PR TITLE
Added Fluent UI 9 theme to the playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.14.1
+
+## Dev / playground
+
+- Added Fluent UI v9 (React Components) theme to playground
+
 # 5.14.0
 
 ## @rjsf/fluentui-rc

--- a/package-lock.json
+++ b/package-lock.json
@@ -34650,6 +34650,7 @@
         "@rjsf/chakra-ui": "^5.14.0",
         "@rjsf/core": "^5.14.0",
         "@rjsf/fluent-ui": "^5.14.0",
+        "@rjsf/fluentui-rc": "^5.14.0",
         "@rjsf/material-ui": "^5.14.0",
         "@rjsf/mui": "^5.14.0",
         "@rjsf/semantic-ui": "^5.14.0",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -45,6 +45,7 @@
     "@rjsf/chakra-ui": "^5.14.0",
     "@rjsf/core": "^5.14.0",
     "@rjsf/fluent-ui": "^5.14.0",
+    "@rjsf/fluentui-rc": "^5.14.0",
     "@rjsf/material-ui": "^5.14.0",
     "@rjsf/mui": "^5.14.0",
     "@rjsf/semantic-ui": "^5.14.0",

--- a/packages/playground/src/app.tsx
+++ b/packages/playground/src/app.tsx
@@ -1,6 +1,7 @@
 import { Theme as MuiV4Theme } from '@rjsf/material-ui';
 import { Theme as MuiV5Theme } from '@rjsf/mui';
 import { Theme as FluentUITheme } from '@rjsf/fluent-ui';
+import { Theme as FluentUIRCTheme } from '@rjsf/fluentui-rc';
 import { Theme as SuiTheme } from '@rjsf/semantic-ui';
 import { Theme as AntdTheme } from '@rjsf/antd';
 import { Theme as Bootstrap4Theme } from '@rjsf/bootstrap-4';
@@ -103,6 +104,10 @@ const themes: PlaygroundProps['themes'] = {
   'fluent-ui': {
     stylesheet: '//static2.sharepointonline.com/files/fabric/office-ui-fabric-core/11.0.0/css/fabric.min.css',
     theme: FluentUITheme,
+  },
+  'fluentui-rc': {
+    stylesheet: '',
+    theme: FluentUIRCTheme,
   },
   'material-ui-4': {
     stylesheet: '',

--- a/packages/playground/src/components/DemoFrame.tsx
+++ b/packages/playground/src/components/DemoFrame.tsx
@@ -7,6 +7,7 @@ import { jssPreset, StylesProvider } from '@material-ui/core/styles';
 import Frame, { FrameComponentProps, FrameContextConsumer } from 'react-frame-component';
 import { __createChakraFrameProvider } from '@rjsf/chakra-ui';
 import { StyleProvider as AntdStyleProvider } from '@ant-design/cssinjs';
+import { __createFluentUIRCFrameProvider } from '@rjsf/fluentui-rc';
 
 /*
 Adapted from https://github.com/mui-org/material-ui/blob/master/docs/src/modules/components/DemoSandboxed.js
@@ -114,6 +115,8 @@ export default function DemoFrame(props: DemoFrameProps) {
         {children}
       </>
     );
+  } else if (theme === 'fluentui-rc') {
+    body = <FrameContextConsumer>{__createFluentUIRCFrameProvider(props)}</FrameContextConsumer>;
   } else if (theme === 'chakra-ui') {
     body = <FrameContextConsumer>{__createChakraFrameProvider(props)}</FrameContextConsumer>;
   } else if (theme === 'antd') {

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
       '@rjsf/chakra-ui': path.resolve(__dirname, '../chakra-ui/src'),
       '@rjsf/core': path.resolve(__dirname, '../core/src'),
       '@rjsf/fluent-ui': path.resolve(__dirname, '../fluent-ui/src'),
-      "@rjsf/fluentui-rc" : path.resolve(__dirname, '../fluentui-rc/src'),
+      '@rjsf/fluentui-rc': path.resolve(__dirname, '../fluentui-rc/src'),
       '@rjsf/material-ui': path.resolve(__dirname, '../material-ui/src'),
       '@rjsf/mui': path.resolve(__dirname, '../mui/src'),
       '@rjsf/semantic-ui': path.resolve(__dirname, '../semantic-ui/src'),

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       '@rjsf/chakra-ui': path.resolve(__dirname, '../chakra-ui/src'),
       '@rjsf/core': path.resolve(__dirname, '../core/src'),
       '@rjsf/fluent-ui': path.resolve(__dirname, '../fluent-ui/src'),
+      "@rjsf/fluentui-rc" : path.resolve(__dirname, '../fluentui-rc/src'),
       '@rjsf/material-ui': path.resolve(__dirname, '../material-ui/src'),
       '@rjsf/mui': path.resolve(__dirname, '../mui/src'),
       '@rjsf/semantic-ui': path.resolve(__dirname, '../semantic-ui/src'),


### PR DESCRIPTION
### Reasons for making this change

Fluent UI 9 package was already added to the repo, now a change to add it to the playground.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
