### PR TITLE
chore: Avoid Form retrieveSchema twice when liveValidate is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,6 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
-# 5.14.3
-
-## @rjsf/core
-
-- avoid call `retrieveSchema` twice during `getStateFromProps` and `mustValidate` is true [#3959](https://github.com/rjsf-team/react-jsonschema-form/pull/3959)
-
 # 5.14.2
 
 ## @rjsf/mui
@@ -32,6 +26,10 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/utils
 
 - Update `sanitizeDataForNewSchema()` to avoid spreading strings and Arrays into the returned value when the old schema is of type `string` or `array` and the new schema is of type `object`. Fixing [#3922](https://github.com/rjsf-team/react-jsonschema-form/issues/3922)
+
+## @rjsf/core
+
+- avoid call `retrieveSchema` twice during `getStateFromProps` and `mustValidate` is true [#3959](https://github.com/rjsf-team/react-jsonschema-form/pull/3959)
 
 # 5.14.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.14.3
+
+## @rjsf/core
+
+- avoid call `retrieveSchema` twice during `getStateFromProps` and `mustValidate` is true [#3959](https://github.com/rjsf-team/react-jsonschema-form/pull/3959)
+
 # 5.14.2
 
 ## @rjsf/mui

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -394,7 +394,7 @@ export default class Form<
     let schemaValidationErrors: RJSFValidationError[] = state.schemaValidationErrors;
     let schemaValidationErrorSchema: ErrorSchema<T> = state.schemaValidationErrorSchema;
     if (mustValidate) {
-      const schemaValidation = this.validate(formData, schema, schemaUtils);
+      const schemaValidation = this.validate(formData, schema, schemaUtils, retrievedSchema);
       errors = schemaValidation.errors;
       errorSchema = schemaValidation.errorSchema;
       schemaValidationErrors = errors;
@@ -451,11 +451,12 @@ export default class Form<
   validate(
     formData: T | undefined,
     schema = this.props.schema,
-    altSchemaUtils?: SchemaUtilsType<T, S, F>
+    altSchemaUtils?: SchemaUtilsType<T, S, F>,
+    retrievedSchema?: S
   ): ValidationData<T> {
     const schemaUtils = altSchemaUtils ? altSchemaUtils : this.state.schemaUtils;
     const { customValidate, transformErrors, uiSchema } = this.props;
-    const resolvedSchema = schemaUtils.retrieveSchema(schema, formData);
+    const resolvedSchema = retrievedSchema ?? schemaUtils.retrieveSchema(schema, formData);
     return schemaUtils
       .getValidator()
       .validateFormData(formData, resolvedSchema, customValidate, transformErrors, uiSchema);


### PR DESCRIPTION
### Reasons for making this change

When utilizing the Form with `liveValidate`, the `getStateFromProps` function triggers the `retrieveSchema` function twice. Profiling timings indicate that the retrieveSchema function accounts for approximately 20% (18ms out of 99ms) of the total execution time for `getStateFromProps`.

![image](https://github.com/rjsf-team/react-jsonschema-form/assets/15680320/272ada60-9dd8-401b-a0f3-5a8e27a161c6) (getStateFromProps from the form first render)

This issue becomes more pronounced, particularly when the form is "controlled" with `liveValidate`. In this scenario, each key press triggers the `getStateFromProps` function, resulting in two calls to `retrieveSchema`. Given that `retrieveSchema` consumes more than 20% of `getStateFromProps` execution time, this pull request addresses the inefficiency by optimizing the retrieval process, ultimately improving the overall performance of the form while typing.

Related to #1961 

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
