### PR TITLE
fix: Update schema builder add/set actions to have unique errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated `Experimental_DefaultFormStateBehavior` to add a new `constAsDefaults` option
 - Updated `getDefaultFormState()` to use the new `constAsDefaults` option to control how const is used for defaulting, fixing [#4344](https://github.com/rjsf-team/react-jsonschema-form/issues/4344), [#4361](https://github.com/rjsf-team/react-jsonschema-form/issues/4361) and [#4377](https://github.com/rjsf-team/react-jsonschema-form/issues/4377)
 - Use `experimental_customMergeAllOf` option in functions that have previously missed it.
+- Updated `ErrorSchemaBuilder` methods `addErrors` and `setErrors` to prevent duplicate error messages.
 
 ## Dev / docs / playground
 

--- a/packages/utils/src/ErrorSchemaBuilder.ts
+++ b/packages/utils/src/ErrorSchemaBuilder.ts
@@ -75,9 +75,9 @@ export default class ErrorSchemaBuilder<T = any> {
     }
 
     if (Array.isArray(errorOrList)) {
-      errorsList.push(...errorOrList);
+      set(errorBlock, ERRORS_KEY, [...new Set([...errorsList, ...errorOrList])]);
     } else {
-      errorsList.push(errorOrList);
+      set(errorBlock, ERRORS_KEY, [...new Set([...errorsList, errorOrList])]);
     }
     return this;
   }
@@ -93,7 +93,7 @@ export default class ErrorSchemaBuilder<T = any> {
   setErrors(errorOrList: string | string[], pathOfError?: string | (string | number)[]) {
     const errorBlock: ErrorSchema = this.getOrCreateErrorBlock(pathOfError);
     // Effectively clone the array being given to prevent accidental outside manipulation of the given list
-    const listToAdd = Array.isArray(errorOrList) ? [...errorOrList] : [errorOrList];
+    const listToAdd = Array.isArray(errorOrList) ? [...new Set([...errorOrList])] : [errorOrList];
     set(errorBlock, ERRORS_KEY, listToAdd);
     return this;
   }

--- a/packages/utils/test/ErrorSchemaBuilder.test.ts
+++ b/packages/utils/test/ErrorSchemaBuilder.test.ts
@@ -240,6 +240,24 @@ describe('ErrorSchemaBuilder', () => {
     it('resetting error restores things back to an empty object', () => {
       expect(builder.resetAllErrors().ErrorSchema).toEqual({});
     });
+    it('adding duplicated error string with a path puts only the unique errors at the path', () => {
+      builder.addErrors([AN_ERROR], STRING_PATH);
+      builder.addErrors([AN_ERROR], STRING_PATH);
+      expect(builder.ErrorSchema).toEqual({
+        [STRING_PATH]: {
+          [ERRORS_KEY]: [AN_ERROR],
+        },
+      });
+    });
+
+    it('setting duplicated error string with a path puts only the unique errors at the path', () => {
+      builder.setErrors([AN_ERROR, AN_ERROR], STRING_PATH);
+      expect(builder.ErrorSchema).toEqual({
+        [STRING_PATH]: {
+          [ERRORS_KEY]: [AN_ERROR],
+        },
+      });
+    });
   });
   describe('using initial schema', () => {
     let builder: ErrorSchemaBuilder;


### PR DESCRIPTION
### Reasons for making this change

I believe adding the same error to the list does not provide additional value.

- Updated schema builder errors list to only contain unique errors
  - `addErrors` & `setErrors` were updated

### Example

Before
<img width="561" alt="image" src="https://github.com/user-attachments/assets/6a427065-3211-47db-a80f-5d455446931e">

After
<img width="528" alt="image" src="https://github.com/user-attachments/assets/0b2be372-40b7-4a68-9804-2d77c4555796">


### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
