### PR TITLE
Skip populate function proposal in Experimental_ArrayMinItems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/utils
 
 - Added a new `skipEmptyDefault` option in `emptyObjectFields`, fixing [#3880](https://github.com/rjsf-team/react-jsonschema-form/issues/3880)
+- Added a new `computeSkipPopulate` option in `arrayMinItems`, allowing custom logic to skip populating arrays with default values, implementing [#4121](https://github.com/rjsf-team/react-jsonschema-form/pull/4121).
+
 
 ## Dev / docs / playground
 

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -88,6 +88,8 @@ Optional enumerated flag controlling how array minItems are populated, defaultin
 
 A function that determines whether to skip populating the array with default values based on the provided validator, schema, and root schema. If the function returns `true`, the array will not be populated with default values. If the function returns `false`, the array will be populated with default values according to the `populate` option.
 
+##### Example
+
 ```tsx
 import { RJSFSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -83,6 +83,9 @@ Optional enumerated flag controlling how array minItems are populated, defaultin
 | `requiredOnly` | Ignore `minItems` on a field when calculating defaults unless the field is required.                                                               |
 | `never`        | Ignore `minItems` on a field when calculating defaults for required and non-required. Value will set only if defined `default` and from `formData` |
 
+#### `arrayMinItems.computeSkipPopulate`
+A function that determines whether to skip populating the array with default values based on the provided validator, schema, and root schema. If the function returns `true`, the array will not be populated with default values. If the function returns `false`, the array will be populated with default values according to the `populate` option.
+
 #### `arrayMinItems.mergeExtraDefaults`
 
 Optional boolean flag, defaulting to `false` when not specified.

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -84,7 +84,49 @@ Optional enumerated flag controlling how array minItems are populated, defaultin
 | `never`        | Ignore `minItems` on a field when calculating defaults for required and non-required. Value will set only if defined `default` and from `formData` |
 
 #### `arrayMinItems.computeSkipPopulate`
+
 A function that determines whether to skip populating the array with default values based on the provided validator, schema, and root schema. If the function returns `true`, the array will not be populated with default values. If the function returns `false`, the array will be populated with default values according to the `populate` option.
+
+```tsx
+import { RJSFSchema } from '@rjsf/utils';
+import validator from '@rjsf/validator-ajv8';
+
+const schema: RJSFSchema = {
+  type: 'object',
+  properties: {
+    stringArray: {
+      type: 'array',
+      items: { type: 'string' },
+      minItems: 1,
+    },
+    numberArray: {
+      type: 'array',
+      items: { type: 'number' },
+      minItems: 1,
+    },
+  },
+  required: ['stringArray', 'numberArray'],
+};
+
+const computeSkipPopulateNumberArrays = (validator, schema, rootSchema) =>
+  // These conditions are needed to narrow down the type of the schema.items
+  !Array.isArray(schema?.items) &&
+  typeof schema?.items !== 'boolean' &&
+  schema?.items?.type === 'number',
+
+render(
+  <Form
+    schema={schema}
+    validator={validator}
+    experimental_defaultFormStateBehavior={{
+      arrayMinItems: {
+        computeSkipPopulate: computeSkipPopulateNumberArrays,
+      },
+    }}
+  />,
+  document.getElementById('app')
+);
+```
 
 #### `arrayMinItems.mergeExtraDefaults`
 

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -86,7 +86,24 @@ Optional enumerated flag controlling how array minItems are populated, defaultin
 
 #### `arrayMinItems.computeSkipPopulate`
 
-A function that determines whether to skip populating the array with default values based on the provided validator, schema, and root schema. If the function returns `true`, the array will not be populated with default values. If the function returns `false`, the array will be populated with default values according to the `populate` option.
+The signature and documentation for this property is as follow:
+
+##### computeSkipPopulate <T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>()
+
+A function that determines whether to skip populating the array with default values based on the provided validator, schema, and root schema.
+ If the function returns `true`, the array will not be populated with default values.
+ If the function returns `false`, the array will be populated with default values according to the `populate` option.
+
+###### Parameters
+
+- validator: ValidatorType<T, S, F> - An implementation of the `ValidatorType` interface that is used to detect valid schema conditions
+- schema: S - The schema for which resolving a condition is desired
+- [rootSchema]: S - The root schema that will be forwarded to all the APIs
+
+###### Returns
+
+- boolean: A boolean indicating whether to skip populating the array with default values.
+
 
 ##### Example
 

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -350,6 +350,7 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
       const neverPopulate = experimental_defaultFormStateBehavior?.arrayMinItems?.populate === 'never';
       const ignoreMinItemsFlagSet = experimental_defaultFormStateBehavior?.arrayMinItems?.populate === 'requiredOnly';
       const isSkipEmptyDefaults = experimental_defaultFormStateBehavior?.emptyObjectFields === 'skipEmptyDefaults';
+      const skipPopulate = experimental_defaultFormStateBehavior?.arrayMinItems?.skipPopulate ?? (() => false);
 
       const emptyDefault = isSkipEmptyDefaults ? undefined : [];
 
@@ -399,6 +400,7 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
       if (
         !schema.minItems ||
         isMultiSelect<T, S, F>(validator, schema, rootSchema) ||
+        skipPopulate<T, S, F>(validator, schema, rootSchema) ||
         schema.minItems <= defaultsLength
       ) {
         return defaults ? defaults : emptyDefault;

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -350,7 +350,8 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
       const neverPopulate = experimental_defaultFormStateBehavior?.arrayMinItems?.populate === 'never';
       const ignoreMinItemsFlagSet = experimental_defaultFormStateBehavior?.arrayMinItems?.populate === 'requiredOnly';
       const isSkipEmptyDefaults = experimental_defaultFormStateBehavior?.emptyObjectFields === 'skipEmptyDefaults';
-      const skipPopulate = experimental_defaultFormStateBehavior?.arrayMinItems?.skipPopulate ?? (() => false);
+      const computeSkipPopulate =
+        experimental_defaultFormStateBehavior?.arrayMinItems?.computeSkipPopulate ?? (() => false);
 
       const emptyDefault = isSkipEmptyDefaults ? undefined : [];
 
@@ -400,7 +401,7 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
       if (
         !schema.minItems ||
         isMultiSelect<T, S, F>(validator, schema, rootSchema) ||
-        skipPopulate<T, S, F>(validator, schema, rootSchema) ||
+        computeSkipPopulate<T, S, F>(validator, schema, rootSchema) ||
         schema.minItems <= defaultsLength
       ) {
         return defaults ? defaults : emptyDefault;

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -41,8 +41,16 @@ export type Experimental_ArrayMinItems = {
    * - `never`: Ignore `minItems` on a field even the field is required.
    */
   populate?: 'all' | 'requiredOnly' | 'never';
-  /** TODO */
-  skipPopulate?: <T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+  /** A function that determines whether to skip populating the array with default values based on the provided validator,
+   * schema, and root schema.
+   * If the function returns true, the array will not be populated with default values.
+   * If the function returns false, the array will be populated with default values according to the `populate` option.
+   * @param validator - An implementation of the `ValidatorType` interface that is used to detect valid schema conditions
+   * @param schema - The schema for which resolving a condition is desired
+   * @param rootSchema - The root schema that will be forwarded to all the APIs
+   * @returns A boolean indicating whether to skip populating the array with default values.
+   */
+  computeSkipPopulate?: <T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
     validator: ValidatorType<T, S, F>,
     schema: S,
     rootSchema?: S

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -47,7 +47,7 @@ export type Experimental_ArrayMinItems = {
    * If the function returns false, the array will be populated with default values according to the `populate` option.
    * @param validator - An implementation of the `ValidatorType` interface that is used to detect valid schema conditions
    * @param schema - The schema for which resolving a condition is desired
-   * @param rootSchema - The root schema that will be forwarded to all the APIs
+   * @param [rootSchema] - The root schema that will be forwarded to all the APIs
    * @returns A boolean indicating whether to skip populating the array with default values.
    */
   computeSkipPopulate?: <T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -41,6 +41,12 @@ export type Experimental_ArrayMinItems = {
    * - `never`: Ignore `minItems` on a field even the field is required.
    */
   populate?: 'all' | 'requiredOnly' | 'never';
+  /** TODO */
+  skipPopulate?: <T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
+    validator: ValidatorType<T, S, F>,
+    schema: S,
+    rootSchema?: S
+  ) => boolean;
   /** When `formData` is provided and does not contain `minItems` worth of data, this flag (`false` by default) controls
    * whether the extra data provided by the defaults is appended onto the existing `formData` items to ensure the
    * `minItems` condition is met. When false (legacy behavior), only the `formData` provided is merged into the default

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -2872,5 +2872,31 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         })
       ).toEqual({ requiredArray: ['raw0', 'default0'] });
     });
+    it('should not populate defaults for array items when computeSkipPopulate returns true', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          stringArray: {
+            type: 'array',
+            items: { type: 'string' },
+            minItems: 1,
+          },
+          numberArray: {
+            type: 'array',
+            items: { type: 'number' },
+            minItems: 1,
+          },
+        },
+        required: ['stringArray', 'numberArray'],
+      };
+      expect(
+        getDefaultFormState(testValidator, schema, {}, schema, false, {
+          arrayMinItems: {
+            computeSkipPopulate: (_, schema) =>
+              !Array.isArray(schema?.items) && typeof schema?.items !== 'boolean' && schema?.items?.type === 'number',
+          },
+        })
+      ).toEqual({ stringArray: [undefined], numberArray: [] });
+    });
   });
 }


### PR DESCRIPTION
### Reasons for making this change

As we use our custom implementation of file upload, we would like to have case-by-case method how to control population of arrays in `Experimental_ArrayMinItems` (and there might be need from others with advanced usages). 

Our files implementation yields this schema:
https://github.com/bratislava/konto.bratislava.sk/blob/8ce56b7fa4a62c7dd67351b617ba5ad13bc363b8/next/schema-generator/generator/functions.ts#L372

We would like to use `{ populate: 'requiredOnly' }`. It works fine for our [multiselects](https://github.com/bratislava/konto.bratislava.sk/blob/8ce56b7fa4a62c7dd67351b617ba5ad13bc363b8/next/schema-generator/generator/functions.ts#L113) and [checkbox group](https://github.com/bratislava/konto.bratislava.sk/blob/8ce56b7fa4a62c7dd67351b617ba5ad13bc363b8/next/schema-generator/generator/functions.ts#L326), as they are handled by the [isMultiSelect condition](https://github.com/rjsf-team/react-jsonschema-form/blob/af8932a60fb77250dd238ea32257731d3d8308f9/packages/utils/src/schema/getDefaultFormState.ts#L401), but it populates our files array with `[null]`. Therefore I would like to implement `skipPopulate` (name is up for consideration) function that would allow us to have a custom logic to skip population similar to what `isMultiSelect` does.

As a temporary solution, we have our own [fork](https://github.com/bratislava/react-jsonschema-form/commit/df33db5638ce3626a72f8b8411df498a8a8ae5fc) that allows us to add `overrideArrayMinItemsBehaviour` to schema, but this might be better and more scalable solution.

What do you think? Should I continue with this idea?

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
