### PR TITLE
[fix] Resetting number fields should check the entire string when deciding to leave the input text alone (#4202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.18.5
+
+## @rjsf/core
+
+- Fix case where NumberField would not properly reset the field when using programmatic form reset (#4202)[https://github.com/rjsf-team/react-jsonschema-form/issues/4202]
+
 # 5.18.4
 
 ## Dev / docs / playground

--- a/packages/core/src/components/fields/NumberField.tsx
+++ b/packages/core/src/components/fields/NumberField.tsx
@@ -71,7 +71,8 @@ function NumberField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends
     // Construct a regular expression that checks for a string that consists
     // of the formData value suffixed with zero or one '.' characters and zero
     // or more '0' characters
-    const re = new RegExp(`${value}`.replace('.', '\\.') + '\\.?0*$');
+    // const re = new RegExp(`${value}`.replace('.', '\\.') + '\\.?0*$');
+    const re = new RegExp(`^(${String(value).replace('.', '\\.')})?\\.?0*$`);
 
     // If the cached "lastValue" is a match, use that instead of the formData
     // value to prevent the input value from changing in the UI

--- a/packages/core/src/components/fields/NumberField.tsx
+++ b/packages/core/src/components/fields/NumberField.tsx
@@ -71,7 +71,6 @@ function NumberField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends
     // Construct a regular expression that checks for a string that consists
     // of the formData value suffixed with zero or one '.' characters and zero
     // or more '0' characters
-    // const re = new RegExp(`${value}`.replace('.', '\\.') + '\\.?0*$');
     const re = new RegExp(`^(${String(value).replace('.', '\\.')})?\\.?0*$`);
 
     // If the cached "lastValue" is a match, use that instead of the formData

--- a/packages/core/test/NumberField.test.jsx
+++ b/packages/core/test/NumberField.test.jsx
@@ -340,6 +340,40 @@ describe('NumberField', () => {
         expect($input.value).eql('203');
       });
 
+      it('form reset should work for a default value', () => {
+        const onChangeSpy = sinon.spy();
+        const schema = {
+          type: 'number',
+          default: 1,
+        };
+
+        const ref = React.createRef();
+
+        const { node } = createFormComponent({
+          ref: ref,
+          schema,
+          uiSchema,
+          onChange: onChangeSpy,
+        });
+
+        act(() => {
+          fireEvent.change(node.querySelector('input'), {
+            target: { value: '231' },
+          });
+        });
+
+        const $input = node.querySelector('input');
+        expect($input.value).eql('231');
+        sinon.assert.calledWithMatch(onChangeSpy.lastCall, { formData: 231 });
+
+        act(() => {
+          ref.current.reset();
+        });
+
+        expect($input.value).eql('1');
+        sinon.assert.calledWithMatch(onChangeSpy.lastCall, { formData: 1 });
+      });
+
       it('should render the widget with the expected id', () => {
         const { node } = createFormComponent({
           schema: {


### PR DESCRIPTION
The regular expression should check that the value matches at the beginning of the string