### PR TITLE
Fix: fixes the antd peer dependencies for the @ant-design/icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # 5.14.2
 
+## @rjsf/antd
+
+- Fixed the `peerDependencies` for `@ant-design/icons` to also support v5, fixing [#3507](https://github.com/rjsf-team/react-jsonschema-form/issues/3507)
+
+## @rjsf/core
+
+- avoid call `retrieveSchema` twice during `getStateFromProps` and `mustValidate` is true [#3959](https://github.com/rjsf-team/react-jsonschema-form/pull/3959)
+
 ## @rjsf/mui
 - Resolve the React error caused by the propagation of the `hideError` property to the DOM element, fixing [#3945](https://github.com/rjsf-team/react-jsonschema-form/issues/3945)
 
@@ -26,10 +34,6 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/utils
 
 - Update `sanitizeDataForNewSchema()` to avoid spreading strings and Arrays into the returned value when the old schema is of type `string` or `array` and the new schema is of type `object`. Fixing [#3922](https://github.com/rjsf-team/react-jsonschema-form/issues/3922)
-
-## @rjsf/core
-
-- avoid call `retrieveSchema` twice during `getStateFromProps` and `mustValidate` is true [#3959](https://github.com/rjsf-team/react-jsonschema-form/pull/3959)
 
 # 5.14.1
 

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -33,7 +33,7 @@
     "node": ">=14"
   },
   "peerDependencies": {
-    "@ant-design/icons": "^4.0.0",
+    "@ant-design/icons": "^4.0.0 || ^5.0.0",
     "@rjsf/core": "^5.12.x",
     "@rjsf/utils": "^5.12.x",
     "antd": "^4.24.0 || ^5.8.5",


### PR DESCRIPTION
### Reasons for making this change

Fixes: #3507 to allow v5 `@ant-design/icons`
- Updated the `antd` package.json to add `@ant-design/icons` v5 to the peer dependencies
- Updated the `CHANGELOG.md` accordingly, putting the packages in alphabetical order

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
