### PR TITLE
Fix: Pass required props to anyof/oneof field components

### DIFF
--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -317,6 +317,7 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
               schemaUtils.retrieveSchema(isObject(_schema) ? (_schema as S) : ({} as S), formData)
             )}
             registry={registry}
+            required={required}
             schema={schema}
             uiSchema={uiSchema}
           />
@@ -340,6 +341,7 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
               schemaUtils.retrieveSchema(isObject(_schema) ? (_schema as S) : ({} as S), formData)
             )}
             registry={registry}
+            required={required}
             schema={schema}
             uiSchema={uiSchema}
           />


### PR DESCRIPTION
## Reasons for making this change

`required` is not passed into `AnyOfField`/`OneOfField` fields from `SchemaField`.

### Example case

In case of following schema:

```
{
  "type": "object",
  "properties": {
    "textOrNumber": {
      "oneOf": [
        {"type": "string"},
        {"type": "number"}
      ]
    }
  },
  "required": ["text"]
}
```

#### Actual result:

`required` is not passed down to `AnyOfField`/`OneOfField` fields from `SchemaField`.
`textOrNumber` is not required (**no asterisk**)

<img width="197" alt="image" src="https://github.com/user-attachments/assets/5499cd1d-9e79-4ae7-a75a-4b0f98308f47">






#### Expected result

After the fix.
Required is passed down, fields render with proper required value. 
`textOrNumber` is required (**asterisk present**)

<img width="199" alt="image" src="https://github.com/user-attachments/assets/6640c549-3f24-46ee-9b4b-0546ca3260fe">


## Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
