### PR TITLE
fix: xss when rendering schema errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
-# 5.20.0
+# 5.19.4
 
 ## @rjsf/core 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.20.0
+
+## @rjsf/core 
+
+- Fix XSS when rendering schema validation errors [#4254](https://github.com/rjsf-team/react-jsonschema-form/issues/2718)
+
 # 5.19.3
 
 ## @rjsf/antd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core 
 
 - Fix XSS when rendering schema validation errors [#4254](https://github.com/rjsf-team/react-jsonschema-form/issues/2718)
+  - NOTE: This will have potential consequences if you are using the [translateString](https://rjsf-team.github.io/react-jsonschema-form/docs/api-reference/form-props/#translatestring) feature and are trying to render HTML. Switching to [Markdown](https://www.markdownguide.org/) will solve your problems.
 
 ## @rjsf/utils
 

--- a/packages/core/src/components/fields/ObjectField.tsx
+++ b/packages/core/src/components/fields/ObjectField.tsx
@@ -263,7 +263,7 @@ class ObjectField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
       return (
         <div>
           <p className='config-error' style={{ color: 'red' }}>
-            <Markdown>
+            <Markdown options={{ disableParsingRawHTML: true }}>
               {translateString(TranslatableString.InvalidObjectField, [name || 'root', (err as Error).message])}
             </Markdown>
           </p>

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -201,8 +201,12 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
 
   const description = uiOptions.description || props.schema.description || schema.description || '';
 
-  const richDescription = uiOptions.enableMarkdownInDescription ? <Markdown>{description}</Markdown> : description;
-
+  const richDescription = uiOptions.enableMarkdownInDescription ? (
+    <Markdown options={{ disableParsingRawHTML: true }}>{description}</Markdown>
+  ) : (
+    description
+  );
+  
   const help = uiOptions.help;
   const hidden = uiOptions.widget === 'hidden';
 

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -206,7 +206,6 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
   ) : (
     description
   );
-  
   const help = uiOptions.help;
   const hidden = uiOptions.widget === 'hidden';
 

--- a/packages/core/src/components/templates/UnsupportedField.tsx
+++ b/packages/core/src/components/templates/UnsupportedField.tsx
@@ -27,7 +27,9 @@ function UnsupportedField<T = any, S extends StrictRJSFSchema = RJSFSchema, F ex
   return (
     <div className='unsupported-field'>
       <p>
-        <Markdown options={{ disableParsingRawHTML: true }}>{translateString(translateEnum, translateParams)}</Markdown>
+        <Markdown options={{ disableParsingRawHTML: true }}>
+          {translateString(translateEnum, translateParams)}
+        </Markdown>
       </p>
       {schema && <pre>{JSON.stringify(schema, null, 2)}</pre>}
     </div>

--- a/packages/core/src/components/templates/UnsupportedField.tsx
+++ b/packages/core/src/components/templates/UnsupportedField.tsx
@@ -27,7 +27,7 @@ function UnsupportedField<T = any, S extends StrictRJSFSchema = RJSFSchema, F ex
   return (
     <div className='unsupported-field'>
       <p>
-        <Markdown>{translateString(translateEnum, translateParams)}</Markdown>
+        <Markdown options={{ disableParsingRawHTML: true }}>{translateString(translateEnum, translateParams)}</Markdown>
       </p>
       {schema && <pre>{JSON.stringify(schema, null, 2)}</pre>}
     </div>

--- a/packages/core/src/components/templates/UnsupportedField.tsx
+++ b/packages/core/src/components/templates/UnsupportedField.tsx
@@ -27,9 +27,7 @@ function UnsupportedField<T = any, S extends StrictRJSFSchema = RJSFSchema, F ex
   return (
     <div className='unsupported-field'>
       <p>
-        <Markdown options={{ disableParsingRawHTML: true }}>
-          {translateString(translateEnum, translateParams)}
-        </Markdown>
+        <Markdown options={{ disableParsingRawHTML: true }}>{translateString(translateEnum, translateParams)}</Markdown>
       </p>
       {schema && <pre>{JSON.stringify(schema, null, 2)}</pre>}
     </div>


### PR DESCRIPTION
### Reasons for making this change

When rendering schema validation errors, the `jsonSchema` is rendered as HTML in the `<Markdown>` component. This opens up the potential for an XSS.

fixes #4254 

### Checklist

- [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
- [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
- [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
