### PR TITLE
feat(core): add support for `<optgroup>` tag

### DIFF
--- a/packages/playground/src/samples/widgets.tsx
+++ b/packages/playground/src/samples/widgets.tsx
@@ -106,6 +106,11 @@ const widgets: Sample = {
           },
         ],
       },
+      selectWidgetOptions3: {
+        title: 'Custom select widget with options grouped by optgroups',
+        type: 'string',
+        enum: ['foo', 'bar'],
+      },
     },
   },
   uiSchema: {
@@ -196,6 +201,14 @@ const widgets: Sample = {
         backgroundColor: 'pink',
       },
     },
+    selectWidgetOptions3: {
+      'ui:options': {
+        'optgroups': {
+          'lipsum': ['foo'],
+          'dolorem': ['bar']
+        }
+      }
+    }
   },
   formData: {
     stringFormats: {


### PR DESCRIPTION
### Reasons for making this change

HTML Select Element offers a native way to organize options in option groups. This update extends rjsf SelectWidget to support `<optgroup>` as well.

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

fixes #1813 

If your PR is non-trivial and you'd like to schedule a synchronous review, please add it to the weekly meeting agenda: https://docs.google.com/document/d/12PjTvv21k6LIky6bNQVnsplMLLnmEuypTLQF8a-8Wss/edit

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [x] **I'm adding a new feature**
  - [x] I've updated the playground with an example use of the feature
