### PR TITLE
Fix typo L12n -> L10n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1994,7 +1994,7 @@ const Component = () => {
 
 ## @rjsf/validator-ajv8
 
-- Support for localization (L12n) on a customized validator using a `Localizer` function passed as a second parameter to `customizeValidator()`, fixing (https://github.com/rjsf-team/react-jsonschema-form/pull/846, and https://github.com/rjsf-team/react-jsonschema-form/issues/1195)
+- Support for localization (L10n) on a customized validator using a `Localizer` function passed as a second parameter to `customizeValidator()`, fixing (https://github.com/rjsf-team/react-jsonschema-form/pull/846, and https://github.com/rjsf-team/react-jsonschema-form/issues/1195)
 - Fixed the `README.md` to correct the package name in several places to match the actual package
 
 ## Dev / docs / playground

--- a/packages/docs/docs/usage/validation.md
+++ b/packages/docs/docs/usage/validation.md
@@ -703,7 +703,7 @@ const validator = customizeValidator({ AjvClass: Ajv2019 });
 render(<Form schema={schema} validator={validator} />, document.getElementById('app'));
 ```
 
-### Localization (L12n) support
+### Localization (L10n) support
 
 The Ajv 8 validator supports the localization of error messages using [ajv-i18n](https://github.com/ajv-validator/ajv-i18n).
 In addition, you may provide a custom solution by implementing a function that conforms to the `Localizer` interface if your language is not supported.


### PR DESCRIPTION
### Reasons for making this change

Correct a basic typo.

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
