### PR TITLE
fix 4215 and 4260 by updating optionsList() to take a uiSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,14 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core 
 
 - Support allowing raising errors from within a custom Widget [#2718](https://github.com/rjsf-team/react-jsonschema-form/issues/2718)
+- Updated `ArrayField`, `BooleanField` and `StringField` to call `optionsList()` with the additional `UiSchema` parameter, fixing [#4215](https://github.com/rjsf-team/react-jsonschema-form/issues/4215) and  [#4260](https://github.com/rjsf-team/react-jsonschema-form/issues/4260)
 
 ## @rjsf/utils
 
 - Updated the `WidgetProps` type to add `es?: ErrorSchema<T>, id?: string` to the params of the `onChange` handler function
+- Updated `UIOptionsBaseType` to add the new `enumNames` prop to support an alternate way to provide labels for `enum`s in a schema, fixing [#4215](https://github.com/rjsf-team/react-jsonschema-form/issues/4215)
+- Updated `optionsList()` to take an optional `uiSchema` that is used to extract alternate labels for `enum`s or `oneOf`/`anyOf` in a schema, fixing [#4215](https://github.com/rjsf-team/react-jsonschema-form/issues/4215) and  [#4260](https://github.com/rjsf-team/react-jsonschema-form/issues/4260)
+  - NOTE: The generics for `optionsList()` were expanded from `<S extends StrictRJSFSchema = RJSFSchema>` to `<S extends StrictRJSFSchema = RJSFSchema, T = any, F extends FormContextType = any>` to support the `UiSchema`.
 
 ## Dev / docs / playground
 
@@ -41,7 +45,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Updated the `ValidatorType` interface to add an optional `reset?: () => void` prop that can be implemented to reset a validator back to initial constructed state
   - Updated the `ParserValidator` to provide a `reset()` function that clears the schema map
-- Also updated the default translatable string to use `Markdown` rather than HTML tags since we now render them with `Markdown` 
+- Also updated the default translatable string to use `Markdown` rather than HTML tags since we now render them with `Markdown`
 
 ## @rjsf/validator-ajv8
 

--- a/packages/core/src/components/fields/ArrayField.tsx
+++ b/packages/core/src/components/fields/ArrayField.tsx
@@ -612,7 +612,7 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
     } = this.props;
     const { widgets, schemaUtils, formContext, globalUiOptions } = registry;
     const itemsSchema = schemaUtils.retrieveSchema(schema.items as S, items);
-    const enumOptions = optionsList(itemsSchema);
+    const enumOptions = optionsList<S, T[], F>(itemsSchema, uiSchema);
     const { widget = 'select', title: uiTitle, ...options } = getUiOptions<T[], S, F>(uiSchema, globalUiOptions);
     const Widget = getWidget<T[], S, F>(schema, widget, widgets);
     const label = uiTitle ?? schema.title ?? name;

--- a/packages/core/src/components/fields/BooleanField.tsx
+++ b/packages/core/src/components/fields/BooleanField.tsx
@@ -52,19 +52,22 @@ function BooleanField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
   let enumOptions: EnumOptionsType<S>[] | undefined;
   const label = uiTitle ?? schemaTitle ?? title ?? name;
   if (Array.isArray(schema.oneOf)) {
-    enumOptions = optionsList<S>({
-      oneOf: schema.oneOf
-        .map((option) => {
-          if (isObject(option)) {
-            return {
-              ...option,
-              title: option.title || (option.const === true ? yes : no),
-            };
-          }
-          return undefined;
-        })
-        .filter((o: any) => o) as S[], // cast away the error that typescript can't grok is fixed
-    } as unknown as S);
+    enumOptions = optionsList<S, T, F>(
+      {
+        oneOf: schema.oneOf
+          .map((option) => {
+            if (isObject(option)) {
+              return {
+                ...option,
+                title: option.title || (option.const === true ? yes : no),
+              };
+            }
+            return undefined;
+          })
+          .filter((o: any) => o) as S[], // cast away the error that typescript can't grok is fixed
+      } as unknown as S,
+      uiSchema
+    );
   } else {
     // We deprecated enumNames in v5. It's intentionally omitted from RSJFSchema type, so we need to cast here.
     const schemaWithEnumNames = schema as S & { enumNames?: string[] };
@@ -81,11 +84,14 @@ function BooleanField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
         },
       ];
     } else {
-      enumOptions = optionsList<S>({
-        enum: enums,
-        // NOTE: enumNames is deprecated, but still supported for now.
-        enumNames: schemaWithEnumNames.enumNames,
-      } as unknown as S);
+      enumOptions = optionsList<S, T, F>(
+        {
+          enum: enums,
+          // NOTE: enumNames is deprecated, but still supported for now.
+          enumNames: schemaWithEnumNames.enumNames,
+        } as unknown as S,
+        uiSchema
+      );
     }
   }
 

