### PR TITLE
Adding feature to support const as default bug fix seeming like a regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.23.0
+
+## @rjsf/core
+
+- Updated `SchemaField` to no longer make schema fields with const read-only by default, partially fixing [#4344](https://github.com/rjsf-team/react-jsonschema-form/issues/4344)
+
+## @rjsf/utils
+
+- Updated `Experimental_DefaultFormStateBehavior` to add a new `constAsDefaults` option
+- Updated `getDefaultFormState()` to use the new `constAsDefaults` option to control how const is used for defaulting, fixing [#4344](https://github.com/rjsf-team/react-jsonschema-form/issues/4344), [#4361](https://github.com/rjsf-team/react-jsonschema-form/issues/4361) and [#4377](https://github.com/rjsf-team/react-jsonschema-form/issues/4377)
+
+## Dev / docs / playground
+
+- Updated the playground to add a selector for the `constAsDefaults` option
+
 # 5.22.4
 
 ## @rjsf/utils

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -151,9 +151,7 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
 
   const FieldComponent = getFieldComponent<T, S, F>(schema, uiOptions, idSchema, registry);
   const disabled = Boolean(uiOptions.disabled ?? props.disabled);
-  const readonly = Boolean(
-    uiOptions.readonly ?? (props.readonly || props.schema.const || props.schema.readOnly || schema.readOnly)
-  );
+  const readonly = Boolean(uiOptions.readonly ?? (props.readonly || props.schema.readOnly || schema.readOnly));
   const uiSchemaHideError = uiOptions.hideError;
   // Set hideError to the value provided in the uiSchema, otherwise stick with the prop to propagate to children
   const hideError = uiSchemaHideError === undefined ? props.hideError : Boolean(uiSchemaHideError);

--- a/packages/docs/docs/api-reference/form-props.md
+++ b/packages/docs/docs/api-reference/form-props.md
@@ -251,6 +251,18 @@ render(
 );
 ```
 
+### constAsDefaults
+
+Optional enumerated flag controlling how const values are merged into the form data as defaults when dealing with undefined values, defaulting to `always`.
+The defaulting behavior for this flag will always be controlled by the `emptyObjectField` flag value.
+For instance, if `populateRequiredDefaults` is set and the const value is not required, it will not be set.
+
+| Flag Value  | Description                                                                                                                                                                                                                     |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `always`    | A const value will always be merged into the form as a default. If there is are const values in a `oneOf` (for instance to create an enumeration with title different from the values), the first const value will be defaulted |
+| `skipOneOf` | If const is in a `oneOf` it will NOT pick the first value as a default                                                                                                                                                          |
+| `never`     | A const value will never be used as a default                                                                                                                                                                                   |
+
 ### mergeDefaultsIntoFormData
 
 Optional enumerated flag controlling how the defaults are merged into the form data when dealing with undefined values, defaulting to `useFormDataIfPresent`.

--- a/packages/playground/src/components/Header.tsx
+++ b/packages/playground/src/components/Header.tsx
@@ -128,6 +128,28 @@ const liveSettingsSelectSchema: RJSFSchema = {
             },
           ],
         },
+        constAsDefaults: {
+          type: 'string',
+          title: 'const as default behavior',
+          default: 'always',
+          oneOf: [
+            {
+              type: 'string',
+              title: 'A const value will always be merged into the form as a default',
+              enum: ['always'],
+            },
+            {
+              type: 'string',
+              title: 'If const is in a `oneOf` it will NOT pick the first value as a default',
+              enum: ['skipOneOf'],
+            },
+            {
+              type: 'string',
+              title: 'A const value will never be used as a default',
+              enum: ['never'],
+            },
+          ],
+        },
         emptyObjectFields: {
           type: 'string',
           title: 'Object fields default behavior',

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -96,6 +96,18 @@ export type Experimental_DefaultFormStateBehavior = {
    *        default value instead
    */
   mergeDefaultsIntoFormData?: 'useFormDataIfPresent' | 'useDefaultIfFormDataUndefined';
+  /** Optional enumerated flag controlling how const values are merged into the form data as defaults when dealing with
+   * undefined values, defaulting to `always`. The defaulting behavior for this flag will always be controlled by the
+   * `emptyObjectField` flag value. For instance, if `populateRequiredDefaults` is set and the const value is not
+   * required, it will not be set.
+   * - `always`: A const value will always be merged into the form as a default. If there is are const values in a
+   *        `oneOf` (for instance to create an enumeration with title different from the values), the first const value
+   *        will be defaulted
+   * - `skipOneOf`: If const is in a `oneOf` it will NOT pick the first value as a default
+   * - `never`: A const value will never be used as a default
+   *
+   */
+  constAsDefaults?: 'always' | 'skipOneOf' | 'never';
 };
 
 /** Optional function that allows for custom merging of `allOf` schemas

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -79,6 +79,56 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         fromFormData: 'fromFormData',
       });
     });
+    it('test an object const value merge with formData and constAsDefault is never', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          localConst: {
+            type: 'string',
+            const: 'local',
+          },
+          RootConst: {
+            type: 'object',
+            properties: {
+              attr1: {
+                type: 'number',
+              },
+              attr2: {
+                type: 'boolean',
+              },
+            },
+            const: {
+              attr1: 1,
+              attr2: true,
+            },
+          },
+          RootAndLocalConst: {
+            type: 'string',
+            const: 'FromLocal',
+          },
+          fromFormData: {
+            type: 'string',
+          },
+        },
+        const: {
+          RootAndLocalConst: 'FromRoot',
+        },
+      };
+      expect(
+        getDefaultFormState(
+          testValidator,
+          schema,
+          {
+            fromFormData: 'fromFormData',
+          },
+          schema,
+          false,
+          { emptyObjectFields: 'skipDefaults', constAsDefaults: 'never' }
+        )
+      ).toEqual({
+        fromFormData: 'fromFormData',
+      });
+    });
     it('test an object with deep nested dependencies with formData', () => {
       const schema: RJSFSchema = {
         type: 'object',
@@ -288,6 +338,106 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         expect(computeDefaults(testValidator, schema, { rootSchema: schema })).toEqual({
           test: 'test',
         });
+      });
+      it('test computeDefaults that is passed a schema with a const property and constAsDefaults is never', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            test: {
+              type: 'string',
+              const: 'test',
+            },
+          },
+        };
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            experimental_defaultFormStateBehavior: { constAsDefaults: 'never' },
+          })
+        ).toEqual({});
+      });
+      it('test oneOf with const values and constAsDefaults is always', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            oneOfField: {
+              title: 'One Of Field',
+              type: 'string',
+              oneOf: [
+                {
+                  const: 'username',
+                  title: 'Username and password',
+                },
+                {
+                  const: 'secret',
+                  title: 'SSO',
+                },
+              ],
+            },
+          },
+          required: ['oneOfField'],
+        };
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            experimental_defaultFormStateBehavior: { constAsDefaults: 'always' },
+          })
+        ).toEqual({ oneOfField: 'username' });
+      });
+      it('test oneOf with const values and constAsDefaults is skipOneOf', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            oneOfField: {
+              title: 'One Of Field',
+              type: 'string',
+              oneOf: [
+                {
+                  const: 'username',
+                  title: 'Username and password',
+                },
+                {
+                  const: 'secret',
+                  title: 'SSO',
+                },
+              ],
+            },
+          },
+          required: ['oneOfField'],
+        };
+        const result = computeDefaults(testValidator, schema, {
+          rootSchema: schema,
+          experimental_defaultFormStateBehavior: { constAsDefaults: 'skipOneOf' },
+        });
+        expect(result).toEqual({});
+      });
+      it('test oneOf with const values and constAsDefaults is never', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            oneOfField: {
+              title: 'One Of Field',
+              type: 'string',
+              oneOf: [
+                {
+                  const: 'username',
+                  title: 'Username and password',
+                },
+                {
+                  const: 'secret',
+                  title: 'SSO',
+                },
+              ],
+            },
+          },
+          required: ['oneOfField'],
+        };
+        expect(
+          computeDefaults(testValidator, schema, {
+            rootSchema: schema,
+            experimental_defaultFormStateBehavior: { constAsDefaults: 'never' },
+          })
+        ).toEqual({});
       });
       it('test an object with an optional property that has a nested required property', () => {
         const schema: RJSFSchema = {
@@ -1257,6 +1407,52 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           RootAndLocalConst: 'FromLocal',
         });
       });
+      it('test an object const value NOT populate as field defaults when constAsDefault is never', () => {
+        const schema: RJSFSchema = {
+          type: 'object',
+          properties: {
+            localConst: {
+              type: 'string',
+              const: 'local',
+            },
+            RootConst: {
+              type: 'object',
+              properties: {
+                attr1: {
+                  type: 'number',
+                },
+                attr2: {
+                  type: 'boolean',
+                },
+              },
+              const: {
+                attr1: 1,
+                attr2: true,
+              },
+            },
+            fromFormData: {
+              type: 'string',
+              default: 'notUsed',
+            },
+            RootAndLocalConst: {
+              type: 'string',
+              const: 'FromLocal',
+            },
+          },
+          const: {
+            RootAndLocalConst: 'FromRoot',
+          },
+        };
+        expect(
+          getObjectDefaults(testValidator, schema, {
+            rootSchema: schema,
+            experimental_defaultFormStateBehavior: { emptyObjectFields: 'skipDefaults', constAsDefaults: 'never' },
+            rawFormData: {
+              fromFormData: 'fromFormData',
+            },
+          })
+        ).toEqual({});
+      });
       it('test an object with an additionalProperties', () => {
         const schema: RJSFSchema = {
           type: 'object',
@@ -1496,6 +1692,30 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
             ['ConstFromRoot', 'ConstFromRoot']
           )
         ).toEqual(['ConstFromRoot', 'ConstFromRoot', 'Constant', 'Constant']);
+      });
+      it('test an array const value NOT populate as defaults when constAsDefaults is never', () => {
+        const schema: RJSFSchema = {
+          type: 'array',
+          minItems: 4,
+          const: ['ConstFromRoot', 'ConstFromRoot'],
+          items: {
+            type: 'string',
+            const: 'Constant',
+          },
+        };
+
+        expect(
+          getArrayDefaults(
+            testValidator,
+            schema,
+            {
+              rootSchema: schema,
+              includeUndefinedValues: 'excludeObjectChildren',
+              experimental_defaultFormStateBehavior: { constAsDefaults: 'never' },
+            },
+            ['ConstFromRoot', 'ConstFromRoot']
+          )
+        ).toEqual(['ConstFromRoot', 'ConstFromRoot']);
       });
       it('test an array with no defaults', () => {
         const schema: RJSFSchema = {


### PR DESCRIPTION
### Reasons for making this change

Fixes #4344, #4361 and #4377
- In `@rjsf/utils`:
  - Updated the `Experimental_DefaultFormStateBehavior` type to add new optional `constAsDefaults` prop with three choices
  - Updated `getDefaultFormState()` to respond to the new `constAsDefaults` feature to limit `const` as defaults based on the `never` or `skipOneOf` choices
  - Added tests for `getDefaultFormState()` to verify the new feature
- In `@rjsf/core`:
  - Updated `SchemaField` to remove making the field readonly when const
- In `playground`:
  - Updated `Header` to add support for `constAsDefaults`
- Updated `form-props.md` to document the new `constAsDefaults` property
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
