### PR TITLE
fix: Short-circuit File and Date constructor access in isObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Fix default value population when switching between options in `MultiSchemaField` [#4375](https://github.com/rjsf-team/react-jsonschema-form/pull/4375). Fixes [#4367](https://github.com/rjsf-team/react-jsonschema-form/issues/4367)
 
+## @rjsf/utils
+
+- Short-circuit `File` and `Date` constructor access in isObject to optimize performance in scenarios where `globalThis` is a `Proxy` that incurs overhead for each class constructor access ([#4413](https://github.com/rjsf-team/react-jsonschema-form/pull/4413)). Fixes [#4409](https://github.com/rjsf-team/react-jsonschema-form/issues/4409)
+
 ## @rjsf/validator-ajv8
 
 - Fixed issue where `ui:title` in anyOf/oneOf is not shown in error messages. Fixes [#4368](https://github.com/rjsf-team/react-jsonschema-form/issues/4368)

--- a/packages/utils/src/isObject.ts
+++ b/packages/utils/src/isObject.ts
@@ -1,15 +1,22 @@
-/** Determines whether a `thing` is an object for the purposes of RSJF. In this case, `thing` is an object if it has
+/** Determines whether a `thing` is an object for the purposes of RJSF. In this case, `thing` is an object if it has
  * the type `object` but is NOT null, an array or a File.
  *
  * @param thing - The thing to check to see whether it is an object
  * @returns - True if it is a non-null, non-array, non-File object
  */
 export default function isObject(thing: any) {
-  if (typeof File !== 'undefined' && thing instanceof File) {
+  if (typeof thing !== 'object' || thing === null) {
     return false;
   }
-  if (typeof Date !== 'undefined' && thing instanceof Date) {
+  // lastModified is guaranteed to be a number on a File instance
+  // as per https://w3c.github.io/FileAPI/#dfn-lastModified
+  if (typeof thing.lastModified === 'number' && typeof File !== 'undefined' && thing instanceof File) {
     return false;
   }
-  return typeof thing === 'object' && thing !== null && !Array.isArray(thing);
+  // getMonth is guaranteed to be a method on a Date instance
+  // as per https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getmonth
+  if (typeof thing.getMonth === 'function' && typeof Date !== 'undefined' && thing instanceof Date) {
+    return false;
+  }
+  return !Array.isArray(thing);
 }

--- a/packages/utils/test/isObject.test.ts
+++ b/packages/utils/test/isObject.test.ts
@@ -26,4 +26,38 @@ describe('isObject()', () => {
       expect(isObject(object)).toBe(true);
     });
   });
+  describe('without accessing File and Date classes', () => {
+    const NativeFile = File;
+    const NativeDate = Date;
+
+    beforeEach(() => {
+      Object.defineProperty(global, 'File', {
+        get() {
+          throw new Error('File should not have been accessed');
+        },
+      });
+      Object.defineProperty(global, 'Date', {
+        get() {
+          throw new Error('Date should not have been accessed');
+        },
+      });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(global, 'File', NativeFile);
+      Object.defineProperty(global, 'Date', NativeDate);
+    });
+
+    it('returns false when a non-object is provided', () => {
+      NON_OBJECTS.forEach((nonObject: string | number | boolean | null | undefined) => {
+        expect(isObject(nonObject)).toBe(false);
+      });
+    });
+
+    it('returns true when an object is provided', () => {
+      OBJECTS.forEach((object: any) => {
+        expect(isObject(object)).toBe(true);
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Reasons for making this change

This change refactors `isObject` to significantly reduce the frequency of accesses to `File` and `Date` by short-circuiting the function with several simple checks prior to running `instanceof` checks involving the two native classes. The motivation for making this change is explained within the issue this pull request fixes.

fixes #4409 

#### Prior `isObject` logic

* If `File` is defined and the value is an instance of `File`, return false
* If `Date` is defined and the value is an instance of `Date`, return false
* Return true if and only if the value is a non-null, non-array object

#### New `isObject` logic

* If value is null or a non-object, return false
* If value has a [`lastModified` number property ](https://w3c.github.io/FileAPI/#dfn-lastModified) and `File` is defined and the value is an instance of `File`, return false
* If value has a [`getMonth` method](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getmonth) and `Date` is defined and the value is an instance of `Date`, return false
* Return true if the value if an only if the value is a non-array object

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
