### PR TITLE
fix(utils): direct lodash function import to improve bundling on library client side

### DIFF
--- a/packages/utils/src/enumOptionsSelectValue.ts
+++ b/packages/utils/src/enumOptionsSelectValue.ts
@@ -1,6 +1,6 @@
 import { EnumOptionsType, RJSFSchema, StrictRJSFSchema } from './types';
 import enumOptionsValueForIndex from './enumOptionsValueForIndex';
-import { isNil } from 'lodash';
+import isNil from 'lodash/isNil';
 
 /** Add the enum option value at the `valueIndex` to the list of `selected` values in the proper order as defined by
  * `allEnumOptions`


### PR DESCRIPTION
### Reasons for making this change

Improves bundling on library client side and prevents from loading whole `lodash` library

Before:
![image](https://github.com/rjsf-team/react-jsonschema-form/assets/11319154/01c389f6-8bf0-4481-a281-67bf3ff8c45c)
![image](https://github.com/rjsf-team/react-jsonschema-form/assets/11319154/ae8b9ef8-d90d-4a8a-af46-6511b3b9d611)

After:
![image](https://github.com/rjsf-team/react-jsonschema-form/assets/11319154/a0e1411a-75d0-485f-a7d5-daca21a42853)![image](https://github.com/rjsf-team/react-jsonschema-form/assets/11319154/61105743-1468-4c29-a787-d2af39663eae)


### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
