### PR TITLE
fix: Validation error messages are inconsistent #4348

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Fixed `AJV8Validator#transformRJSFValidationErrors` to replace the error message field with either the `uiSchema`'s `ui:title` field if one exists or the `parentSchema` title if one exists. Fixes [#4348](https://github.com/rjsf-team/react-jsonschema-form/issues/4348)
 
-
 # 5.22.0
 
 ## @rjsf/core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.22.2
+
+## @rjsf/validator-ajv8
+
+- Fixed `AJV8Validator#transformRJSFValidationErrors` to replace the error message field with either the `uiSchema`'s `ui:title` field if one exists or the `parentSchema` title if one exists. Fixes [#4348](https://github.com/rjsf-team/react-jsonschema-form/issues/4348)
+
+
 # 5.22.0
 
 ## @rjsf/core
@@ -30,10 +37,6 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated `mergeDefaultsWithFormData()` to add new optional `defaultSupercedesUndefined` that when true uses the defaults rather than `undefined` formData, fixing [#4322](https://github.com/rjsf-team/react-jsonschema-form/issues/4322)
 - Updated `getDefaultFormState()` to pass true to `mergeDefaultsWithFormData` for `defaultSupercedesUndefined` when `mergeDefaultsIntoFormData` has the value `useDefaultIfFormDataUndefined`, fixing [#4322](https://github.com/rjsf-team/react-jsonschema-form/issues/4322)
 - Updated `getClosestMatchingOption()` to improve the scoring of sub-property objects that are provided over ones that aren't, fixing [#3997](https://github.com/rjsf-team/react-jsonschema-form/issues/3977) and [#4314](https://github.com/rjsf-team/react-jsonschema-form/issues/4314)
-
-## @rjsf/validator-ajv8
-
-- Fixed `AJV8Validator#transformRJSFValidationErrors` to replace the error message field with either the `uiSchema`'s `ui:title` field if one exists or the `parentSchema` title if one exists. Fixes [#4348](https://github.com/rjsf-team/react-jsonschema-form/issues/4348)
 
 ## Dev / docs / playground
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated `getDefaultFormState()` to pass true to `mergeDefaultsWithFormData` for `defaultSupercedesUndefined` when `mergeDefaultsIntoFormData` has the value `useDefaultIfFormDataUndefined`, fixing [#4322](https://github.com/rjsf-team/react-jsonschema-form/issues/4322)
 - Updated `getClosestMatchingOption()` to improve the scoring of sub-property objects that are provided over ones that aren't, fixing [#3997](https://github.com/rjsf-team/react-jsonschema-form/issues/3977) and [#4314](https://github.com/rjsf-team/react-jsonschema-form/issues/4314)
 
+## @rjsf/validator-ajv8
+
+- Fixed `AJV8Validator#transformRJSFValidationErrors` to replace the error message field with either the `uiSchema`'s `ui:title` field if one exists or the `parentSchema` title if one exists. Fixes [#4348](https://github.com/rjsf-team/react-jsonschema-form/issues/4348)
+
 ## Dev / docs / playground
 
 - Updated the `form-props.md` to add documentation for the new `experimental_customMergeAllOf` props and the `experimental_defaultFormStateBehavior.mergeDefaultsIntoFormData` option

--- a/packages/validator-ajv8/src/processRawValidationErrors.ts
+++ b/packages/validator-ajv8/src/processRawValidationErrors.ts
@@ -43,12 +43,12 @@ export function transformRJSFValidationErrors<
       const uiSchemaTitle = getUiOptions(get(uiSchema, `${property.replace(/^\./, '')}`)).title;
 
       if (uiSchemaTitle) {
-        message = message.replace(currentProperty, uiSchemaTitle);
+        message = message.replace(`'${currentProperty}'`, `'${uiSchemaTitle}'`);
       } else {
         const parentSchemaTitle = get(parentSchema, [PROPERTIES_KEY, currentProperty, 'title']);
 
         if (parentSchemaTitle) {
-          message = message.replace(currentProperty, parentSchemaTitle);
+          message = message.replace(`'${currentProperty}'`, `'${parentSchemaTitle}'`);
         }
       }
 

--- a/packages/validator-ajv8/test/validator.test.ts
+++ b/packages/validator-ajv8/test/validator.test.ts
@@ -1401,6 +1401,67 @@ describe('AJV8Validator', () => {
             expect(errorSchema.nested!.numberOfChildren!.__errors![0]).toEqual('must match pattern "\\d+"');
           });
         });
+        describe('replace the error message field with schema property title', () => {
+          beforeAll(() => {
+            const schema: RJSFSchema = {
+              type: 'object',
+              required: ['a', 'r'],
+              properties: {
+                a: { title: 'First Name', type: 'string' },
+                r: { title: 'Last Name', type: 'string' },
+              },
+            };
+
+            const formData = {};
+            const result = validator.validateFormData(formData, schema);
+            errors = result.errors;
+            errorSchema = result.errorSchema;
+          });
+          it('should return an error list', () => {
+            expect(errors).toHaveLength(2);
+
+            const stack = errors.map((e) => e.stack);
+
+            expect(stack).toEqual([
+              "must have required property 'First Name'",
+              "must have required property 'Last Name'",
+            ]);
+          });
+        });
+        describe('replace the error message field with uiSchema property title', () => {
+          beforeAll(() => {
+            const schema: RJSFSchema = {
+              type: 'object',
+              required: ['a', 'r'],
+              properties: {
+                a: { type: 'string', title: 'First Name' },
+                r: { type: 'string', title: 'Last Name' },
+              },
+            };
+            const uiSchema: UiSchema = {
+              a: {
+                'ui:title': 'uiSchema First Name',
+              },
+              r: {
+                'ui:title': 'uiSchema Last Name',
+              },
+            };
+
+            const formData = {};
+            const result = validator.validateFormData(formData, schema, undefined, undefined, uiSchema);
+            errors = result.errors;
+            errorSchema = result.errorSchema;
+          });
+          it('should return an error list', () => {
+            expect(errors).toHaveLength(2);
+            const stack = errors.map((e) => e.stack);
+
+            expect(stack).toEqual([
+              "must have required property 'uiSchema First Name'",
+              "must have required property 'uiSchema Last Name'",
+            ]);
+          });
+        });
       });
       describe('No custom validate function, single additionalProperties value', () => {
         let errors: RJSFValidationError[];


### PR DESCRIPTION
### Reasons for making this change

- Replaced message field with property `schema title` or `ui:title` correctly
- Fixes #4348

### Images
- Before
![image](https://github.com/user-attachments/assets/97a03762-e7ec-408e-8f1c-8fcac93a5757)

- After
![image](https://github.com/user-attachments/assets/7634e5ac-e837-4b50-8fb2-658e80a05a96)




### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
