### PR TITLE
Add support back for semantic version 1 via peerdependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.18.3
+
+## @rjsf/semantic-ui
+
+- Added support for version 2 in the `peerDependencies`
+
+## Dev / docs / playground
+
+- Bumped devDependencies on `react` to `18.x`
+
 # 5.18.2
 
 ## @rjsf/core

--- a/package-lock.json
+++ b/package-lock.json
@@ -35026,7 +35026,8 @@
         "react-dom": "^18.2.0",
         "react-frame-component": "^4.1.3",
         "react-is": "^18.2.0",
-        "react-portal": "^4.2.2"
+        "react-portal": "^4.2.2",
+        "semantic-ui-react": "^2.1.3"
       },
       "devDependencies": {
         "@babel/cli": "^7.23.9",
@@ -35101,8 +35102,7 @@
       "version": "5.18.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "semantic-ui-css": "^2.5.0",
-        "semantic-ui-react": "^2.1.3"
+        "semantic-ui-css": "^2.5.0"
       },
       "devDependencies": {
         "@babel/core": "^7.23.9",
@@ -35132,6 +35132,7 @@
         "react-test-renderer": "^18.2.0",
         "rimraf": "^5.0.5",
         "rollup": "^3.29.4",
+        "semantic-ui-react": "^2.1.3",
         "typescript": "^4.9.5"
       },
       "engines": {
@@ -35141,7 +35142,7 @@
         "@rjsf/core": "^5.18.x",
         "@rjsf/utils": "^5.18.x",
         "react": "^16.14.0 || >=17",
-        "semantic-ui-react": "^2.1.3"
+        "semantic-ui-react": "^1.3.1 || ^2.1.3"
       }
     },
     "packages/snapshot-tests": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -72,7 +72,8 @@
     "react-dom": "^18.2.0",
     "react-frame-component": "^4.1.3",
     "react-is": "^18.2.0",
-    "react-portal": "^4.2.2"
+    "react-portal": "^4.2.2",
+    "semantic-ui-react": "^2.1.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.23.9",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -36,7 +36,7 @@
     "@rjsf/core": "^5.18.x",
     "@rjsf/utils": "^5.18.x",
     "react": "^16.14.0 || >=17",
-    "semantic-ui-react": "^2.1.3"
+    "semantic-ui-react": "^1.3.1 || ^2.1.3"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",
@@ -66,6 +66,7 @@
     "react-test-renderer": "^18.2.0",
     "rimraf": "^5.0.5",
     "rollup": "^3.29.4",
+    "semantic-ui-react": "^2.1.3",
     "typescript": "^4.9.5"
   },
   "publishConfig": {
@@ -93,7 +94,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "semantic-ui-css": "^2.5.0",
-    "semantic-ui-react": "^2.1.3"
+    "semantic-ui-css": "^2.5.0"
   }
 }


### PR DESCRIPTION
### Reasons for making this change

- In `@rjsf/semantic-ui` - added back `semantic-ui-react` version `^1.3.1` to the peer dependencies
  - Also made `semantic-ui-react` a devDependency for `^2.1.3`
- In the playground, added `semantic-ui-react@2.1.3` due to the transition of `semantic-ui-react` as a devDependency
- Updated `CHANGELOG.md` accordlingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
