### PR TITLE
fix: multiple file upload issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 
 - Updated `MultiSchemaField` to call the `onChange` handler after setting the new option, fixing [#3997](https://github.com/rjsf-team/react-jsonschema-form/issues/3977) and [#4314](https://github.com/rjsf-team/react-jsonschema-form/issues/4314)
+- Fix an issue where only the first file was uploaded when users selected multiple files for upload.
 
 ## @rjsf/utils
 

--- a/packages/core/src/components/widgets/FileWidget.tsx
+++ b/packages/core/src/components/widgets/FileWidget.tsx
@@ -169,7 +169,7 @@ function FileWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends 
       processFiles(event.target.files).then((filesInfoEvent) => {
         const newValue = filesInfoEvent.map((fileInfo) => fileInfo.dataURL);
         if (multiple) {
-          onChange(value.concat(newValue[0]));
+          onChange(value.concat(newValue));
         } else {
           onChange(newValue[0]);
         }


### PR DESCRIPTION
### Reasons for making this change

Resolved a bug where only the first file was uploaded when multiple files were selected. Now, all selected files are uploaded as expected.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
