### PR TITLE
fix: not merge the `allOf.contains` schemas

### DIFF
--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -412,9 +412,24 @@ export function retrieveSchemaInternal<
         return [...(allOf as S[]), restOfSchema as S];
       }
       try {
+        const withContainsSchemas = [] as S[];
+        const withoutContainsSchemas = [] as S[];
+        resolvedSchema.allOf?.forEach((s) => {
+          if (typeof s === 'object' && s.contains) {
+            withContainsSchemas.push(s as S);
+          } else {
+            withoutContainsSchemas.push(s as S);
+          }
+        });
+        if (withContainsSchemas.length) {
+          resolvedSchema = { ...resolvedSchema, allOf: withoutContainsSchemas };
+        }
         resolvedSchema = mergeAllOf(resolvedSchema, {
           deep: false,
         } as Options) as S;
+        if (withContainsSchemas.length) {
+          resolvedSchema.allOf = withContainsSchemas;
+        }
       } catch (e) {
         console.warn('could not merge subschemas in allOf:\n', e);
         const { allOf, ...resolvedSchemaWithoutAllOf } = resolvedSchema;

--- a/packages/utils/test/schema/retrieveSchemaTest.ts
+++ b/packages/utils/test/schema/retrieveSchemaTest.ts
@@ -759,6 +759,81 @@ export default function retrieveSchemaTest(testValidator: TestValidatorType) {
           type: 'string',
         });
       });
+      it('should not merge `allOf.contains` schemas', () => {
+        // https://github.com/rjsf-team/react-jsonschema-form/issues/2923#issuecomment-1946034240
+        const schema: RJSFSchema = {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              a: {
+                type: 'string',
+              },
+            },
+          },
+          allOf: [
+            {
+              maxItems: 5,
+            },
+            {
+              contains: {
+                type: 'object',
+                properties: {
+                  a: {
+                    pattern: '1',
+                  },
+                },
+              },
+            },
+            {
+              contains: {
+                type: 'object',
+                properties: {
+                  a: {
+                    pattern: '2',
+                  },
+                },
+              },
+            },
+          ],
+        };
+        const rootSchema: RJSFSchema = { definitions: {} };
+        const formData = {};
+        expect(retrieveSchema(testValidator, schema, rootSchema, formData)).toEqual({
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              a: {
+                type: 'string',
+              },
+            },
+          },
+          maxItems: 5,
+          allOf: [
+            {
+              contains: {
+                type: 'object',
+                properties: {
+                  a: {
+                    pattern: '1',
+                  },
+                },
+              },
+            },
+            {
+              contains: {
+                type: 'object',
+                properties: {
+                  a: {
+                    pattern: '2',
+                  },
+                },
+              },
+            },
+          ],
+        });
+      });
       it('should not merge incompatible types', () => {
         const schema: RJSFSchema = {
           allOf: [{ type: 'string' }, { type: 'boolean' }],


### PR DESCRIPTION
### Reasons for making this change

ref https://github.com/rjsf-team/react-jsonschema-form/issues/2923#issuecomment-1946034240

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
