### PR TITLE
Fix typo in ErrorsListTemplate example

### DIFF
--- a/packages/docs/docs/advanced-customization/custom-templates.md
+++ b/packages/docs/docs/advanced-customization/custom-templates.md
@@ -480,7 +480,7 @@ function ErrorListTemplate(props: ErrorListProps) {
 }
 
 render(
-  <Form schema={schema} validator={validator} templates={{ DescriptionFieldTemplate }} />,
+  <Form schema={schema} validator={validator} templates={{ ErrorListTemplate }} />,
   document.getElementById('app')
 );
 ```


### PR DESCRIPTION
### Reasons for making this change

Theres a typo (probably just copy paste error from previous example). The ErrorListTemplate example shows how to create an ErrorListTemplate, but does not correctly use the template in the `templates` prop on `<Form>`

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
