### PR TITLE
Fix potential XSS in the preview button of FileWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,13 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 
 - Added support for `anyOf`/`oneOf` in `uiSchema`s in the `MultiSchemaField`, fixing [#4039](https://github.com/rjsf-team/react-jsonschema-form/issues/4039)
+- Fix potential XSS vulnerability in the preview button of FileWidget, fixing [#4057](https://github.com/rjsf-team/react-jsonschema-form/issues/4057)
 
 ## @rjsf/utils
 
 - [4024](https://github.com/rjsf-team/react-jsonschema-form/issues/4024) Added `base64` to support `encoding`
   and `decoding` using the `UTF-8` charset to support the characters out of the `Latin1` range.
+- Changes the way of parsing the data URL, to fix [#4057](https://github.com/rjsf-team/react-jsonschema-form/issues/4057)
 
 ## Dev / docs / playground
 

--- a/packages/core/src/components/widgets/FileWidget.tsx
+++ b/packages/core/src/components/widgets/FileWidget.tsx
@@ -126,17 +126,26 @@ function FilesInfo<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends F
 }
 
 function extractFileInfo(dataURLs: string[]): FileInfoType[] {
-  return dataURLs
-    .filter((dataURL) => dataURL)
-    .map((dataURL) => {
+  return dataURLs.reduce((acc, dataURL) => {
+    if (!dataURL) {
+      return acc;
+    }
+    try {
       const { blob, name } = dataURItoBlob(dataURL);
-      return {
-        dataURL,
-        name: name,
-        size: blob.size,
-        type: blob.type,
-      };
-    });
+      return [
+        ...acc,
+        {
+          dataURL,
+          name: name,
+          size: blob.size,
+          type: blob.type,
+        },
+      ];
+    } catch (e) {
+      // Invalid dataURI, so just ignore it.
+      return acc;
+    }
+  }, [] as FileInfoType[]);
 }
 
 /**

--- a/packages/core/src/components/widgets/FileWidget.tsx
+++ b/packages/core/src/components/widgets/FileWidget.tsx
@@ -72,7 +72,7 @@ function FileInfoPreview<T = any, S extends StrictRJSFSchema = RJSFSchema, F ext
   // If type is JPEG, PNG, or GIF, then show image preview.
   // Originally, any type of image was supported, but this was changed into a whitelist
   // since SVGs are also images, which is generally considered a security risk.
-  if (['image/jpeg', 'image/png', 'image/gif'].includes(type)) {
+  if (['image/jpeg', 'image/png'].includes(type)) {
     return <img src={dataURL} style={{ maxWidth: '100%' }} className='file-preview' />;
   }
 

--- a/packages/core/src/components/widgets/FileWidget.tsx
+++ b/packages/core/src/components/widgets/FileWidget.tsx
@@ -69,9 +69,9 @@ function FileInfoPreview<T = any, S extends StrictRJSFSchema = RJSFSchema, F ext
     return null;
   }
 
-  // If type is JPEG, PNG, or GIF, then show image preview.
+  // If type is JPEG or PNG then show image preview.
   // Originally, any type of image was supported, but this was changed into a whitelist
-  // since SVGs are also images, which is generally considered a security risk.
+  // since SVGs and animated GIFs are also images, which are generally considered a security risk.
   if (['image/jpeg', 'image/png'].includes(type)) {
     return <img src={dataURL} style={{ maxWidth: '100%' }} className='file-preview' />;
   }

--- a/packages/core/src/components/widgets/FileWidget.tsx
+++ b/packages/core/src/components/widgets/FileWidget.tsx
@@ -69,9 +69,14 @@ function FileInfoPreview<T = any, S extends StrictRJSFSchema = RJSFSchema, F ext
     return null;
   }
 
-  if (type.indexOf('image') !== -1) {
+  // If type is JPEG, PNG, or GIF, then show image preview.
+  // Originally, any type of image was supported, but this was changed into a whitelist
+  // since SVGs are also images, which is generally considered a security risk.
+  if (['image/jpeg', 'image/png', 'image/gif'].includes(type)) {
     return <img src={dataURL} style={{ maxWidth: '100%' }} className='file-preview' />;
   }
+
+  // otherwise, let users download file
 
   return (
     <>

--- a/packages/utils/src/dataURItoBlob.ts
+++ b/packages/utils/src/dataURItoBlob.ts
@@ -10,15 +10,21 @@ export default function dataURItoBlob(dataURILike: string) {
     throw new Error('File is invalid: URI must be a dataURI');
   }
   const dataURI = dataURILike.slice(5);
+  // split the dataURI into media and base64, with the base64 signature
   const splitted = dataURI.split(';base64,');
-  // check if the dataURI is base64
+  // if the base64 signature is not present, the latter part will become empty
   if (splitted.length !== 2) {
     throw new Error('File is invalid: dataURI must be base64');
   }
+  // extract the mime type, media parameters including the name, and the base64 string
   const [media, base64] = splitted;
   const [mime, ...mediaparams] = media.split(';');
   const type = mime || '';
+
+  // extract the name from the parameters
   const name = decodeURI(
+    // parse the parameters into key-value pairs, find a key, and extract a value
+    // if no key is found, then the name is unknown
     mediaparams.map((param) => param.split('=')).find(([key]) => key === 'name')?.[1] || 'unknown'
   );
 
@@ -34,6 +40,10 @@ export default function dataURItoBlob(dataURILike: string) {
 
     return { blob, name };
   } catch (error) {
-    throw new Error('File is invalid: failed to decode base64');
+    if (error instanceof Error) {
+      throw new Error('File is invalid: ' + error.message);
+    } else {
+      throw new Error('File is invalid: failed to decode base64');
+    }
   }
 }

--- a/packages/utils/src/dataURItoBlob.ts
+++ b/packages/utils/src/dataURItoBlob.ts
@@ -4,39 +4,36 @@
  * @param dataURI - The `DataUrl` potentially containing name and raw data to be converted to a Blob
  * @returns - an object containing a Blob and its name, extracted from the URI
  */
-export default function dataURItoBlob(dataURI: string) {
-  // Split metadata from data
-  const splitted: string[] = dataURI.split(',');
-  // Split params
-  const params: string[] = splitted[0].split(';');
-  // Get mime-type from params
-  const type: string = params[0].replace('data:', '');
-  // Filter the name property from params
-  const properties = params.filter((param) => {
-    return param.split('=')[0] === 'name';
-  });
-  // Look for the name and use unknown if no name property.
-  let name: string;
-  if (properties.length !== 1) {
-    name = 'unknown';
-  } else {
-    // Because we filtered out the other property,
-    // we only have the name case here, which we decode to make it human-readable
-    name = decodeURI(properties[0].split('=')[1]);
+export default function dataURItoBlob(dataURILike: string) {
+  // check if is dataURI
+  if (dataURILike.indexOf('data:') === -1) {
+    throw new Error('File is invalid: URI must be a dataURI');
   }
+  const dataURI = dataURILike.slice(5);
+  const splitted = dataURI.split(';base64,');
+  // check if the dataURI is base64
+  if (splitted.length !== 2) {
+    throw new Error('File is invalid: dataURI must be base64');
+  }
+  const [media, base64] = splitted;
+  const [mime, ...mediaparams] = media.split(';');
+  const type = mime || '';
+  const name = decodeURI(
+    mediaparams.map((param) => param.split('=')).find(([key]) => key === 'name')?.[1] || 'unknown'
+  );
 
   // Built the Uint8Array Blob parameter from the base64 string.
   try {
-    const binary = atob(splitted[1]);
-    const array = [];
+    const binary = atob(base64);
+    const array = new Array(binary.length);
     for (let i = 0; i < binary.length; i++) {
-      array.push(binary.charCodeAt(i));
+      array[i] = binary.charCodeAt(i);
     }
     // Create the blob object
     const blob = new window.Blob([new Uint8Array(array)], { type });
 
     return { blob, name };
   } catch (error) {
-    return { blob: { size: 0, type: (error as Error).message }, name: dataURI };
+    throw new Error('File is invalid: failed to decode base64');
   }
 }

--- a/packages/utils/src/dataURItoBlob.ts
+++ b/packages/utils/src/dataURItoBlob.ts
@@ -40,10 +40,6 @@ export default function dataURItoBlob(dataURILike: string) {
 
     return { blob, name };
   } catch (error) {
-    if (error instanceof Error) {
-      throw new Error('File is invalid: ' + error.message);
-    } else {
-      throw new Error('File is invalid: failed to decode base64');
-    }
+    throw new Error('File is invalid: ' + (error as Error).message);
   }
 }

--- a/packages/utils/test/dataURItoBlob.test.ts
+++ b/packages/utils/test/dataURItoBlob.test.ts
@@ -33,10 +33,10 @@ describe('dataURItoBlob()', () => {
 
   it('should throw the body is not valid Base64', () => {
     expect(() => dataURItoBlob('data:text/plain;base64,Hello%20World')).toThrow(
-      new Error('File is invalid: failed to decode base64')
+      new Error('File is invalid: The string to be decoded contains invalid characters.')
     );
     expect(() => dataURItoBlob('data:text/plain;base64,こんにちわ')).toThrow(
-      new Error('File is invalid: failed to decode base64')
+      new Error('File is invalid: The string to be decoded contains invalid characters.')
     );
   });
 

--- a/packages/utils/test/dataURItoBlob.test.ts
+++ b/packages/utils/test/dataURItoBlob.test.ts
@@ -1,6 +1,45 @@
 import { dataURItoBlob } from '../src';
 
 describe('dataURItoBlob()', () => {
+  it('should pass when the data is empty', () => {
+    const { blob, name } = dataURItoBlob('data:text/plain;base64,');
+    expect(name).toEqual('unknown');
+    expect(blob).toHaveProperty('size', 0);
+    expect(blob).toHaveProperty('type', 'text/plain');
+  });
+  it('should pass when the both body and media type are empty', () => {
+    const { blob, name } = dataURItoBlob('data:;base64,');
+    expect(name).toEqual('unknown');
+    expect(blob).toHaveProperty('size', 0);
+    expect(blob).toHaveProperty('type', '');
+  });
+  it('should return the body is empty', () => {
+    const { blob, name } = dataURItoBlob('data:application/json;name=test.png;base64,');
+    expect(name).toEqual('test.png');
+    expect(blob).toHaveProperty('size', 0);
+    expect(blob).toHaveProperty('type', 'application/json');
+  });
+  it('should throw when the body is not a Base64 encoded dataURI', () => {
+    expect(() => dataURItoBlob('data:;Hello%20World')).toThrow(new Error('File is invalid: dataURI must be base64'));
+    expect(() => dataURItoBlob('data:text/plain;Hello%20World')).toThrow(
+      new Error('File is invalid: dataURI must be base64')
+    );
+    expect(() => dataURItoBlob('data:Hello%20World')).toThrow(new Error('File is invalid: dataURI must be base64'));
+  });
+  it('should throw if the body is not a valid dataURI', () => {
+    expect(() => dataURItoBlob('Hello%20World')).toThrow(new Error('File is invalid: URI must be a dataURI'));
+    expect(() => dataURItoBlob('javascript:alert()')).toThrow(new Error('File is invalid: URI must be a dataURI'));
+  });
+
+  it('should throw the body is not valid Base64', () => {
+    expect(() => dataURItoBlob('data:text/plain;base64,Hello%20World')).toThrow(
+      new Error('File is invalid: failed to decode base64')
+    );
+    expect(() => dataURItoBlob('data:text/plain;base64,こんにちわ')).toThrow(
+      new Error('File is invalid: failed to decode base64')
+    );
+  });
+
   it('should return the name of the file if present', () => {
     const { blob, name } = dataURItoBlob('data:image/png;name=test.png;base64,VGVzdC5wbmc=');
     expect(name).toEqual('test.png');
@@ -24,11 +63,5 @@ describe('dataURItoBlob()', () => {
     expect(name).toEqual('test.png');
     expect(blob).toHaveProperty('size', 8);
     expect(blob).toHaveProperty('type', 'image/png');
-  });
-  it('should return error blob when blob conversion fails', () => {
-    const { blob, name } = dataURItoBlob('test.png');
-    expect(name).toEqual('test.png');
-    expect(blob).toHaveProperty('size', 0);
-    expect(blob).toHaveProperty('type', 'The string to be decoded contains invalid characters.');
   });
 });


### PR DESCRIPTION
### Reasons for making this change

fixes #4057

The value prop in FileWidget parses the data URL inappropriately, which also permits the use of `javascript:` schema. 
When the `javascript:` schema is set, and `ui:filePreview` is `true`, and when the user clicks `Preview` button, the JavaScript code is evaluated, and then allows XSS attack.

I fixed it by: 
- parsing the data URL correctly
- throwing `Error` when the URL is invalid
- restricting image types from any image to JPEG, PNG, GIF

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
