### PR TITLE
Fix: filename should be bold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/utils
 
 - Added a new `skipEmptyDefault` option in `emptyObjectFields`, fixing [#3880](https://github.com/rjsf-team/react-jsonschema-form/issues/3880)
+- Fixed bug where the string `"\</strong>"` would get printed next to filenames when uploading files, and restored intended bolding of filenames fixing [#4120](https://github.com/rjsf-team/react-jsonschema-form/issues/4120).
 
 ## Dev / docs / playground
 

--- a/packages/utils/src/enums.ts
+++ b/packages/utils/src/enums.ts
@@ -70,5 +70,5 @@ export enum TranslatableString {
   /** File name, type and size info, where %1, %2 and %3 will be replaced by the file name, file type and file size as
    * provided by FileWidget
    */
-  FilesInfo = '<strong>%1</strong> (%2, %3 bytes)',
+  FilesInfo = '**%1** (%2, %3 bytes)',
 }


### PR DESCRIPTION
Also prevents horrible looking "\</strong>" from being printed on screen.

### Reasons for making this change
fixes #4120 

### Checklist
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
