### PR TITLE
Fix issue where ui:title in anyOf/oneOf is not shown in error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Fix default value population when switching between options in `MultiSchemaField` [#4375](https://github.com/rjsf-team/react-jsonschema-form/pull/4375). Fixes [#4367](https://github.com/rjsf-team/react-jsonschema-form/issues/4367)
 
+## @rjsf/validator-ajv8
+
+- Fixed issue where `ui:title` in anyOf/oneOf is not shown in error messages. Fixes [#4368](https://github.com/rjsf-team/react-jsonschema-form/issues/4368)
+
 # 5.23.1
 
 ## @rjsf/chakra-ui

--- a/packages/validator-ajv8/src/processRawValidationErrors.ts
+++ b/packages/validator-ajv8/src/processRawValidationErrors.ts
@@ -43,7 +43,7 @@ export function transformRJSFValidationErrors<
       let uiSchemaTitle = getUiOptions(get(uiSchema, `${property.replace(/^\./, '')}`)).title;
       if (uiSchemaTitle === undefined) {
         const uiSchemaPath = schemaPath
-          .replaceAll('/properties/', '/')
+          .replace(/\/properties\//g, '/')
           .split('/')
           .slice(1, -1)
           .concat([currentProperty]);

--- a/packages/validator-ajv8/src/processRawValidationErrors.ts
+++ b/packages/validator-ajv8/src/processRawValidationErrors.ts
@@ -40,7 +40,15 @@ export function transformRJSFValidationErrors<
     if ('missingProperty' in params) {
       property = property ? `${property}.${params.missingProperty}` : params.missingProperty;
       const currentProperty: string = params.missingProperty;
-      const uiSchemaTitle = getUiOptions(get(uiSchema, `${property.replace(/^\./, '')}`)).title;
+      let uiSchemaTitle = getUiOptions(get(uiSchema, `${property.replace(/^\./, '')}`)).title;
+      if (uiSchemaTitle === undefined) {
+        const uiSchemaPath = schemaPath
+          .replaceAll('/properties/', '/')
+          .split('/')
+          .slice(1, -1)
+          .concat([currentProperty]);
+        uiSchemaTitle = getUiOptions(get(uiSchema, uiSchemaPath)).title;
+      }
 
       if (uiSchemaTitle) {
         message = message.replace(`'${currentProperty}'`, `'${uiSchemaTitle}'`);


### PR DESCRIPTION
### Reasons for making this change

Fixed issue where `ui:title` in `anyOf`/`oneOf` is not shown in error messages.

This fixes #4368 with the following limitations.

1. This is only applicable in the case `missingProperty` exists.
2. As `schemaPath` is not stable (see [ajv-validator/ajv#512](https://github.com/ajv-validator/ajv/issues/512)), this may cause unexpected results occasionally.

As the first limitation is not directly related to #4368, it should be fixed in a separate PR if it is really an issue.

The second limitation can be a known issue as this fix does not lead any degradation and the problem only happens with nested `$ref` (i.e. happen in very limited cases).

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
