### PR TITLE
give instructions for material ui 5, not 4

### DIFF
--- a/packages/docs/docs/usage/themes.md
+++ b/packages/docs/docs/usage/themes.md
@@ -40,10 +40,10 @@ For example, to use the standard bootstrap 3 form, you can run:
 import Form from '@rjsf/core';
 ```
 
-To use the material-ui form, you should first install both `@rjsf/core` and `@rjsf/material-ui`. Then, you can run:
+To use the material-ui 5 form, you should first install both `@rjsf/core` and `@rjsf/mui`. Then, you can run:
 
 ```ts
-import Form from '@rjsf/material-ui';
+import Form from '@rjsf/mui';
 ```
 
 For more information on how to create a custom theme, see documentation on the `withTheme` component.


### PR DESCRIPTION
### Reasons for making this change

It seems reasonable to use instructions for the newest material ui when describing how to switch to it from the default bootstrap theme.

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added even though it was a bit of a pain. :)
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
