### PR TITLE
chore: add `retrieveSchema` at `Form` state to memoize the result of `schemUtils.retrieveSchema`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # 5.14.3
 
+## @rjsf/core
+
+- add `retrieveSchema` at `Form` state to memoize the result of `schemUtils.retrieveSchema`
+
 ## @rjsf/fluentui-rc
 - Updated README.md references
 - Fixed width of `ArrayFieldItemTemplate` items

--- a/packages/core/test/Form.test.jsx
+++ b/packages/core/test/Form.test.jsx
@@ -140,6 +140,7 @@ describeRepeated('Form common', (createFormComponent) => {
           schemaValidationErrors: undefined,
           schemaValidationErrorSchema: undefined,
           schemaUtils: sinon.match.object,
+          retrievedSchema: schema,
         });
       });
     });
@@ -1480,6 +1481,7 @@ describeRepeated('Form common', (createFormComponent) => {
           schemaValidationErrors: undefined,
           schemaValidationErrorSchema: undefined,
           schemaUtils: sinon.match.object,
+          retrievedSchema: formProps.schema,
         });
       });
     });


### PR DESCRIPTION
### Reasons for making this change

This PR focus on improve the onChange performance avoiding recalculate the `retrievedSchema` multiples times when Form has `liveValidate` prop true.

Before:
At the image below from a profiling of a keystroke on a field, the onChange function call retrieveSchema 2 and one more time during the update of the form component is, at getSnapshotBeforeUpdate. The time of `onChange` (~260ms) + `getSnapshotBeforeUpdate` (~166ms) represents 65% of task duration (~685ms)
![image](https://github.com/rjsf-team/react-jsonschema-form/assets/15680320/b087fcff-f28b-4df1-8a82-87d21bb8bcfd)


After:
As you can see at the profiling below, the `retrieveSchema` function isn't called at `onChange` and `getSnapshotBeforeUpdate`. The result is, the onChange took ~100ms and the getSnapshotBeforeUpdate took ~87ms, this represents ~28% of the task duration ~652ms.
![image](https://github.com/rjsf-team/react-jsonschema-form/assets/15680320/093f3165-ff79-4fd5-97cc-b1aefc9aca5d)

This PR follows the same idea from this one https://github.com/rjsf-team/react-jsonschema-form/pull/3959

If your PR is non-trivial and you'd like to schedule a synchronous review, please add it to the weekly meeting agenda: https://docs.google.com/document/d/12PjTvv21k6LIky6bNQVnsplMLLnmEuypTLQF8a-8Wss/edit

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
