### PR TITLE
Partially fixed dependency error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 5.23.3
+
+## @rjsf/validator-ajv8
+
+- Partially fixed issue where dependency errors do not show `title` or `ui:title`. This fix only applicable if we use an ajv-i18n localizer. Ref. [#4402](https://github.com/rjsf-team/react-jsonschema-form/issues/4402).
+
 # 5.23.2
 
 ## @rjsf/core

--- a/package-lock.json
+++ b/package-lock.json
@@ -35330,6 +35330,7 @@
         "@types/jest": "^29.5.12",
         "@types/json-schema": "^7.0.15",
         "@types/lodash": "^4.14.202",
+        "ajv-i18n": "^4.2.0",
         "babel-jest": "^29.7.0",
         "eslint": "^8.56.0",
         "jest": "^29.7.0",

--- a/packages/validator-ajv8/package.json
+++ b/packages/validator-ajv8/package.json
@@ -52,6 +52,7 @@
     "@types/jest": "^29.5.12",
     "@types/json-schema": "^7.0.15",
     "@types/lodash": "^4.14.202",
+    "ajv-i18n": "^4.2.0",
     "babel-jest": "^29.7.0",
     "eslint": "^8.56.0",
     "jest": "^29.7.0",

--- a/packages/validator-ajv8/src/processRawValidationErrors.ts
+++ b/packages/validator-ajv8/src/processRawValidationErrors.ts
@@ -47,6 +47,8 @@ export function transformRJSFValidationErrors<
         const path = property ? `${property}.${currentProperty}` : currentProperty;
         let uiSchemaTitle = getUiOptions(get(uiSchema, `${path.replace(/^\./, '')}`)).title;
         if (uiSchemaTitle === undefined) {
+          // To retrieve a title from UI schema, construct a path to UI schema from `schemaPath` and `currentProperty`.
+          // For example, when `#/properties/A/properties/B/required` and `C` are given, they are converted into `['A', 'B', 'C']`.
           const uiSchemaPath = schemaPath
             .replace(/\/properties\//g, '/')
             .split('/')

--- a/packages/validator-ajv8/src/processRawValidationErrors.ts
+++ b/packages/validator-ajv8/src/processRawValidationErrors.ts
@@ -81,6 +81,7 @@ export function transformRJSFValidationErrors<
       }
     }
 
+    // If params.missingProperty is undefined, it is removed from rawPropertyNames by filter((item) => item).
     if ('missingProperty' in params) {
       property = property ? `${property}.${params.missingProperty}` : params.missingProperty;
     }

--- a/packages/validator-ajv8/src/processRawValidationErrors.ts
+++ b/packages/validator-ajv8/src/processRawValidationErrors.ts
@@ -36,29 +36,33 @@ export function transformRJSFValidationErrors<
     let { message = '' } = rest;
     let property = instancePath.replace(/\//g, '.');
     let stack = `${property} ${message}`.trim();
+    const rawPropertyNames: string[] = [
+      ...(params.deps?.split(', ') || []),
+      params.missingProperty,
+      params.property,
+    ].filter((item) => item);
 
-    if ('missingProperty' in params) {
-      property = property ? `${property}.${params.missingProperty}` : params.missingProperty;
-      const currentProperty: string = params.missingProperty;
-      let uiSchemaTitle = getUiOptions(get(uiSchema, `${property.replace(/^\./, '')}`)).title;
-      if (uiSchemaTitle === undefined) {
-        const uiSchemaPath = schemaPath
-          .replace(/\/properties\//g, '/')
-          .split('/')
-          .slice(1, -1)
-          .concat([currentProperty]);
-        uiSchemaTitle = getUiOptions(get(uiSchema, uiSchemaPath)).title;
-      }
-
-      if (uiSchemaTitle) {
-        message = message.replace(`'${currentProperty}'`, `'${uiSchemaTitle}'`);
-      } else {
-        const parentSchemaTitle = get(parentSchema, [PROPERTIES_KEY, currentProperty, 'title']);
-
-        if (parentSchemaTitle) {
-          message = message.replace(`'${currentProperty}'`, `'${parentSchemaTitle}'`);
+    if (rawPropertyNames.length > 0) {
+      rawPropertyNames.forEach((currentProperty) => {
+        const path = property ? `${property}.${currentProperty}` : currentProperty;
+        let uiSchemaTitle = getUiOptions(get(uiSchema, `${path.replace(/^\./, '')}`)).title;
+        if (uiSchemaTitle === undefined) {
+          const uiSchemaPath = schemaPath
+            .replace(/\/properties\//g, '/')
+            .split('/')
+            .slice(1, -1)
+            .concat([currentProperty]);
+          uiSchemaTitle = getUiOptions(get(uiSchema, uiSchemaPath)).title;
         }
-      }
+        if (uiSchemaTitle) {
+          message = message.replace(`'${currentProperty}'`, `'${uiSchemaTitle}'`);
+        } else {
+          const parentSchemaTitle = get(parentSchema, [PROPERTIES_KEY, currentProperty, 'title']);
+          if (parentSchemaTitle) {
+            message = message.replace(`'${currentProperty}'`, `'${parentSchemaTitle}'`);
+          }
+        }
+      });
 
       stack = message;
     } else {
@@ -73,6 +77,10 @@ export function transformRJSFValidationErrors<
           stack = `'${parentSchemaTitle}' ${message}`.trim();
         }
       }
+    }
+
+    if ('missingProperty' in params) {
+      property = property ? `${property}.${params.missingProperty}` : params.missingProperty;
     }
 
     // put data in expected format

--- a/packages/validator-ajv8/src/validator.ts
+++ b/packages/validator-ajv8/src/validator.ts
@@ -100,6 +100,8 @@ export default class AJV8Validator<T = any, S extends StrictRJSFSchema = RJSFSch
             }
           });
           if (error.params?.deps) {
+            // As `error.params.deps` is the comma+space separated list of missing dependencies, enclose each dependency separately.
+            // For example, `A, B` is converted into `'A', 'B'`.
             error.params.deps = error.params.deps
               .split(', ')
               .map((v: string) => `'${v}'`)
@@ -115,6 +117,7 @@ export default class AJV8Validator<T = any, S extends StrictRJSFSchema = RJSFSch
             }
           });
           if (error.params?.deps) {
+            // Remove surrounding quotes from each missing dependency. For example, `'A', 'B'` is reverted to `A, B`.
             error.params.deps = error.params.deps
               .split(', ')
               .map((v: string) => v.slice(1, -1))

--- a/packages/validator-ajv8/src/validator.ts
+++ b/packages/validator-ajv8/src/validator.ts
@@ -90,19 +90,35 @@ export default class AJV8Validator<T = any, S extends StrictRJSFSchema = RJSFSch
     let errors;
     if (compiledValidator) {
       if (typeof this.localizer === 'function') {
-        // Missing properties need to be enclosed with quotes so that
+        // Properties need to be enclosed with quotes so that
         // `AJV8Validator#transformRJSFValidationErrors` replaces property names
-        // with `title` or `ui:title`. See #4348, #4349, and #4387.
+        // with `title` or `ui:title`. See #4348, #4349, #4387, and #4402.
         (compiledValidator.errors ?? []).forEach((error) => {
-          if (error.params?.missingProperty) {
-            error.params.missingProperty = `'${error.params.missingProperty}'`;
+          ['missingProperty', 'property'].forEach((key) => {
+            if (error.params?.[key]) {
+              error.params[key] = `'${error.params[key]}'`;
+            }
+          });
+          if (error.params?.deps) {
+            error.params.deps = error.params.deps
+              .split(', ')
+              .map((v: string) => `'${v}'`)
+              .join(', ');
           }
         });
         this.localizer(compiledValidator.errors);
         // Revert to originals
         (compiledValidator.errors ?? []).forEach((error) => {
-          if (error.params?.missingProperty) {
-            error.params.missingProperty = error.params.missingProperty.slice(1, -1);
+          ['missingProperty', 'property'].forEach((key) => {
+            if (error.params?.[key]) {
+              error.params[key] = error.params[key].slice(1, -1);
+            }
+          });
+          if (error.params?.deps) {
+            error.params.deps = error.params.deps
+              .split(', ')
+              .map((v: string) => v.slice(1, -1))
+              .join(', ');
           }
         });
       }


### PR DESCRIPTION
### Reasons for making this change

Partially fixed issue where dependency errors do not show title or ui:title. This fix only applicable if we use an ajv-i18n localizer. Ref. #4402.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
