### PR TITLE
Make getFieldNames correctly defines array of primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.15.1
+
+## @rjsf/core
+
+- fix `getFieldNames`. Now correctly defines an array of primitives.
+
 # 5.15.0
 
 ## @rjsf/mui

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -533,7 +533,11 @@ export default class Form<
             const formValue = _get(formData, path);
             // adds path to fieldNames if it points to a value
             // or an empty object/array
-            if (typeof formValue !== 'object' || _isEmpty(formValue)) {
+            if (
+              typeof formValue !== 'object' ||
+              _isEmpty(formValue) ||
+              (Array.isArray(formValue) && formValue.every((val) => typeof val !== 'object'))
+            ) {
               acc.push(path);
             }
           });

--- a/packages/core/test/Form.test.jsx
+++ b/packages/core/test/Form.test.jsx
@@ -3463,6 +3463,7 @@ describe('Form omitExtraData and liveOmit', () => {
             extra: 'asdf',
             anotherThingNested2: 0,
           },
+          stringArray: ['scobochka'],
         },
         level1a: 1.23,
       };
@@ -3488,6 +3489,9 @@ describe('Form omitExtraData and liveOmit', () => {
               $name: 'level1.anotherThing.anotherThingNested2',
             },
           },
+          stringArray: {
+            $name: 'level1.stringArray',
+          },
         },
         level1a: {
           $name: 'level1a',
@@ -3500,6 +3504,7 @@ describe('Form omitExtraData and liveOmit', () => {
           ['level1', 'anotherThing', 'anotherThingNested'],
           ['level1', 'anotherThing', 'anotherThingNested2'],
           ['level1', 'level2'],
+          ['level1', 'stringArray'],
           ['level1a'],
         ].sort()
       );


### PR DESCRIPTION
### Reasons for making this change

I have custom multiple select that has value like `string[]`. If i use `omitExtraData` and `liveOmit` and chose value, rjsf clear select and rerender it. I have determined that this is due to getFieldNames skipping arrays with primitives `['value1']`, causing such fields to be defined as empty.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
