### PR TITLE
update build config, removing need for tslib dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.14.3
+
+## Dev
+- update tsconfigs:
+  - `"importHelpers": false` to remove need for tslib dependency [#3958](https://github.com/rjsf-team/react-jsonschema-form/issues/3958)
+  - increase compilation target level from es6 to es2018 (so there are no need for transpiling object spread/rest feature)
+  - add missing typescript project reference for `snapshot-tests` in a root tsconfig, update it to also use es modules
+
 # 5.14.2
 
 ## @rjsf/antd

--- a/packages/snapshot-tests/tsconfig.json
+++ b/packages/snapshot-tests/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "module": "CommonJS",
     "baseUrl": "./",
     "rootDir": "./src",
     "outDir": "./lib",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     "composite": true,
-    "target": "es6",
+    "target": "ES2018",
     "module": "esnext",
     "lib": ["dom", "esnext"],
-    "importHelpers": true,
+    "importHelpers": false,
     "declaration": true,
     "sourceMap": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,6 +42,9 @@
     },
     {
       "path": "./packages/validator-ajv8"
+    },
+    {
+      "path": "./packages/snapshot-tests"
     }
   ]
 }


### PR DESCRIPTION
### Reasons for making this change

fixes  #3958

Updating tsconfig files:
  - `"importHelpers": false` to remove need for tslib dependency
  - increase compilation target level from es6 to es2018 (so there are no need for transpiling object spread/rest feature, and so the helper for which tslib was needed)
  - add missing typescript project reference for `snapshot-tests` in a root tsconfig, also update it to use es modules like other packages
 
### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
