### PR TITLE
Fix: Make 'ui:rows' option work with chakra-ui for textarea elements (#4070)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.17.1
+
+## @rjsf/chakra-ui
+
+- Added support for `UiSchema` `"ui:rows"` option for `textarea` elements, fixing [#4070](https://github.com/rjsf-team/react-jsonschema-form/issues/4070).
+
 # 5.17.0
 
 ## @rjsf/core

--- a/packages/chakra-ui/src/TextareaWidget/TextareaWidget.tsx
+++ b/packages/chakra-ui/src/TextareaWidget/TextareaWidget.tsx
@@ -57,6 +57,7 @@ export default function TextareaWidget<
         onChange={_onChange}
         onBlur={_onBlur}
         onFocus={_onFocus}
+        rows={options.rows}
         aria-describedby={ariaDescribedByIds<T>(id)}
       />
     </FormControl>


### PR DESCRIPTION
### Reasons for making this change

fixes #4070 

### Checklist

- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR

### Notes

1. I didn't see relevant tests for this on other frameworks, so didn't add any.  
2. I looked at the other TextArea implementations, for multiple frameworks a default value is provided and there's some sort of type checking. 

An example from `packages/mui/src/TextareaWidget/TextareaWidget.tsx`:
```
  let rows: string | number = 5;
  if (typeof options.rows === 'string' || typeof options.rows === 'number') {
    rows = options.rows;
  }
```

I don't think it is really required with Chakra and it didn't feel too relevant so I just went with the simpler option.  

Passing something that isn't a string or a number results in a warning in console (and a change in the textarea `min-height` for some reason), which I would say is a slightly better behavior than silently using a default value.

If I'm missing something please let me know, we can go with the 'type checking and default value' approach :ok_hand: .  