### PR TITLE
Fixes: error TS7006: Parameter '_' implicitly has an 'any' type.

### DIFF
--- a/packages/fluent-ui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/fluent-ui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -66,7 +66,7 @@ export default function CheckboxWidget<
   );
 
   const _onChange = useCallback(
-    (_, checked?: boolean): void => {
+    (_: any, checked?: boolean): void => {
       onChange(checked);
     },
     [onChange]


### PR DESCRIPTION
Fixes build failure due to noImplicitAny set to true:
```
src/CheckboxWidget/CheckboxWidget.tsx(69,6): error TS7006: Parameter '_' implicitly has an 'any' type.
```