### PR TITLE
Remove duplicate mention of hideError

### DIFF
--- a/packages/docs/docs/advanced-customization/custom-templates.md
+++ b/packages/docs/docs/advanced-customization/custom-templates.md
@@ -634,7 +634,6 @@ The following props are passed to a custom field template component:
 - `description`: A component instance rendering the field description, if one is defined (this will use any [custom `DescriptionFieldTemplate`](#descriptionfieldtemplate) defined in the `templates` passed to the `Form`).
 - `rawDescription`: A string containing any `ui:description` uiSchema directive defined.
 - `children`: The field or widget component instance for this field row.
-- `hideError`: A boolean value stating if the field is hiding its errors.
 - `errors`: A component instance listing any encountered errors for this field.
 - `rawErrors`: An array of strings listing all generated error messages from encountered errors for this field.
 - `help`: A component instance rendering any `ui:help` uiSchema directive defined.


### PR DESCRIPTION
### Reasons for making this change

`hideError` option is already mentioned in the same section in https://github.com/rjsf-team/react-jsonschema-form/blob/e63f8aea75c872ed6e71c19a95899452b28650a9/packages/docs/docs/advanced-customization/custom-templates.md?plain=1#L644

### Checklist

- [X] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added