### PR TITLE
Bump peer deps and packages for 5.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.19.1
+
+## Dev / docs / playground
+
+- Bumped the peer dependencies to `5.19.x` due to use of new API in `5.19.0`
+
 # 5.19.0
 
 ##@rjsf/antd

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -34,8 +34,8 @@
   },
   "peerDependencies": {
     "@ant-design/icons": "^4.0.0 || ^5.0.0",
-    "@rjsf/core": "^5.18.x",
-    "@rjsf/utils": "^5.18.x",
+    "@rjsf/core": "^5.19.x",
+    "@rjsf/utils": "^5.19.x",
     "antd": "^4.24.0 || ^5.8.5",
     "dayjs": "^1.8.0",
     "react": "^16.14.0 || >=17"

--- a/packages/bootstrap-4/package.json
+++ b/packages/bootstrap-4/package.json
@@ -33,8 +33,8 @@
     ]
   },
   "peerDependencies": {
-    "@rjsf/core": "^5.18.x",
-    "@rjsf/utils": "^5.18.x",
+    "@rjsf/core": "^5.19.x",
+    "@rjsf/utils": "^5.19.x",
     "react": "^16.14.0 || >=17",
     "react-bootstrap": "^1.6.5"
   },

--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -37,8 +37,8 @@
     "@chakra-ui/icons": ">=1.1.1",
     "@chakra-ui/react": ">=1.7.3",
     "@chakra-ui/system": ">=1.12.1",
-    "@rjsf/core": "^5.18.x",
-    "@rjsf/utils": "^5.18.x",
+    "@rjsf/core": "^5.19.x",
+    "@rjsf/utils": "^5.19.x",
     "chakra-react-select": ">=3.3.8",
     "framer-motion": ">=5.6.0",
     "react": "^16.14.0 || >=17"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
     "node": ">=14"
   },
   "peerDependencies": {
-    "@rjsf/utils": "^5.18.x",
+    "@rjsf/utils": "^5.19.x",
     "react": "^16.14.0 || >=17"
   },
   "dependencies": {

--- a/packages/fluent-ui/package.json
+++ b/packages/fluent-ui/package.json
@@ -34,8 +34,8 @@
   },
   "peerDependencies": {
     "@fluentui/react": ">= 7",
-    "@rjsf/core": "^5.18.x",
-    "@rjsf/utils": "^5.18.x",
+    "@rjsf/core": "^5.19.x",
+    "@rjsf/utils": "^5.19.x",
     "react": "^16.14.0 || >=17"
   },
   "devDependencies": {

--- a/packages/fluentui-rc/package.json
+++ b/packages/fluentui-rc/package.json
@@ -37,7 +37,7 @@
     "node": ">=14"
   },
   "peerDependencies": {
-    "@rjsf/utils": "^5.18.x",
+    "@rjsf/utils": "^5.19.x",
     "react": "^16.14.0 || >=17"
   },
   "dependencies": {

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -34,8 +34,8 @@
   "peerDependencies": {
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
-    "@rjsf/core": "^5.18.x",
-    "@rjsf/utils": "^5.18.x",
+    "@rjsf/core": "^5.19.x",
+    "@rjsf/utils": "^5.19.x",
     "react": "^16.14.0 || >=17"
   },
   "devDependencies": {

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -36,8 +36,8 @@
     "@emotion/styled": "^11.6.0",
     "@mui/icons-material": "^5.2.0",
     "@mui/material": "^5.2.2",
-    "@rjsf/core": "^5.18.x",
-    "@rjsf/utils": "^5.18.x",
+    "@rjsf/core": "^5.19.x",
+    "@rjsf/utils": "^5.19.x",
     "react": ">=17"
   },
   "devDependencies": {

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -33,8 +33,8 @@
     ]
   },
   "peerDependencies": {
-    "@rjsf/core": "^5.18.x",
-    "@rjsf/utils": "^5.18.x",
+    "@rjsf/core": "^5.19.x",
+    "@rjsf/utils": "^5.19.x",
     "react": "^16.14.0 || >=17",
     "semantic-ui-react": "^1.3.1 || ^2.1.3"
   },

--- a/packages/validator-ajv6/package.json
+++ b/packages/validator-ajv6/package.json
@@ -37,7 +37,7 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "@rjsf/utils": "^5.18.x"
+    "@rjsf/utils": "^5.19.x"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",

--- a/packages/validator-ajv8/package.json
+++ b/packages/validator-ajv8/package.json
@@ -39,7 +39,7 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "@rjsf/utils": "^5.18.x"
+    "@rjsf/utils": "^5.19.x"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",


### PR DESCRIPTION
### Reasons for making this change

Since other repos required a new API in `utils` we need to bump peer dependencies
- Ran `npm run bump-peer-deps` and `npm run committed changes
- Updated the test snapshots for `antd`, `fluentui-rc`, `mui` and `semantic-ui` due to className changes 
- Updated the `CHANGELOG.md` accordingly
 
### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
