### PR TITLE
treat default field in additionalProperties

### DIFF
--- a/packages/core/src/components/fields/ObjectField.tsx
+++ b/packages/core/src/components/fields/ObjectField.tsx
@@ -202,13 +202,16 @@ class ObjectField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
     const newFormData = { ...formData } as T;
 
     let type: RJSFSchema['type'] = undefined;
+    let defaultValue: RJSFSchema['default'] = undefined;
     if (isObject(schema.additionalProperties)) {
       type = schema.additionalProperties.type;
+      defaultValue = schema.additionalProperties.default;
       let apSchema = schema.additionalProperties;
       if (REF_KEY in apSchema) {
         const { schemaUtils } = registry;
         apSchema = schemaUtils.retrieveSchema({ $ref: apSchema[REF_KEY] } as S, formData);
         type = apSchema.type;
+        defaultValue = apSchema.default;
       }
       if (!type && (ANY_OF_KEY in apSchema || ONE_OF_KEY in apSchema)) {
         type = 'object';
@@ -217,7 +220,7 @@ class ObjectField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
 
     const newKey = this.getAvailableKey('newKey', newFormData);
     // Cast this to make the `set` work properly
-    set(newFormData as GenericObjectType, newKey, this.getDefaultValue(type));
+    set(newFormData as GenericObjectType, newKey, defaultValue ?? this.getDefaultValue(type));
 
     onChange(newFormData);
   };

--- a/packages/core/test/ObjectField.test.jsx
+++ b/packages/core/test/ObjectField.test.jsx
@@ -896,6 +896,50 @@ describe('ObjectField', () => {
       });
     });
 
+    it("should add a new default item if default is provided in the additionalProperties' schema", () => {
+      const customSchema = {
+        ...schema,
+        additionalProperties: {
+          type: 'string',
+          default: 'default value',
+        },
+      };
+      const { node, onChange } = createFormComponent({
+        schema: customSchema,
+        formData: {},
+      });
+
+      fireEvent.click(node.querySelector('.object-property-expand button'));
+
+      sinon.assert.calledWithMatch(onChange.lastCall, {
+        formData: {
+          newKey: 'default value',
+        },
+      });
+    });
+
+    it('should add a new default item even if the schema of default value is invalid', () => {
+      const customSchema = {
+        ...schema,
+        additionalProperties: {
+          type: 'string',
+          default: 1,
+        },
+      };
+      const { node, onChange } = createFormComponent({
+        schema: customSchema,
+        formData: {},
+      });
+
+      fireEvent.click(node.querySelector('.object-property-expand button'));
+
+      sinon.assert.calledWithMatch(onChange.lastCall, {
+        formData: {
+          newKey: 1,
+        },
+      });
+    });
+
     it('should not provide an expand button if length equals maxProperties', () => {
       const { node } = createFormComponent({
         schema: { maxProperties: 1, ...schema },


### PR DESCRIPTION
### Reasons for making this change

feat #3915

Before this PR, adding a 'default' field to 'additionalProperty' did not affect the functionality. With this change, label/value will be added with the value specified in 'default' of 'additionalProperty'.

```ts
// sample schema

const schema = {
  type: "object",
  additionalProperties: {
    type: "string",
    default: "sample default"
  }
}
```

#### ⚠️ Note

If a default value that does not conform to the schema is provided, the label/value will be added with that default value.

```ts
const schema = {
  type: "object",
  additionalProperties: {
    type: "string",
    default: 1
  }
}
```

In the above example, if an item is added, a label/value with the value `1` will be added.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown 
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
