### PR TITLE
Fix: Change FormHelperText usage with @mui/material to render divs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
-# 5.15.3
+# 5.16.0
 
 ## @rjsf/utils
 
@@ -33,6 +33,10 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/chakra-ui
 
 - Removed `dateElementProps` function implementation, and replaced it with `getDateElementProps` from `@rjsf/utils`.
+
+## @rjsf/mui
+
+- Updated the `FieldErrorTemplate` and `FieldHelpTemplate` to support html-based errors that cause `<xxxx> cannot appear as a descendant of <p>` browser warnings, fixing [#4031](https://github.com/rjsf-team/react-jsonschema-form/issues/4031)
 
 ## Dev / docs / playground
 

--- a/packages/mui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/mui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -19,11 +19,13 @@ export default function FieldErrorTemplate<
   const id = errorId<T>(idSchema);
 
   return (
-    <List dense={true} disablePadding={true}>
+    <List id={id} dense={true} disablePadding={true}>
       {errors.map((error, i: number) => {
         return (
           <ListItem key={i} disableGutters={true}>
-            <FormHelperText id={id}>{error}</FormHelperText>
+            <FormHelperText component='div' id={`${id}-${i}`}>
+              {error}
+            </FormHelperText>
           </ListItem>
         );
       })}

--- a/packages/mui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/mui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -15,5 +15,9 @@ export default function FieldHelpTemplate<
     return null;
   }
   const id = helpId<T>(idSchema);
-  return <FormHelperText id={id}>{help}</FormHelperText>;
+  return (
+    <FormHelperText component='div' id={id}>
+      {help}
+    </FormHelperText>
+  );
 }

--- a/packages/mui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Array.test.tsx.snap
@@ -4205,17 +4205,18 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-16:focus::-ms-input-
               </div>
               <ul
                 className="MuiList-root MuiList-dense emotion-19"
+                id="root_name__error"
               >
                 <li
                   className="MuiListItem-root MuiListItem-dense MuiListItem-padding emotion-20"
                   disabled={false}
                 >
-                  <p
+                  <div
                     className="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-contained emotion-21"
-                    id="root_name__error"
+                    id="root_name__error-0"
                   >
                     Bad input
-                  </p>
+                  </div>
                 </li>
               </ul>
             </div>

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -4738,25 +4738,26 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
       </div>
       <ul
         className="MuiList-root MuiList-dense emotion-15"
+        id="root__error"
       >
         <li
           className="MuiListItem-root MuiListItem-dense MuiListItem-padding emotion-16"
           disabled={false}
         >
-          <p
+          <div
             className="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-contained emotion-17"
-            id="root__error"
+            id="root__error-0"
           >
             an error
-          </p>
+          </div>
         </li>
       </ul>
-      <p
+      <div
         className="MuiFormHelperText-root Mui-error MuiFormHelperText-sizeMedium MuiFormHelperText-contained emotion-17"
         id="root__help"
       >
         help me!
-      </p>
+      </div>
     </div>
   </div>
   <div


### PR DESCRIPTION
### Reasons for making this change

Fixes #4031 by switching the render component for `FormHelperText` to be `div`
- In `@rjsf/mui`, updated `FieldErrorTemplate` and `FieldHelpTemplate` to use the `div` component for `FormHelperText`
  - Also fixed the `id` generation for `FieldErrorTemplate` to not create duplicates for multiple errors
- Updated the `CHANGELOG.md` accordingly, bumping the version to `5.16.0` since other changes are adding new features

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
