### PR TITLE
Passes missing uiSchema prop to Form component.

### DIFF
--- a/packages/docs/docs/01-quickstart.md
+++ b/packages/docs/docs/01-quickstart.md
@@ -98,7 +98,7 @@ const uiSchema: UiSchema = {
   },
 };
 
-render(<Form schema={schema} validator={validator} />, document.getElementById('app'));
+render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />, document.getElementById('app'));
 ```
 
 ## Form initialization


### PR DESCRIPTION
### Reasons for making this change

The uiSchema prop wasn't being passed to the Form component, so I've updated the example to include it.

### Checklist

- [x] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
