### PR TITLE
Fix mui imports in docs

### DIFF
--- a/packages/material-ui/README.md
+++ b/packages/material-ui/README.md
@@ -90,7 +90,7 @@ or
 
 ```js
 import { withTheme } from '@rjsf/core';
-import Theme from '@rjsf/material-ui';
+import { Theme } from '@rjsf/material-ui';
 
 // Make modifications to the theme with your own fields and widgets
 

--- a/packages/mui/README.md
+++ b/packages/mui/README.md
@@ -97,7 +97,7 @@ or
 
 ```js
 import { withTheme } from '@rjsf/core';
-import Theme from '@rjsf/mui';
+import { Theme } from '@rjsf/mui';
 
 // Make modifications to the theme with your own fields and widgets
 


### PR DESCRIPTION
### Reasons for making this change

Continues a fix of #3760 (started in #3770).

Default export is `Form`, not `Theme`. It cannot be passed to `withTheme`.

https://github.com/rjsf-team/react-jsonschema-form/blob/ec932db942dd046640303056c89e3501b16ec469/packages/material-ui/src/index.ts#L8

https://github.com/rjsf-team/react-jsonschema-form/blob/ec932db942dd046640303056c89e3501b16ec469/packages/mui/src/index.ts#L8

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
