### PR TITLE
Revert "feat: improve deepEquals performance (#4292)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.21.1
+
+## @rjsf/utils
+
+- Revert of updating `deepEquals()` from [#4292]
+
+## @validator-ajv8
+
+- Revert of using `deepEquals()` instead of `lodash.isEqual()` from [#4292]
+
 # 5.21.0
 
 ## @rjsf/core

--- a/package-lock.json
+++ b/package-lock.json
@@ -16648,15 +16648,6 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
-    "node_modules/fast-equals": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
-      "integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -35245,7 +35236,6 @@
       "version": "5.21.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "fast-equals": "^5.0.1",
         "json-schema-merge-allof": "^0.8.1",
         "jsonpointer": "^5.0.1",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -79,5 +79,6 @@
     "packages/validator-ajv6",
     "packages/validator-ajv8",
     "packages/snapshot-tests"
-  ]
+  ],
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,5 @@
     "packages/validator-ajv6",
     "packages/validator-ajv8",
     "packages/snapshot-tests"
-  ],
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  ]
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -36,7 +36,6 @@
     "react": "^16.14.0 || >=17"
   },
   "dependencies": {
-    "fast-equals": "^5.0.1",
     "json-schema-merge-allof": "^0.8.1",
     "jsonpointer": "^5.0.1",
     "lodash": "^4.17.21",

--- a/packages/utils/src/createSchemaUtils.ts
+++ b/packages/utils/src/createSchemaUtils.ts
@@ -14,9 +14,9 @@ import {
   ValidatorType,
 } from './types';
 import {
-  getClosestMatchingOption,
   getDefaultFormState,
   getDisplayLabel,
+  getClosestMatchingOption,
   getFirstMatchingOption,
   getMatchingOption,
   isFilesArray,

--- a/packages/utils/src/deepEquals.ts
+++ b/packages/utils/src/deepEquals.ts
@@ -1,37 +1,6 @@
-import { createCustomEqual, State } from 'fast-equals';
+import isEqualWith from 'lodash/isEqualWith';
 
-/** Check if all parameters are typeof function.
- *
- * @param a - The first element to check typeof
- * @param b - The second element to check typeof
- * @returns - if typeof a and b are equal to function return true, otherwise false
- */
-function isFunctions(a: any, b: any) {
-  return typeof a === 'function' && typeof b === 'function';
-}
-
-/** Implements a deep equals using the `fast-equal.createCustomEqual` function, that provides a customized comparator that
- * assumes all functions in objects are equivalent.
- *
- * @param a - The first element to compare
- * @param b - The second element to compare
- * @returns - True if the `a` and `b` are deeply equal, false otherwise
- */
-const customDeepEqual = createCustomEqual({
-  createInternalComparator: (comparator: (a: any, b: any, state: State<any>) => boolean) => {
-    return (a: any, b: any, _idxA: any, _idxB: any, _parentA: any, _parentB: any, state: State<any>) => {
-      if (isFunctions(a, b)) {
-        // Assume all functions are equivalent
-        // see https://github.com/rjsf-team/react-jsonschema-form/issues/255
-        return true;
-      }
-
-      return comparator(a, b, state);
-    };
-  },
-});
-
-/** Implements a deep equals using the `fast-equal.createCustomEqual` function, that provides a customized comparator that
+/** Implements a deep equals using the `lodash.isEqualWith` function, that provides a customized comparator that
  * assumes all functions are equivalent.
  *
  * @param a - The first element to compare
@@ -39,8 +8,12 @@ const customDeepEqual = createCustomEqual({
  * @returns - True if the `a` and `b` are deeply equal, false otherwise
  */
 export default function deepEquals(a: any, b: any): boolean {
-  if (isFunctions(a, b)) {
-    return true;
-  }
-  return customDeepEqual(a, b);
+  return isEqualWith(a, b, (obj: any, other: any) => {
+    if (typeof obj === 'function' && typeof other === 'function') {
+      // Assume all functions are equivalent
+      // see https://github.com/rjsf-team/react-jsonschema-form/issues/255
+      return true;
+    }
+    return undefined; // fallback to default isEquals behavior
+  });
 }

--- a/packages/utils/src/enumOptionsDeselectValue.ts
+++ b/packages/utils/src/enumOptionsDeselectValue.ts
@@ -1,6 +1,7 @@
+import isEqual from 'lodash/isEqual';
+
 import { EnumOptionsType, RJSFSchema, StrictRJSFSchema } from './types';
 import enumOptionsValueForIndex from './enumOptionsValueForIndex';
-import deepEquals from './deepEquals';
 
 /** Removes the enum option value at the `valueIndex` from the currently `selected` (list of) value(s). If `selected` is
  * a list, then that list is updated to remove the enum option value with the `valueIndex` in `allEnumOptions`. If it is
@@ -21,7 +22,7 @@ export default function enumOptionsDeselectValue<S extends StrictRJSFSchema = RJ
 ): EnumOptionsType<S>['value'] | EnumOptionsType<S>['value'][] | undefined {
   const value = enumOptionsValueForIndex<S>(valueIndex, allEnumOptions);
   if (Array.isArray(selected)) {
-    return selected.filter((v) => !deepEquals(v, value));
+    return selected.filter((v) => !isEqual(v, value));
   }
-  return deepEquals(value, selected) ? undefined : selected;
+  return isEqual(value, selected) ? undefined : selected;
 }

--- a/packages/utils/src/enumOptionsIsSelected.ts
+++ b/packages/utils/src/enumOptionsIsSelected.ts
@@ -1,4 +1,5 @@
-import deepEquals from './deepEquals';
+import isEqual from 'lodash/isEqual';
+
 import { EnumOptionsType, RJSFSchema, StrictRJSFSchema } from './types';
 
 /** Determines whether the given `value` is (one of) the `selected` value(s).
@@ -12,7 +13,7 @@ export default function enumOptionsIsSelected<S extends StrictRJSFSchema = RJSFS
   selected: EnumOptionsType<S>['value'] | EnumOptionsType<S>['value'][]
 ) {
   if (Array.isArray(selected)) {
-    return selected.some((sel) => deepEquals(sel, value));
+    return selected.some((sel) => isEqual(sel, value));
   }
-  return deepEquals(selected, value);
+  return isEqual(selected, value);
 }

--- a/packages/utils/src/parser/ParserValidator.ts
+++ b/packages/utils/src/parser/ParserValidator.ts
@@ -1,4 +1,5 @@
 import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
 
 import { ID_KEY } from '../constants';
 import hashForSchema from '../hashForSchema';
@@ -14,7 +15,6 @@ import {
   ValidationData,
   ValidatorType,
 } from '../types';
-import deepEquals from '../deepEquals';
 
 /** The type of the map of schema hash to schema
  */
@@ -67,7 +67,7 @@ export default class ParserValidator<T = any, S extends StrictRJSFSchema = RJSFS
     const existing = this.schemaMap[key];
     if (!existing) {
       this.schemaMap[key] = identifiedSchema;
-    } else if (!deepEquals(existing, identifiedSchema)) {
+    } else if (!isEqual(existing, identifiedSchema)) {
       console.error('existing schema:', JSON.stringify(existing, null, 2));
       console.error('new schema:', JSON.stringify(identifiedSchema, null, 2));
       throw new Error(
@@ -91,7 +91,7 @@ export default class ParserValidator<T = any, S extends StrictRJSFSchema = RJSFS
    * @throws - Error when the given `rootSchema` differs from the root schema provided during construction
    */
   isValid(schema: S, _formData: T, rootSchema: S): boolean {
-    if (!deepEquals(rootSchema, this.rootSchema)) {
+    if (!isEqual(rootSchema, this.rootSchema)) {
       throw new Error('Unexpectedly calling isValid() with a rootSchema that differs from the construction rootSchema');
     }
     this.addSchema(schema, hashForSchema<S>(schema));

--- a/packages/utils/src/parser/schemaParser.ts
+++ b/packages/utils/src/parser/schemaParser.ts
@@ -1,10 +1,10 @@
 import forEach from 'lodash/forEach';
+import isEqual from 'lodash/isEqual';
 
 import { FormContextType, RJSFSchema, StrictRJSFSchema } from '../types';
-import { ITEMS_KEY, PROPERTIES_KEY } from '../constants';
+import { PROPERTIES_KEY, ITEMS_KEY } from '../constants';
 import ParserValidator, { SchemaMap } from './ParserValidator';
-import { resolveAnyOrOneOfSchemas, retrieveSchemaInternal } from '../schema/retrieveSchema';
-import deepEquals from '../deepEquals';
+import { retrieveSchemaInternal, resolveAnyOrOneOfSchemas } from '../schema/retrieveSchema';
 
 /** Recursive function used to parse the given `schema` belonging to the `rootSchema`. The `validator` is used to
  * capture the sub-schemas that the `isValid()` function is called with. For each schema returned by the
@@ -24,7 +24,7 @@ function parseSchema<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends
 ) {
   const schemas = retrieveSchemaInternal<T, S, F>(validator, schema, rootSchema, undefined, true);
   schemas.forEach((schema) => {
-    const sameSchemaIndex = recurseList.findIndex((item) => deepEquals(item, schema));
+    const sameSchemaIndex = recurseList.findIndex((item) => isEqual(item, schema));
     if (sameSchemaIndex === -1) {
       recurseList.push(schema);
       const allOptions = resolveAnyOrOneOfSchemas<T, S, F>(validator, schema, rootSchema, true);

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -1,4 +1,5 @@
 import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
 import set from 'lodash/set';
 import times from 'lodash/times';
 import transform from 'lodash/transform';
@@ -14,10 +15,10 @@ import {
   ANY_OF_KEY,
   DEPENDENCIES_KEY,
   IF_KEY,
-  ITEMS_KEY,
   ONE_OF_KEY,
-  PROPERTIES_KEY,
   REF_KEY,
+  PROPERTIES_KEY,
+  ITEMS_KEY,
 } from '../constants';
 import findSchemaDefinition, { splitKeyElementFromObject } from '../findSchemaDefinition';
 import getDiscriminatorFieldFromSchema from '../getDiscriminatorFieldFromSchema';
@@ -26,7 +27,6 @@ import isObject from '../isObject';
 import mergeSchemas from '../mergeSchemas';
 import { FormContextType, GenericObjectType, RJSFSchema, StrictRJSFSchema, ValidatorType } from '../types';
 import getFirstMatchingOption from './getFirstMatchingOption';
-import deepEquals from '../deepEquals';
 
 /** Retrieves an expanded schema that has had all of its conditions, additional properties, references and dependencies
  * resolved and merged into the `schema` given a `validator`, `rootSchema` and `rawFormData` that is used to do the
@@ -196,10 +196,7 @@ export function resolveSchema<T = any, S extends StrictRJSFSchema = RJSFSchema, 
       )
     );
     const allPermutations = getAllPermutationsOfXxxOf<S>(allOfSchemaElements);
-    return allPermutations.map((permutation) => ({
-      ...schema,
-      allOf: permutation,
-    }));
+    return allPermutations.map((permutation) => ({ ...schema, allOf: permutation }));
   }
   // No $ref or dependencies or allOf attribute was found, returning the original schema.
   return [schema];
@@ -296,7 +293,7 @@ export function resolveAllReferences<S extends StrictRJSFSchema = RJSFSchema>(
     };
   }
 
-  return deepEquals(schema, resolvedSchema) ? schema : resolvedSchema;
+  return isEqual(schema, resolvedSchema) ? schema : resolvedSchema;
 }
 
 /** Creates new 'properties' items for each key in the `formData`

--- a/packages/utils/src/schema/toIdSchema.ts
+++ b/packages/utils/src/schema/toIdSchema.ts
@@ -1,11 +1,11 @@
 import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
 
 import { ALL_OF_KEY, DEPENDENCIES_KEY, ID_KEY, ITEMS_KEY, PROPERTIES_KEY, REF_KEY } from '../constants';
 import isObject from '../isObject';
 import { FormContextType, GenericObjectType, IdSchema, RJSFSchema, StrictRJSFSchema, ValidatorType } from '../types';
 import retrieveSchema from './retrieveSchema';
 import getSchemaType from '../getSchemaType';
-import deepEquals from '../deepEquals';
 
 /** An internal helper that generates an `IdSchema` object for the `schema`, recursively with protection against
  * infinite recursion
@@ -32,7 +32,7 @@ function toIdSchemaInternal<T = any, S extends StrictRJSFSchema = RJSFSchema, F 
 ): IdSchema<T> {
   if (REF_KEY in schema || DEPENDENCIES_KEY in schema || ALL_OF_KEY in schema) {
     const _schema = retrieveSchema<T, S, F>(validator, schema, rootSchema, formData);
-    const sameSchemaIndex = _recurseList.findIndex((item) => deepEquals(item, _schema));
+    const sameSchemaIndex = _recurseList.findIndex((item) => isEqual(item, _schema));
     if (sameSchemaIndex === -1) {
       return toIdSchemaInternal<T, S, F>(
         validator,

--- a/packages/utils/src/schema/toPathSchema.ts
+++ b/packages/utils/src/schema/toPathSchema.ts
@@ -1,10 +1,11 @@
 import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
 import set from 'lodash/set';
 
 import {
-  ADDITIONAL_PROPERTIES_KEY,
   ALL_OF_KEY,
   ANY_OF_KEY,
+  ADDITIONAL_PROPERTIES_KEY,
   DEPENDENCIES_KEY,
   ITEMS_KEY,
   NAME_KEY,
@@ -17,7 +18,6 @@ import getDiscriminatorFieldFromSchema from '../getDiscriminatorFieldFromSchema'
 import { FormContextType, GenericObjectType, PathSchema, RJSFSchema, StrictRJSFSchema, ValidatorType } from '../types';
 import getClosestMatchingOption from './getClosestMatchingOption';
 import retrieveSchema from './retrieveSchema';
-import deepEquals from '../deepEquals';
 
 /** An internal helper that generates an `PathSchema` object for the `schema`, recursively with protection against
  * infinite recursion
@@ -40,7 +40,7 @@ function toPathSchemaInternal<T = any, S extends StrictRJSFSchema = RJSFSchema, 
 ): PathSchema<T> {
   if (REF_KEY in schema || DEPENDENCIES_KEY in schema || ALL_OF_KEY in schema) {
     const _schema = retrieveSchema<T, S, F>(validator, schema, rootSchema, formData);
-    const sameSchemaIndex = _recurseList.findIndex((item) => deepEquals(item, _schema));
+    const sameSchemaIndex = _recurseList.findIndex((item) => isEqual(item, _schema));
     if (sameSchemaIndex === -1) {
       return toPathSchemaInternal<T, S, F>(
         validator,

--- a/packages/utils/test/deepEquals.test.ts
+++ b/packages/utils/test/deepEquals.test.ts
@@ -1,7 +1,7 @@
 import { deepEquals } from '../src';
 
 describe('deepEquals()', () => {
-  // Note: deepEquals implementation uses fast-equal.createCustomEqual, so we focus on the behavioral differences we introduced.
+  // Note: deepEquals implementation uses isEqualWith, so we focus on the behavioral differences we introduced.
   it('should assume functions are always equivalent', () => {
     expect(
       deepEquals(

--- a/packages/validator-ajv8/src/precompiledValidator.ts
+++ b/packages/validator-ajv8/src/precompiledValidator.ts
@@ -1,21 +1,21 @@
 import { ErrorObject } from 'ajv';
 import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
 import {
   CustomValidator,
-  deepEquals,
   ErrorSchema,
   ErrorTransformer,
   FormContextType,
   hashForSchema,
   ID_KEY,
   JUNK_OPTION_ID,
-  retrieveSchema,
   RJSFSchema,
   StrictRJSFSchema,
   toErrorList,
   UiSchema,
   ValidationData,
   ValidatorType,
+  retrieveSchema,
 } from '@rjsf/utils';
 
 import { CompiledValidateFunction, Localizer, ValidatorFunctions } from './types';
@@ -92,10 +92,10 @@ export default class AJV8PrecompiledValidator<
    * @param [formData] - The form data to validate if any
    */
   ensureSameRootSchema(schema: S, formData?: T) {
-    if (!deepEquals(schema, this.rootSchema)) {
+    if (!isEqual(schema, this.rootSchema)) {
       // Resolve the root schema with the passed in form data since that may affect the resolution
       const resolvedRootSchema = retrieveSchema(this, this.rootSchema, this.rootSchema, formData);
-      if (!deepEquals(schema, resolvedRootSchema)) {
+      if (!isEqual(schema, resolvedRootSchema)) {
         throw new Error(
           'The schema associated with the precompiled validator differs from the rootSchema provided for validation'
         );


### PR DESCRIPTION
### Reasons for making this change
This reverts the pr #4292 due to `maximum call stack exceeded` issue reported https://github.com/rjsf-team/react-jsonschema-form/pull/4292#issuecomment-2345672065

If your PR is non-trivial and you'd like to schedule a synchronous review, please add it to the weekly meeting agenda: https://docs.google.com/document/d/12PjTvv21k6LIky6bNQVnsplMLLnmEuypTLQF8a-8Wss/edit

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
