### PR TITLE
Fix Maximum call stack size exceeded in findSchemaDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,15 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
-# 5.18.1
+# 5.18.2
 
 ## @rjsf/core
+
 - Fixed Programmatic submit not working properly in Firefox [#3121](https://github.com/rjsf-team/react-jsonschema-form/issues/3121)
+
+## @rjsf/utils
+
+- [#4116](https://github.com/rjsf-team/react-jsonschema-form/issues/4116) Fix Maximum call stack size exceeded when encountering circular definitions ([Link to PR](https://github.com/rjsf-team/react-jsonschema-form/pull/4123))
 
 # 5.18.0
 

--- a/packages/utils/test/findSchemaDefinition.test.ts
+++ b/packages/utils/test/findSchemaDefinition.test.ts
@@ -1,4 +1,5 @@
 import { RJSFSchema, findSchemaDefinition } from '../src';
+import { findSchemaDefinitionRecursive } from '../src/findSchemaDefinition';
 
 const schema: RJSFSchema = {
   type: 'object',
@@ -63,6 +64,41 @@ describe('findSchemaDefinition()', () => {
   });
   it('throws error when ref is a deep circular reference', () => {
     expect(() => findSchemaDefinition('#/definitions/badCircularDeepNestedRef', schema)).toThrowError(
+      'Definition for #/definitions/badCircularDeepNestedRef contains a circular reference through #/definitions/badCircularDeeperNestedRef -> #/definitions/badCircularDeepestNestedRef -> #/definitions/badCircularDeepNestedRef'
+    );
+  });
+});
+
+describe('findSchemaDefinitionRecursive()', () => {
+  it('throws error when ref is missing', () => {
+    expect(() => findSchemaDefinitionRecursive()).toThrowError('Could not find a definition for undefined');
+  });
+  it('throws error when ref is malformed', () => {
+    expect(() => findSchemaDefinitionRecursive('definitions/missing')).toThrowError(
+      'Could not find a definition for definitions/missing'
+    );
+  });
+  it('throws error when ref does not exist', () => {
+    expect(() => findSchemaDefinitionRecursive('#/definitions/missing', schema)).toThrowError(
+      'Could not find a definition for #/definitions/missing'
+    );
+  });
+  it('returns the string ref from its definition', () => {
+    expect(findSchemaDefinitionRecursive('#/definitions/stringRef', schema)).toBe(schema.definitions!.stringRef);
+  });
+  it('returns the string ref from its nested definition', () => {
+    expect(findSchemaDefinitionRecursive('#/definitions/nestedRef', schema)).toBe(schema.definitions!.stringRef);
+  });
+  it('returns a combined schema made from its nested definition with the extra props', () => {
+    expect(findSchemaDefinitionRecursive('#/definitions/extraNestedRef', schema)).toEqual(EXTRA_EXPECTED);
+  });
+  it('throws error when ref is a circular reference', () => {
+    expect(() => findSchemaDefinitionRecursive('#/definitions/badCircularNestedRef', schema)).toThrowError(
+      'Definition for #/definitions/badCircularNestedRef is a circular reference'
+    );
+  });
+  it('throws error when ref is a deep circular reference', () => {
+    expect(() => findSchemaDefinitionRecursive('#/definitions/badCircularDeepNestedRef', schema)).toThrowError(
       'Definition for #/definitions/badCircularDeepNestedRef contains a circular reference through #/definitions/badCircularDeeperNestedRef -> #/definitions/badCircularDeepestNestedRef -> #/definitions/badCircularDeepNestedRef'
     );
   });

--- a/packages/utils/test/findSchemaDefinition.test.ts
+++ b/packages/utils/test/findSchemaDefinition.test.ts
@@ -13,6 +13,21 @@ const schema: RJSFSchema = {
       $ref: '#/definitions/stringRef',
       title: 'foo',
     },
+    // Reference accidentally pointing to itself.
+    badCircularNestedRef: {
+      $ref: '#/definitions/badCircularNestedRef',
+    },
+    // Reference accidentally pointing to a chain of references which ultimately
+    // point back to the original reference.
+    badCircularDeepNestedRef: {
+      $ref: '#/definitions/badCircularDeeperNestedRef',
+    },
+    badCircularDeeperNestedRef: {
+      $ref: '#/definitions/badCircularDeepestNestedRef',
+    },
+    badCircularDeepestNestedRef: {
+      $ref: '#/definitions/badCircularDeepNestedRef',
+    },
   },
 };
 
@@ -40,5 +55,15 @@ describe('findSchemaDefinition()', () => {
   });
   it('returns a combined schema made from its nested definition with the extra props', () => {
     expect(findSchemaDefinition('#/definitions/extraNestedRef', schema)).toEqual(EXTRA_EXPECTED);
+  });
+  it('throws error when ref is a circular reference', () => {
+    expect(() => findSchemaDefinition('#/definitions/badCircularNestedRef', schema)).toThrowError(
+      'Definition for #/definitions/badCircularNestedRef is a circular reference'
+    );
+  });
+  it('throws error when ref is a deep circular reference', () => {
+    expect(() => findSchemaDefinition('#/definitions/badCircularDeepNestedRef', schema)).toThrowError(
+      'Definition for #/definitions/badCircularDeepNestedRef contains a circular reference through #/definitions/badCircularDeeperNestedRef -> #/definitions/badCircularDeepestNestedRef -> #/definitions/badCircularDeepNestedRef'
+    );
   });
 });


### PR DESCRIPTION
### Reasons for making this change

Fixes #4116 

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed (not needed)
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed (not needed)
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
