### PR TITLE
chore(bootstrap-4): add repo to package.json

### DIFF
--- a/packages/bootstrap-4/package.json
+++ b/packages/bootstrap-4/package.json
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": ""
+    "url": "git+https://github.com/rjsf-team/react-jsonschema-form.git"
   },
   "scripts": {
     "build:ts": "tsc -b",


### PR DESCRIPTION
### Reasons for making this change

Without the repo in the package docs tooling like [Mend Renovate](https://www.mend.io/renovate/) is not able to find release notes or join the multiple packages into a single update PR. 

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