--- a/packages/core/src/components/fields/StringField.tsx
+++ b/packages/core/src/components/fields/StringField.tsx
@@ -35,7 +35,7 @@ function StringField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends
   } = props;
   const { title, format } = schema;
   const { widgets, formContext, schemaUtils, globalUiOptions } = registry;
-  const enumOptions = schemaUtils.isSelect(schema) ? optionsList(schema) : undefined;
+  const enumOptions = schemaUtils.isSelect(schema) ? optionsList<S, T, F>(schema, uiSchema) : undefined;
   let defaultWidget = enumOptions ? 'select' : 'text';
   if (format && hasWidget<T, S, F>(schema, format, widgets)) {
     defaultWidget = format;

--- a/packages/core/test/BooleanField.test.jsx
+++ b/packages/core/test/BooleanField.test.jsx
@@ -387,7 +387,7 @@ describe('BooleanField', () => {
 
     const labels = [].map.call(node.querySelectorAll('.field-radio-group label'), (label) => label.textContent);
     expect(labels).eql(['Yes', 'No']);
-    expect(console.warn.calledWithMatch(/The enumNames property is deprecated/)).to.be.true;
+    expect(console.warn.calledWithMatch(/The "enumNames" property in the schema is deprecated/)).to.be.true;
   });
 
   it('should support oneOf titles for radio widgets', () => {
@@ -411,6 +411,29 @@ describe('BooleanField', () => {
 
     const labels = [].map.call(node.querySelectorAll('.field-radio-group label'), (label) => label.textContent);
     expect(labels).eql(['Yes', 'No']);
+  });
+
+  it('should support oneOf titles for radio widgets, overrides in uiSchema', () => {
+    const { node } = createFormComponent({
+      schema: {
+        type: 'boolean',
+        oneOf: [
+          {
+            const: true,
+            title: 'Yes',
+          },
+          {
+            const: false,
+            title: 'No',
+          },
+        ],
+      },
+      formData: true,
+      uiSchema: { 'ui:widget': 'radio', oneOf: [{ 'ui:title': 'Si!' }, { 'ui:title': 'No!' }] },
+    });
+
+    const labels = [].map.call(node.querySelectorAll('.field-radio-group label'), (label) => label.textContent);
+    expect(labels).eql(['Si!', 'No!']);
   });
 
   it('should preserve oneOf option ordering for radio widgets', () => {
@@ -495,19 +518,19 @@ describe('BooleanField', () => {
     expect(onBlur.calledWith(element.id, false)).to.be.true;
   });
 
-  it('should support enumNames for select', () => {
+  it('should support enumNames for select, with overrides in uiSchema', () => {
     const { node } = createFormComponent({
       schema: {
         type: 'boolean',
         enumNames: ['Yes', 'No'],
       },
       formData: true,
-      uiSchema: { 'ui:widget': 'select' },
+      uiSchema: { 'ui:widget': 'select', 'ui:enumNames': ['Si!', 'No!'] },
     });
 
     const labels = [].map.call(node.querySelectorAll('.field option'), (label) => label.textContent);
-    expect(labels).eql(['', 'Yes', 'No']);
-    expect(console.warn.calledWithMatch(/The enumNames property is deprecated/)).to.be.true;
+    expect(labels).eql(['', 'Si!', 'No!']);
+    expect(console.warn.calledWithMatch(/TThe "enumNames" property in the schema is deprecated/)).to.be.false;
   });
 
   it('should handle a focus event with checkbox', () => {

--- a/packages/docs/docs/api-reference/uiSchema.md
+++ b/packages/docs/docs/api-reference/uiSchema.md
@@ -228,6 +228,22 @@ const uiSchema: UiSchema = {
 };
 ```
 
+### enumNames
+
+Allows a user to provide a list of labels for enum values in the schema.
+
+```tsx
+import { RJSFSchema, UiSchema } from '@rjsf/utils';
+
+const schema: RJSFSchema = {
+  type: 'number',
+  enum: [1, 2, 3],
+};
+const uiSchema: UiSchema = {
+  'ui:enumNames': ['one', 'two', 'three'],
+};
+```
+
 ### filePreview
 
 The `FileWidget` can be configured to show a preview of an image or a download link for non-images using this flag.

--- a/packages/docs/docs/api-reference/utility-functions.md
+++ b/packages/docs/docs/api-reference/utility-functions.md
@@ -621,17 +621,21 @@ Return a consistent `id` for the `optionIndex`s of a `Radio` or `Checkboxes` wid
 
 - string: An id for the option index based on the parent `id`
 
-### optionsList&lt;S extends StrictRJSFSchema = RJSFSchema>()
+### optionsList&lt;S extends StrictRJSFSchema = RJSFSchema, T = any, F extends FormContextType = any>()
 
-Gets the list of options from the schema. If the schema has an enum list, then those enum values are returned.
-The labels for the options will be extracted from the non-standard `enumNames` if it exists otherwise will be the same as the `value`.
-If the schema has a `oneOf` or `anyOf`, then the value is the list of `const` values from the schema and the label is either the `schema.title` or the value.
+Gets the list of options from the `schema`. If the schema has an enum list, then those enum values are returned.
+The labels for the options will be extracted from the non-standard, RJSF-deprecated `enumNames` if it exists, otherwise
+the label will be the same as the `value`. If the schema has a `oneOf` or `anyOf`, then the value is the list of
+`const` values from the schema and the label is either the `schema.title` or the value. If a `uiSchema` is provided
+and it has the `ui:enumNames` matched with `enum` or it has an associated `oneOf` or `anyOf` with a list of objects
+containing `ui:title` then the UI schema values will replace the values from the schema.
 
-NOTE: `enumNames` is deprecated and may be removed in a future major version of RJSF.
+NOTE: `enumNames` is deprecated and will be removed in a future major version of RJSF. Use the "ui:enumNames" property in the uiSchema instead.
 
 #### Parameters
 
 - schema: S - The schema from which to extract the options list
+- uiSchema: UiSchema<T, S, F> - The optional uiSchema from which to get alternate labels for the options
 
 #### Returns
 

--- a/packages/docs/docs/json-schema/single.md
+++ b/packages/docs/docs/json-schema/single.md
@@ -107,7 +107,7 @@ const schema: RJSFSchema = {
 render(<Form schema={schema} validator={validator} />, document.getElementById('app'));
 ```
 
-In your JSON Schema, you may also specify `enumNames`, a non-standard field which RJSF can use to label an enumeration. **This behavior is deprecated and may be removed in a future major release of RJSF.**
+In your JSON Schema, you may also specify `enumNames`, a non-standard field which RJSF can use to label an enumeration. **This behavior is deprecated and will be removed in a future major release of RJSF. Use the "ui:enumNames" property in the uiSchema instead.**
 
 ```tsx
 import { RJSFSchema } from '@rjsf/utils';
@@ -119,6 +119,22 @@ const schema: RJSFSchema = {
   enumNames: ['one', 'two', 'three'],
 };
 render(<Form schema={schema} validator={validator} />, document.getElementById('app'));
+```
+
+Same example using the `uiSchema`'s `ui:enumNames` instead.
+
+```tsx
+import { RJSFSchema, UiSchema } from '@rjsf/utils';
+import validator from '@rjsf/validator-ajv8';
+
+const schema: RJSFSchema = {
+  type: 'number',
+  enum: [1, 2, 3],
+};
+const uiSchema: UiSchema = {
+  'ui:enumNames': ['one', 'two', 'three'],
+};
+render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />, document.getElementById('app'));
 ```
 
 ### Disabled attribute for `enum` fields

--- a/packages/docs/docs/migration-guides/v5.x upgrade guide.md
+++ b/packages/docs/docs/migration-guides/v5.x upgrade guide.md
@@ -437,7 +437,7 @@ The utility function `getMatchingOption()` was deprecated in favor of the more a
 
 `enumNames` is a non-standard JSON Schema field that was deprecated in version 5.
 `enumNames` could be included in the schema to apply labels that differed from an enumeration value.
-This behavior can still be accomplished with `oneOf` or `anyOf` containing `const` values, so `enumNames` support may be removed from a future major version of RJSF.
+This behavior can still be accomplished with `oneOf` or `anyOf` containing `const` values, so `enumNames` support will be removed from a future major version of RJSF.
 For more information, see [#532](https://github.com/rjsf-team/react-jsonschema-form/issues/532).
 
 ##### uiSchema.classNames

--- a/packages/utils/src/optionsList.ts
+++ b/packages/utils/src/optionsList.ts
@@ -1,36 +1,61 @@
 import toConstant from './toConstant';
-import { RJSFSchema, EnumOptionsType, StrictRJSFSchema } from './types';
+import { RJSFSchema, EnumOptionsType, StrictRJSFSchema, FormContextType, UiSchema } from './types';
+import getUiOptions from './getUiOptions';
 
-/** Gets the list of options from the schema. If the schema has an enum list, then those enum values are returned. The
+/** Gets the list of options from the `schema`. If the schema has an enum list, then those enum values are returned. The
  * labels for the options will be extracted from the non-standard, RJSF-deprecated `enumNames` if it exists, otherwise
  * the label will be the same as the `value`. If the schema has a `oneOf` or `anyOf`, then the value is the list of
- * `const` values from the schema and the label is either the `schema.title` or the value.
+ * `const` values from the schema and the label is either the `schema.title` or the value. If a `uiSchema` is provided
+ * and it has the `ui:enumNames` matched with `enum` or it has an associated `oneOf` or `anyOf` with a list of objects
+ * containing `ui:title` then the UI schema values will replace the values from the schema.
  *
  * @param schema - The schema from which to extract the options list
+ * @param [uiSchema] - The optional uiSchema from which to get alternate labels for the options
  * @returns - The list of options from the schema
  */
-export default function optionsList<S extends StrictRJSFSchema = RJSFSchema>(
-  schema: S
+export default function optionsList<S extends StrictRJSFSchema = RJSFSchema, T = any, F extends FormContextType = any>(
+  schema: S,
+  uiSchema?: UiSchema<T, S, F>
 ): EnumOptionsType<S>[] | undefined {
-  // enumNames was deprecated in v5 and is intentionally omitted from the RJSFSchema type.
-  // Cast the type to include enumNames so the feature still works.
+  // TODO flip generics to move T first in v6
   const schemaWithEnumNames = schema as S & { enumNames?: string[] };
-  if (schemaWithEnumNames.enumNames && process.env.NODE_ENV !== 'production') {
-    console.warn('The enumNames property is deprecated and may be removed in a future major release.');
-  }
   if (schema.enum) {
+    let enumNames: string[] | undefined;
+    if (uiSchema) {
+      const { enumNames: uiEnumNames } = getUiOptions<T, S, F>(uiSchema);
+      enumNames = uiEnumNames;
+    }
+    if (!enumNames && schemaWithEnumNames.enumNames) {
+      // enumNames was deprecated in v5 and is intentionally omitted from the RJSFSchema type.
+      // Cast the type to include enumNames so the feature still works.
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(
+          'The "enumNames" property in the schema is deprecated and will be removed in a future major release. Use the "ui:enumNames" property in the uiSchema instead.'
+        );
+      }
+      enumNames = schemaWithEnumNames.enumNames;
+    }
     return schema.enum.map((value, i) => {
-      const label = (schemaWithEnumNames.enumNames && schemaWithEnumNames.enumNames[i]) || String(value);
+      const label = enumNames?.[i] || String(value);
       return { label, value };
     });
   }
-  const altSchemas = schema.oneOf || schema.anyOf;
+  let altSchemas: S['anyOf'] | S['oneOf'] = undefined;
+  let altUiSchemas: UiSchema<T, S, F> | undefined = undefined;
+  if (schema.anyOf) {
+    altSchemas = schema.anyOf;
+    altUiSchemas = uiSchema?.anyOf;
+  } else if (schema.oneOf) {
+    altSchemas = schema.oneOf;
+    altUiSchemas = uiSchema?.oneOf;
+  }
   return (
     altSchemas &&
-    altSchemas.map((aSchemaDef) => {
+    altSchemas.map((aSchemaDef, index) => {
+      const { title } = getUiOptions<T, S, F>(altUiSchemas?.[index]);
       const aSchema = aSchemaDef as S;
       const value = toConstant(aSchema);
-      const label = aSchema.title || String(value);
+      const label = title || aSchema.title || String(value);
       return {
         schema: aSchema,
         label,

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -890,6 +890,8 @@ type UIOptionsBaseType<T = any, S extends StrictRJSFSchema = RJSFSchema, F exten
      * to look up an implementation from the `widgets` list or an actual one-off widget implementation itself
      */
     widget?: Widget<T, S, F> | string;
+    /** Allows a user to provide a list of labels for enum values in the schema */
+    enumNames?: string[];
   };
 
 /** The type that represents the Options potentially provided by `ui:options` */

--- a/packages/utils/test/optionsList.test.ts
+++ b/packages/utils/test/optionsList.test.ts
@@ -64,7 +64,7 @@ describe('optionsList()', () => {
       );
       expect(console.warn).not.toHaveBeenCalled();
     });
-    it('generates options and doesn not emit a deprecation warning for a schema with enumNames in production', () => {
+    it('generates options and does not emit a deprecation warning for a schema with enumNames in production', () => {
       process.env.NODE_ENV = 'production';
       const enumSchema: RJSFSchema = {
         type: 'string',

--- a/packages/utils/test/optionsList.test.ts
+++ b/packages/utils/test/optionsList.test.ts
@@ -1,103 +1,280 @@
-import { RJSFSchema, optionsList } from '../src';
+import { RJSFSchema, UiSchema, optionsList } from '../src';
 
 describe('optionsList()', () => {
   let consoleWarnSpy: jest.SpyInstance;
+  let oldProcessEnv: string | undefined;
   beforeAll(() => {
+    oldProcessEnv = process.env.NODE_ENV;
     consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
   });
   afterAll(() => {
     consoleWarnSpy.mockRestore();
   });
   afterEach(() => {
+    process.env.NODE_ENV = oldProcessEnv;
     consoleWarnSpy.mockClear();
   });
-
-  it('should generate options for an enum schema', () => {
-    const enumSchema: RJSFSchema = {
-      type: 'string',
-      enum: ['Opt1', 'Opt2', 'Opt3'],
-    };
-
-    expect(optionsList(enumSchema)).toEqual(enumSchema.enum!.map((opt) => ({ label: opt, value: opt })));
+  it('returns undefined when schema does not have any options', () => {
+    expect(optionsList({})).toBeUndefined();
   });
+  describe('enums', () => {
+    it('should generate options for an enum schema', () => {
+      const enumSchema: RJSFSchema = {
+        type: 'string',
+        enum: ['Opt1', 'Opt2', 'Opt3'],
+      };
 
-  it('generates options and emits a deprecation warning for a schema with enumNames', () => {
-    const enumSchema: RJSFSchema = {
-      type: 'string',
-      enum: ['Opt1', 'Opt2', 'Opt3'],
-    };
+      expect(optionsList(enumSchema)).toEqual(enumSchema.enum!.map((opt) => ({ label: opt, value: opt })));
+    });
+    it('should generate options for an enum schema and uiSchema enumNames', () => {
+      const enumSchema: RJSFSchema = {
+        type: 'string',
+        enum: ['Opt1', 'Opt2', 'Opt3'],
+      };
+      const uiSchema: UiSchema = {
+        'ui:enumNames': ['Option1', 'Option2', 'Option3'],
+      };
 
-    const enumNameSchema = {
-      ...enumSchema,
-      enumNames: ['Option1', 'Option2', 'Option3'],
-    };
+      expect(optionsList(enumSchema, uiSchema)).toEqual(
+        enumSchema.enum!.map((opt, index) => {
+          const label: string = uiSchema['ui:enumNames']![index] ?? opt;
+          return { label, value: opt };
+        })
+      );
+    });
+    it('generates options and favors uiSchema if schema.enumNames is present', () => {
+      const enumSchema: RJSFSchema = {
+        type: 'string',
+        enum: ['Opt1', 'Opt2', 'Opt3'],
+      };
+      const uiSchema: UiSchema = {
+        'ui:enumNames': ['Option1', 'Option2', 'Option3'],
+      };
 
-    expect(optionsList(enumNameSchema)).toEqual(
-      enumNameSchema.enum!.map((opt, index) => {
-        const label = enumNameSchema.enumNames[index] || opt;
-        return { label: label, value: opt };
-      })
-    );
-    expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/The enumNames property is deprecated/));
+      const enumNameSchema = {
+        ...enumSchema,
+        enumNames: ['Option One', 'Option Two', 'Option Three'],
+      };
+
+      expect(optionsList(enumNameSchema, uiSchema)).toEqual(
+        enumNameSchema.enum!.map((opt, index) => {
+          const label: string = uiSchema['ui:enumNames']![index] ?? opt;
+          return { label, value: opt };
+        })
+      );
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+    it('generates options and doesn not emit a deprecation warning for a schema with enumNames in production', () => {
+      process.env.NODE_ENV = 'production';
+      const enumSchema: RJSFSchema = {
+        type: 'string',
+        enum: ['Opt1', 'Opt2', 'Opt3'],
+      };
+
+      const enumNameSchema = {
+        ...enumSchema,
+        enumNames: ['Option1', 'Option2', 'Option3'],
+      };
+
+      expect(optionsList(enumNameSchema)).toEqual(
+        enumNameSchema.enum!.map((opt, index) => {
+          const label = enumNameSchema.enumNames[index] || opt;
+          return { label, value: opt };
+        })
+      );
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+    it('generates options and emits a deprecation warning for a schema with enumNames', () => {
+      const enumSchema: RJSFSchema = {
+        type: 'string',
+        enum: ['Opt1', 'Opt2', 'Opt3'],
+      };
+
+      const enumNameSchema = {
+        ...enumSchema,
+        enumNames: ['Option1', 'Option2', 'Option3'],
+      };
+
+      expect(optionsList(enumNameSchema)).toEqual(
+        enumNameSchema.enum!.map((opt, index) => {
+          const label = enumNameSchema.enumNames[index] || opt;
+          return { label, value: opt };
+        })
+      );
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringMatching(/The "enumNames" property in the schema is deprecated/)
+      );
+    });
   });
-
-  it('should generate options for a oneOf|anyOf schema', () => {
-    const oneOfSchema = {
-      title: 'string',
-      oneOf: [
-        {
-          const: 'Option1',
-          title: 'Option1 title',
-          description: 'Option1 description',
-        },
-        {
-          const: 'Option2',
-          title: 'Option2 title',
-          description: 'Option2 description',
-        },
-        {
-          const: 'Option3',
-          title: 'Option3 title',
-          description: 'Option3 description',
-        },
-      ],
-    };
-    const anyofSchema = {
-      ...oneOfSchema,
-      oneOf: undefined,
-      anyOf: oneOfSchema.oneOf,
-    };
-    expect(optionsList(oneOfSchema)).toEqual(
-      oneOfSchema.oneOf.map((schema) => ({
-        schema,
-        label: schema.title,
-        value: schema.const,
-      }))
-    );
-    expect(optionsList(anyofSchema)).toEqual(
-      anyofSchema.anyOf.map((schema) => ({
-        schema,
-        label: schema.title,
-        value: schema.const,
-      }))
-    );
+  describe('anyOf', () => {
+    it('should generate options for a anyOf schema', () => {
+      const anyOfSchema = {
+        title: 'string',
+        anyOf: [
+          {
+            const: 'Option1',
+            title: 'Option1 title',
+            description: 'Option1 description',
+          },
+          {
+            const: 'Option2',
+            title: 'Option2 title',
+            description: 'Option2 description',
+          },
+          {
+            const: 'Option3',
+            title: 'Option3 title',
+            description: 'Option3 description',
+          },
+        ],
+      };
+      const anyofSchema = {
+        ...anyOfSchema,
+        anyOf: anyOfSchema.anyOf,
+      };
+      expect(optionsList(anyOfSchema)).toEqual(
+        anyOfSchema.anyOf.map((schema) => ({
+          schema,
+          label: schema.title,
+          value: schema.const,
+        }))
+      );
+      expect(optionsList(anyofSchema)).toEqual(
+        anyofSchema.anyOf.map((schema) => ({
+          schema,
+          label: schema.title,
+          value: schema.const,
+        }))
+      );
+    });
+    it('should generate options for a anyOf schema and uiSchema', () => {
+      const anyOfSchema = {
+        title: 'string',
+        anyOf: [
+          {
+            const: 'Option',
+            description: 'Option description',
+          },
+        ],
+      };
+      const anyOfUiSchema: UiSchema = {
+        anyOf: [
+          {
+            'ui:title': 'Alternate',
+          },
+        ],
+      };
+      expect(optionsList<RJSFSchema>(anyOfSchema, anyOfUiSchema)).toEqual(
+        anyOfSchema.anyOf.map((schema, index) => ({
+          schema,
+          label: anyOfUiSchema.anyOf[index]['ui:title'],
+          value: schema.const,
+        }))
+      );
+    });
+    it('should generate options for a anyOf schema uses value as fallback title', () => {
+      const anyOfSchema = {
+        title: 'string',
+        anyOf: [
+          {
+            const: 'Option',
+            description: 'Option description',
+          },
+        ],
+      };
+      expect(optionsList(anyOfSchema)).toEqual(
+        anyOfSchema.anyOf.map((schema) => ({
+          schema,
+          label: schema.const,
+          value: schema.const,
+        }))
+      );
+    });
   });
-  it('should generate options for a oneOf schema uses value as fallback title', () => {
-    const oneOfSchema = {
-      title: 'string',
-      oneOf: [
-        {
-          const: 'Option',
-          description: 'Option description',
-        },
-      ],
-    };
-    expect(optionsList(oneOfSchema)).toEqual(
-      oneOfSchema.oneOf.map((schema) => ({
-        schema,
-        label: schema.const,
-        value: schema.const,
-      }))
-    );
+  describe('oneOf', () => {
+    it('should generate options for a oneOf schema', () => {
+      const oneOfSchema = {
+        title: 'string',
+        oneOf: [
+          {
+            const: 'Option1',
+            title: 'Option1 title',
+            description: 'Option1 description',
+          },
+          {
+            const: 'Option2',
+            title: 'Option2 title',
+            description: 'Option2 description',
+          },
+          {
+            const: 'Option3',
+            title: 'Option3 title',
+            description: 'Option3 description',
+          },
+        ],
+      };
+      const anyofSchema = {
+        ...oneOfSchema,
+        oneOf: undefined,
+        anyOf: oneOfSchema.oneOf,
+      };
+      expect(optionsList(oneOfSchema)).toEqual(
+        oneOfSchema.oneOf.map((schema) => ({
+          schema,
+          label: schema.title,
+          value: schema.const,
+        }))
+      );
+      expect(optionsList(anyofSchema)).toEqual(
+        anyofSchema.anyOf.map((schema) => ({
+          schema,
+          label: schema.title,
+          value: schema.const,
+        }))
+      );
+    });
+    it('should generate options for a oneOf schema and uiSchema', () => {
+      const oneOfSchema = {
+        title: 'string',
+        oneOf: [
+          {
+            const: 'Option',
+            description: 'Option description',
+          },
+        ],
+      };
+      const oneOfUiSchema: UiSchema = {
+        oneOf: [
+          {
+            'ui:title': 'Alternate',
+          },
+        ],
+      };
+      expect(optionsList<RJSFSchema>(oneOfSchema, oneOfUiSchema)).toEqual(
+        oneOfSchema.oneOf.map((schema, index) => ({
+          schema,
+          label: oneOfUiSchema.oneOf[index]['ui:title'],
+          value: schema.const,
+        }))
+      );
+    });
+    it('should generate options for a oneOf schema uses value as fallback title', () => {
+      const oneOfSchema = {
+        title: 'string',
+        oneOf: [
+          {
+            const: 'Option',
+            description: 'Option description',
+          },
+        ],
+      };
+      expect(optionsList(oneOfSchema)).toEqual(
+        oneOfSchema.oneOf.map((schema) => ({
+          schema,
+          label: schema.const,
+          value: schema.const,
+        }))
+      );
+    });
   });
 });


### PR DESCRIPTION
### Reasons for making this change

Fixes #4215 and #4260 by supporting alternate titles for enums and anyOf/oneOf lists via the uiSchema

- In `@rjsf/utils` added support for alternate option labels from the `UiSchema` as follows:
  - Updated `UIOptionsBaseType` to add the new `enumNames` prop to support an alternate way to provide labels for `enum`s in a schema
  - Updated `optionsList()` to take an optional `uiSchema` that is used to extract alternate labels for `enum`s or `oneOf`/`anyOf` in a schema
    - NOTE: The generics for `optionsList()` were expanded to add `T = any, F extends FormContextType = any` to support the `UiSchema`
    - Added unit tests to maintain 100% coverage
- In `@rjsf/core` updated `ArrayField`, `BooleanField` and `StringField` to call `optionsList()` with the additional `UiSchema` parameter
- In `docs` added documentation about the new `ui:enumNames` property, fixing up the `enumNames` documentation to indicate it WILL be removed
  - Also updated the `optionsList()` function's documentation to add the new `uiSchema` prop
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
