### PR TITLE
Fix: Corrected test descriptions for file widget attributes

### DIFF
--- a/packages/core/test/StringField.test.jsx
+++ b/packages/core/test/StringField.test.jsx
@@ -2104,7 +2104,7 @@ describe('StringField', () => {
       });
     });
 
-    it('should render the widget with the expected id', () => {
+    it('should render the file widget with accept attribute', () => {
       const { node } = createFormComponent({
         schema: {
           type: 'string',
@@ -2118,7 +2118,7 @@ describe('StringField', () => {
       expect(node.querySelector('[type=file]').accept).eql('.pdf');
     });
 
-    it('should render the file widget with accept attribute', () => {
+    it('should render the widget with the expected id', () => {
       const { node } = createFormComponent({
         schema: {
           type: 'string',


### PR DESCRIPTION
### Reasons for making this change

The descriptions for two tests in StringField.test.jsx were reversed.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
