### PR TITLE
(feature) Add new relative Years feature to AltDateWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,29 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.19.0
+
+##@rjsf/antd
+
+- Updated `AltDateWidget` to use the new `dateRangeOptions()` function in `utils` to support relative Years and reversing the order of the Year choices
+
+##@rjsf/chakra-ui
+
+- Updated `AltDateWidget` to use the new `dateRangeOptions()` function in `utils` to support relative Years and reversing the order of the Year choices
+
+## @rjsf/core
+
+- Fixed case where `readOnly` from a JSON Schema was not applied in SchemaField ([#4236](https://github.com/rjsf-team/react-jsonschema-form/issues/4236))
+- Updated `AltDateWidget` to use the new `dateRangeOptions()` function in `utils` to support relative Years and reversing the order of the Year choices
+
+## @rjsf/utils
+
+- Added a new `dateRangeOptions()` function to implement relative Years in (via negative ranges) and reversing the order of the Year choices
+
+## Dev / docs / playground
+
+- Added documentation for the new `dateRangeOptions()` function as well as showing examples of using relative Years and reversed Year ordering
+
 # 5.18.6
 
 ## @rjsf/antd
@@ -25,7 +48,6 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 
 - Fixed `omitExtraData` not working in `onSubmit` and `validateForm`; fixing [#4187](https://github.com/rjsf-team/react-jsonschema-form/issues/4187), [#4165](https://github.com/rjsf-team/react-jsonschema-form/issues/4165) and [#4109](https://github.com/rjsf-team/react-jsonschema-form/issues/4109)
-- Fixed case where `readOnly` from a JSON Schema was not applied in SchemaField ([#4236](https://github.com/rjsf-team/react-jsonschema-form/issues/4236))
 
 ## @rjsf/utils
 

--- a/packages/antd/src/widgets/AltDateWidget/index.tsx
+++ b/packages/antd/src/widgets/AltDateWidget/index.tsx
@@ -2,8 +2,8 @@ import { MouseEvent, useEffect, useState } from 'react';
 import { Row, Col, Button } from 'antd';
 import {
   ariaDescribedByIds,
+  dateRangeOptions,
   getDateElementProps,
-  pad,
   parseDateString,
   toDateString,
   DateObject,
@@ -23,14 +23,6 @@ type DateElementProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
   select: (property: keyof DateObject, value: any) => void;
   type: string;
   range: [number, number];
-};
-
-const rangeOptions = (start: number, stop: number) => {
-  const options = [];
-  for (let i = start; i <= stop; i++) {
-    options.push({ value: i, label: pad(i, 2) });
-  }
-  return options;
 };
 
 const readyForChange = (state: DateObject) => {
@@ -107,7 +99,7 @@ export default function AltDateWidget<
       onChange={(elemValue) => elemProps.select(elemProps.type as keyof DateObject, elemValue)}
       onFocus={elemProps.onFocus}
       options={{
-        enumOptions: rangeOptions(elemProps.range[0], elemProps.range[1]),
+        enumOptions: dateRangeOptions<S>(elemProps.range[0], elemProps.range[1]),
       }}
       placeholder={elemProps.type}
       readonly={elemProps.readonly}

--- a/packages/chakra-ui/src/AltDateWidget/AltDateWidget.tsx
+++ b/packages/chakra-ui/src/AltDateWidget/AltDateWidget.tsx
@@ -1,11 +1,11 @@
 import { MouseEvent, useEffect, useState } from 'react';
 import {
   ariaDescribedByIds,
+  dateRangeOptions,
   DateElementFormat,
   DateObject,
   FormContextType,
   getDateElementProps,
-  pad,
   parseDateString,
   RJSFSchema,
   StrictRJSFSchema,
@@ -14,14 +14,6 @@ import {
   WidgetProps,
 } from '@rjsf/utils';
 import { Box, Button } from '@chakra-ui/react';
-
-const rangeOptions = (start: number, stop: number) => {
-  const options = [];
-  for (let i = start; i <= stop; i++) {
-    options.push({ value: i, label: pad(i, 2) });
-  }
-  return options;
-};
 
 function DateElement<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   props: WidgetProps<T, S, F>
@@ -35,7 +27,7 @@ function DateElement<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends
       className='form-control'
       onChange={(elemValue: WidgetProps<T, S, F>) => props.select(props.type, elemValue)}
       options={{
-        enumOptions: rangeOptions(props.range[0], props.range[1]),
+        enumOptions: dateRangeOptions<S>(props.range[0], props.range[1]),
       }}
       placeholder={props.type}
       schema={{ type: 'integer' } as S}

--- a/packages/core/src/components/widgets/AltDateWidget.tsx
+++ b/packages/core/src/components/widgets/AltDateWidget.tsx
@@ -1,9 +1,9 @@
 import { MouseEvent, useCallback, useEffect, useReducer, useState } from 'react';
 import {
   ariaDescribedByIds,
+  dateRangeOptions,
   parseDateString,
   toDateString,
-  pad,
   DateObject,
   type DateElementFormat,
   FormContextType,
@@ -13,14 +13,6 @@ import {
   WidgetProps,
   getDateElementProps,
 } from '@rjsf/utils';
-
-function rangeOptions(start: number, stop: number) {
-  const options = [];
-  for (let i = start; i <= stop; i++) {
-    options.push({ value: i, label: pad(i, 2) });
-  }
-  return options;
-}
 
 function readyForChange(state: DateObject) {
   return Object.values(state).every((value) => value !== -1);
@@ -58,7 +50,7 @@ function DateElement<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends
       id={id}
       name={name}
       className='form-control'
-      options={{ enumOptions: rangeOptions(range[0], range[1]) }}
+      options={{ enumOptions: dateRangeOptions<S>(range[0], range[1]) }}
       placeholder={type}
       value={value}
       disabled={disabled}

--- a/packages/core/test/StringField.test.jsx
+++ b/packages/core/test/StringField.test.jsx
@@ -1335,6 +1335,67 @@ describe('StringField', () => {
         expect(ids).eql(['root_month', 'root_day', 'root_year', 'root_hour', 'root_minute', 'root_second']);
       });
     });
+
+    describe.only('AltDateTimeWidget with yearsRange option', () => {
+      it('should render a date field with years range from 1980-1985', () => {
+        const uiSchema = { 'ui:widget': 'alt-datetime', 'ui:options': { yearsRange: [1980, 1985] } };
+        const { node } = createFormComponent({
+          schema: {
+            type: 'string',
+            format: 'date',
+          },
+          uiSchema,
+        });
+
+        const yearOptions = node.querySelectorAll('select#root_year option');
+        const yearOptionsLabels = [].map.call(yearOptions, (o) => o.text);
+        expect(yearOptionsLabels).eql(['year', '1980', '1981', '1982', '1983', '1984', '1985']);
+      });
+      it('should render a date field with years range from 1985-1980', () => {
+        const uiSchema = { 'ui:widget': 'alt-datetime', 'ui:options': { yearsRange: [1985, 1980] } };
+        const { node } = createFormComponent({
+          schema: {
+            type: 'string',
+            format: 'date',
+          },
+          uiSchema,
+        });
+
+        const yearOptions = node.querySelectorAll('select#root_year option');
+        const yearOptionsLabels = [].map.call(yearOptions, (o) => o.text);
+        expect(yearOptionsLabels).eql(['year', '1985', '1984', '1983', '1982', '1981', '1980']);
+      });
+      it('should render a date field with years range from this year to 3 years ago', () => {
+        const uiSchema = { 'ui:widget': 'alt-datetime', 'ui:options': { yearsRange: [0, -3] } };
+        const { node } = createFormComponent({
+          schema: {
+            type: 'string',
+            format: 'date',
+          },
+          uiSchema,
+        });
+
+        const thisYear = new Date().getFullYear();
+        const yearOptions = node.querySelectorAll('select#root_year option');
+        const yearOptionsLabels = [].map.call(yearOptions, (o) => o.text);
+        expect(yearOptionsLabels).eql(['year', `${thisYear}`, `${thisYear - 1}`, `${thisYear - 2}`, `${thisYear - 3}`]);
+      });
+      it('should render a date field with years range from this year to 3 years ago', () => {
+        const uiSchema = { 'ui:widget': 'alt-datetime', 'ui:options': { yearsRange: [-3, 0] } };
+        const { node } = createFormComponent({
+          schema: {
+            type: 'string',
+            format: 'date',
+          },
+          uiSchema,
+        });
+
+        const thisYear = new Date().getFullYear();
+        const yearOptions = node.querySelectorAll('select#root_year option');
+        const yearOptionsLabels = [].map.call(yearOptions, (o) => o.text);
+        expect(yearOptionsLabels).eql(['year', `${thisYear - 3}`, `${thisYear - 2}`, `${thisYear - 1}`, `${thisYear}`]);
+      });
+    });
   });
 
   describe('AltDateWidget', () => {

--- a/packages/core/test/StringField.test.jsx
+++ b/packages/core/test/StringField.test.jsx
@@ -1380,7 +1380,7 @@ describe('StringField', () => {
         const yearOptionsLabels = [].map.call(yearOptions, (o) => o.text);
         expect(yearOptionsLabels).eql(['year', `${thisYear}`, `${thisYear - 1}`, `${thisYear - 2}`, `${thisYear - 3}`]);
       });
-      it('should render a date field with years range from this year to 3 years ago', () => {
+      it('should render a date field with years range from 3 years ago to this year ', () => {
         const uiSchema = { 'ui:widget': 'alt-datetime', 'ui:options': { yearsRange: [-3, 0] } };
         const { node } = createFormComponent({
           schema: {

--- a/packages/docs/docs/api-reference/utility-functions.md
+++ b/packages/docs/docs/api-reference/utility-functions.md
@@ -110,6 +110,25 @@ of that Blob if provided in the URL. If no name is provided, then the name falls
 
 - { blob: Blob, name: string }: An object containing a Blob and its name, extracted from the URI
 
+### dateRangeOptions&lt;S extends StrictRJSFSchema = RJSFSchema>()
+
+Returns a list of options for a date range between `start` and `stop`.
+If the start date is greater than the end date, then the date range is reversed.
+If `start` and `stop` are negative numbers (or zero), then they will be treated as relative to the current year.
+
+#### Parameters
+
+- start: number - The starting point of the date range
+- stop: number - The ending point of the date range
+
+#### Returns
+
+- EnumOptionsType&lt;S>[]: The list of EnumOptionsType for the date range between `start` and `stop`
+
+#### Throws
+
+- Error when `start` and `stop` aren't both <= 0 or > 0
+
 ### deepEquals()
 
 Implements a deep equals using the `lodash.isEqualWith` function, that provides a customized comparator that assumes all functions are equivalent.

--- a/packages/docs/docs/usage/widgets.md
+++ b/packages/docs/docs/usage/widgets.md
@@ -90,7 +90,9 @@ Please note that, even though they are standardized, `datetime-local`, `date` an
 
 ![](https://i.imgur.com/VF5tY60.png)
 
-You can customize the list of years displayed in the `year` dropdown by providing a `yearsRange` property to `ui:options` in your uiSchema. It's also possible to remove the `Now` and `Clear` buttons with the `hideNowButton` and `hideClearButton` options.
+You can customize the list of years displayed in the `year` dropdown by providing a `yearsRange` property to `ui:options` in your uiSchema.
+The range can be descending by specifying the larger value first.
+It's also possible to remove the `Now` and `Clear` buttons with the `hideNowButton` and `hideClearButton` options.
 
 You can also, customize the order in which date input fields are displayed by providing `format` property to `ui:options` in your uiSchema, available values are `YMD`(default), `MDY` and `DMY`.
 
@@ -115,6 +117,22 @@ const uiSchema: UiSchema = {
 
 render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />, document.getElementById('app'));
 ```
+
+You can also specify negative values which will be treated relative to the current year, so if it is 2020 and the range is set as follows.
+
+```
+   yearsRange: [-120, -18],
+```
+
+Years from 1900-2002 will be shown. You can also specify the dates with the higher date first to display dates in reverse order.
+
+```
+   yearsRange: [2030, 1980],
+   ...
+   yearsRange: [-18, -120],
+```
+
+Years from 2030-1980 and 2002-1900, respectively will be shown.
 
 ## For `number` and `integer` fields
 

--- a/packages/utils/src/dateRangeOptions.ts
+++ b/packages/utils/src/dateRangeOptions.ts
@@ -1,0 +1,31 @@
+import pad from './pad';
+import { EnumOptionsType, RJSFSchema, StrictRJSFSchema } from './types';
+
+/** Returns a list of options for a date range between `start` and `stop`. If the start date is greater than the end
+ * date, then the date range is reversed. If `start` and `stop` are negative numbers (or zero), then they will be
+ * treated as relative to the current year.
+ *
+ * @param start - The starting point of the date range
+ * @param stop - The ending point of the date range
+ * @returns - The list of EnumOptionsType for the date range between `start` and `stop`
+ * @throws - Error when `start` and `stop` aren't both <= 0 or > 0
+ */
+export default function dateRangeOptions<S extends StrictRJSFSchema = RJSFSchema>(
+  start: number,
+  stop: number
+): EnumOptionsType<S>[] {
+  if (start <= 0 && stop <= 0) {
+    start = new Date().getFullYear() + start;
+    stop = new Date().getFullYear() + stop;
+  } else if (start < 0 || stop < 0) {
+    throw new Error(`Both start (${start}) and stop (${stop}) must both be <= 0 or > 0, got one of each`);
+  }
+  if (start > stop) {
+    return dateRangeOptions<S>(stop, start).reverse();
+  }
+  const options: EnumOptionsType<S>[] = [];
+  for (let i = start; i <= stop; i++) {
+    options.push({ value: i, label: pad(i, 2) });
+  }
+  return options;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -4,6 +4,7 @@ import canExpand from './canExpand';
 import createErrorHandler from './createErrorHandler';
 import createSchemaUtils from './createSchemaUtils';
 import dataURItoBlob from './dataURItoBlob';
+import dateRangeOptions from './dateRangeOptions';
 import deepEquals from './deepEquals';
 import englishStringTranslator from './englishStringTranslator';
 import enumOptionsDeselectValue from './enumOptionsDeselectValue';
@@ -68,6 +69,7 @@ export {
   createSchemaUtils,
   DateElementFormat,
   dataURItoBlob,
+  dateRangeOptions,
   deepEquals,
   descriptionId,
   englishStringTranslator,

--- a/packages/utils/test/dateRangeOptions.test.ts
+++ b/packages/utils/test/dateRangeOptions.test.ts
@@ -1,0 +1,69 @@
+import { dateRangeOptions, pad } from '../src';
+
+describe('dateRangeOptions()', () => {
+  it('start & stop are positive integers, where stop < start', () => {
+    expect(dateRangeOptions(2, 10)).toEqual([
+      { value: 2, label: pad(2, 2) },
+      { value: 3, label: pad(3, 2) },
+      { value: 4, label: pad(4, 2) },
+      { value: 5, label: pad(5, 2) },
+      { value: 6, label: pad(6, 2) },
+      { value: 7, label: pad(7, 2) },
+      { value: 8, label: pad(8, 2) },
+      { value: 9, label: pad(9, 2) },
+      { value: 10, label: pad(10, 2) },
+    ]);
+  });
+  it('start & stop are positive integers, where stop > start', () => {
+    expect(dateRangeOptions(10, 2)).toEqual([
+      { value: 10, label: pad(10, 2) },
+      { value: 9, label: pad(9, 2) },
+      { value: 8, label: pad(8, 2) },
+      { value: 7, label: pad(7, 2) },
+      { value: 6, label: pad(6, 2) },
+      { value: 5, label: pad(5, 2) },
+      { value: 4, label: pad(4, 2) },
+      { value: 3, label: pad(3, 2) },
+      { value: 2, label: pad(2, 2) },
+    ]);
+  });
+  it('start & stop are negative integers, returns years from today in reverse order', () => {
+    const startYear = new Date().getFullYear() - 10;
+    expect(dateRangeOptions(-10, 0)).toEqual([
+      { value: startYear, label: `${startYear}` },
+      { value: startYear + 1, label: `${startYear + 1}` },
+      { value: startYear + 2, label: `${startYear + 2}` },
+      { value: startYear + 3, label: `${startYear + 3}` },
+      { value: startYear + 4, label: `${startYear + 4}` },
+      { value: startYear + 5, label: `${startYear + 5}` },
+      { value: startYear + 6, label: `${startYear + 6}` },
+      { value: startYear + 7, label: `${startYear + 7}` },
+      { value: startYear + 8, label: `${startYear + 8}` },
+      { value: startYear + 9, label: `${startYear + 9}` },
+      { value: startYear + 10, label: `${startYear + 10}` },
+    ]);
+  });
+  it('start & stop are negative integers, returns years from today in reverse order', () => {
+    const startYear = new Date().getFullYear() - 2;
+    expect(dateRangeOptions(-2, -10)).toEqual([
+      { value: startYear, label: `${startYear}` },
+      { value: startYear - 1, label: `${startYear - 1}` },
+      { value: startYear - 2, label: `${startYear - 2}` },
+      { value: startYear - 3, label: `${startYear - 3}` },
+      { value: startYear - 4, label: `${startYear - 4}` },
+      { value: startYear - 5, label: `${startYear - 5}` },
+      { value: startYear - 6, label: `${startYear - 6}` },
+      { value: startYear - 7, label: `${startYear - 7}` },
+      { value: startYear - 8, label: `${startYear - 8}` },
+    ]);
+  });
+  it('start & stop are zero, returns the year for today', () => {
+    const startYear = new Date().getFullYear();
+    expect(dateRangeOptions(0, 0)).toEqual([{ value: startYear, label: `${startYear}` }]);
+  });
+  it('throws when start and stop are different signs', () => {
+    expect(() => dateRangeOptions(1, -1)).toThrowError(
+      new Error(`Both start (${1}) and stop (${-1}) must both be <= 0 or > 0, got one of each`)
+    );
+  });
+});


### PR DESCRIPTION
### Reasons for making this change

Added a new feature supporting relate Years and reversing Years ordering to `AltDateWidget`
- In `@rjsf/utils`
  - Refactored and improved the `dateRangeOptions()` function from all implementations of `AltDateWidget`
  - Added 100% unit tests for the new function
- In `@rjsf/antd`, `@rjsf/chakra-ui` and `@rjsf/core` replaced `rangeOptions()` with `dateRangeOptions()`
- In `docs`, added documentation for `dateRangeOptions()` to the `utility-functions.md` and feature documentation to `widgets.md`
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [x] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
