### PR TITLE
experimental_customMergeAllOf v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Updated `Experimental_DefaultFormStateBehavior` to add a new `constAsDefaults` option
 - Updated `getDefaultFormState()` to use the new `constAsDefaults` option to control how const is used for defaulting, fixing [#4344](https://github.com/rjsf-team/react-jsonschema-form/issues/4344), [#4361](https://github.com/rjsf-team/react-jsonschema-form/issues/4361) and [#4377](https://github.com/rjsf-team/react-jsonschema-form/issues/4377)
+- Use `experimental_customMergeAllOf` option in functions that have previously missed it.
 
 ## Dev / docs / playground
 

--- a/packages/docs/docs/api-reference/utility-functions.md
+++ b/packages/docs/docs/api-reference/utility-functions.md
@@ -899,7 +899,7 @@ Returns the superset of `formData` that includes the given set updated to includ
 - [rootSchema]: S | undefined - The root schema, used to primarily to look up `$ref`s
 - [includeUndefinedValues=false]: boolean | "excludeObjectChildren" - Optional flag, if true, cause undefined values to be added as defaults. If "excludeObjectChildren", cause undefined values for this object and pass `includeUndefinedValues` as false when computing defaults for any nested object properties.
 - [experimental_defaultFormStateBehavior]: Experimental_DefaultFormStateBehavior - See `Form` documentation for the [experimental_defaultFormStateBehavior](./form-props.md#experimental_defaultFormStateBehavior) prop
-- [experimental_customMergeAllOf]: Experimental_CustomMergeAllOf&lt;S&gt; - See `Form` documentation for the [experimental_customMergeAllOf](./form-props.md#experimental_customMergeAllOf) prop
+- [experimental_customMergeAllOf]: Experimental_CustomMergeAllOf&lt;S&gt; - See `Form` documentation for the [experimental_customMergeAllOf](./form-props.md#experimental_custommergeallof) prop
 
 #### Returns
 
@@ -916,6 +916,7 @@ Determines whether the combination of `schema` and `uiSchema` properties indicat
 - [uiSchema={}]: UiSchema<T, S, F> - The UI schema from which to derive potentially displayable information
 - [rootSchema]: S | undefined - The root schema, used to primarily to look up `$ref`s
 - [globalOptions={}]: GlobalUISchemaOptions - The optional Global UI Schema from which to get any fallback `xxx` options
+- [experimental_customMergeAllOf]: Experimental_CustomMergeAllOf&lt;S&gt; - See `Form` documentation for the [experimental_customMergeAllOf](./form-props.md#experimental_custommergeallof) prop
 
 #### Returns
 
@@ -936,6 +937,7 @@ The closest match is determined using the number of matching properties, and mor
 - options: S[] - The list of options to find a matching options from
 - [selectedOption=-1]: number - The index of the currently selected option, defaulted to -1 if not specified
 - [discriminatorField]: string | undefined - The optional name of the field within the options object whose value is used to determine which option is selected
+- [experimental_customMergeAllOf]: Experimental_CustomMergeAllOf&lt;S&gt; - See `Form` documentation for the [experimental_customMergeAllOf](./form-props.md#experimental_custommergeallof) prop
 
 #### Returns
 
@@ -985,6 +987,7 @@ Checks to see if the `schema` and `uiSchema` combination represents an array of 
 - schema: S - The schema for which check for array of files flag is desired
 - [uiSchema={}]: UiSchema<T, S, F> - The UI schema from which to check the widget
 - [rootSchema]: S | undefined - The root schema, used to primarily to look up `$ref`s
+- [experimental_customMergeAllOf]: Experimental_CustomMergeAllOf&lt;S&gt; - See `Form` documentation for the [experimental_customMergeAllOf](./form-props.md#experimental_custommergeallof) prop
 
 #### Returns
 
@@ -999,6 +1002,7 @@ Checks to see if the `schema` combination represents a multi-select
 - validator: ValidatorType<T, S, F> - An implementation of the `ValidatorType` interface that will be used when necessary
 - schema: S - The schema for which check for a multi-select flag is desired
 - [rootSchema]: S | undefined - The root schema, used to primarily to look up `$ref`s
+- [experimental_customMergeAllOf]: Experimental_CustomMergeAllOf&lt;S&gt; - See `Form` documentation for the [experimental_customMergeAllOf](./form-props.md#experimental_custommergeallof) prop
 
 #### Returns
 
@@ -1013,6 +1017,7 @@ Checks to see if the `schema` combination represents a select
 - validator: ValidatorType<T, S, F> - An implementation of the `ValidatorType` interface that will be used when necessary
 - theSchema: S - The schema for which check for a select flag is desired
 - [rootSchema]: S | undefined - The root schema, used to primarily to look up `$ref`s
+- [experimental_customMergeAllOf]: Experimental_CustomMergeAllOf&lt;S&gt; - See `Form` documentation for the [experimental_customMergeAllOf](./form-props.md#experimental_custommergeallof) prop
 
 #### Returns
 
@@ -1048,6 +1053,7 @@ potentially recursive resolution.
 - schema: S - The schema for which retrieving a schema is desired
 - [rootSchema={}]: S - The root schema that will be forwarded to all the APIs
 - [rawFormData]: T | undefined - The current formData, if any, to assist retrieving a schema
+- [experimental_customMergeAllOf]: Experimental_CustomMergeAllOf&lt;S&gt; - See `Form` documentation for the [experimental_customMergeAllOf](./form-props.md#experimental_custommergeallof) prop
 
 #### Returns
 
@@ -1067,6 +1073,7 @@ Also, any properties in the old schema that are non-existent in the new schema a
 - [newSchema]: S | undefined - The new schema for which the data is being sanitized
 - [oldSchema]: S | undefined - The old schema from which the data originated
 - [data={}]: any - The form data associated with the schema, defaulting to an empty object when undefined
+- [experimental_customMergeAllOf]: Experimental_CustomMergeAllOf&lt;S&gt; - See `Form` documentation for the [experimental_customMergeAllOf](./form-props.md#experimental_custommergeallof) prop
 
 #### Returns
 
@@ -1085,6 +1092,7 @@ Generates an `IdSchema` object for the `schema`, recursively
 - [formData]: T | undefined - The current formData, if any, to assist retrieving a schema
 - [idPrefix='root']: string - The prefix to use for the id
 - [idSeparator='_']: string - The separator to use for the path segments in the id
+- [experimental_customMergeAllOf]: Experimental_CustomMergeAllOf&lt;S&gt; - See `Form` documentation for the [experimental_customMergeAllOf](./form-props.md#experimental_custommergeallof) prop
 
 #### Returns
 
@@ -1101,6 +1109,7 @@ Generates an `PathSchema` object for the `schema`, recursively
 - [name='']: string - The base name for the schema
 - [rootSchema]: S | undefined - The root schema, used to primarily to look up `$ref`s
 - [formData]: T | undefined - The current formData, if any, to assist retrieving a schema
+- [experimental_customMergeAllOf]: Experimental_CustomMergeAllOf&lt;S&gt; - See `Form` documentation for the [experimental_customMergeAllOf](./form-props.md#experimental_custommergeallof) prop
 
 #### Returns
 

--- a/packages/utils/src/createSchemaUtils.ts
+++ b/packages/utils/src/createSchemaUtils.ts
@@ -133,7 +133,14 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
    * @returns - True if the label should be displayed or false if it should not
    */
   getDisplayLabel(schema: S, uiSchema?: UiSchema<T, S, F>, globalOptions?: GlobalUISchemaOptions) {
-    return getDisplayLabel<T, S, F>(this.validator, schema, uiSchema, this.rootSchema, globalOptions);
+    return getDisplayLabel<T, S, F>(
+      this.validator,
+      schema,
+      uiSchema,
+      this.rootSchema,
+      globalOptions,
+      this.experimental_customMergeAllOf
+    );
   }
 
   /** Determines which of the given `options` provided most closely matches the `formData`.
@@ -161,7 +168,8 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
       formData,
       options,
       selectedOption,
-      discriminatorField
+      discriminatorField,
+      this.experimental_customMergeAllOf
     );
   }
 
@@ -199,7 +207,7 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
    * @returns - True if schema/uiSchema contains an array of files, otherwise false
    */
   isFilesArray(schema: S, uiSchema?: UiSchema<T, S, F>) {
-    return isFilesArray<T, S, F>(this.validator, schema, uiSchema, this.rootSchema);
+    return isFilesArray<T, S, F>(this.validator, schema, uiSchema, this.rootSchema, this.experimental_customMergeAllOf);
   }
 
   /** Checks to see if the `schema` combination represents a multi-select
@@ -208,7 +216,7 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
    * @returns - True if schema contains a multi-select, otherwise false
    */
   isMultiSelect(schema: S) {
-    return isMultiSelect<T, S, F>(this.validator, schema, this.rootSchema);
+    return isMultiSelect<T, S, F>(this.validator, schema, this.rootSchema, this.experimental_customMergeAllOf);
   }
 
   /** Checks to see if the `schema` combination represents a select
@@ -217,7 +225,7 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
    * @returns - True if schema contains a select, otherwise false
    */
   isSelect(schema: S) {
-    return isSelect<T, S, F>(this.validator, schema, this.rootSchema);
+    return isSelect<T, S, F>(this.validator, schema, this.rootSchema, this.experimental_customMergeAllOf);
   }
 
   /** Merges the errors in `additionalErrorSchema` into the existing `validationData` by combining the hierarchies in
@@ -265,7 +273,14 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
    *      to `undefined`. Will return `undefined` if the new schema is not an object containing properties.
    */
   sanitizeDataForNewSchema(newSchema?: S, oldSchema?: S, data?: any): T {
-    return sanitizeDataForNewSchema(this.validator, this.rootSchema, newSchema, oldSchema, data);
+    return sanitizeDataForNewSchema(
+      this.validator,
+      this.rootSchema,
+      newSchema,
+      oldSchema,
+      data,
+      this.experimental_customMergeAllOf
+    );
   }
 
   /** Generates an `IdSchema` object for the `schema`, recursively
@@ -298,7 +313,14 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
    * @returns - The `PathSchema` object for the `schema`
    */
   toPathSchema(schema: S, name?: string, formData?: T): PathSchema<T> {
-    return toPathSchema<T, S, F>(this.validator, schema, name, this.rootSchema, formData);
+    return toPathSchema<T, S, F>(
+      this.validator,
+      schema,
+      name,
+      this.rootSchema,
+      formData,
+      this.experimental_customMergeAllOf
+    );
   }
 }
 

--- a/packages/utils/src/schema/getClosestMatchingOption.ts
+++ b/packages/utils/src/schema/getClosestMatchingOption.ts
@@ -10,7 +10,7 @@ import getFirstMatchingOption from './getFirstMatchingOption';
 import retrieveSchema, { resolveAllReferences } from './retrieveSchema';
 import { ONE_OF_KEY, REF_KEY, JUNK_OPTION_ID, ANY_OF_KEY } from '../constants';
 import guessType from '../guessType';
-import { FormContextType, RJSFSchema, StrictRJSFSchema, ValidatorType } from '../types';
+import { Experimental_CustomMergeAllOf, FormContextType, RJSFSchema, StrictRJSFSchema, ValidatorType } from '../types';
 import getDiscriminatorFieldFromSchema from '../getDiscriminatorFieldFromSchema';
 import getOptionMatchingSimpleDiscriminator from '../getOptionMatchingSimpleDiscriminator';
 
@@ -45,13 +45,15 @@ export const JUNK_OPTION: StrictRJSFSchema = {
  * @param rootSchema - The root JSON schema of the entire form
  * @param schema - The schema for which the score is being calculated
  * @param formData - The form data associated with the schema, used to calculate the score
+ * @param [experimental_customMergeAllOf] - Optional function that allows for custom merging of `allOf` schemas
  * @returns - The score a schema against the formData
  */
 export function calculateIndexScore<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   validator: ValidatorType<T, S, F>,
   rootSchema: S,
   schema?: S,
-  formData?: any
+  formData?: any,
+  experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>
 ): number {
   let totalScore = 0;
   if (schema) {
@@ -64,8 +66,23 @@ export function calculateIndexScore<T = any, S extends StrictRJSFSchema = RJSFSc
             return score;
           }
           if (has(value, REF_KEY)) {
-            const newSchema = retrieveSchema<T, S, F>(validator, value as S, rootSchema, formValue);
-            return score + calculateIndexScore<T, S, F>(validator, rootSchema, newSchema, formValue || {});
+            const newSchema = retrieveSchema<T, S, F>(
+              validator,
+              value as S,
+              rootSchema,
+              formValue,
+              experimental_customMergeAllOf
+            );
+            return (
+              score +
+              calculateIndexScore<T, S, F>(
+                validator,
+                rootSchema,
+                newSchema,
+                formValue || {},
+                experimental_customMergeAllOf
+              )
+            );
           }
           if ((has(value, ONE_OF_KEY) || has(value, ANY_OF_KEY)) && formValue) {
             const key = has(value, ONE_OF_KEY) ? ONE_OF_KEY : ANY_OF_KEY;
@@ -78,7 +95,8 @@ export function calculateIndexScore<T = any, S extends StrictRJSFSchema = RJSFSc
                 formValue,
                 get(value, key) as S[],
                 -1,
-                discriminator
+                discriminator,
+                experimental_customMergeAllOf
               )
             );
           }
@@ -87,7 +105,10 @@ export function calculateIndexScore<T = any, S extends StrictRJSFSchema = RJSFSc
               // If the structure is matching then give it a little boost in score
               score += 1;
             }
-            return score + calculateIndexScore<T, S, F>(validator, rootSchema, value as S, formValue);
+            return (
+              score +
+              calculateIndexScore<T, S, F>(validator, rootSchema, value as S, formValue, experimental_customMergeAllOf)
+            );
           }
           if (value.type === guessType(formValue)) {
             // If the types match, then we bump the score by one
@@ -135,6 +156,7 @@ export function calculateIndexScore<T = any, S extends StrictRJSFSchema = RJSFSc
  * @param [selectedOption=-1] - The index of the currently selected option, defaulted to -1 if not specified
  * @param [discriminatorField] - The optional name of the field within the options object whose value is used to
  *          determine which option is selected
+ * @param [experimental_customMergeAllOf] - Optional function that allows for custom merging of `allOf` schemas
  * @returns - The index of the option that is the closest match to the `formData` or the `selectedOption` if no match
  */
 export default function getClosestMatchingOption<
@@ -147,7 +169,8 @@ export default function getClosestMatchingOption<
   formData: T | undefined,
   options: S[],
   selectedOption = -1,
-  discriminatorField?: string
+  discriminatorField?: string,
+  experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>
 ): number {
   // First resolve any refs in the options
   const resolvedOptions = options.map((option) => {
@@ -185,7 +208,7 @@ export default function getClosestMatchingOption<
     (scoreData: BestType, index: number) => {
       const { bestScore } = scoreData;
       const option = resolvedOptions[index];
-      const score = calculateIndexScore(validator, rootSchema, option, formData);
+      const score = calculateIndexScore(validator, rootSchema, option, formData, experimental_customMergeAllOf);
       scoreCount.add(score);
       if (score > bestScore) {
         return { bestIndex: index, bestScore: score };

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -241,6 +241,7 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
         includeUndefinedValues,
         _recurseList,
         experimental_defaultFormStateBehavior,
+        experimental_customMergeAllOf,
         parentDefaults: Array.isArray(parentDefaults) ? parentDefaults[idx] : undefined,
         rawFormData: formData as T,
         required,
@@ -268,7 +269,8 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
         isEmpty(formData) ? undefined : formData,
         oneOf as S[],
         0,
-        discriminator
+        discriminator,
+        experimental_customMergeAllOf
       )
     ] as S;
     schemaToCompute = mergeSchemas(remaining, schemaToCompute) as S;
@@ -285,7 +287,8 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
         isEmpty(formData) ? undefined : formData,
         anyOf as S[],
         0,
-        discriminator
+        discriminator,
+        experimental_customMergeAllOf
       )
     ] as S;
     schemaToCompute = mergeSchemas(remaining, schemaToCompute) as S;
@@ -297,6 +300,7 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
       includeUndefinedValues,
       _recurseList: updatedRecurseList,
       experimental_defaultFormStateBehavior: experimental_dfsb_to_compute,
+      experimental_customMergeAllOf,
       parentDefaults: defaults as T | undefined,
       rawFormData: formData as T,
       required,
@@ -404,6 +408,7 @@ export function getObjectDefaults<T = any, S extends StrictRJSFSchema = RJSFSche
           rootSchema,
           _recurseList,
           experimental_defaultFormStateBehavior,
+          experimental_customMergeAllOf,
           includeUndefinedValues: includeUndefinedValues === true,
           parentDefaults: get(defaults, [key]),
           rawFormData: get(formData, [key]),
@@ -440,6 +445,7 @@ export function getArrayDefaults<T = any, S extends StrictRJSFSchema = RJSFSchem
     rootSchema = {} as S,
     _recurseList = [],
     experimental_defaultFormStateBehavior = undefined,
+    experimental_customMergeAllOf = undefined,
     required,
   }: ComputeDefaultsProps<T, S> = {},
   defaults?: T | T[] | undefined
@@ -465,6 +471,7 @@ export function getArrayDefaults<T = any, S extends StrictRJSFSchema = RJSFSchem
         rootSchema,
         _recurseList,
         experimental_defaultFormStateBehavior,
+        experimental_customMergeAllOf,
         parentDefaults: item,
         required,
       });
@@ -482,6 +489,7 @@ export function getArrayDefaults<T = any, S extends StrictRJSFSchema = RJSFSchem
           rootSchema,
           _recurseList,
           experimental_defaultFormStateBehavior,
+          experimental_customMergeAllOf,
           rawFormData: item,
           parentDefaults: get(defaults, [idx]),
           required,
@@ -513,7 +521,7 @@ export function getArrayDefaults<T = any, S extends StrictRJSFSchema = RJSFSchem
   const defaultsLength = Array.isArray(defaults) ? defaults.length : 0;
   if (
     !schema.minItems ||
-    isMultiSelect<T, S, F>(validator, schema, rootSchema) ||
+    isMultiSelect<T, S, F>(validator, schema, rootSchema, experimental_customMergeAllOf) ||
     computeSkipPopulate<T, S, F>(validator, schema, rootSchema) ||
     schema.minItems <= defaultsLength
   ) {
@@ -531,6 +539,7 @@ export function getArrayDefaults<T = any, S extends StrictRJSFSchema = RJSFSchem
       rootSchema,
       _recurseList,
       experimental_defaultFormStateBehavior,
+      experimental_customMergeAllOf,
       required,
     })
   ) as T[];

--- a/packages/utils/src/schema/getDisplayLabel.ts
+++ b/packages/utils/src/schema/getDisplayLabel.ts
@@ -9,6 +9,7 @@ import {
   StrictRJSFSchema,
   UiSchema,
   ValidatorType,
+  Experimental_CustomMergeAllOf,
 } from '../types';
 import isFilesArray from './isFilesArray';
 import isMultiSelect from './isMultiSelect';
@@ -21,6 +22,7 @@ import isMultiSelect from './isMultiSelect';
  * @param [uiSchema={}] - The UI schema from which to derive potentially displayable information
  * @param [rootSchema] - The root schema, used to primarily to look up `$ref`s
  * @param [globalOptions={}] - The optional Global UI Schema from which to get any fallback `xxx` options
+ * @param [experimental_customMergeAllOf] - Optional function that allows for custom merging of `allOf` schemas
  * @returns - True if the label should be displayed or false if it should not
  */
 export default function getDisplayLabel<
@@ -32,7 +34,8 @@ export default function getDisplayLabel<
   schema: S,
   uiSchema: UiSchema<T, S, F> = {},
   rootSchema?: S,
-  globalOptions?: GlobalUISchemaOptions
+  globalOptions?: GlobalUISchemaOptions,
+  experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>
 ): boolean {
   const uiOptions = getUiOptions<T, S, F>(uiSchema, globalOptions);
   const { label = true } = uiOptions;
@@ -41,8 +44,8 @@ export default function getDisplayLabel<
 
   if (schemaType === 'array') {
     displayLabel =
-      isMultiSelect<T, S, F>(validator, schema, rootSchema) ||
-      isFilesArray<T, S, F>(validator, schema, uiSchema, rootSchema) ||
+      isMultiSelect<T, S, F>(validator, schema, rootSchema, experimental_customMergeAllOf) ||
+      isFilesArray<T, S, F>(validator, schema, uiSchema, rootSchema, experimental_customMergeAllOf) ||
       isCustomWidget(uiSchema);
   }
 

--- a/packages/utils/src/schema/isFilesArray.ts
+++ b/packages/utils/src/schema/isFilesArray.ts
@@ -1,5 +1,12 @@
 import { UI_WIDGET_KEY } from '../constants';
-import { FormContextType, RJSFSchema, StrictRJSFSchema, UiSchema, ValidatorType } from '../types';
+import {
+  Experimental_CustomMergeAllOf,
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+  UiSchema,
+  ValidatorType,
+} from '../types';
 import retrieveSchema from './retrieveSchema';
 
 /** Checks to see if the `schema` and `uiSchema` combination represents an array of files
@@ -8,19 +15,27 @@ import retrieveSchema from './retrieveSchema';
  * @param schema - The schema for which check for array of files flag is desired
  * @param [uiSchema={}] - The UI schema from which to check the widget
  * @param [rootSchema] - The root schema, used to primarily to look up `$ref`s
+ * @param [experimental_customMergeAllOf] - Optional function that allows for custom merging of `allOf` schemas
  * @returns - True if schema/uiSchema contains an array of files, otherwise false
  */
 export default function isFilesArray<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   validator: ValidatorType<T, S, F>,
   schema: S,
   uiSchema: UiSchema<T, S, F> = {},
-  rootSchema?: S
+  rootSchema?: S,
+  experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>
 ) {
   if (uiSchema[UI_WIDGET_KEY] === 'files') {
     return true;
   }
   if (schema.items) {
-    const itemsSchema = retrieveSchema<T, S, F>(validator, schema.items as S, rootSchema);
+    const itemsSchema = retrieveSchema<T, S, F>(
+      validator,
+      schema.items as S,
+      rootSchema,
+      undefined,
+      experimental_customMergeAllOf
+    );
     return itemsSchema.type === 'string' && itemsSchema.format === 'data-url';
   }
   return false;

--- a/packages/utils/src/schema/isMultiSelect.ts
+++ b/packages/utils/src/schema/isMultiSelect.ts
@@ -1,4 +1,4 @@
-import { FormContextType, RJSFSchema, StrictRJSFSchema, ValidatorType } from '../types';
+import { FormContextType, RJSFSchema, StrictRJSFSchema, ValidatorType, Experimental_CustomMergeAllOf } from '../types';
 
 import isSelect from './isSelect';
 
@@ -7,15 +7,21 @@ import isSelect from './isSelect';
  * @param validator - An implementation of the `ValidatorType` interface that will be used when necessary
  * @param schema - The schema for which check for a multi-select flag is desired
  * @param [rootSchema] - The root schema, used to primarily to look up `$ref`s
+ * @param [experimental_customMergeAllOf] - Optional function that allows for custom merging of `allOf` schemas
  * @returns - True if schema contains a multi-select, otherwise false
  */
 export default function isMultiSelect<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any
->(validator: ValidatorType<T, S, F>, schema: S, rootSchema?: S) {
+>(
+  validator: ValidatorType<T, S, F>,
+  schema: S,
+  rootSchema?: S,
+  experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>
+) {
   if (!schema.uniqueItems || !schema.items || typeof schema.items === 'boolean') {
     return false;
   }
-  return isSelect<T, S, F>(validator, schema.items as S, rootSchema);
+  return isSelect<T, S, F>(validator, schema.items as S, rootSchema, experimental_customMergeAllOf);
 }

--- a/packages/utils/src/schema/isSelect.ts
+++ b/packages/utils/src/schema/isSelect.ts
@@ -1,5 +1,5 @@
 import isConstant from '../isConstant';
-import { FormContextType, RJSFSchema, StrictRJSFSchema, ValidatorType } from '../types';
+import { FormContextType, RJSFSchema, StrictRJSFSchema, ValidatorType, Experimental_CustomMergeAllOf } from '../types';
 import retrieveSchema from './retrieveSchema';
 
 /** Checks to see if the `schema` combination represents a select
@@ -7,14 +7,16 @@ import retrieveSchema from './retrieveSchema';
  * @param validator - An implementation of the `ValidatorType` interface that will be used when necessary
  * @param theSchema - The schema for which check for a select flag is desired
  * @param [rootSchema] - The root schema, used to primarily to look up `$ref`s
+ * @param [experimental_customMergeAllOf] - Optional function that allows for custom merging of `allOf` schemas
  * @returns - True if schema contains a select, otherwise false
  */
 export default function isSelect<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   validator: ValidatorType<T, S, F>,
   theSchema: S,
-  rootSchema: S = {} as S
+  rootSchema: S = {} as S,
+  experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>
 ) {
-  const schema = retrieveSchema<T, S, F>(validator, theSchema, rootSchema, undefined);
+  const schema = retrieveSchema<T, S, F>(validator, theSchema, rootSchema, undefined, experimental_customMergeAllOf);
   const altSchemas = schema.oneOf || schema.anyOf;
   if (Array.isArray(schema.enum)) {
     return true;

--- a/packages/utils/src/schema/toIdSchema.ts
+++ b/packages/utils/src/schema/toIdSchema.ts
@@ -41,7 +41,7 @@ function toIdSchemaInternal<T = any, S extends StrictRJSFSchema = RJSFSchema, F 
   experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>
 ): IdSchema<T> {
   if (REF_KEY in schema || DEPENDENCIES_KEY in schema || ALL_OF_KEY in schema) {
-    const _schema = retrieveSchema<T, S, F>(validator, schema, rootSchema, formData);
+    const _schema = retrieveSchema<T, S, F>(validator, schema, rootSchema, formData, experimental_customMergeAllOf);
     const sameSchemaIndex = _recurseList.findIndex((item) => isEqual(item, _schema));
     if (sameSchemaIndex === -1) {
       return toIdSchemaInternal<T, S, F>(


### PR DESCRIPTION
### Reasons for making this change

Unfortunately, in the original PR https://github.com/rjsf-team/react-jsonschema-form/pull/4308, and I am deeply sorry, that I've missed one code branch that the argument must be passed to that led to many other branches to be missed. In this PR the argument is passed in 100% places it should be.

I've had also forgotten to add params to documentation which I've done now.

However, I've tested the code in a real world application and this change really helps the performance. When using [our custom fast merge](https://gist.github.com/MarekBodingerBA/5bb3aeda02d2255c7e1d023eac22168c) the input event duration went from ~300ms to ~80ms in large form.

### Checklist

- [X] **I'm updating documentation**
  - [X] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [X] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
