### PR TITLE
Use default values when switching anyOf option

### DIFF
--- a/packages/core/test/anyOf.test.jsx
+++ b/packages/core/test/anyOf.test.jsx
@@ -165,6 +165,43 @@ describe('anyOf', () => {
     );
   });
 
+  it('should assign a default value and set defaults on option change for scalar types schemas', () => {
+    const { node, onChange } = createFormComponent({
+      schema: {
+        type: 'object',
+        properties: {
+          foo: {
+            anyOf: [
+              {
+                type: 'string',
+                default: 'defaultfoo',
+              },
+              {
+                type: 'boolean',
+                default: true,
+              },
+            ],
+          },
+        },
+      },
+    });
+    sinon.assert.calledWithMatch(onChange.lastCall, {
+      formData: { foo: 'defaultfoo' },
+    });
+
+    const $select = node.querySelector('select');
+
+    act(() => {
+      fireEvent.change($select, {
+        target: { value: $select.options[1].value },
+      });
+    });
+
+    sinon.assert.calledWithMatch(onChange.lastCall, {
+      formData: { foo: true },
+    });
+  });
+
   it('should assign a default value and set defaults on option change when using references', () => {
     const { node, onChange } = createFormComponent({
       schema: {

--- a/packages/utils/src/schema/sanitizeDataForNewSchema.ts
+++ b/packages/utils/src/schema/sanitizeDataForNewSchema.ts
@@ -44,6 +44,8 @@ const NO_VALUE = Symbol('no Value');
  *         - For each element in the `data` recursively sanitize the data, stopping at `maxItems` if specified
  *       - Otherwise, just return the `data` removing any values after `maxItems` if it is set
  *   - If the type of the old and new schema `items` are booleans of the same value, return `data` as is
+ * - If the new schema contains a default value then:
+ *   - return the default value. We expect this to be a scalar value
  * - Otherwise return `undefined`
  *
  * @param validator - An implementation of the `ValidatorType` interface that will be used when necessary
@@ -52,7 +54,8 @@ const NO_VALUE = Symbol('no Value');
  * @param [oldSchema] - The old schema from which the data originated
  * @param [data={}] - The form data associated with the schema, defaulting to an empty object when undefined
  * @returns - The new form data, with all the fields uniquely associated with the old schema set
- *      to `undefined`. Will return `undefined` if the new schema is not an object containing properties.
+ *      to `undefined`. Will return `undefined` if the new schema is not an object containing properties
+ *      and doesn't provide a default value
  */
 export default function sanitizeDataForNewSchema<
   T = any,
@@ -192,6 +195,13 @@ export default function sanitizeDataForNewSchema<
       newFormData = data;
     }
     // Also probably want to deal with `prefixItems` as tuples with the latest 2020 draft
+  }
+  // Schema contains a single scalar value
+  else {
+    const newDefaultValue = get(newSchema, 'default');
+    if (newDefaultValue !== undefined) {
+      newFormData = newDefaultValue;
+    }
   }
   return newFormData as T;
 }

--- a/packages/utils/test/schema/sanitizeDataForNewSchemaTest.ts
+++ b/packages/utils/test/schema/sanitizeDataForNewSchemaTest.ts
@@ -483,5 +483,16 @@ export default function sanitizeDataForNewSchemaTest(testValidator: TestValidato
       };
       expect(schemaUtils.sanitizeDataForNewSchema(newSchema, oldSchema, ['qwerty', 'asdfg'])).toEqual({});
     });
+
+    it('returns default value when new schema is a scalar schema', () => {
+      const oldSchema: RJSFSchema = {
+        type: 'string',
+      };
+      const newSchema: RJSFSchema = {
+        type: 'boolean',
+        default: true,
+      };
+      expect(schemaUtils.sanitizeDataForNewSchema(newSchema, oldSchema, 'oldValue')).toEqual(true);
+    });
   });
 }


### PR DESCRIPTION
### Reasons for making this change


`sanitizeDataForNewSchema` is called when switching the option selected from a anyOf field. It doesn't check default values in the new schema. This leads to the formData being cleared completely. This PR makes it respect default values.

Maybe this is a bad idea. The implementation seemed very aware that it wasn't handling cases for scalar values. Let me know what you think about it.

The UI wasn't properly handling the option change resulting in undefined data (See my video in #4367).

In summary this change makes this schema work as expected:
```json
{
  "additionalProperties": false,
  "properties": {
    "any_of_array_or_null": {
      "anyOf": [
        {
          "items": {
            "type": "integer"
          },
          "type": "array",
          "title": "Array value selected"
        },
        {
          "type": "null",
          "title": "Null value selected"
        }
      ]
    }
  },
  "required": [
    "any_of_array_or_null"
  ],
  "type": "object"
}
```

fixes #4367

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
