### PR TITLE
Bug: Issue with array schema defaults not applying properly when formData is an empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,17 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.22.4
+
+## @rjsf/utils
+
+- Fixed issue with array schema defaults not applying properly when formData is an empty array, fixing [#4335](https://github.com/rjsf-team/react-jsonschema-form/issues/4335).
+
 # 5.22.3 
 
 ## @rjsf/utils
 
-- Fixed deep nested dependencies issue with assigning values to formData, fixing [[#4334](https://github.com/rjsf-team/react-jsonschema-form/issues/4334)]
+- Fixed deep nested dependencies issue with assigning values to formData, fixing [#4334](https://github.com/rjsf-team/react-jsonschema-form/issues/4334)
 
 # 5.22.2
 

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -432,11 +432,15 @@ export function getArrayDefaults<T = any, S extends StrictRJSFSchema = RJSFSchem
 ): T | T[] | undefined {
   const schema: S = rawSchema;
 
-  const neverPopulate = experimental_defaultFormStateBehavior?.arrayMinItems?.populate === 'never';
-  const ignoreMinItemsFlagSet = experimental_defaultFormStateBehavior?.arrayMinItems?.populate === 'requiredOnly';
+  const arrayMinItemsStateBehavior = experimental_defaultFormStateBehavior?.arrayMinItems;
+  const arrayMinItemsPopulate = arrayMinItemsStateBehavior?.populate;
+  const arrayMergeExtraDefaults = arrayMinItemsStateBehavior?.mergeExtraDefaults;
+
+  const neverPopulate = arrayMinItemsPopulate === 'never';
+  const ignoreMinItemsFlagSet = arrayMinItemsPopulate === 'requiredOnly';
+  const isPopulateAll = arrayMinItemsPopulate === 'all' || (!neverPopulate && !ignoreMinItemsFlagSet);
+  const computeSkipPopulate = arrayMinItemsStateBehavior?.computeSkipPopulate ?? (() => false);
   const isSkipEmptyDefaults = experimental_defaultFormStateBehavior?.emptyObjectFields === 'skipEmptyDefaults';
-  const computeSkipPopulate =
-    experimental_defaultFormStateBehavior?.arrayMinItems?.computeSkipPopulate ?? (() => false);
 
   const emptyDefault = isSkipEmptyDefaults ? undefined : [];
 
@@ -460,7 +464,7 @@ export function getArrayDefaults<T = any, S extends StrictRJSFSchema = RJSFSchem
     if (neverPopulate) {
       defaults = rawFormData;
     } else {
-      defaults = rawFormData.map((item: T, idx: number) => {
+      const itemDefaults = rawFormData.map((item: T, idx: number) => {
         return computeDefaults<T, S, F>(validator, schemaItem, {
           rootSchema,
           _recurseList,
@@ -470,6 +474,11 @@ export function getArrayDefaults<T = any, S extends StrictRJSFSchema = RJSFSchem
           required,
         });
       }) as T[];
+
+      // If the populate 'requiredOnly' flag is set then we only merge and include extra defaults if they are required.
+      // Or if populate 'all' is set we merge and include extra defaults.
+      const mergeExtraDefaults = ((ignoreMinItemsFlagSet && required) || isPopulateAll) && arrayMergeExtraDefaults;
+      defaults = mergeDefaultsWithFormData(defaults, itemDefaults, mergeExtraDefaults);
     }
   }
 

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -644,6 +644,49 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           },
         });
       });
+      it('test an array with defaults with no formData', () => {
+        const schema: RJSFSchema = {
+          type: 'array',
+          minItems: 4,
+          default: ['Raphael', 'Michaelangelo'],
+          items: {
+            type: 'string',
+            default: 'Unknown',
+          },
+        };
+
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            includeUndefinedValues: 'excludeObjectChildren',
+          })
+        ).toEqual(['Raphael', 'Michaelangelo', 'Unknown', 'Unknown']);
+      });
+      it('test an array with defaults with empty array as formData', () => {
+        const schema: RJSFSchema = {
+          type: 'array',
+          minItems: 4,
+          default: ['Raphael', 'Michaelangelo'],
+          items: {
+            type: 'string',
+            default: 'Unknown',
+          },
+        };
+
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            rawFormData: [],
+            includeUndefinedValues: 'excludeObjectChildren',
+            experimental_defaultFormStateBehavior: {
+              arrayMinItems: {
+                mergeExtraDefaults: true,
+                populate: 'all',
+              },
+            },
+          })
+        ).toEqual(['Raphael', 'Michaelangelo', 'Unknown', 'Unknown']);
+      });
       it('test computeDefaults handles an invalid property schema', () => {
         const schema: RJSFSchema = {
           type: 'object',


### PR DESCRIPTION
### Reasons for making this change

Fixes #4335 

when you enable the `mergeExtraDefaults` and you have `formData` as an empty array, the `default` on the root of the array schema doesn't get applied and only applies the `default` from the items property. If `formData` is undefined or null, it will apply the `default` from the root schema and `items.default` and the root `default` will take precedence over `item` property default.

### Checklist

- [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a 
