### PR TITLE
fix: Added support for anyOf/oneOf in uiSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 5.16.2
 
+## @rjsf/core
+
+- Added support for `anyOf`/`oneOf` in `uiSchema`s in the `MultiSchemaField`, fixing [#4039](https://github.com/rjsf-team/react-jsonschema-form/issues/4039)
+
 ## @rjsf/utils
 
 - [4024](https://github.com/rjsf-team/react-jsonschema-form/issues/4024) Added `base64` to support `encoding`
@@ -27,6 +31,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 - [4024](https://github.com/rjsf-team/react-jsonschema-form/issues/4024) Updated the base64 references from (`atob`
   and `btoa`) to invoke the functions from the new `base64` object in `@rjsf/utils`.
+- Updated the `uiSchema.md` documentation to describe how to use the new `anyOf`/`oneOf` support
 
 # 5.16.1
 

--- a/packages/docs/docs/api-reference/uiSchema.md
+++ b/packages/docs/docs/api-reference/uiSchema.md
@@ -454,6 +454,90 @@ const uiSchema = {
 };
 ```
 
+## Using uiSchema with oneOf, anyOf
+
+### anyOf
+
+The uiSchema will work with elements inside an `anyOf` as long as the uiSchema defines the `anyOf` key at the same level as the `anyOf` within the `schema`.
+Because the `anyOf` in the `schema` is an array, so must be the one in the `uiSchema`.
+If you want to override the titles of the first two elements within the `anyOf` list you would do the following:
+
+```ts
+import { RJSFSchema, UiSchema } from '@rjsf/utils';
+
+const schema: RJSFSchema = {
+  type: 'object',
+  anyOf: [
+    {
+      title: 'Strings',
+      type: 'string',
+    },
+    {
+      title: 'Numbers',
+      type: 'number',
+    },
+    {
+      title: 'Booleans',
+      type: 'boolean',
+    },
+  ],
+};
+
+const uiSchema: UiSchema = {
+  anyOf: [
+    {
+      'ui:title': 'Custom String Title',
+    },
+    {
+      'ui:title': 'Custom Number Title',
+    },
+  ],
+};
+```
+
+> NOTE: Because the third element in the `schema` does not have an associated element in the `uiSchema`, it will keep its original title.
+
+### oneOf
+
+The uiSchema will work with elements inside an `oneOf` as long as the uiSchema defines the `oneOf` key at the same level as the `oneOf` within the `schema`.
+Because the `oneOf` in the `schema` is an array, so must be the one in the `uiSchema`.
+If you want to override the titles of the first two elements within the `oneOf` list you would do the following:
+
+```ts
+import { RJSFSchema, UiSchema } from '@rjsf/utils';
+
+const schema: RJSFSchema = {
+  type: 'object',
+  oneOf: [
+    {
+      title: 'Strings',
+      type: 'string',
+    },
+    {
+      title: 'Numbers',
+      type: 'number',
+    },
+    {
+      title: 'Booleans',
+      type: 'boolean',
+    },
+  ],
+};
+
+const uiSchema: UiSchema = {
+  oneOf: [
+    {
+      'ui:title': 'Custom String Title',
+    },
+    {
+      'ui:title': 'Custom Number Title',
+    },
+  ],
+};
+```
+
+> NOTE: Because the third element in the `schema` does not have an associated element in the `uiSchema`, it will keep its original title.
+
 ## Theme Options
 
 - [AntD Customization](themes/antd/uiSchema.md)

--- a/packages/utils/src/base64.ts
+++ b/packages/utils/src/base64.ts
@@ -1,6 +1,8 @@
 /**
- * An object that provides base64 encoding and decoding functions using the utf-8 charset to support the characters outside the latin1 range
- * By default, btoa() and atob() only support the latin1 character range.
+ * An object that provides base64 encoding and decoding functions using the utf-8 charset to support the characters
+ * outside the latin1 range. By default, btoa() and atob() only support the latin1 character range.
+ *
+ * This is built as an on-the-fly executed function to support testing the node vs browser implementations
  */
 const base64 = (function () {
   // If we are in the browser, we can use the built-in TextEncoder and TextDecoder

--- a/packages/utils/test/base64.test.ts
+++ b/packages/utils/test/base64.test.ts
@@ -45,11 +45,9 @@ describe('browser behavior', () => {
   });
   // restore the TextEncoder and TextDecoder to undefined
   afterAll(() => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error The TextEncoder type is not allowed to be undefined, but we do need to do it for tests
     global.TextEncoder = undefined;
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
+    // @ts-expect-error The TextDecoder type is not allowed to be undefined, but we do need to do it for tests
     global.TextDecoder = undefined;
   });
   it('should successfully create a base64 object and encode/decode string in browser', () => {


### PR DESCRIPTION
### Reasons for making this change

Fixes #4039 by updating `MultiSchemaField` to properly support `anyOf`/`oneOf` arrays in the `uiSchema`
- In `@rjsf/utils`: Improved documentation and typescript ignores in tests related to `base64` from previous PR
- In `@rjsf/core`: Updated `MultiSchemaField` to support `anyOf`/`oneOf` arrays in the `uiSchema`
  - Updated the tests to verify the new feature
  - Also, did some work to synchronize tests that were in the `anyOf.test.jsx` and missing in the `oneOf.test.jsx` and vica-versa
- In `docs`: Added documentation to the `uiSchema.md` file describing how to use the new feature
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
