### PR TITLE
docs: update link to markdown-to-jsx homepage

### DIFF
--- a/packages/docs/docs/json-schema/single.md
+++ b/packages/docs/docs/json-schema/single.md
@@ -29,7 +29,7 @@ render(<Form schema={schema} validator={validator} />, document.getElementById('
 
 Fields can have titles and descriptions specified by the `title` keyword in the schema and the `description` keyword in the schema, respectively. These two can also be overridden by the `ui:title` and `ui:description` keywords in the uiSchema.
 
-Description can render markdown. This feature is disabled by default. It needs to be enabled by the `ui:enableMarkdownInDescription` keyword and setting to `true`. Read more about markdown options in the `markdown-to-jsx` official [docs](https://probablyup.com/markdown-to-jsx/).
+Description can render markdown. This feature is disabled by default. It needs to be enabled by the `ui:enableMarkdownInDescription` keyword and setting to `true`. Read more about markdown options in the `markdown-to-jsx` official [docs](https://markdown-to-jsx.quantizor.dev/).
 
 ```tsx
 import { RJSFSchema } from '@rjsf/utils';

--- a/packages/playground/src/samples/simple.ts
+++ b/packages/playground/src/samples/simple.ts
@@ -44,7 +44,7 @@ const simple: Sample = {
       'ui:autocomplete': 'family-name',
       'ui:enableMarkdownInDescription': true,
       'ui:description':
-        'Make text **bold** or *italic*. Take a look at other options [here](https://probablyup.com/markdown-to-jsx/).',
+        'Make text **bold** or *italic*. Take a look at other options [here](https://markdown-to-jsx.quantizor.dev/).',
     },
     lastName: {
       'ui:autocomplete': 'given-name',


### PR DESCRIPTION
### Reasons for making this change

I noticed when browsing your example page that the link to the `markdown-to-jsx` package website was dead. This PR updates it to the current url, as displayed in their [repo on GitHub](https://github.com/quantizor/markdown-to-jsx). This was updated on their side in https://github.com/quantizor/markdown-to-jsx/commit/342f5878b45b71fb7b6d5fd9679d862509064cfc, 29 days ago today.

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
