### PR TITLE
Fix: Error state not resetting when schema changes (#4079)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 5.18.0
 
+## @rjsf/core
+
+- Fix Error state not resetting when schema changes [#4079](https://github.com/rjsf-team/react-jsonschema-form/issues/4079)
+
 ## @rjsf/utils
 
 - Added a new `skipEmptyDefault` option in `emptyObjectFields`, fixing [#3880](https://github.com/rjsf-team/react-jsonschema-form/issues/3880)

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -382,7 +382,9 @@ export default class Form<
     const _retrievedSchema = retrievedSchema ?? schemaUtils.retrieveSchema(schema, formData);
 
     const getCurrentErrors = (): ValidationData<T> => {
-      if (props.noValidate) {
+      // f the `props.novalidate` option is set, we reset the error state.
+      // Or if the `retrievedSchema` param is undefined, this indicates that the schema has changed. Therefore, we also reset the error state.
+      if (props.noValidate || typeof retrievedSchema === 'undefined') {
         return { errors: [], errorSchema: {} };
       } else if (!props.liveValidate) {
         return {

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -317,7 +317,6 @@ export default class Form<
           : this.state.retrievedSchema,
         isSchemaChanged
       );
-      console.log('nextState _retrieved', nextState.retrievedSchema);
       const shouldUpdate = !deepEquals(nextState, prevState);
       return { nextState, shouldUpdate };
     }

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -307,14 +307,14 @@ export default class Form<
   ): { nextState: FormState<T, S, F>; shouldUpdate: true } | { shouldUpdate: false } {
     if (!deepEquals(this.props, prevProps)) {
       const isSchemaChanged = !deepEquals(prevProps.schema, this.props.schema);
+      const isFormDataChanged = !deepEquals(prevProps.formData, this.props.formData);
       const nextState = this.getStateFromProps(
         this.props,
         this.props.formData,
         // If the `schema` has changed, we need to update the retrieved schema.
-        // Or if the `formData` changes, for example in the case of a schema with dependencies that need to match one of the subSchemas, the retrieved schema must be updated.
-        isSchemaChanged || !deepEquals(prevProps.formData, this.props.formData)
-          ? undefined
-          : this.state.retrievedSchema,
+        // Or if the `formData` changes, for example in the case of a schema with dependencies that need to
+        //  match one of the subSchemas, the retrieved schema must be updated.
+        isSchemaChanged || isFormDataChanged ? undefined : this.state.retrievedSchema,
         isSchemaChanged
       );
       const shouldUpdate = !deepEquals(nextState, prevState);

--- a/packages/core/test/Form.test.jsx
+++ b/packages/core/test/Form.test.jsx
@@ -4020,31 +4020,37 @@ describe('Form omitExtraData and liveOmit', () => {
         properties: {
           foo: { type: 'string' },
         },
+        required: ['foo'],
       };
 
-      const extraErrors = {
-        foo: {
-          __errors: ['foo'],
-        },
-      };
-
-      const { comp } = createFormComponent({
+      const { comp, node } = createFormComponent({
         schema,
-        extraErrors,
-        liveValidate: true,
-        formData: { foo: 1 },
       });
 
+      Simulate.submit(node);
+      expect(comp.state.errorSchema).eql({ foo: { __errors: ["must have required property 'foo'"] } });
+      expect(comp.state.errors).eql([
+        {
+          message: "must have required property 'foo'",
+          property: 'foo',
+          name: 'required',
+          params: {
+            missingProperty: 'foo',
+          },
+          schemaPath: '#/required',
+          stack: "must have required property 'foo'",
+        },
+      ]);
+
+      // Changing schema to reset errors state.
       setProps(comp, {
         schema: {
           type: 'object',
           properties: {
             foo: { type: 'string' },
           },
-          required: ['foo'],
         },
       });
-
       expect(comp.state.errorSchema).eql({});
       expect(comp.state.errors).eql([]);
     });

--- a/packages/core/test/Form.test.jsx
+++ b/packages/core/test/Form.test.jsx
@@ -4013,6 +4013,41 @@ describe('Form omitExtraData and liveOmit', () => {
       // We use setTimeout with a delay of 0ms to allow all asynchronous operations to complete in the React component.
       // Despite this being a workaround, it turned out to be the only effective method to handle this test case.
     });
+
+    it('should reset when schema changes', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          foo: { type: 'string' },
+        },
+      };
+
+      const extraErrors = {
+        foo: {
+          __errors: ['foo'],
+        },
+      };
+
+      const { comp } = createFormComponent({
+        schema,
+        extraErrors,
+        liveValidate: true,
+        formData: { foo: 1 },
+      });
+
+      setProps(comp, {
+        schema: {
+          type: 'object',
+          properties: {
+            foo: { type: 'string' },
+          },
+          required: ['foo'],
+        },
+      });
+
+      expect(comp.state.errorSchema).eql({});
+      expect(comp.state.errors).eql([]);
+    });
   });
 
   it('should keep schema errors when extraErrors set after submit and liveValidate is false', () => {


### PR DESCRIPTION
### Reasons for making this change

Fixes #4079

### Checklist

- [X] **I'm adding or updating code**
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
