### PR TITLE
Pass errorSchema from ArrayField to ArrayFieldTemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,15 +22,19 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Added support for `UiSchema` `"ui:rows"` option for `textarea` elements, fixing [#4070](https://github.com/rjsf-team/react-jsonschema-form/issues/4070).
 
-# @rjsf/utils
+## @rjsf/core
+
+- [#4091](https://github.com/rjsf-team/react-jsonschema-form/issues/4091) Added `errorSchema` to `ArrayFieldTemplate` props.
+
+## @rjsf/utils
 
 - [#4080](https://github.com/rjsf-team/react-jsonschema-form/issues/4080) - BREAKING CHANGE: Removed the `base64` object from the `@rjsf/utils` package. Note that this is a breaking change if you relied on the `base64` object exported by `@rjsf/utils`. Since this change caused [#4080](https://github.com/rjsf-team/react-jsonschema-form/issues/4080), and was only internally used by playground code, we are shipping this change in a patch release.
+- [#4091](https://github.com/rjsf-team/react-jsonschema-form/issues/4091) Added `errorSchema` to the `ArrayFieldTemplateProps` type.
 
 ## Dev / docs / playground
 
 - [#4080](https://github.com/rjsf-team/react-jsonschema-form/issues/4080) - Moved the `base64` encoder/decoder object to the Playground package. 
-- Added test configuration and script to the Playground. 
-
+- Added test configuration and script to the Playground.
 
 # 5.17.0
 

--- a/packages/core/src/components/fields/ArrayField.tsx
+++ b/packages/core/src/components/fields/ArrayField.tsx
@@ -787,6 +787,7 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
       uiSchema,
       title: fieldTitle,
       formContext,
+      errorSchema,
       rawErrors,
     };
 

--- a/packages/docs/docs/advanced-customization/custom-templates.md
+++ b/packages/docs/docs/advanced-customization/custom-templates.md
@@ -104,6 +104,7 @@ The following props are passed to each `ArrayFieldTemplate`:
 - `title`: A string value containing the title for the array.
 - `formContext`: The `formContext` object that you passed to Form.
 - `formData`: The formData for this array.
+- `errorSchema`: The optional validation errors for the array field and the items within it, in the form of an `ErrorSchema`
 - `rawErrors`: An array of strings listing all generated error messages from encountered errors for this widget
 - `registry`: The `registry` object.
 

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -601,6 +601,8 @@ export type ArrayFieldTemplateProps<
   formContext?: F;
   /** The formData for this array */
   formData?: T;
+  /** The tree of errors for this field and its children */
+  errorSchema?: ErrorSchema<T>;
   /** An array of strings listing all generated error messages from encountered errors for this widget */
   rawErrors?: string[];
   /** The `registry` object */


### PR DESCRIPTION
### Reasons for making this change

fixes #4091 

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
    - Should I? If so, under a new version?
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
