### PR TITLE
fix(antd): disabled property of options of antd theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/antd
 
-- Fix disabled property of options in CheckboxesWidget and RadioWidgep ([#4216](https://github.com/rjsf-team/react-jsonschema-form/pull/4216))
+- Fix disabled property of options in CheckboxesWidget and RadioWidget ([#4216](https://github.com/rjsf-team/react-jsonschema-form/pull/4216))
 
 # 5.18.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.18.6
+
+## @rjsf/antd
+
+- Fix disabled property of options in CheckboxesWidget and RadioWidgep ([#4216](https://github.com/rjsf-team/react-jsonschema-form/pull/4216))
+
 # 5.18.5
 
 ## @rjsf/antd

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ If your PR is non-trivial and you'd like to schedule a synchronous review, pleas
 - [ ] **I'm updating documentation**
   - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
 - [ ] **I'm adding or updating code**
-  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
+  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
   - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
   - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
 - [ ] **I'm adding a new feature**

--- a/packages/antd/src/widgets/CheckboxesWidget/index.tsx
+++ b/packages/antd/src/widgets/CheckboxesWidget/index.tsx
@@ -61,7 +61,7 @@ export default function CheckboxesWidget<
                 id={optionId(id, i)}
                 name={id}
                 autoFocus={i === 0 ? autofocus : false}
-                disabled={Array.isArray(enumDisabled) && enumDisabled.indexOf(value) !== -1}
+                disabled={Array.isArray(enumDisabled) && enumDisabled.indexOf(option.value) !== -1}
                 value={String(i)}
               >
                 {option.label}

--- a/packages/antd/src/widgets/RadioWidget/index.tsx
+++ b/packages/antd/src/widgets/RadioWidget/index.tsx
@@ -61,7 +61,7 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
             id={optionId(id, i)}
             name={id}
             autoFocus={i === 0 ? autofocus : false}
-            disabled={Array.isArray(enumDisabled) && enumDisabled.indexOf(value) !== -1}
+            disabled={Array.isArray(enumDisabled) && enumDisabled.indexOf(option.value) !== -1}
             key={i}
             value={String(i)}
           >

--- a/packages/antd/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Form.test.tsx.snap
@@ -2674,6 +2674,181 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
 </form>
 `;
 
+exports[`single fields select field multiple choice enumDisabled using checkboxes 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-array"
+  >
+    <div
+      className="ant-form-item css-dev-only-do-not-override-1b0bdye"
+    >
+      <div
+        className="ant-row ant-form-item-row css-dev-only-do-not-override-1b0bdye"
+        style={
+          {
+            "rowGap": undefined,
+          }
+        }
+      >
+        <div
+          className="ant-col ant-col-24 ant-form-item-control css-dev-only-do-not-override-1b0bdye"
+          style={{}}
+        >
+          <div
+            className="ant-form-item-control-input"
+          >
+            <div
+              className="ant-form-item-control-input-content"
+            >
+              <div
+                aria-describedby="root__error root__description root__help"
+                className="ant-checkbox-group css-dev-only-do-not-override-1b0bdye"
+                id="root"
+                name="root"
+                onBlur={[Function]}
+                onFocus={[Function]}
+              >
+                <span>
+                  <label
+                    className="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item css-dev-only-do-not-override-1b0bdye"
+                    style={{}}
+                  >
+                    <span
+                      className="ant-checkbox ant-wave-target css-dev-only-do-not-override-1b0bdye"
+                    >
+                      <input
+                        autoFocus={false}
+                        checked={false}
+                        className="ant-checkbox-input"
+                        disabled={false}
+                        id="root-0"
+                        name="root"
+                        onChange={[Function]}
+                        type="checkbox"
+                        value="0"
+                      />
+                      <span
+                        className="ant-checkbox-inner"
+                      />
+                    </span>
+                    <span>
+                      foo
+                    </span>
+                  </label>
+                  <br />
+                </span>
+                <span>
+                  <label
+                    className="ant-checkbox-wrapper ant-checkbox-wrapper-disabled ant-checkbox-wrapper-in-form-item css-dev-only-do-not-override-1b0bdye"
+                    style={{}}
+                  >
+                    <span
+                      className="ant-checkbox ant-wave-target css-dev-only-do-not-override-1b0bdye ant-checkbox-disabled"
+                    >
+                      <input
+                        autoFocus={false}
+                        checked={false}
+                        className="ant-checkbox-input"
+                        disabled={true}
+                        id="root-1"
+                        name="root"
+                        onChange={[Function]}
+                        type="checkbox"
+                        value="1"
+                      />
+                      <span
+                        className="ant-checkbox-inner"
+                      />
+                    </span>
+                    <span>
+                      bar
+                    </span>
+                  </label>
+                  <br />
+                </span>
+                <span>
+                  <label
+                    className="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item css-dev-only-do-not-override-1b0bdye"
+                    style={{}}
+                  >
+                    <span
+                      className="ant-checkbox ant-wave-target css-dev-only-do-not-override-1b0bdye"
+                    >
+                      <input
+                        autoFocus={false}
+                        checked={false}
+                        className="ant-checkbox-input"
+                        disabled={false}
+                        id="root-2"
+                        name="root"
+                        onChange={[Function]}
+                        type="checkbox"
+                        value="2"
+                      />
+                      <span
+                        className="ant-checkbox-inner"
+                      />
+                    </span>
+                    <span>
+                      fuzz
+                    </span>
+                  </label>
+                  <br />
+                </span>
+                <span>
+                  <label
+                    className="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item css-dev-only-do-not-override-1b0bdye"
+                    style={{}}
+                  >
+                    <span
+                      className="ant-checkbox ant-wave-target css-dev-only-do-not-override-1b0bdye"
+                    >
+                      <input
+                        autoFocus={false}
+                        checked={false}
+                        className="ant-checkbox-input"
+                        disabled={false}
+                        id="root-3"
+                        name="root"
+                        onChange={[Function]}
+                        type="checkbox"
+                        value="3"
+                      />
+                      <span
+                        className="ant-checkbox-inner"
+                      />
+                    </span>
+                    <span>
+                      qux
+                    </span>
+                  </label>
+                  <br />
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="ant-btn css-dev-only-do-not-override-1b0bdye ant-btn-submit"
+    disabled={false}
+    onClick={[Function]}
+    style={{}}
+    type="submit"
+  >
+    <span>
+      Submit
+    </span>
+  </button>
+</form>
+`;
+
 exports[`single fields select field multiple choice formData 1`] = `
 <form
   className="rjsf"
@@ -3248,6 +3423,116 @@ exports[`single fields select field single choice enumDisabled 1`] = `
                     </svg>
                   </span>
                 </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="ant-btn css-dev-only-do-not-override-1b0bdye ant-btn-submit"
+    disabled={false}
+    onClick={[Function]}
+    style={{}}
+    type="submit"
+  >
+    <span>
+      Submit
+    </span>
+  </button>
+</form>
+`;
+
+exports[`single fields select field single choice enumDisabled using radio widget 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <div
+      className="ant-form-item css-dev-only-do-not-override-1b0bdye"
+    >
+      <div
+        className="ant-row ant-form-item-row css-dev-only-do-not-override-1b0bdye"
+        style={
+          {
+            "rowGap": undefined,
+          }
+        }
+      >
+        <div
+          className="ant-col ant-col-24 ant-form-item-control css-dev-only-do-not-override-1b0bdye"
+          style={{}}
+        >
+          <div
+            className="ant-form-item-control-input"
+          >
+            <div
+              className="ant-form-item-control-input-content"
+            >
+              <div
+                aria-describedby="root__error root__description root__help"
+                className="ant-radio-group ant-radio-group-outline css-dev-only-do-not-override-1b0bdye"
+                id="root"
+                onBlur={[Function]}
+                onFocus={[Function]}
+              >
+                <label
+                  className="ant-radio-wrapper ant-radio-wrapper-in-form-item css-dev-only-do-not-override-1b0bdye"
+                  style={{}}
+                >
+                  <span
+                    className="ant-radio ant-wave-target"
+                  >
+                    <input
+                      autoFocus={false}
+                      checked={false}
+                      className="ant-radio-input"
+                      disabled={false}
+                      id="root-0"
+                      name="root"
+                      onChange={[Function]}
+                      type="radio"
+                      value="0"
+                    />
+                    <span
+                      className="ant-radio-inner"
+                    />
+                  </span>
+                  <span>
+                    foo
+                  </span>
+                </label>
+                <label
+                  className="ant-radio-wrapper ant-radio-wrapper-disabled ant-radio-wrapper-in-form-item css-dev-only-do-not-override-1b0bdye"
+                  style={{}}
+                >
+                  <span
+                    className="ant-radio ant-wave-target ant-radio-disabled"
+                  >
+                    <input
+                      autoFocus={false}
+                      checked={false}
+                      className="ant-radio-input"
+                      disabled={true}
+                      id="root-1"
+                      name="root"
+                      onChange={[Function]}
+                      type="radio"
+                      value="1"
+                    />
+                    <span
+                      className="ant-radio-inner"
+                    />
+                  </span>
+                  <span>
+                    bar
+                  </span>
+                </label>
               </div>
             </div>
           </div>

--- a/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/bootstrap-4/test/__snapshots__/Form.test.tsx.snap
@@ -1303,6 +1303,140 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
 </form>
 `;
 
+exports[`single fields select field multiple choice enumDisabled using checkboxes 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-array"
+  >
+    <div
+      className="form-group"
+    >
+      <label
+        className="form-label"
+        htmlFor="root"
+      />
+      <div
+        className="form-group"
+      >
+        <div
+          className="bg-transparent border-0 custom-control custom-checkbox"
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            autoFocus={false}
+            checked={false}
+            className="custom-control-input"
+            disabled={false}
+            id="root-0"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={false}
+            type="checkbox"
+          />
+          <label
+            className="custom-control-label"
+            htmlFor="root-0"
+            title=""
+          >
+            foo
+          </label>
+        </div>
+        <div
+          className="bg-transparent border-0 custom-control custom-checkbox"
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            autoFocus={false}
+            checked={false}
+            className="custom-control-input"
+            disabled={true}
+            id="root-1"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={false}
+            type="checkbox"
+          />
+          <label
+            className="custom-control-label"
+            htmlFor="root-1"
+            title=""
+          >
+            bar
+          </label>
+        </div>
+        <div
+          className="bg-transparent border-0 custom-control custom-checkbox"
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            autoFocus={false}
+            checked={false}
+            className="custom-control-input"
+            disabled={false}
+            id="root-2"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={false}
+            type="checkbox"
+          />
+          <label
+            className="custom-control-label"
+            htmlFor="root-2"
+            title=""
+          >
+            fuzz
+          </label>
+        </div>
+        <div
+          className="bg-transparent border-0 custom-control custom-checkbox"
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            autoFocus={false}
+            checked={false}
+            className="custom-control-input"
+            disabled={false}
+            id="root-3"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={false}
+            type="checkbox"
+          />
+          <label
+            className="custom-control-label"
+            htmlFor="root-3"
+            title=""
+          >
+            qux
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields select field multiple choice formData 1`] = `
 <form
   className="rjsf"
@@ -1493,6 +1627,88 @@ exports[`single fields select field single choice enumDisabled 1`] = `
           bar
         </option>
       </select>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields select field single choice enumDisabled using radio widget 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <div
+      className="form-group"
+    >
+      <label
+        className="form-label"
+        htmlFor="root"
+      />
+      <div
+        className="mb-0 form-group"
+      >
+        <div
+          className="form-check"
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            checked={false}
+            className="form-check-input"
+            disabled={false}
+            id="root-0"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="radio"
+            value="0"
+          />
+          <label
+            className="form-check-label"
+            htmlFor="root-0"
+            title=""
+          >
+            foo
+          </label>
+        </div>
+        <div
+          className="form-check"
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            checked={false}
+            className="form-check-input"
+            disabled={true}
+            id="root-1"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="radio"
+            value="1"
+          />
+          <label
+            className="form-check-label"
+            htmlFor="root-1"
+            title=""
+          >
+            bar
+          </label>
+        </div>
+      </div>
     </div>
   </div>
   <div>

--- a/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
@@ -3312,6 +3312,365 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
 </form>
 `;
 
+exports[`single fields select field multiple choice enumDisabled using checkboxes 1`] = `
+.emotion-1 {
+  margin-bottom: 1px;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-2>*:not(style)~*:not(style) {
+  margin-top: 0.5rem;
+  -webkit-margin-end: 0px;
+  margin-inline-end: 0px;
+  margin-bottom: 0px;
+  -webkit-margin-start: 0px;
+  margin-inline-start: 0px;
+}
+
+.emotion-3 {
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  vertical-align: top;
+  position: relative;
+}
+
+.emotion-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  vertical-align: top;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-5 {
+  -webkit-margin-start: 0.5rem;
+  margin-inline-start: 0.5rem;
+}
+
+.emotion-19 {
+  margin-top: 3px;
+}
+
+.emotion-20 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  position: relative;
+  white-space: nowrap;
+  vertical-align: middle;
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  width: auto;
+}
+
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-array"
+  >
+    <div
+      className="chakra-form-control emotion-0"
+      role="group"
+    >
+      <div
+        className="chakra-form-control emotion-1"
+        role="group"
+      >
+        <div
+          className="chakra-stack emotion-2"
+        >
+          <label
+            className="chakra-checkbox emotion-3"
+            onClick={[Function]}
+          >
+            <input
+              aria-disabled={false}
+              aria-invalid={false}
+              checked={false}
+              className="chakra-checkbox__input"
+              disabled={false}
+              id="root-0"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              readOnly={false}
+              required={false}
+              style={
+                {
+                  "border": "0px",
+                  "clip": "rect(0px, 0px, 0px, 0px)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0px",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+              type="checkbox"
+              value="0"
+            />
+            <span
+              aria-hidden={true}
+              className="chakra-checkbox__control emotion-4"
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+            />
+            <span
+              className="chakra-checkbox__label emotion-5"
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            >
+              <p
+                className="chakra-text emotion-0"
+              >
+                foo
+              </p>
+            </span>
+          </label>
+          <label
+            className="chakra-checkbox emotion-3"
+            data-disabled=""
+            onClick={[Function]}
+          >
+            <input
+              aria-disabled={true}
+              aria-invalid={false}
+              checked={false}
+              className="chakra-checkbox__input"
+              disabled={true}
+              id="root-1"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              readOnly={false}
+              required={false}
+              style={
+                {
+                  "border": "0px",
+                  "clip": "rect(0px, 0px, 0px, 0px)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0px",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+              type="checkbox"
+              value="1"
+            />
+            <span
+              aria-hidden={true}
+              className="chakra-checkbox__control emotion-4"
+              data-disabled=""
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+            />
+            <span
+              className="chakra-checkbox__label emotion-5"
+              data-disabled=""
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            >
+              <p
+                className="chakra-text emotion-0"
+              >
+                bar
+              </p>
+            </span>
+          </label>
+          <label
+            className="chakra-checkbox emotion-3"
+            onClick={[Function]}
+          >
+            <input
+              aria-disabled={false}
+              aria-invalid={false}
+              checked={false}
+              className="chakra-checkbox__input"
+              disabled={false}
+              id="root-2"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              readOnly={false}
+              required={false}
+              style={
+                {
+                  "border": "0px",
+                  "clip": "rect(0px, 0px, 0px, 0px)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0px",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+              type="checkbox"
+              value="2"
+            />
+            <span
+              aria-hidden={true}
+              className="chakra-checkbox__control emotion-4"
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+            />
+            <span
+              className="chakra-checkbox__label emotion-5"
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            >
+              <p
+                className="chakra-text emotion-0"
+              >
+                fuzz
+              </p>
+            </span>
+          </label>
+          <label
+            className="chakra-checkbox emotion-3"
+            onClick={[Function]}
+          >
+            <input
+              aria-disabled={false}
+              aria-invalid={false}
+              checked={false}
+              className="chakra-checkbox__input"
+              disabled={false}
+              id="root-3"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              readOnly={false}
+              required={false}
+              style={
+                {
+                  "border": "0px",
+                  "clip": "rect(0px, 0px, 0px, 0px)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0px",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                }
+              }
+              type="checkbox"
+              value="3"
+            />
+            <span
+              aria-hidden={true}
+              className="chakra-checkbox__control emotion-4"
+              onMouseDown={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+            />
+            <span
+              className="chakra-checkbox__label emotion-5"
+              onMouseDown={[Function]}
+              onTouchStart={[Function]}
+            >
+              <p
+                className="chakra-text emotion-0"
+              >
+                qux
+              </p>
+            </span>
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="emotion-19"
+  >
+    <button
+      className="chakra-button emotion-20"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields select field multiple choice formData 1`] = `
 .emotion-1 {
   margin-bottom: 1px;
@@ -4381,6 +4740,246 @@ exports[`single fields select field single choice enumDisabled 1`] = `
   >
     <button
       className="chakra-button emotion-15"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields select field single choice enumDisabled using radio widget 1`] = `
+.emotion-1 {
+  margin-bottom: 1px;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.emotion-3>*:not(style)~*:not(style) {
+  margin-top: 0.5rem;
+  -webkit-margin-end: 0px;
+  margin-inline-end: 0px;
+  margin-bottom: 0px;
+  -webkit-margin-start: 0px;
+  margin-inline-start: 0px;
+}
+
+.emotion-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  vertical-align: top;
+  cursor: pointer;
+}
+
+.emotion-5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.emotion-6 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  -webkit-margin-start: 0.5rem;
+  margin-inline-start: 0.5rem;
+}
+
+.emotion-10 {
+  margin-top: 3px;
+}
+
+.emotion-11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  appearance: none;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  position: relative;
+  white-space: nowrap;
+  vertical-align: middle;
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  width: auto;
+}
+
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <div
+      className="chakra-form-control emotion-0"
+      role="group"
+    >
+      <div
+        className="chakra-form-control emotion-1"
+        role="group"
+      >
+        <div
+          aria-describedby="root__error root__description root__help"
+          className="chakra-radio-group emotion-0"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          role="radiogroup"
+        >
+          <div
+            className="chakra-stack emotion-3"
+          >
+            <label
+              className="chakra-radio emotion-4"
+            >
+              <input
+                checked={false}
+                className="chakra-radio__input"
+                disabled={false}
+                id="root-0"
+                name="root"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                readOnly={false}
+                required={false}
+                style={
+                  {
+                    "border": "0px",
+                    "clip": "rect(0px, 0px, 0px, 0px)",
+                    "height": "1px",
+                    "margin": "-1px",
+                    "overflow": "hidden",
+                    "padding": "0px",
+                    "position": "absolute",
+                    "whiteSpace": "nowrap",
+                    "width": "1px",
+                  }
+                }
+                type="radio"
+                value="0"
+              />
+              <span
+                aria-hidden={true}
+                className="chakra-radio__control emotion-5"
+                disabled={false}
+                onMouseDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+              />
+              <span
+                className="chakra-radio__label emotion-6"
+                onMouseDown={[Function]}
+                onTouchStart={[Function]}
+              >
+                foo
+              </span>
+            </label>
+            <label
+              className="chakra-radio emotion-4"
+            >
+              <input
+                checked={false}
+                className="chakra-radio__input"
+                disabled={false}
+                id="root-1"
+                name="root"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                readOnly={false}
+                required={false}
+                style={
+                  {
+                    "border": "0px",
+                    "clip": "rect(0px, 0px, 0px, 0px)",
+                    "height": "1px",
+                    "margin": "-1px",
+                    "overflow": "hidden",
+                    "padding": "0px",
+                    "position": "absolute",
+                    "whiteSpace": "nowrap",
+                    "width": "1px",
+                  }
+                }
+                type="radio"
+                value="1"
+              />
+              <span
+                aria-hidden={true}
+                className="chakra-radio__control emotion-5"
+                disabled={true}
+                onMouseDown={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                onMouseUp={[Function]}
+              />
+              <span
+                className="chakra-radio__label emotion-6"
+                onMouseDown={[Function]}
+                onTouchStart={[Function]}
+              >
+                bar
+              </span>
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="emotion-10"
+  >
+    <button
+      className="chakra-button emotion-11"
       disabled={false}
       type="submit"
     >

--- a/packages/core/test/__snapshots__/FormSnap.test.jsx.snap
+++ b/packages/core/test/__snapshots__/FormSnap.test.jsx.snap
@@ -1074,6 +1074,129 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
 </form>
 `;
 
+exports[`single fields select field multiple choice enumDisabled using checkboxes 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-array"
+  >
+    <div
+      className="checkboxes"
+      id="root"
+    >
+      <div
+        className="checkbox "
+      >
+        <label>
+          <span>
+            <input
+              aria-describedby="root__error root__description root__help"
+              autoFocus={false}
+              checked={false}
+              disabled={false}
+              id="root-0"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              type="checkbox"
+              value="0"
+            />
+            <span>
+              foo
+            </span>
+          </span>
+        </label>
+      </div>
+      <div
+        className="checkbox disabled"
+      >
+        <label>
+          <span>
+            <input
+              aria-describedby="root__error root__description root__help"
+              autoFocus={false}
+              checked={false}
+              disabled={true}
+              id="root-1"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              type="checkbox"
+              value="1"
+            />
+            <span>
+              bar
+            </span>
+          </span>
+        </label>
+      </div>
+      <div
+        className="checkbox "
+      >
+        <label>
+          <span>
+            <input
+              aria-describedby="root__error root__description root__help"
+              autoFocus={false}
+              checked={false}
+              disabled={false}
+              id="root-2"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              type="checkbox"
+              value="2"
+            />
+            <span>
+              fuzz
+            </span>
+          </span>
+        </label>
+      </div>
+      <div
+        className="checkbox "
+      >
+        <label>
+          <span>
+            <input
+              aria-describedby="root__error root__description root__help"
+              autoFocus={false}
+              checked={false}
+              disabled={false}
+              id="root-3"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              type="checkbox"
+              value="3"
+            />
+            <span>
+              qux
+            </span>
+          </span>
+        </label>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-info "
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields select field multiple choice formData 1`] = `
 <form
   className="rjsf"
@@ -1226,6 +1349,81 @@ exports[`single fields select field single choice enumDisabled 1`] = `
         bar
       </option>
     </select>
+  </div>
+  <div>
+    <button
+      className="btn btn-info "
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields select field single choice enumDisabled using radio widget 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <div
+      className="field-radio-group"
+      id="root"
+    >
+      <div
+        className="radio "
+      >
+        <label>
+          <span>
+            <input
+              aria-describedby="root__error root__description root__help"
+              autoFocus={false}
+              checked={false}
+              disabled={false}
+              id="root-0"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              type="radio"
+              value="0"
+            />
+            <span>
+              foo
+            </span>
+          </span>
+        </label>
+      </div>
+      <div
+        className="radio disabled"
+      >
+        <label>
+          <span>
+            <input
+              aria-describedby="root__error root__description root__help"
+              autoFocus={false}
+              checked={false}
+              disabled={true}
+              id="root-1"
+              name="root"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              type="radio"
+              value="1"
+            />
+            <span>
+              bar
+            </span>
+          </span>
+        </label>
+      </div>
+    </div>
   </div>
   <div>
     <button

--- a/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluent-ui/test/__snapshots__/Form.test.tsx.snap
@@ -15,13 +15,13 @@ exports[`single fields checkbox field 1`] = `
     }
   >
     <div
-      className="ms-Checkbox is-enabled root-202"
+      className="ms-Checkbox is-enabled root-210"
     >
       <input
         aria-disabled={false}
         autoFocus={false}
         checked={false}
-        className="input-203"
+        className="input-211"
         data-ktp-execute-target={true}
         disabled={false}
         id="root"
@@ -32,16 +32,16 @@ exports[`single fields checkbox field 1`] = `
         type="checkbox"
       />
       <label
-        className="ms-Checkbox-label label-204"
+        className="ms-Checkbox-label label-212"
         htmlFor="root"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-205"
+          className="ms-Checkbox-checkbox checkbox-213"
           data-ktp-target={true}
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-208"
+            className="ms-Checkbox-checkmark checkmark-216"
             data-icon-name="CheckMark"
           >
             
@@ -75,7 +75,7 @@ exports[`single fields checkbox field 1`] = `
           >
             <span
               className="ms-Button-label label-126"
-              id="id__169"
+              id="id__177"
             >
               Submit
             </span>
@@ -102,13 +102,13 @@ exports[`single fields checkbox field with label 1`] = `
     }
   >
     <div
-      className="ms-Checkbox is-enabled root-202"
+      className="ms-Checkbox is-enabled root-210"
     >
       <input
         aria-disabled={false}
         autoFocus={false}
         checked={false}
-        className="input-203"
+        className="input-211"
         data-ktp-execute-target={true}
         disabled={false}
         id="root"
@@ -119,23 +119,23 @@ exports[`single fields checkbox field with label 1`] = `
         type="checkbox"
       />
       <label
-        className="ms-Checkbox-label label-204"
+        className="ms-Checkbox-label label-212"
         htmlFor="root"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-205"
+          className="ms-Checkbox-checkbox checkbox-213"
           data-ktp-target={true}
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-208"
+            className="ms-Checkbox-checkmark checkmark-216"
             data-icon-name="CheckMark"
           >
             
           </i>
         </div>
         <span
-          className="ms-Checkbox-text text-207"
+          className="ms-Checkbox-text text-215"
         >
           test
         </span>
@@ -167,7 +167,7 @@ exports[`single fields checkbox field with label 1`] = `
           >
             <span
               className="ms-Button-label label-126"
-              id="id__172"
+              id="id__180"
             >
               Submit
             </span>
@@ -199,13 +199,13 @@ exports[`single fields checkboxes field 1`] = `
       An enum list rendered as checkboxes
     </label>
     <div
-      className="ms-Checkbox is-enabled root-202"
+      className="ms-Checkbox is-enabled root-210"
     >
       <input
         aria-disabled={false}
         autoFocus={false}
         checked={false}
-        className="input-203"
+        className="input-211"
         data-ktp-execute-target={true}
         disabled={false}
         id="root-0"
@@ -216,36 +216,36 @@ exports[`single fields checkboxes field 1`] = `
         type="checkbox"
       />
       <label
-        className="ms-Checkbox-label label-204"
+        className="ms-Checkbox-label label-212"
         htmlFor="root-0"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-205"
+          className="ms-Checkbox-checkbox checkbox-213"
           data-ktp-target={true}
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-208"
+            className="ms-Checkbox-checkmark checkmark-216"
             data-icon-name="CheckMark"
           >
             
           </i>
         </div>
         <span
-          className="ms-Checkbox-text text-207"
+          className="ms-Checkbox-text text-215"
         >
           foo
         </span>
       </label>
     </div>
     <div
-      className="ms-Checkbox is-enabled root-202"
+      className="ms-Checkbox is-enabled root-210"
     >
       <input
         aria-disabled={false}
         autoFocus={false}
         checked={false}
-        className="input-203"
+        className="input-211"
         data-ktp-execute-target={true}
         disabled={false}
         id="root-1"
@@ -256,36 +256,36 @@ exports[`single fields checkboxes field 1`] = `
         type="checkbox"
       />
       <label
-        className="ms-Checkbox-label label-204"
+        className="ms-Checkbox-label label-212"
         htmlFor="root-1"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-205"
+          className="ms-Checkbox-checkbox checkbox-213"
           data-ktp-target={true}
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-208"
+            className="ms-Checkbox-checkmark checkmark-216"
             data-icon-name="CheckMark"
           >
             
           </i>
         </div>
         <span
-          className="ms-Checkbox-text text-207"
+          className="ms-Checkbox-text text-215"
         >
           bar
         </span>
       </label>
     </div>
     <div
-      className="ms-Checkbox is-enabled root-202"
+      className="ms-Checkbox is-enabled root-210"
     >
       <input
         aria-disabled={false}
         autoFocus={false}
         checked={false}
-        className="input-203"
+        className="input-211"
         data-ktp-execute-target={true}
         disabled={false}
         id="root-2"
@@ -296,36 +296,36 @@ exports[`single fields checkboxes field 1`] = `
         type="checkbox"
       />
       <label
-        className="ms-Checkbox-label label-204"
+        className="ms-Checkbox-label label-212"
         htmlFor="root-2"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-205"
+          className="ms-Checkbox-checkbox checkbox-213"
           data-ktp-target={true}
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-208"
+            className="ms-Checkbox-checkmark checkmark-216"
             data-icon-name="CheckMark"
           >
             
           </i>
         </div>
         <span
-          className="ms-Checkbox-text text-207"
+          className="ms-Checkbox-text text-215"
         >
           fuzz
         </span>
       </label>
     </div>
     <div
-      className="ms-Checkbox is-enabled root-202"
+      className="ms-Checkbox is-enabled root-210"
     >
       <input
         aria-disabled={false}
         autoFocus={false}
         checked={false}
-        className="input-203"
+        className="input-211"
         data-ktp-execute-target={true}
         disabled={false}
         id="root-3"
@@ -336,23 +336,23 @@ exports[`single fields checkboxes field 1`] = `
         type="checkbox"
       />
       <label
-        className="ms-Checkbox-label label-204"
+        className="ms-Checkbox-label label-212"
         htmlFor="root-3"
       >
         <div
-          className="ms-Checkbox-checkbox checkbox-205"
+          className="ms-Checkbox-checkbox checkbox-213"
           data-ktp-target={true}
         >
           <i
             aria-hidden={true}
-            className="ms-Checkbox-checkmark checkmark-208"
+            className="ms-Checkbox-checkmark checkmark-216"
             data-icon-name="CheckMark"
           >
             
           </i>
         </div>
         <span
-          className="ms-Checkbox-text text-207"
+          className="ms-Checkbox-text text-215"
         >
           qux
         </span>
@@ -394,7 +394,7 @@ exports[`single fields checkboxes field 1`] = `
           >
             <span
               className="ms-Button-label label-126"
-              id="id__175"
+              id="id__183"
             >
               Submit
             </span>
@@ -407,124 +407,6 @@ exports[`single fields checkboxes field 1`] = `
 `;
 
 exports[`single fields field with description 1`] = `
-<form
-  className="rjsf"
-  noValidate={false}
-  onSubmit={[Function]}
->
-  <div
-    className="ms-Grid-col ms-sm12  field field-object"
-    style={
-      {
-        "marginBottom": 15,
-      }
-    }
-  >
-    <div
-      className="ms-Grid"
-      dir="ltr"
-    >
-      <div
-        className="ms-Grid-row"
-      >
-        <div
-          className="ms-Grid-col ms-sm12  field field-string"
-          style={
-            {
-              "marginBottom": 15,
-            }
-          }
-        >
-          <div
-            className="ms-TextField root-111"
-          >
-            <div
-              className="ms-TextField-wrapper"
-            >
-              <label
-                className="ms-Label root-130"
-                htmlFor="root_my-field"
-                id="TextFieldLabel191"
-              >
-                my-field
-              </label>
-              <div
-                className="ms-TextField-fieldGroup fieldGroup-112"
-              >
-                <input
-                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
-                  aria-invalid={false}
-                  aria-labelledby="TextFieldLabel191"
-                  autoFocus={false}
-                  className="ms-TextField-field field-113"
-                  disabled={false}
-                  id="root_my-field"
-                  name="root_my-field"
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onInput={[Function]}
-                  placeholder=""
-                  readOnly={false}
-                  required={false}
-                  type="text"
-                  value=""
-                />
-              </div>
-            </div>
-          </div>
-          <span
-            className="css-230"
-          >
-            <span
-              className="css-230"
-              id="root_my-field__description"
-            >
-              some description
-            </span>
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <br />
-    <div
-      className="ms-Grid-col ms-sm12"
-    >
-      <button
-        className="ms-Button ms-Button--primary root-122"
-        data-is-focusable={true}
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        type="submit"
-      >
-        <span
-          className="ms-Button-flexContainer flexContainer-123"
-          data-automationid="splitbuttonprimary"
-        >
-          <span
-            className="ms-Button-textContainer textContainer-124"
-          >
-            <span
-              className="ms-Button-label label-126"
-              id="id__194"
-            >
-              Submit
-            </span>
-          </span>
-        </span>
-      </button>
-    </div>
-  </div>
-</form>
-`;
-
-exports[`single fields field with description in uiSchema 1`] = `
 <form
   className="rjsf"
   noValidate={false}
@@ -592,10 +474,128 @@ exports[`single fields field with description in uiSchema 1`] = `
             </div>
           </div>
           <span
-            className="css-230"
+            className="css-237"
           >
             <span
-              className="css-230"
+              className="css-237"
+              id="root_my-field__description"
+            >
+              some description
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <br />
+    <div
+      className="ms-Grid-col ms-sm12"
+    >
+      <button
+        className="ms-Button ms-Button--primary root-122"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="submit"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-123"
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className="ms-Button-textContainer textContainer-124"
+          >
+            <span
+              className="ms-Button-label label-126"
+              id="id__202"
+            >
+              Submit
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`single fields field with description in uiSchema 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="ms-Grid-col ms-sm12  field field-object"
+    style={
+      {
+        "marginBottom": 15,
+      }
+    }
+  >
+    <div
+      className="ms-Grid"
+      dir="ltr"
+    >
+      <div
+        className="ms-Grid-row"
+      >
+        <div
+          className="ms-Grid-col ms-sm12  field field-string"
+          style={
+            {
+              "marginBottom": 15,
+            }
+          }
+        >
+          <div
+            className="ms-TextField root-111"
+          >
+            <div
+              className="ms-TextField-wrapper"
+            >
+              <label
+                className="ms-Label root-130"
+                htmlFor="root_my-field"
+                id="TextFieldLabel207"
+              >
+                my-field
+              </label>
+              <div
+                className="ms-TextField-fieldGroup fieldGroup-112"
+              >
+                <input
+                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                  aria-invalid={false}
+                  aria-labelledby="TextFieldLabel207"
+                  autoFocus={false}
+                  className="ms-TextField-field field-113"
+                  disabled={false}
+                  id="root_my-field"
+                  name="root_my-field"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onInput={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <span
+            className="css-237"
+          >
+            <span
+              className="css-237"
               id="root_my-field__description"
             >
               some other description
@@ -630,7 +630,7 @@ exports[`single fields field with description in uiSchema 1`] = `
           >
             <span
               className="ms-Button-label label-126"
-              id="id__202"
+              id="id__210"
             >
               Submit
             </span>
@@ -1409,18 +1409,18 @@ exports[`single fields help and error display 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="ms-MessageBar ms-MessageBar--error ms-MessageBar-singleline root-232"
+    className="ms-MessageBar ms-MessageBar--error ms-MessageBar-singleline root-239"
   >
     <div
-      className="ms-MessageBar-content content-233"
+      className="ms-MessageBar-content content-240"
     >
       <div
         aria-hidden={true}
-        className="ms-MessageBar-icon iconContainer-234"
+        className="ms-MessageBar-icon iconContainer-241"
       >
         <i
           aria-hidden={true}
-          className="icon-242"
+          className="icon-249"
           data-icon-name="ErrorBadge"
         >
           
@@ -1428,12 +1428,12 @@ exports[`single fields help and error display 1`] = `
       </div>
       <div
         aria-live="assertive"
-        className="ms-MessageBar-text text-236"
-        id="MessageBar237"
+        className="ms-MessageBar-text text-243"
+        id="MessageBar245"
         role="alert"
       >
         <span
-          className="ms-MessageBar-innerText innerText-237"
+          className="ms-MessageBar-innerText innerText-244"
         />
       </div>
     </div>
@@ -1453,10 +1453,10 @@ exports[`single fields help and error display 1`] = `
         className="ms-TextField-wrapper"
       >
         <div
-          className="ms-TextField-fieldGroup fieldGroup-243"
+          className="ms-TextField-fieldGroup fieldGroup-250"
         >
           <input
-            aria-describedby="TextFieldDescription239"
+            aria-describedby="TextFieldDescription247"
             aria-invalid={true}
             autoFocus={false}
             className="ms-TextField-field field-113"
@@ -1475,7 +1475,7 @@ exports[`single fields help and error display 1`] = `
         </div>
       </div>
       <span
-        id="TextFieldDescription239"
+        id="TextFieldDescription247"
       >
         <div
           role="alert"
@@ -1506,7 +1506,7 @@ exports[`single fields help and error display 1`] = `
       </div>
     </div>
     <span
-      className="css-230"
+      className="css-237"
       id="root__help"
     >
       help me!
@@ -1537,7 +1537,7 @@ exports[`single fields help and error display 1`] = `
           >
             <span
               className="ms-Button-label label-126"
-              id="id__243"
+              id="id__251"
             >
               Submit
             </span>
@@ -1612,7 +1612,7 @@ exports[`single fields hidden field 1`] = `
           >
             <span
               className="ms-Button-label label-126"
-              id="id__186"
+              id="id__194"
             >
               Submit
             </span>
@@ -1693,7 +1693,7 @@ exports[`single fields hidden label 1`] = `
           >
             <span
               className="ms-Button-label label-126"
-              id="id__218"
+              id="id__226"
             >
               Submit
             </span>
@@ -2016,7 +2016,7 @@ exports[`single fields radio field 1`] = `
     }
   >
     <div
-      className="ms-ChoiceFieldGroup root-209"
+      className="ms-ChoiceFieldGroup root-201"
       id="root"
       name="root"
       onBlur={[Function]}
@@ -2030,7 +2030,7 @@ exports[`single fields radio field 1`] = `
           className="ms-ChoiceFieldGroup-flexContainer"
         >
           <div
-            className="ms-ChoiceField root-210"
+            className="ms-ChoiceField root-202"
           >
             <div
               className="ms-ChoiceField-wrapper"
@@ -2038,9 +2038,9 @@ exports[`single fields radio field 1`] = `
               <input
                 aria-describedby="root__error root__description root__help"
                 checked={false}
-                className="ms-ChoiceField-input input-211"
+                className="ms-ChoiceField-input input-203"
                 disabled={false}
-                id="ChoiceGroup178-0"
+                id="ChoiceGroup186-0"
                 name="root"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -2048,12 +2048,12 @@ exports[`single fields radio field 1`] = `
                 type="radio"
               />
               <label
-                className="ms-ChoiceField-field field-212"
-                htmlFor="ChoiceGroup178-0"
+                className="ms-ChoiceField-field field-204"
+                htmlFor="ChoiceGroup186-0"
               >
                 <span
                   className="ms-ChoiceFieldLabel"
-                  id="ChoiceGroupLabel179-0"
+                  id="ChoiceGroupLabel187-0"
                 >
                   Yes
                 </span>
@@ -2061,7 +2061,7 @@ exports[`single fields radio field 1`] = `
             </div>
           </div>
           <div
-            className="ms-ChoiceField root-210"
+            className="ms-ChoiceField root-202"
           >
             <div
               className="ms-ChoiceField-wrapper"
@@ -2069,9 +2069,9 @@ exports[`single fields radio field 1`] = `
               <input
                 aria-describedby="root__error root__description root__help"
                 checked={false}
-                className="ms-ChoiceField-input input-211"
+                className="ms-ChoiceField-input input-203"
                 disabled={false}
-                id="ChoiceGroup178-1"
+                id="ChoiceGroup186-1"
                 name="root"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -2079,12 +2079,12 @@ exports[`single fields radio field 1`] = `
                 type="radio"
               />
               <label
-                className="ms-ChoiceField-field field-212"
-                htmlFor="ChoiceGroup178-1"
+                className="ms-ChoiceField-field field-204"
+                htmlFor="ChoiceGroup186-1"
               >
                 <span
                   className="ms-ChoiceFieldLabel"
-                  id="ChoiceGroupLabel179-1"
+                  id="ChoiceGroupLabel187-1"
                 >
                   No
                 </span>
@@ -2120,7 +2120,7 @@ exports[`single fields radio field 1`] = `
           >
             <span
               className="ms-Button-label label-126"
-              id="id__180"
+              id="id__188"
             >
               Submit
             </span>
@@ -2221,7 +2221,7 @@ exports[`single fields schema examples 1`] = `
           >
             <span
               className="ms-Button-label label-126"
-              id="id__234"
+              id="id__242"
             >
               Submit
             </span>
@@ -2499,7 +2499,232 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
           >
             <span
               className="ms-Button-label label-126"
-              id="id__160"
+              id="id__165"
+            >
+              Submit
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</form>
+`;
+
+exports[`single fields select field multiple choice enumDisabled using checkboxes 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="ms-Grid-col ms-sm12  field field-array"
+    style={
+      {
+        "marginBottom": 15,
+      }
+    }
+  >
+    <label
+      className="ms-Label root-130"
+    />
+    <div
+      className="ms-Checkbox is-enabled root-210"
+    >
+      <input
+        aria-disabled={false}
+        autoFocus={false}
+        checked={false}
+        className="input-211"
+        data-ktp-execute-target={true}
+        disabled={false}
+        id="root-0"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        type="checkbox"
+      />
+      <label
+        className="ms-Checkbox-label label-212"
+        htmlFor="root-0"
+      >
+        <div
+          className="ms-Checkbox-checkbox checkbox-213"
+          data-ktp-target={true}
+        >
+          <i
+            aria-hidden={true}
+            className="ms-Checkbox-checkmark checkmark-216"
+            data-icon-name="CheckMark"
+          >
+            
+          </i>
+        </div>
+        <span
+          className="ms-Checkbox-text text-215"
+        >
+          foo
+        </span>
+      </label>
+    </div>
+    <div
+      className="ms-Checkbox is-disabled root-217"
+    >
+      <input
+        aria-disabled={true}
+        autoFocus={false}
+        checked={false}
+        className="input-211"
+        data-ktp-execute-target={true}
+        disabled={true}
+        id="root-1"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        type="checkbox"
+      />
+      <label
+        className="ms-Checkbox-label label-218"
+        htmlFor="root-1"
+      >
+        <div
+          className="ms-Checkbox-checkbox checkbox-219"
+          data-ktp-target={true}
+        >
+          <i
+            aria-hidden={true}
+            className="ms-Checkbox-checkmark checkmark-222"
+            data-icon-name="CheckMark"
+          >
+            
+          </i>
+        </div>
+        <span
+          className="ms-Checkbox-text text-221"
+        >
+          bar
+        </span>
+      </label>
+    </div>
+    <div
+      className="ms-Checkbox is-enabled root-210"
+    >
+      <input
+        aria-disabled={false}
+        autoFocus={false}
+        checked={false}
+        className="input-211"
+        data-ktp-execute-target={true}
+        disabled={false}
+        id="root-2"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        type="checkbox"
+      />
+      <label
+        className="ms-Checkbox-label label-212"
+        htmlFor="root-2"
+      >
+        <div
+          className="ms-Checkbox-checkbox checkbox-213"
+          data-ktp-target={true}
+        >
+          <i
+            aria-hidden={true}
+            className="ms-Checkbox-checkmark checkmark-216"
+            data-icon-name="CheckMark"
+          >
+            
+          </i>
+        </div>
+        <span
+          className="ms-Checkbox-text text-215"
+        >
+          fuzz
+        </span>
+      </label>
+    </div>
+    <div
+      className="ms-Checkbox is-enabled root-210"
+    >
+      <input
+        aria-disabled={false}
+        autoFocus={false}
+        checked={false}
+        className="input-211"
+        data-ktp-execute-target={true}
+        disabled={false}
+        id="root-3"
+        name="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        type="checkbox"
+      />
+      <label
+        className="ms-Checkbox-label label-212"
+        htmlFor="root-3"
+      >
+        <div
+          className="ms-Checkbox-checkbox checkbox-213"
+          data-ktp-target={true}
+        >
+          <i
+            aria-hidden={true}
+            className="ms-Checkbox-checkmark checkmark-216"
+            data-icon-name="CheckMark"
+          >
+            
+          </i>
+        </div>
+        <span
+          className="ms-Checkbox-text text-215"
+        >
+          qux
+        </span>
+      </label>
+    </div>
+    <span
+      style={
+        {
+          "color": "rgb(164, 38, 44)",
+          "fontFamily": ""Segoe UI", "Segoe UI Web (West European)", "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif",
+          "fontSize": 12,
+          "fontWeight": "normal",
+        }
+      }
+    />
+  </div>
+  <div>
+    <br />
+    <div
+      className="ms-Grid-col ms-sm12"
+    >
+      <button
+        className="ms-Button ms-Button--primary root-122"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="submit"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-123"
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className="ms-Button-textContainer textContainer-124"
+          >
+            <span
+              className="ms-Button-label label-126"
+              id="id__168"
             >
               Submit
             </span>
@@ -2550,9 +2775,11 @@ exports[`single fields select field multiple choice formData 1`] = `
       >
         <span
           aria-invalid={false}
-          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-183"
+          className="ms-Dropdown-title title-223"
           id="root-option"
-        />
+        >
+          foo, bar
+        </span>
         <span
           className="ms-Dropdown-caretDownWrapper caretDownWrapper-184"
         >
@@ -2592,7 +2819,7 @@ exports[`single fields select field multiple choice formData 1`] = `
           >
             <span
               className="ms-Button-label label-126"
-              id="id__166"
+              id="id__174"
             >
               Submit
             </span>
@@ -2789,6 +3016,137 @@ exports[`single fields select field single choice enumDisabled 1`] = `
 </form>
 `;
 
+exports[`single fields select field single choice enumDisabled using radio widget 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="ms-Grid-col ms-sm12  field field-string"
+    style={
+      {
+        "marginBottom": 15,
+      }
+    }
+  >
+    <div
+      className="ms-ChoiceFieldGroup root-201"
+      id="root"
+      name="root"
+      onBlur={[Function]}
+      onFocus={[Function]}
+    >
+      <div
+        onFocus={[Function]}
+        role="radiogroup"
+      >
+        <div
+          className="ms-ChoiceFieldGroup-flexContainer"
+        >
+          <div
+            className="ms-ChoiceField root-202"
+          >
+            <div
+              className="ms-ChoiceField-wrapper"
+            >
+              <input
+                aria-describedby="root__error root__description root__help"
+                checked={false}
+                className="ms-ChoiceField-input input-203"
+                disabled={false}
+                id="ChoiceGroup160-0"
+                name="root"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                type="radio"
+              />
+              <label
+                className="ms-ChoiceField-field field-204"
+                htmlFor="ChoiceGroup160-0"
+              >
+                <span
+                  className="ms-ChoiceFieldLabel"
+                  id="ChoiceGroupLabel161-0"
+                >
+                  foo
+                </span>
+              </label>
+            </div>
+          </div>
+          <div
+            className="ms-ChoiceField root-202"
+          >
+            <div
+              className="ms-ChoiceField-wrapper"
+            >
+              <input
+                aria-describedby="root__error root__description root__help"
+                checked={false}
+                className="ms-ChoiceField-input is-disabled input-203"
+                disabled={true}
+                id="ChoiceGroup160-1"
+                name="root"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                type="radio"
+              />
+              <label
+                className="ms-ChoiceField-field field-209"
+                htmlFor="ChoiceGroup160-1"
+              >
+                <span
+                  className="ms-ChoiceFieldLabel"
+                  id="ChoiceGroupLabel161-1"
+                >
+                  bar
+                </span>
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <br />
+    <div
+      className="ms-Grid-col ms-sm12"
+    >
+      <button
+        className="ms-Button ms-Button--primary root-122"
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="submit"
+      >
+        <span
+          className="ms-Button-flexContainer flexContainer-123"
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className="ms-Button-textContainer textContainer-124"
+          >
+            <span
+              className="ms-Button-label label-126"
+              id="id__162"
+            >
+              Submit
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</form>
+`;
+
 exports[`single fields select field single choice formData 1`] = `
 <form
   className="rjsf"
@@ -2827,11 +3185,9 @@ exports[`single fields select field single choice formData 1`] = `
       >
         <span
           aria-invalid={false}
-          className="ms-Dropdown-title title-201"
+          className="ms-Dropdown-title ms-Dropdown-titleIsPlaceHolder title-183"
           id="root-option"
-        >
-          bar
-        </span>
+        />
         <span
           className="ms-Dropdown-caretDownWrapper caretDownWrapper-184"
         >
@@ -2871,7 +3227,7 @@ exports[`single fields select field single choice formData 1`] = `
           >
             <span
               className="ms-Button-label label-126"
-              id="id__163"
+              id="id__171"
             >
               Submit
             </span>
@@ -2902,14 +3258,14 @@ exports[`single fields slider field 1`] = `
       htmlFor="root"
     />
     <div
-      className="ms-Slider ms-Slider-enabled ms-Slider-row root-217"
+      className="ms-Slider ms-Slider-enabled ms-Slider-row root-224"
     >
       <label
-        className="ms-Label titleLabel-228"
+        className="ms-Label titleLabel-235"
         htmlFor="root"
       />
       <div
-        className="ms-Slider-container container-219"
+        className="ms-Slider-container container-226"
       >
         <div
           aria-disabled={false}
@@ -2917,7 +3273,7 @@ exports[`single fields slider field 1`] = `
           aria-valuemin={42}
           aria-valuenow={42}
           aria-valuetext="42"
-          className="ms-Slider-slideBox ms-Slider-showValue slideBox-220"
+          className="ms-Slider-slideBox ms-Slider-showValue slideBox-227"
           data-is-focusable={true}
           id="root"
           onKeyDown={[Function]}
@@ -2927,10 +3283,10 @@ exports[`single fields slider field 1`] = `
           tabIndex={0}
         >
           <div
-            className="ms-Slider-line line-222"
+            className="ms-Slider-line line-229"
           >
             <span
-              className="ms-Slider-thumb thumb-221"
+              className="ms-Slider-thumb thumb-228"
               style={
                 {
                   "left": "0%",
@@ -2938,7 +3294,7 @@ exports[`single fields slider field 1`] = `
               }
             />
             <span
-              className="lineContainer-223 ms-Slider-inactive inactiveSection-225"
+              className="lineContainer-230 ms-Slider-inactive inactiveSection-232"
               style={
                 {
                   "width": "0%",
@@ -2946,7 +3302,7 @@ exports[`single fields slider field 1`] = `
               }
             />
             <span
-              className="lineContainer-223 ms-Slider-active activeSection-224"
+              className="lineContainer-230 ms-Slider-active activeSection-231"
               style={
                 {
                   "width": "0%",
@@ -2954,7 +3310,7 @@ exports[`single fields slider field 1`] = `
               }
             />
             <span
-              className="lineContainer-223 ms-Slider-inactive inactiveSection-225"
+              className="lineContainer-230 ms-Slider-inactive inactiveSection-232"
               style={
                 {
                   "width": "100%",
@@ -2964,7 +3320,7 @@ exports[`single fields slider field 1`] = `
           </div>
         </div>
         <label
-          className="ms-Label ms-Slider-value valueLabel-229"
+          className="ms-Label ms-Slider-value valueLabel-236"
         >
           42
         </label>
@@ -2996,7 +3352,7 @@ exports[`single fields slider field 1`] = `
           >
             <span
               className="ms-Button-label label-126"
-              id="id__183"
+              id="id__191"
             >
               Submit
             </span>
@@ -3511,7 +3867,7 @@ exports[`single fields title field 1`] = `
     }
   >
     <label
-      className="ms-Label root-231"
+      className="ms-Label root-238"
       id="root__title"
     >
       Titre 1
@@ -3540,7 +3896,7 @@ exports[`single fields title field 1`] = `
               <label
                 className="ms-Label root-130"
                 htmlFor="root_title"
-                id="TextFieldLabel207"
+                id="TextFieldLabel215"
               >
                 Titre 2
               </label>
@@ -3550,7 +3906,7 @@ exports[`single fields title field 1`] = `
                 <input
                   aria-describedby="root_title__error root_title__description root_title__help"
                   aria-invalid={false}
-                  aria-labelledby="TextFieldLabel207"
+                  aria-labelledby="TextFieldLabel215"
                   autoFocus={false}
                   className="ms-TextField-field field-113"
                   disabled={false}
@@ -3598,7 +3954,7 @@ exports[`single fields title field 1`] = `
           >
             <span
               className="ms-Button-label label-126"
-              id="id__210"
+              id="id__218"
             >
               Submit
             </span>
@@ -3908,7 +4264,7 @@ exports[`single fields using custom tagName 1`] = `
           >
             <span
               className="ms-Button-label label-126"
-              id="id__226"
+              id="id__234"
             >
               Submit
             </span>

--- a/packages/fluentui-rc/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluentui-rc/test/__snapshots__/Form.test.tsx.snap
@@ -1370,8 +1370,8 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
       >
         <label
           className="fui-Label fui-Field__label ___1r7nw7g_1a9hq9n fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-          htmlFor="field-rt__control"
-          id="field-rt__label"
+          htmlFor="field-r11__control"
+          id="field-r11__label"
         />
         <div
           className="fui-Dropdown form-control ___1t74ezd_q04bao0 f1aa9q02 f16jpd5f f1jar5jt fyu767a f1ewtqcl ftuwxu6 f1exfvgq f10pi13n f14a1fxs f3e99gv fhljsf7 f1gw3sf2 f13zj6fq f1mdlcz9 f1a7op3 f1gboi2j f1cjjd47 ffyw7fx f1kp91vd f1ibwz09 f14pi962 f1lh990p f1jc6hxc f13evtba f1yk9hq fhwpy7i f14ee0xe f1xhbsuh fv8e3ye ftb5wc6 fjw5xc1 f1xdyd5c fatpbeo fb7uyps f1cmft4k f1x58t8o f1ibeo51 f132nw8t f1htdosj fxugw4r f192inf7 f5tn483 f1vxd6vx f1ojsxk5 fzkkow9 fcdblym fg706s2 fjik90z fj3muxo f1akhkt f1c1zstj f1lxtadh fvcxoqz f1ub3y4t flmw63s f1m52nbi fvs00aa f1assf6x fqhmt4z f4ruux4"
@@ -1379,7 +1379,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
           <button
             aria-describedby="root__error root__description root__help"
             aria-expanded={false}
-            aria-labelledby="field-rt__label"
+            aria-labelledby="field-r11__label"
             autoFocus={false}
             className="fui-Dropdown__button ___10ah4o2_6igl400 f122n59 f1c21dwh fre7gi1 f1358rze fqdk4by f1rvrf73 f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f1sbtcvk f11gcy0p fdghr9 f1e60jzv"
             disabled={false}
@@ -1433,6 +1433,151 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
 </form>
 `;
 
+exports[`single fields select field multiple choice enumDisabled using checkboxes 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-array"
+  >
+    <div
+      className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
+    >
+      <label
+        className="fui-Label ___1yevxz2_yljzsa0 fk6fouc f19n0e5 fkhj508 f1i3iumi"
+        htmlFor="root"
+      />
+      <div
+        className="fui-Flex ___1ccp5kb_1s932w9 f22iagw f1vx9l62"
+      >
+        <span
+          className="fui-Checkbox r10zo65y ___1v6wcsu_941lme0 f3p8bqa fium13f f1r2dosr f1729es6"
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            autoFocus={false}
+            checked={false}
+            className="fui-Checkbox__input ruo9svu ___qlal8r0_1xrlghj f1vgc2s3"
+            disabled={false}
+            id="root-0"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="checkbox"
+          />
+          <div
+            aria-hidden={true}
+            className="fui-Checkbox__indicator rl7ci6d"
+          />
+          <label
+            className="fui-Label fui-Checkbox__label ___noxlvg0_1xjoun4 fk6fouc f1ym3bx4 fkhj508 f1i3iumi f7nlbp4 fpo1scq f1kwiid1 f1vdfbxk f5b47ha fruq291 fjzwpt6 fh6j2fo"
+            htmlFor="root-0"
+          >
+            foo
+          </label>
+        </span>
+        <span
+          className="fui-Checkbox r10zo65y ___8i7d4u0_1q3ajh0 f158kwzp f1s2aq7o f1w7mfl5 fcoafq6 f1dcs8yz fxb3eh3"
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            autoFocus={false}
+            checked={false}
+            className="fui-Checkbox__input ruo9svu ___qlal8r0_1xrlghj f1vgc2s3"
+            disabled={true}
+            id="root-1"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="checkbox"
+          />
+          <div
+            aria-hidden={true}
+            className="fui-Checkbox__indicator rl7ci6d"
+          />
+          <label
+            className="fui-Label fui-Checkbox__label ___186rvlj_12dx2by fk6fouc f1ym3bx4 f1dcs8yz fkhj508 f1i3iumi f7nlbp4 fpo1scq f1kwiid1 f1vdfbxk f5b47ha fruq291 fjzwpt6 fh6j2fo"
+            htmlFor="root-1"
+          >
+            bar
+          </label>
+        </span>
+        <span
+          className="fui-Checkbox r10zo65y ___1v6wcsu_941lme0 f3p8bqa fium13f f1r2dosr f1729es6"
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            autoFocus={false}
+            checked={false}
+            className="fui-Checkbox__input ruo9svu ___qlal8r0_1xrlghj f1vgc2s3"
+            disabled={false}
+            id="root-2"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="checkbox"
+          />
+          <div
+            aria-hidden={true}
+            className="fui-Checkbox__indicator rl7ci6d"
+          />
+          <label
+            className="fui-Label fui-Checkbox__label ___noxlvg0_1xjoun4 fk6fouc f1ym3bx4 fkhj508 f1i3iumi f7nlbp4 fpo1scq f1kwiid1 f1vdfbxk f5b47ha fruq291 fjzwpt6 fh6j2fo"
+            htmlFor="root-2"
+          >
+            fuzz
+          </label>
+        </span>
+        <span
+          className="fui-Checkbox r10zo65y ___1v6wcsu_941lme0 f3p8bqa fium13f f1r2dosr f1729es6"
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            autoFocus={false}
+            checked={false}
+            className="fui-Checkbox__input ruo9svu ___qlal8r0_1xrlghj f1vgc2s3"
+            disabled={false}
+            id="root-3"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="checkbox"
+          />
+          <div
+            aria-hidden={true}
+            className="fui-Checkbox__indicator rl7ci6d"
+          />
+          <label
+            className="fui-Label fui-Checkbox__label ___noxlvg0_1xjoun4 fk6fouc f1ym3bx4 fkhj508 f1i3iumi f7nlbp4 fpo1scq f1kwiid1 f1vdfbxk f5b47ha fruq291 fjzwpt6 fh6j2fo"
+            htmlFor="root-3"
+          >
+            qux
+          </label>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    className="___fko12g0_0000000 f1wswflg"
+  >
+    <button
+      className="fui-Button r1alrhcs ___1akj6hk_ih97uj0 ffp7eso f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1phragk f15wkkf3 f1s2uweq fr80ssc f1ukrpxl fecsdlb f1rq72xc fnp9lpt f1h0usnq fs4ktlq f16h9ulv fx2bmrt f1d6v5y2 f1rirnrt f1uu00uk fkvaka8 f1ux7til f9a0qzu f1lkg8j3 fkc42ay fq7113v ff1wgvm fiob0tu f1j6scgf f1x4h75k f4xjyn1 fbgcvur f1ks1yx8 f1o6qegi fcnxywj fmxjhhp f9ddjv3 f17t0x8g f194v5ow f1qgg65p fk7jm04 fhgccpy f32wu9k fu5nqqq f13prjl2 f1czftr5 f1nl83rv f12k37oa fr96u23"
+      disabled={false}
+      onClick={[Function]}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields select field multiple choice formData 1`] = `
 <form
   className="rjsf"
@@ -1450,8 +1595,8 @@ exports[`single fields select field multiple choice formData 1`] = `
       >
         <label
           className="fui-Label fui-Field__label ___1r7nw7g_1a9hq9n fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-          htmlFor="field-r13__control"
-          id="field-r13__label"
+          htmlFor="field-r1c__control"
+          id="field-r1c__label"
         />
         <div
           className="fui-Dropdown form-control ___1t74ezd_q04bao0 f1aa9q02 f16jpd5f f1jar5jt fyu767a f1ewtqcl ftuwxu6 f1exfvgq f10pi13n f14a1fxs f3e99gv fhljsf7 f1gw3sf2 f13zj6fq f1mdlcz9 f1a7op3 f1gboi2j f1cjjd47 ffyw7fx f1kp91vd f1ibwz09 f14pi962 f1lh990p f1jc6hxc f13evtba f1yk9hq fhwpy7i f14ee0xe f1xhbsuh fv8e3ye ftb5wc6 fjw5xc1 f1xdyd5c fatpbeo fb7uyps f1cmft4k f1x58t8o f1ibeo51 f132nw8t f1htdosj fxugw4r f192inf7 f5tn483 f1vxd6vx f1ojsxk5 fzkkow9 fcdblym fg706s2 fjik90z fj3muxo f1akhkt f1c1zstj f1lxtadh fvcxoqz f1ub3y4t flmw63s f1m52nbi fvs00aa f1assf6x fqhmt4z f4ruux4"
@@ -1459,7 +1604,7 @@ exports[`single fields select field multiple choice formData 1`] = `
           <button
             aria-describedby="root__error root__description root__help"
             aria-expanded={false}
-            aria-labelledby="field-r13__label"
+            aria-labelledby="field-r1c__label"
             autoFocus={false}
             className="fui-Dropdown__button ___10ah4o2_6igl400 f122n59 f1c21dwh fre7gi1 f1358rze fqdk4by f1rvrf73 f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f1sbtcvk f11gcy0p fdghr9 f1e60jzv"
             disabled={false}
@@ -1696,6 +1841,97 @@ exports[`single fields select field single choice enumDisabled 1`] = `
 </form>
 `;
 
+exports[`single fields select field single choice enumDisabled using radio widget 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <div
+      className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
+    >
+      <label
+        className="fui-Label ___1yevxz2_yljzsa0 fk6fouc f19n0e5 fkhj508 f1i3iumi"
+        htmlFor="root"
+      />
+      <div
+        aria-describedby="root__error root__description root__help"
+        className="fui-RadioGroup ___1tjgnp0_1mgmpxf f22iagw f6jr5hl f1vx9l62"
+        id="root"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        role="radiogroup"
+      >
+        <span
+          className="fui-Radio rm0dkue"
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            className="fui-Radio__input rg1upok ___183j3wl_1dim0pv f9ma1gx"
+            disabled={false}
+            id="root-0"
+            name="root"
+            onChange={[Function]}
+            type="radio"
+            value="0"
+          />
+          <div
+            aria-hidden={true}
+            className="fui-Radio__indicator rwtekvw"
+          />
+          <label
+            className="fui-Label fui-Radio__label ___1o91fp6_qunpvi0 fk6fouc f19n0e5 fkhj508 f1i3iumi f7nlbp4 f1kwiid1 f1vdfbxk f5b47ha fruq291 fjzwpt6 fh6j2fo"
+            htmlFor="root-0"
+          >
+            foo
+          </label>
+        </span>
+        <span
+          className="fui-Radio rm0dkue"
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            className="fui-Radio__input rg1upok ___183j3wl_1dim0pv f9ma1gx"
+            disabled={true}
+            id="root-1"
+            name="root"
+            onChange={[Function]}
+            type="radio"
+            value="1"
+          />
+          <div
+            aria-hidden={true}
+            className="fui-Radio__indicator rwtekvw"
+          />
+          <label
+            className="fui-Label fui-Radio__label ___15z4dte_1wo7efl fk6fouc f1s2aq7o f1dcs8yz fkhj508 f1i3iumi f7nlbp4 f1kwiid1 f1vdfbxk f5b47ha fruq291 fjzwpt6 fh6j2fo"
+            htmlFor="root-1"
+          >
+            bar
+          </label>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    className="___fko12g0_0000000 f1wswflg"
+  >
+    <button
+      className="fui-Button r1alrhcs ___1akj6hk_ih97uj0 ffp7eso f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1phragk f15wkkf3 f1s2uweq fr80ssc f1ukrpxl fecsdlb f1rq72xc fnp9lpt f1h0usnq fs4ktlq f16h9ulv fx2bmrt f1d6v5y2 f1rirnrt f1uu00uk fkvaka8 f1ux7til f9a0qzu f1lkg8j3 fkc42ay fq7113v ff1wgvm fiob0tu f1j6scgf f1x4h75k f4xjyn1 fbgcvur f1ks1yx8 f1o6qegi fcnxywj fmxjhhp f9ddjv3 f17t0x8g f194v5ow f1qgg65p fk7jm04 fhgccpy f32wu9k fu5nqqq f13prjl2 f1czftr5 f1nl83rv f12k37oa fr96u23"
+      disabled={false}
+      onClick={[Function]}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields select field single choice formData 1`] = `
 <form
   className="rjsf"
@@ -1713,8 +1949,8 @@ exports[`single fields select field single choice formData 1`] = `
       >
         <label
           className="fui-Label fui-Field__label ___1r7nw7g_1a9hq9n fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-          htmlFor="field-r10__control"
-          id="field-r10__label"
+          htmlFor="field-r19__control"
+          id="field-r19__label"
         />
         <div
           className="fui-Dropdown form-control ___1t74ezd_q04bao0 f1aa9q02 f16jpd5f f1jar5jt fyu767a f1ewtqcl ftuwxu6 f1exfvgq f10pi13n f14a1fxs f3e99gv fhljsf7 f1gw3sf2 f13zj6fq f1mdlcz9 f1a7op3 f1gboi2j f1cjjd47 ffyw7fx f1kp91vd f1ibwz09 f14pi962 f1lh990p f1jc6hxc f13evtba f1yk9hq fhwpy7i f14ee0xe f1xhbsuh fv8e3ye ftb5wc6 fjw5xc1 f1xdyd5c fatpbeo fb7uyps f1cmft4k f1x58t8o f1ibeo51 f132nw8t f1htdosj fxugw4r f192inf7 f5tn483 f1vxd6vx f1ojsxk5 fzkkow9 fcdblym fg706s2 fjik90z fj3muxo f1akhkt f1c1zstj f1lxtadh fvcxoqz f1ub3y4t flmw63s f1m52nbi fvs00aa f1assf6x fqhmt4z f4ruux4"
@@ -1722,7 +1958,7 @@ exports[`single fields select field single choice formData 1`] = `
           <button
             aria-describedby="root__error root__description root__help"
             aria-expanded={false}
-            aria-labelledby="field-r10__label"
+            aria-labelledby="field-r19__label"
             autoFocus={false}
             className="fui-Dropdown__button ___10ah4o2_6igl400 f122n59 f1c21dwh fre7gi1 f1358rze fqdk4by f1rvrf73 f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f1sbtcvk f11gcy0p fdghr9 f1e60jzv"
             disabled={false}

--- a/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/material-ui/test/__snapshots__/Form.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`single fields checkbox field 1`] = `
         <span
           aria-describedby="root__error root__description root__help"
           aria-disabled={false}
-          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-24 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-21 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
           onBlur={[Function]}
           onDragLeave={[Function]}
           onFocus={[Function]}
@@ -38,7 +38,7 @@ exports[`single fields checkbox field 1`] = `
             <input
               autoFocus={false}
               checked={false}
-              className="PrivateSwitchBase-input-27"
+              className="PrivateSwitchBase-input-24"
               data-indeterminate={false}
               disabled={false}
               id="root"
@@ -69,7 +69,7 @@ exports[`single fields checkbox field 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-28"
+    className="MuiBox-root MuiBox-root-33"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -119,7 +119,7 @@ exports[`single fields checkbox field with label 1`] = `
         <span
           aria-describedby="root__error root__description root__help"
           aria-disabled={false}
-          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-24 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+          className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-21 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
           onBlur={[Function]}
           onDragLeave={[Function]}
           onFocus={[Function]}
@@ -139,7 +139,7 @@ exports[`single fields checkbox field with label 1`] = `
             <input
               autoFocus={false}
               checked={false}
-              className="PrivateSwitchBase-input-27"
+              className="PrivateSwitchBase-input-24"
               data-indeterminate={false}
               disabled={false}
               id="root"
@@ -169,7 +169,7 @@ exports[`single fields checkbox field with label 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-29"
+    className="MuiBox-root MuiBox-root-34"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -226,7 +226,7 @@ exports[`single fields checkboxes field 1`] = `
           <span
             aria-describedby="root__error root__description root__help"
             aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-24 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-21 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
             onBlur={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
@@ -246,7 +246,7 @@ exports[`single fields checkboxes field 1`] = `
               <input
                 autoFocus={false}
                 checked={false}
-                className="PrivateSwitchBase-input-27"
+                className="PrivateSwitchBase-input-24"
                 data-indeterminate={false}
                 disabled={false}
                 id="root-0"
@@ -281,7 +281,7 @@ exports[`single fields checkboxes field 1`] = `
           <span
             aria-describedby="root__error root__description root__help"
             aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-24 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-21 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
             onBlur={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
@@ -301,7 +301,7 @@ exports[`single fields checkboxes field 1`] = `
               <input
                 autoFocus={false}
                 checked={false}
-                className="PrivateSwitchBase-input-27"
+                className="PrivateSwitchBase-input-24"
                 data-indeterminate={false}
                 disabled={false}
                 id="root-1"
@@ -336,7 +336,7 @@ exports[`single fields checkboxes field 1`] = `
           <span
             aria-describedby="root__error root__description root__help"
             aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-24 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-21 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
             onBlur={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
@@ -356,7 +356,7 @@ exports[`single fields checkboxes field 1`] = `
               <input
                 autoFocus={false}
                 checked={false}
-                className="PrivateSwitchBase-input-27"
+                className="PrivateSwitchBase-input-24"
                 data-indeterminate={false}
                 disabled={false}
                 id="root-2"
@@ -391,7 +391,7 @@ exports[`single fields checkboxes field 1`] = `
           <span
             aria-describedby="root__error root__description root__help"
             aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-24 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-21 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
             onBlur={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
@@ -411,7 +411,7 @@ exports[`single fields checkboxes field 1`] = `
               <input
                 autoFocus={false}
                 checked={false}
-                className="PrivateSwitchBase-input-27"
+                className="PrivateSwitchBase-input-24"
                 data-indeterminate={false}
                 disabled={false}
                 id="root-3"
@@ -444,7 +444,7 @@ exports[`single fields checkboxes field 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-30"
+    className="MuiBox-root MuiBox-root-35"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -566,7 +566,7 @@ exports[`single fields field with description 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-42"
+    className="MuiBox-root MuiBox-root-44"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -688,7 +688,7 @@ exports[`single fields field with description in uiSchema 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-43"
+    className="MuiBox-root MuiBox-root-45"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -1013,7 +1013,7 @@ exports[`single fields help and error display 1`] = `
     className="MuiPaper-root MuiPaper-elevation2 MuiPaper-rounded"
   >
     <div
-      className="MuiBox-root MuiBox-root-49"
+      className="MuiBox-root MuiBox-root-51"
     >
       <h6
         className="MuiTypography-root MuiTypography-h6"
@@ -1110,7 +1110,7 @@ exports[`single fields help and error display 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-50"
+    className="MuiBox-root MuiBox-root-52"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -1180,7 +1180,7 @@ exports[`single fields hidden field 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-41"
+    className="MuiBox-root MuiBox-root-43"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -1250,7 +1250,7 @@ exports[`single fields hidden label 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-46"
+    className="MuiBox-root MuiBox-root-48"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -1572,7 +1572,7 @@ exports[`single fields radio field 1`] = `
         >
           <span
             aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-24 MuiRadio-root MuiRadio-colorPrimary MuiIconButton-colorPrimary"
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-21 MuiRadio-root MuiRadio-colorPrimary MuiIconButton-colorPrimary"
             onBlur={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
@@ -1591,7 +1591,7 @@ exports[`single fields radio field 1`] = `
             >
               <input
                 checked={false}
-                className="PrivateSwitchBase-input-27"
+                className="PrivateSwitchBase-input-24"
                 disabled={false}
                 id="root-0"
                 name="root"
@@ -1600,7 +1600,7 @@ exports[`single fields radio field 1`] = `
                 value="0"
               />
               <div
-                className="PrivateRadioButtonIcon-root-31"
+                className="PrivateRadioButtonIcon-root-25"
               >
                 <svg
                   aria-hidden={true}
@@ -1614,7 +1614,7 @@ exports[`single fields radio field 1`] = `
                 </svg>
                 <svg
                   aria-hidden={true}
-                  className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-32"
+                  className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-26"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -1636,7 +1636,7 @@ exports[`single fields radio field 1`] = `
         >
           <span
             aria-disabled={false}
-            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-24 MuiRadio-root MuiRadio-colorPrimary MuiIconButton-colorPrimary"
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-21 MuiRadio-root MuiRadio-colorPrimary MuiIconButton-colorPrimary"
             onBlur={[Function]}
             onDragLeave={[Function]}
             onFocus={[Function]}
@@ -1655,7 +1655,7 @@ exports[`single fields radio field 1`] = `
             >
               <input
                 checked={false}
-                className="PrivateSwitchBase-input-27"
+                className="PrivateSwitchBase-input-24"
                 disabled={false}
                 id="root-1"
                 name="root"
@@ -1664,7 +1664,7 @@ exports[`single fields radio field 1`] = `
                 value="1"
               />
               <div
-                className="PrivateRadioButtonIcon-root-31"
+                className="PrivateRadioButtonIcon-root-25"
               >
                 <svg
                   aria-hidden={true}
@@ -1678,7 +1678,7 @@ exports[`single fields radio field 1`] = `
                 </svg>
                 <svg
                   aria-hidden={true}
-                  className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-32"
+                  className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-26"
                   focusable="false"
                   viewBox="0 0 24 24"
                 >
@@ -1699,7 +1699,7 @@ exports[`single fields radio field 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-34"
+    className="MuiBox-root MuiBox-root-36"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -1789,7 +1789,7 @@ exports[`single fields schema examples 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-48"
+    className="MuiBox-root MuiBox-root-50"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -2078,7 +2078,271 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-21"
+    className="MuiBox-root MuiBox-root-29"
+  >
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+      disabled={false}
+      onBlur={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="submit"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        Submit
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields select field multiple choice enumDisabled using checkboxes 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-array"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth"
+    >
+      <label
+        className="MuiFormLabel-root"
+        htmlFor="root"
+      />
+      <div
+        className="MuiFormGroup-root"
+        id="root"
+      >
+        <label
+          className="MuiFormControlLabel-root"
+        >
+          <span
+            aria-describedby="root__error root__description root__help"
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-21 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <input
+                autoFocus={false}
+                checked={false}
+                className="PrivateSwitchBase-input-24"
+                data-indeterminate={false}
+                disabled={false}
+                id="root-0"
+                name="root"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            foo
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root Mui-disabled"
+        >
+          <span
+            aria-describedby="root__error root__description root__help"
+            aria-disabled={true}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-21 MuiCheckbox-root MuiCheckbox-colorSecondary PrivateSwitchBase-disabled-23 Mui-disabled MuiIconButton-colorSecondary Mui-disabled Mui-disabled"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={-1}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <input
+                autoFocus={false}
+                checked={false}
+                className="PrivateSwitchBase-input-24"
+                data-indeterminate={false}
+                disabled={true}
+                id="root-1"
+                name="root"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label Mui-disabled MuiTypography-body1"
+          >
+            bar
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root"
+        >
+          <span
+            aria-describedby="root__error root__description root__help"
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-21 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <input
+                autoFocus={false}
+                checked={false}
+                className="PrivateSwitchBase-input-24"
+                data-indeterminate={false}
+                disabled={false}
+                id="root-2"
+                name="root"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            fuzz
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root"
+        >
+          <span
+            aria-describedby="root__error root__description root__help"
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-21 MuiCheckbox-root MuiCheckbox-colorSecondary MuiIconButton-colorSecondary"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <input
+                autoFocus={false}
+                checked={false}
+                className="PrivateSwitchBase-input-24"
+                data-indeterminate={false}
+                disabled={false}
+                id="root-3"
+                name="root"
+                onChange={[Function]}
+                type="checkbox"
+              />
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            qux
+          </span>
+        </label>
+      </div>
+    </div>
+  </div>
+  <div
+    className="MuiBox-root MuiBox-root-30"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -2167,7 +2431,7 @@ exports[`single fields select field multiple choice formData 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-23"
+    className="MuiBox-root MuiBox-root-32"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -2390,6 +2654,191 @@ exports[`single fields select field single choice enumDisabled 1`] = `
 </form>
 `;
 
+exports[`single fields select field single choice enumDisabled using radio widget 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth"
+    >
+      <label
+        className="MuiFormLabel-root"
+        htmlFor="root"
+      />
+      <div
+        aria-describedby="root__error root__description root__help"
+        className="MuiFormGroup-root"
+        id="root"
+        onBlur={[Function]}
+        onFocus={[Function]}
+        role="radiogroup"
+      >
+        <label
+          className="MuiFormControlLabel-root"
+        >
+          <span
+            aria-disabled={false}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-21 MuiRadio-root MuiRadio-colorPrimary MuiIconButton-colorPrimary"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <input
+                checked={false}
+                className="PrivateSwitchBase-input-24"
+                disabled={false}
+                id="root-0"
+                name="root"
+                onChange={[Function]}
+                type="radio"
+                value="0"
+              />
+              <div
+                className="PrivateRadioButtonIcon-root-25"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                  />
+                </svg>
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-26"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                  />
+                </svg>
+              </div>
+            </span>
+          </span>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label MuiTypography-body1"
+          >
+            foo
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root Mui-disabled"
+        >
+          <span
+            aria-disabled={true}
+            className="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root-21 MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-disabled-23 Mui-disabled MuiIconButton-colorPrimary Mui-disabled Mui-disabled"
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={-1}
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <input
+                checked={false}
+                className="PrivateSwitchBase-input-24"
+                disabled={true}
+                id="root-1"
+                name="root"
+                onChange={[Function]}
+                type="radio"
+                value="1"
+              />
+              <div
+                className="PrivateRadioButtonIcon-root-25"
+              >
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                  />
+                </svg>
+                <svg
+                  aria-hidden={true}
+                  className="MuiSvgIcon-root PrivateRadioButtonIcon-layer-26"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                  />
+                </svg>
+              </div>
+            </span>
+          </span>
+          <span
+            className="MuiTypography-root MuiFormControlLabel-label Mui-disabled MuiTypography-body1"
+          >
+            bar
+          </span>
+        </label>
+      </div>
+    </div>
+  </div>
+  <div
+    className="MuiBox-root MuiBox-root-28"
+  >
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
+      disabled={false}
+      onBlur={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="submit"
+    >
+      <span
+        className="MuiButton-label"
+      >
+        Submit
+      </span>
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields select field single choice formData 1`] = `
 <form
   className="rjsf"
@@ -2451,7 +2900,7 @@ exports[`single fields select field single choice formData 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-22"
+    className="MuiBox-root MuiBox-root-31"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -2530,7 +2979,7 @@ exports[`single fields slider field 1`] = `
           aria-valuemax={100}
           aria-valuemin={42}
           aria-valuenow={75}
-          className="MuiSlider-thumb MuiSlider-thumbColorPrimary PrivateValueLabel-thumb-35"
+          className="MuiSlider-thumb MuiSlider-thumbColorPrimary PrivateValueLabel-thumb-37"
           data-index={0}
           onBlur={[Function]}
           onFocus={[Function]}
@@ -2546,13 +2995,13 @@ exports[`single fields slider field 1`] = `
           tabIndex={0}
         >
           <span
-            className="PrivateValueLabel-offset-37 MuiSlider-valueLabel"
+            className="PrivateValueLabel-offset-39 MuiSlider-valueLabel"
           >
             <span
-              className="PrivateValueLabel-circle-38"
+              className="PrivateValueLabel-circle-40"
             >
               <span
-                className="PrivateValueLabel-label-39"
+                className="PrivateValueLabel-label-41"
               >
                 75
               </span>
@@ -2563,7 +3012,7 @@ exports[`single fields slider field 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-40"
+    className="MuiBox-root MuiBox-root-42"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -3039,7 +3488,7 @@ exports[`single fields title field 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth"
     >
       <div
-        className="MuiBox-root MuiBox-root-44"
+        className="MuiBox-root MuiBox-root-46"
         id="root__title"
       >
         <h5
@@ -3114,7 +3563,7 @@ exports[`single fields title field 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-45"
+    className="MuiBox-root MuiBox-root-47"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
@@ -3321,7 +3770,7 @@ exports[`single fields using custom tagName 1`] = `
     </div>
   </div>
   <div
-    className="MuiBox-root MuiBox-root-47"
+    className="MuiBox-root MuiBox-root-49"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -9111,6 +9111,18 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   background-color: rgba(0, 0, 0, 0.12);
 }
 
+.emotion-10 {
+  overflow: hidden;
+  pointer-events: none;
+  position: absolute;
+  z-index: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  border-radius: inherit;
+}
+
 <form
   className="rjsf"
   noValidate={false}
@@ -9131,7 +9143,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
           onClick={[Function]}
         >
           <div
-            aria-controls=":rn:"
+            aria-controls=":ro:"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-labelledby="root"
@@ -9197,6 +9209,546 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-9"
+      disabled={false}
+      onBlur={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="submit"
+    >
+      Submit
+      <span
+        className="MuiTouchRipple-root emotion-10"
+      />
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields select field multiple choice enumDisabled using checkboxes 1`] = `
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
+.emotion-1 {
+  color: rgba(0, 0, 0, 0.6);
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  padding: 0;
+  position: relative;
+}
+
+.emotion-1.Mui-focused {
+  color: #1976d2;
+}
+
+.emotion-1.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-1.Mui-error {
+  color: #d32f2f;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.emotion-3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  vertical-align: middle;
+  -webkit-tap-highlight-color: transparent;
+  margin-left: -11px;
+  margin-right: 16px;
+}
+
+.emotion-3.Mui-disabled {
+  cursor: default;
+}
+
+.emotion-3 .MuiFormControlLabel-label.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  padding: 9px;
+  border-radius: 50%;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.emotion-4::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-4.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-4 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-4:hover {
+  background-color: rgba(25, 118, 210, 0.04);
+}
+
+@media (hover: none) {
+  .emotion-4:hover {
+    background-color: transparent;
+  }
+}
+
+.emotion-4.Mui-checked,
+.emotion-4.MuiCheckbox-indeterminate {
+  color: #1976d2;
+}
+
+.emotion-4.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-5 {
+  cursor: inherit;
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  margin: 0;
+  padding: 0;
+  z-index: 1;
+}
+
+.emotion-6 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  fill: currentColor;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  font-size: 1.5rem;
+}
+
+.emotion-7 {
+  margin: 0;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.5;
+  letter-spacing: 0.00938em;
+}
+
+.emotion-23 {
+  margin-top: 24px;
+}
+
+.emotion-24 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  letter-spacing: 0.02857em;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 6px 16px;
+  border-radius: 4px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  color: #fff;
+  background-color: #1976d2;
+  box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+}
+
+.emotion-24::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-24.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-24 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-24:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: #1565c0;
+  box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+}
+
+@media (hover: none) {
+  .emotion-24:hover {
+    background-color: #1976d2;
+  }
+}
+
+.emotion-24:active {
+  box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+}
+
+.emotion-24.Mui-focusVisible {
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+}
+
+.emotion-24.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-array"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    >
+      <label
+        className="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-1"
+        htmlFor="root"
+      />
+      <div
+        className="MuiFormGroup-root emotion-2"
+        id="root"
+      >
+        <label
+          className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
+        >
+          <span
+            aria-describedby="root__error root__description root__help"
+            className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium emotion-4"
+            onBlur={[Function]}
+            onContextMenu={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <input
+              autoFocus={false}
+              checked={false}
+              className="PrivateSwitchBase-input emotion-5"
+              data-indeterminate={false}
+              disabled={false}
+              id="root-0"
+              name="root"
+              onChange={[Function]}
+              required={false}
+              type="checkbox"
+            />
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-6"
+              data-testid="CheckBoxOutlineBlankIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+          </span>
+          <span
+            className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-7"
+          >
+            foo
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd emotion-3"
+        >
+          <span
+            aria-describedby="root__error root__description root__help"
+            aria-disabled={true}
+            className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-disabled PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium Mui-disabled MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium emotion-4"
+            onBlur={[Function]}
+            onContextMenu={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={-1}
+          >
+            <input
+              autoFocus={false}
+              checked={false}
+              className="PrivateSwitchBase-input emotion-5"
+              data-indeterminate={false}
+              disabled={true}
+              id="root-1"
+              name="root"
+              onChange={[Function]}
+              required={false}
+              type="checkbox"
+            />
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-6"
+              data-testid="CheckBoxOutlineBlankIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+          </span>
+          <span
+            className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled emotion-7"
+          >
+            bar
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
+        >
+          <span
+            aria-describedby="root__error root__description root__help"
+            className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium emotion-4"
+            onBlur={[Function]}
+            onContextMenu={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <input
+              autoFocus={false}
+              checked={false}
+              className="PrivateSwitchBase-input emotion-5"
+              data-indeterminate={false}
+              disabled={false}
+              id="root-2"
+              name="root"
+              onChange={[Function]}
+              required={false}
+              type="checkbox"
+            />
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-6"
+              data-testid="CheckBoxOutlineBlankIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+          </span>
+          <span
+            className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-7"
+          >
+            fuzz
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
+        >
+          <span
+            aria-describedby="root__error root__description root__help"
+            className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium emotion-4"
+            onBlur={[Function]}
+            onContextMenu={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <input
+              autoFocus={false}
+              checked={false}
+              className="PrivateSwitchBase-input emotion-5"
+              data-indeterminate={false}
+              disabled={false}
+              id="root-3"
+              name="root"
+              onChange={[Function]}
+              required={false}
+              type="checkbox"
+            />
+            <svg
+              aria-hidden={true}
+              className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-6"
+              data-testid="CheckBoxOutlineBlankIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+              />
+            </svg>
+          </span>
+          <span
+            className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-7"
+          >
+            qux
+          </span>
+        </label>
+      </div>
+    </div>
+  </div>
+  <div
+    className="MuiBox-root emotion-23"
+  >
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-24"
       disabled={false}
       onBlur={[Function]}
       onContextMenu={[Function]}
@@ -9633,7 +10185,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
           onClick={[Function]}
         >
           <div
-            aria-controls=":rr:"
+            aria-controls=":rs:"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-labelledby="root"
@@ -10739,6 +11291,509 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
 </form>
 `;
 
+exports[`single fields select field single choice enumDisabled using radio widget 1`] = `
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
+.emotion-1 {
+  color: rgba(0, 0, 0, 0.6);
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  padding: 0;
+  position: relative;
+}
+
+.emotion-1.Mui-focused {
+  color: #1976d2;
+}
+
+.emotion-1.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-1.Mui-error {
+  color: #d32f2f;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.emotion-3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  vertical-align: middle;
+  -webkit-tap-highlight-color: transparent;
+  margin-left: -11px;
+  margin-right: 16px;
+}
+
+.emotion-3.Mui-disabled {
+  cursor: default;
+}
+
+.emotion-3 .MuiFormControlLabel-label.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  padding: 9px;
+  border-radius: 50%;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.emotion-4::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-4.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-4 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-4:hover {
+  background-color: rgba(25, 118, 210, 0.04);
+}
+
+@media (hover: none) {
+  .emotion-4:hover {
+    background-color: transparent;
+  }
+}
+
+.emotion-4.Mui-checked {
+  color: #1976d2;
+}
+
+.emotion-4.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-5 {
+  cursor: inherit;
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  margin: 0;
+  padding: 0;
+  z-index: 1;
+}
+
+.emotion-6 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-7 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  fill: currentColor;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  font-size: 1.5rem;
+  -webkit-transform: scale(1);
+  -moz-transform: scale(1);
+  -ms-transform: scale(1);
+  transform: scale(1);
+}
+
+.emotion-8 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  fill: currentColor;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  font-size: 1.5rem;
+  left: 0;
+  position: absolute;
+  -webkit-transform: scale(0);
+  -moz-transform: scale(0);
+  -ms-transform: scale(0);
+  transform: scale(0);
+  -webkit-transition: -webkit-transform 150ms cubic-bezier(0.4, 0, 1, 1) 0ms;
+  transition: transform 150ms cubic-bezier(0.4, 0, 1, 1) 0ms;
+}
+
+.emotion-9 {
+  margin: 0;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.5;
+  letter-spacing: 0.00938em;
+}
+
+.emotion-17 {
+  margin-top: 24px;
+}
+
+.emotion-18 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  letter-spacing: 0.02857em;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 6px 16px;
+  border-radius: 4px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  color: #fff;
+  background-color: #1976d2;
+  box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+}
+
+.emotion-18::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-18.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-18 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-18:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-color: #1565c0;
+  box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+}
+
+@media (hover: none) {
+  .emotion-18:hover {
+    background-color: #1976d2;
+  }
+}
+
+.emotion-18:active {
+  box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+}
+
+.emotion-18.Mui-focusVisible {
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+}
+
+.emotion-18.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    >
+      <label
+        className="MuiFormLabel-root MuiFormLabel-colorPrimary emotion-1"
+        htmlFor="root"
+      />
+      <div
+        aria-describedby="root__error root__description root__help"
+        className="MuiFormGroup-root emotion-2"
+        id="root"
+        onBlur={[Function]}
+        onFocus={[Function]}
+        role="radiogroup"
+      >
+        <label
+          className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-3"
+        >
+          <span
+            className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary MuiRadio-root MuiRadio-colorPrimary emotion-4"
+            onBlur={[Function]}
+            onContextMenu={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={null}
+          >
+            <input
+              checked={false}
+              className="PrivateSwitchBase-input emotion-5"
+              disabled={false}
+              id="root-0"
+              name="root"
+              onChange={[Function]}
+              required={false}
+              type="radio"
+              value="0"
+            />
+            <span
+              className="emotion-6"
+            >
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-7"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-8"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-9"
+          >
+            foo
+          </span>
+        </label>
+        <label
+          className="MuiFormControlLabel-root Mui-disabled MuiFormControlLabel-labelPlacementEnd emotion-3"
+        >
+          <span
+            aria-disabled={true}
+            className="MuiButtonBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled PrivateSwitchBase-root MuiRadio-root MuiRadio-colorPrimary Mui-disabled MuiRadio-root MuiRadio-colorPrimary emotion-4"
+            onBlur={[Function]}
+            onContextMenu={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={-1}
+          >
+            <input
+              checked={false}
+              className="PrivateSwitchBase-input emotion-5"
+              disabled={true}
+              id="root-1"
+              name="root"
+              onChange={[Function]}
+              required={false}
+              type="radio"
+              value="1"
+            />
+            <span
+              className="emotion-6"
+            >
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-7"
+                data-testid="RadioButtonUncheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"
+                />
+              </svg>
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-8"
+                data-testid="RadioButtonCheckedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.465 8.465C9.37 7.56 10.62 7 12 7C14.76 7 17 9.24 17 12C17 13.38 16.44 14.63 15.535 15.535C14.63 16.44 13.38 17 12 17C9.24 17 7 14.76 7 12C7 10.62 7.56 9.37 8.465 8.465Z"
+                />
+              </svg>
+            </span>
+          </span>
+          <span
+            className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label Mui-disabled emotion-9"
+          >
+            bar
+          </span>
+        </label>
+      </div>
+    </div>
+  </div>
+  <div
+    className="MuiBox-root emotion-17"
+  >
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium emotion-18"
+      disabled={false}
+      onBlur={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields select field single choice formData 1`] = `
 .emotion-0 {
   display: -webkit-inline-box;
@@ -11165,7 +12220,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
           onClick={[Function]}
         >
           <div
-            aria-controls=":rp:"
+            aria-controls=":rq:"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-labelledby="root"

--- a/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
@@ -1601,6 +1601,164 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
 </form>
 `;
 
+exports[`single fields select field multiple choice enumDisabled using checkboxes 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-array"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      <div
+        className="grouped fields"
+        id="root"
+        name="root"
+      >
+        <div
+          className="field"
+        >
+          <div
+            className="ui checkbox"
+            inverted="false"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              autoFocus={false}
+              checked={false}
+              className="hidden"
+              disabled={false}
+              id="root-0"
+              name="root"
+              readOnly={true}
+              tabIndex={0}
+              type="checkbox"
+            />
+            <label
+              htmlFor="root-0"
+            >
+              foo
+            </label>
+          </div>
+        </div>
+        <div
+          className="disabled field"
+        >
+          <div
+            className="ui disabled checkbox"
+            inverted="false"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              autoFocus={false}
+              checked={false}
+              className="hidden"
+              disabled={true}
+              id="root-1"
+              name="root"
+              readOnly={true}
+              tabIndex={-1}
+              type="checkbox"
+            />
+            <label
+              htmlFor="root-1"
+            >
+              bar
+            </label>
+          </div>
+        </div>
+        <div
+          className="field"
+        >
+          <div
+            className="ui checkbox"
+            inverted="false"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              autoFocus={false}
+              checked={false}
+              className="hidden"
+              disabled={false}
+              id="root-2"
+              name="root"
+              readOnly={true}
+              tabIndex={0}
+              type="checkbox"
+            />
+            <label
+              htmlFor="root-2"
+            >
+              fuzz
+            </label>
+          </div>
+        </div>
+        <div
+          className="field"
+        >
+          <div
+            className="ui checkbox"
+            inverted="false"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              autoFocus={false}
+              checked={false}
+              className="hidden"
+              disabled={false}
+              id="root-3"
+              name="root"
+              readOnly={true}
+              tabIndex={0}
+              type="checkbox"
+            />
+            <label
+              htmlFor="root-3"
+            >
+              qux
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
 exports[`single fields select field multiple choice formData 1`] = `
 <form
   className="ui form rjsf"
@@ -1925,6 +2083,100 @@ exports[`single fields select field single choice enumDisabled 1`] = `
                 bar
               </span>
             </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
+exports[`single fields select field single choice enumDisabled using radio widget 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group field field-string"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      <div
+        className="grouped fields"
+      >
+        <div
+          className="field"
+        >
+          <div
+            className="ui radio checkbox"
+            fluid={true}
+            inverted={false}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              checked={false}
+              className="hidden"
+              disabled={false}
+              id="root-0"
+              name="root"
+              readOnly={true}
+              tabIndex={0}
+              type="radio"
+              value="0"
+            />
+            <label
+              htmlFor="root-0"
+            >
+              foo
+            </label>
+          </div>
+        </div>
+        <div
+          className="disabled field"
+        >
+          <div
+            className="ui disabled radio checkbox"
+            fluid={true}
+            inverted={false}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+          >
+            <input
+              aria-describedby="root__error root__description root__help"
+              checked={false}
+              className="hidden"
+              disabled={true}
+              id="root-1"
+              name="root"
+              readOnly={true}
+              tabIndex={-1}
+              type="radio"
+              value="1"
+            />
+            <label
+              htmlFor="root-1"
+            >
+              bar
+            </label>
           </div>
         </div>
       </div>

--- a/packages/snapshot-tests/src/formTests.tsx
+++ b/packages/snapshot-tests/src/formTests.tsx
@@ -209,6 +209,18 @@ export function formTests(Form: ComponentType<FormProps>, customOptions: FormRen
       const tree = renderer.create(<Form schema={schema} uiSchema={uiSchema} validator={validator} />).toJSON();
       expect(tree).toMatchSnapshot();
     });
+    test('select field single choice enumDisabled using radio widget', () => {
+      const schema: RJSFSchema = {
+        type: 'string',
+        enum: ['foo', 'bar'],
+      };
+      const uiSchema = {
+        'ui:widget': 'radio',
+        'ui:enumDisabled': ['bar'],
+      };
+      const tree = renderer.create(<Form schema={schema} uiSchema={uiSchema} validator={validator} />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
     test('select field multiple choice enumDisabled', () => {
       const schema: RJSFSchema = {
         type: 'array',
@@ -219,6 +231,24 @@ export function formTests(Form: ComponentType<FormProps>, customOptions: FormRen
         uniqueItems: true,
       };
       const uiSchema = {
+        'ui:enumDisabled': ['bar'],
+      };
+      const tree = renderer
+        .create(<Form schema={schema} uiSchema={uiSchema} validator={validator} />, customOptions.selectMulti)
+        .toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+    test('select field multiple choice enumDisabled using checkboxes', () => {
+      const schema: RJSFSchema = {
+        type: 'array',
+        items: {
+          type: 'string',
+          enum: ['foo', 'bar', 'fuzz', 'qux'],
+        },
+        uniqueItems: true,
+      };
+      const uiSchema = {
+        'ui:widget': 'checkboxes',
         'ui:enumDisabled': ['bar'],
       };
       const tree = renderer


### PR DESCRIPTION
### Reasons for making this change

The disabled properties of options of checkboxes and radio widgets are wrongly set.

This PR fixes the issues in the two widgets.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
