### PR TITLE
Bug: Issue 'Maximum call stack size exceeded' with playground share.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.22.4
+
+## Dev / docs / playground
+
+- Fix issue 'Maximum call stack size exceeded' with playground share with large content.
+
 # 5.22.3 
 
 ## @rjsf/utils

--- a/packages/playground/src/utils/base64.ts
+++ b/packages/playground/src/utils/base64.ts
@@ -16,7 +16,7 @@ const base64 = (function () {
         const { TextEncoder } = require('util');
         encoder = new TextEncoder();
       }
-      return btoa(String.fromCharCode(...encoder.encode(text)));
+      return btoa(safeFromCharCode(encoder, text));
     },
     decode(text: string): string {
       let decoder: any;
@@ -30,5 +30,22 @@ const base64 = (function () {
     },
   };
 })();
+
+/**
+ * This function is a workaround for the fact that the String.fromCharCode method can throw a "Maximum call stack size exceeded" error if you try to pass too many arguments to it at once.
+ * This is because String.fromCharCode expects individual character codes as arguments and javascript has a limit on the number of arguments that can be passed to a function.
+ */
+function safeFromCharCode(encoder: any, text: string): string {
+  const codes = encoder.encode(text);
+  const CHUNK_SIZE = 0x9000; // 36864
+  let result = '';
+
+  for (let i = 0; i < codes.length; i += CHUNK_SIZE) {
+    const chunk = codes.slice(i, i + CHUNK_SIZE);
+    result += String.fromCharCode(...chunk);
+  }
+
+  return result;
+}
 
 export default base64;


### PR DESCRIPTION
### Reasons for making this change

Fix issue 'Maximum call stack size exceeded' with playground share with large content.

Fixes sharing issue mentioned in #4296 

### Checklist

- [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
