### PR TITLE
Fix 4134 by filtering out bad DOM props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,18 +18,22 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 5.18.0
 
+## @rjsf/antd
+- Fix issue where the theme provided by the ConfigProvider under antd v5 wasn't respected thereby rendering the form items unusable under dark themes [#4129](https://github.com/rjsf-team/react-jsonschema-form/issues/4129)
+
 ## @rjsf/core
 
 - Fix Error state not resetting when schema changes [#4079](https://github.com/rjsf-team/react-jsonschema-form/issues/4079)
+
+## @rjsf/mui
+
+- Fixed the `SelectWidget` and `BaseInputTemplate` to filter out `errorSchema` and `autocomplete` from the `textFieldProps` being spread onto the `TextField`, fixing [#4134](https://github.com/rjsf-team/react-jsonschema-form/issues/4134)
 
 ## @rjsf/utils
 
 - Added a new `skipEmptyDefault` option in `emptyObjectFields`, fixing [#3880](https://github.com/rjsf-team/react-jsonschema-form/issues/3880)
 - Added a new `computeSkipPopulate` option in `arrayMinItems`, allowing custom logic to skip populating arrays with default values, implementing [#4121](https://github.com/rjsf-team/react-jsonschema-form/pull/4121).
 - Fixed bug where the string `"\</strong>"` would get printed next to filenames when uploading files, and restored intended bolding of filenames fixing [#4120](https://github.com/rjsf-team/react-jsonschema-form/issues/4120).
-
-## @rjsf/antd
-- Fix issue where the theme provided by the ConfigProvider under antd v5 wasn't respected thereby rendering the form items unusable under dark themes [#4129](https://github.com/rjsf-team/react-jsonschema-form/issues/4129)
 
 ## Dev / docs / playground
 

--- a/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -45,6 +45,7 @@ export default function BaseInputTemplate<
     schema,
     uiSchema,
     rawErrors = [],
+    errorSchema,
     formContext,
     registry,
     InputLabelProps,

--- a/packages/mui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/mui/src/SelectWidget/SelectWidget.tsx
@@ -38,6 +38,7 @@ export default function SelectWidget<
   onChange,
   onBlur,
   onFocus,
+  errorSchema,
   rawErrors = [],
   registry,
   uiSchema,
@@ -59,6 +60,7 @@ export default function SelectWidget<
   const _onFocus = ({ target: { value } }: FocusEvent<HTMLInputElement>) =>
     onFocus(id, enumOptionsValueForIndex<S>(value, enumOptions, optEmptyVal));
   const selectedIndexes = enumOptionsIndexForValue<S>(value, enumOptions, multiple);
+  const { InputLabelProps, SelectProps, autocomplete, ...textFieldRemainingProps } = textFieldProps;
 
   return (
     <TextField
@@ -69,19 +71,20 @@ export default function SelectWidget<
       required={required}
       disabled={disabled || readonly}
       autoFocus={autofocus}
+      autoComplete={autocomplete}
       placeholder={placeholder}
       error={rawErrors.length > 0}
       onChange={_onChange}
       onBlur={_onBlur}
       onFocus={_onFocus}
-      {...(textFieldProps as TextFieldProps)}
+      {...(textFieldRemainingProps as TextFieldProps)}
       select // Apply this and the following props after the potential overrides defined in textFieldProps
       InputLabelProps={{
-        ...textFieldProps.InputLabelProps,
+        ...InputLabelProps,
         shrink: !isEmpty,
       }}
       SelectProps={{
-        ...textFieldProps.SelectProps,
+        ...SelectProps,
         multiple,
       }}
       aria-describedby={ariaDescribedByIds<T>(id)}


### PR DESCRIPTION
### Reasons for making this change

Fixes: #4134 by updating the spreading of props onto the `TextField` to remove bad DOM fields
- In `@rjsf/mui`, updated `SelectField` and `BaseInputTemplate` to filter out `errorSchema` and `autocomplete` from the `textFieldProps` before they are spread onto `TextField`
- Updated `CHANGELOG.md` accordingly, moving `@rjsf/antd` above `@rjsf/core`
### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
