### PR TITLE
Fix 4382 by passing errorSchema and id through in NumberField's onChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.23.1
+
+## @rjsf/chakra-ui
+
+- Updated `package.json` to restrict `@chakra-ui/react`'s peer dependency to be < 3.0.0, fixing [#4390](https://github.com/rjsf-team/react-jsonschema-form/issues/4390)
+
+## @rjsf/core
+
+- Updated `NumberField` to properly pass through the `errorSchema` and `id` in the onChange handler, fixing [#4382](https://github.com/rjsf-team/react-jsonschema-form/issues/4382)
+
+## Dev / docs / playground
+
+- Updated the peer dependencies for `@rjsf/*` to be `5.23.x`
+
 # 5.23.0
 
 ## @rjsf/core

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -34,8 +34,8 @@
   },
   "peerDependencies": {
     "@ant-design/icons": "^4.0.0 || ^5.0.0",
-    "@rjsf/core": "^5.22.x",
-    "@rjsf/utils": "^5.22.x",
+    "@rjsf/core": "^5.23.x",
+    "@rjsf/utils": "^5.23.x",
     "antd": "^4.24.0 || ^5.8.5",
     "dayjs": "^1.8.0",
     "react": "^16.14.0 || >=17"

--- a/packages/bootstrap-4/package.json
+++ b/packages/bootstrap-4/package.json
@@ -33,8 +33,8 @@
     ]
   },
   "peerDependencies": {
-    "@rjsf/core": "^5.22.x",
-    "@rjsf/utils": "^5.22.x",
+    "@rjsf/core": "^5.23.x",
+    "@rjsf/utils": "^5.23.x",
     "react": "^16.14.0 || >=17",
     "react-bootstrap": "^1.6.5"
   },

--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -37,8 +37,8 @@
     "@chakra-ui/icons": ">=1.1.1",
     "@chakra-ui/react": ">=1.7.3 <3.0.0",
     "@chakra-ui/system": ">=1.12.1",
-    "@rjsf/core": "^5.22.x",
-    "@rjsf/utils": "^5.22.x",
+    "@rjsf/core": "^5.23.x",
+    "@rjsf/utils": "^5.23.x",
     "chakra-react-select": ">=3.3.8",
     "framer-motion": ">=5.6.0",
     "react": "^16.14.0 || >=17"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
     "node": ">=14"
   },
   "peerDependencies": {
-    "@rjsf/utils": "^5.22.x",
+    "@rjsf/utils": "^5.23.x",
     "react": "^16.14.0 || >=17"
   },
   "dependencies": {

--- a/packages/core/src/components/fields/NumberField.tsx
+++ b/packages/core/src/components/fields/NumberField.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { asNumber, FieldProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
+import { asNumber, ErrorSchema, FieldProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
 
 // Matches a string that ends in a . character, optionally followed by a sequence of
 // digits followed by any number of 0 characters up until the end of the line.
@@ -44,7 +44,7 @@ function NumberField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends
    * @param value - The current value for the change occurring
    */
   const handleChange = useCallback(
-    (value: FieldProps<T, S, F>['value']) => {
+    (value: FieldProps<T, S, F>['value'], errorSchema?: ErrorSchema<T>, id?: string) => {
       // Cache the original value in component state
       setLastValue(value);
 
@@ -62,7 +62,7 @@ function NumberField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends
           ? asNumber(value.replace(trailingCharMatcher, ''))
           : asNumber(value);
 
-      onChange(processed as unknown as T);
+      onChange(processed as unknown as T, errorSchema, id);
     },
     [onChange]
   );

--- a/packages/fluent-ui/package.json
+++ b/packages/fluent-ui/package.json
@@ -34,8 +34,8 @@
   },
   "peerDependencies": {
     "@fluentui/react": ">= 7",
-    "@rjsf/core": "^5.22.x",
-    "@rjsf/utils": "^5.22.x",
+    "@rjsf/core": "^5.23.x",
+    "@rjsf/utils": "^5.23.x",
     "react": "^16.14.0 || >=17"
   },
   "devDependencies": {

--- a/packages/fluentui-rc/package.json
+++ b/packages/fluentui-rc/package.json
@@ -37,7 +37,7 @@
     "node": ">=14"
   },
   "peerDependencies": {
-    "@rjsf/utils": "^5.22.x",
+    "@rjsf/utils": "^5.23.x",
     "react": "^16.14.0 || >=17"
   },
   "dependencies": {

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -34,8 +34,8 @@
   "peerDependencies": {
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
-    "@rjsf/core": "^5.22.x",
-    "@rjsf/utils": "^5.22.x",
+    "@rjsf/core": "^5.23.x",
+    "@rjsf/utils": "^5.23.x",
     "react": "^16.14.0 || >=17"
   },
   "devDependencies": {

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -36,8 +36,8 @@
     "@emotion/styled": "^11.6.0",
     "@mui/icons-material": "^5.2.0 || ^6.0.0",
     "@mui/material": "^5.2.2 || ^6.0.0",
-    "@rjsf/core": "^5.22.x",
-    "@rjsf/utils": "^5.22.x",
+    "@rjsf/core": "^5.23.x",
+    "@rjsf/utils": "^5.23.x",
     "react": ">=17"
   },
   "devDependencies": {

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -33,8 +33,8 @@
     ]
   },
   "peerDependencies": {
-    "@rjsf/core": "^5.22.x",
-    "@rjsf/utils": "^5.22.x",
+    "@rjsf/core": "^5.23.x",
+    "@rjsf/utils": "^5.23.x",
     "react": "^16.14.0 || >=17",
     "semantic-ui-react": "^1.3.1 || ^2.1.3"
   },

--- a/packages/validator-ajv6/package.json
+++ b/packages/validator-ajv6/package.json
@@ -37,7 +37,7 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "@rjsf/utils": "^5.22.x"
+    "@rjsf/utils": "^5.23.x"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",

--- a/packages/validator-ajv8/package.json
+++ b/packages/validator-ajv8/package.json
@@ -39,7 +39,7 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "@rjsf/utils": "^5.22.x"
+    "@rjsf/utils": "^5.23.x"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",


### PR DESCRIPTION
Fixes #4382

- Updated `NumberField`'s `handleChange` callback to pass through the `errorSchema` and `id`
- Updated the peerDependencies for the packages to be `5.23.x`
- Updated `CHANGELOG.md` accordingly

### Reasons for making this change

[Please describe them here]

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

If your PR is non-trivial and you'd like to schedule a synchronous review, please add it to the weekly meeting agenda: https://docs.google.com/document/d/12PjTvv21k6LIky6bNQVnsplMLLnmEuypTLQF8a-8Wss/edit

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
