### PR TITLE
Bug: Programmatic submit not working properly in Firefox(#3121).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.18.1
+
+## @rjsf/core
+- Fixed Programmatic submit not working properly in Firefox [#3121](https://github.com/rjsf-team/react-jsonschema-form/issues/3121)
+
 # 5.18.0
 
 ## @rjsf/antd

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -758,11 +758,11 @@ export default class Form<
   /** Provides a function that can be used to programmatically submit the `Form` */
   submit = () => {
     if (this.formElement.current) {
-      this.formElement.current.dispatchEvent(
-        new CustomEvent('submit', {
-          cancelable: true,
-        })
-      );
+      const submitCustomEvent = new CustomEvent('submit', {
+        cancelable: true,
+      });
+      submitCustomEvent.preventDefault();
+      this.formElement.current.dispatchEvent(submitCustomEvent);
       this.formElement.current.requestSubmit();
     }
   };


### PR DESCRIPTION
### Reasons for making this change

[Please describe them here]

The programmatic submit is not preventing the default form submission in Firefox. This is because the dispatched custom submit event is not the same event as the actual formSubmitEvent. Also the ref.current.formElement.current.requestSubmit() workaround doesn't work on Safari. This fixes the issue by preventing the default form submission.

bug #3121

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
