### PR TITLE
fix: incorrect formData with racing onChange invokes

### DIFF
--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -705,7 +705,13 @@ export default class Form<
         errors: toErrorList(errorSchema),
       };
     }
-    this.setState(state as FormState<T, S, F>, () => onChange && onChange({ ...this.state, ...state }, id));
+    this.setState(prevState => {
+      const newState = { ...prevState, ...state } as FormState<T, S, F>;
+      if (onChange) {
+        onChange(newState, id);
+      }
+      return newState; 
+    });
   };
 
   /**


### PR DESCRIPTION
### Story

I was trying to do a workaround for issue of dependent values not being reset in `formData` when dependee changed (#3838). In my case, it was dependent enums with dynamic options. The workaround worked by triggering `onChange` from dependent widgets and setting the first option as default whenever `enumOptions` changed. During that, I noticed an issue where `formData` only gets the update from last widget in the rendering order.

### Reasons for making this change

The state update in `onChange` is not using the callback form which can handle racing setStates in order. This should allow workarounds to work properly while the root issue is being fixed. It is also a good practice to write setState in callback form generally.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
