### PR TITLE
fix: Improved the widget/field customization docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.21.2
+
+## Dev / docs / playground
+
+- Updated the `custom-widgets-fields.md` to add examples of wrapping a widget/field
+
 # 5.21.1
 
 ## @rjsf/utils

--- a/packages/docs/docs/advanced-customization/custom-widgets-fields.md
+++ b/packages/docs/docs/advanced-customization/custom-widgets-fields.md
@@ -279,6 +279,34 @@ render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />, docum
 
 All the widgets that render a text input use the `BaseInputTemplate` component internally. If you need to customize all text inputs without customizing all widgets individually, you can provide a `BaseInputTemplate` component in the `templates` property of `Form` (see [Custom Templates](./custom-templates.md#baseinputtemplate)).
 
+### Wrapping an exist widget to customize it
+
+Sometimes you just need to customize the properties that are passed to an existing widget.
+The way to do this varies based upon whether you are using core or some other theme (such as mui).
+
+Here is an example of modifying the `SelectWidget` to change the ordering of `enumOptions`:
+
+```tsx
+import { WidgetProps } from '@rjsf/utils';
+import { getDefaultRegistry } from '@rjsf/core';
+import { Widgets } from '@rjsf/mui';
+
+import myOptionsOrderFunction from './myOptionsOrderFunction';
+
+const {
+  widgets: { SelectWidget },
+} = getDefaultRegistry(); // To get widgets from core
+// const { SelectWidget } = Widgets; // To get widgets from a theme do this
+
+function MySelectWidget(props: WidgetProps) {
+  const { options } = props;
+  let { enumOptions } = options;
+  // Reorder the `enumOptions` however you want
+  enumOptions = myOptionsOrderFunction(enumOptions);
+  return <SelectWidget {...props} options={{ ...options, enumOptions }} />;
+}
+```
+
 ## Custom field components
 
 You can provide your own field components to a uiSchema for basically any json schema data type, by specifying a `ui:field` property.
@@ -474,4 +502,38 @@ const schema: RJSFSchema = {
 };
 
 render(<Form schema={schema} validator={validator} fields={fields} />, document.getElementById('app'));
+```
+
+### Wrapping an exist field to customize it
+
+Sometimes you just need to customize the properties that are passed to an existing field.
+
+Here is an example of wrapping the `ObjectField` to tweak the `onChange` handler to look for a specific kind of bad data:
+
+```tsx
+import { useCallback } from 'react';
+import { FieldProps } from '@rjsf/utils';
+import { getDefaultRegistry } from '@rjsf/core';
+
+import checkBadData from './checkBadData';
+
+const {
+  fields: { ObjectField },
+} = getDefaultRegistry();
+
+function MyObjectField(props: FieldProps) {
+  const { onChange } = props;
+  const onChangeHandler = useCallback(
+    (newFormData: T | undefined, es?: ErrorSchema<T>, id?: string) => {
+      let data = newFormData;
+      let error = es;
+      if (checkBadData(newFormData)) {
+        // Format the `error` and fix the `data` here
+      }
+      onChange(data, error, id);
+    },
+    [onChange]
+  );
+  return <ObjectField {...props} onChange={onChangeHandler} />;
+}
 ```

--- a/packages/docs/docs/advanced-customization/custom-widgets-fields.md
+++ b/packages/docs/docs/advanced-customization/custom-widgets-fields.md
@@ -279,7 +279,7 @@ render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />, docum
 
 All the widgets that render a text input use the `BaseInputTemplate` component internally. If you need to customize all text inputs without customizing all widgets individually, you can provide a `BaseInputTemplate` component in the `templates` property of `Form` (see [Custom Templates](./custom-templates.md#baseinputtemplate)).
 
-### Wrapping an exist widget to customize it
+### Wrapping an existing widget to customize it
 
 Sometimes you just need to customize the properties that are passed to an existing widget.
 The way to do this varies based upon whether you are using core or some other theme (such as mui).
@@ -504,7 +504,7 @@ const schema: RJSFSchema = {
 render(<Form schema={schema} validator={validator} fields={fields} />, document.getElementById('app'));
 ```
 
-### Wrapping an exist field to customize it
+### Wrapping an existing field to customize it
 
 Sometimes you just need to customize the properties that are passed to an existing field.
 


### PR DESCRIPTION
### Reasons for making this change

Updated the widget and field customization docs to add examples of wrapping a widget/field to adjust props

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
