### PR TITLE
feat(utils): switch lodash.isEqualWith to fast-equals comparator to improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.24.2
+
+## @rjsf/utils
+
+- switch `lodash.isEqualWith` to `fast-equals.createCustomEqual` providing `areFunctionsEqual` assuming any functions are equal.
 
 # 5.24.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16648,6 +16648,15 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -35236,6 +35245,7 @@
       "version": "5.24.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "fast-equals": "^5.2.2",
         "json-schema-merge-allof": "^0.8.1",
         "jsonpointer": "^5.0.1",
         "lodash": "^4.17.21",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -36,6 +36,7 @@
     "react": "^16.14.0 || >=17"
   },
   "dependencies": {
+    "fast-equals": "^5.2.2",
     "json-schema-merge-allof": "^0.8.1",
     "jsonpointer": "^5.0.1",
     "lodash": "^4.17.21",

--- a/packages/utils/src/deepEquals.ts
+++ b/packages/utils/src/deepEquals.ts
@@ -1,19 +1,22 @@
-import isEqualWith from 'lodash/isEqualWith';
+import { createCustomEqual } from 'fast-equals';
 
-/** Implements a deep equals using the `lodash.isEqualWith` function, that provides a customized comparator that
- * assumes all functions are equivalent.
+/** Implements a deep equals using the `fast-equals.createCustomEqual` function, providing a customized comparator that assumes all functions are equivalent.
  *
  * @param a - The first element to compare
  * @param b - The second element to compare
  * @returns - True if the `a` and `b` are deeply equal, false otherwise
  */
-export default function deepEquals(a: any, b: any): boolean {
-  return isEqualWith(a, b, (obj: any, other: any) => {
-    if (typeof obj === 'function' && typeof other === 'function') {
-      // Assume all functions are equivalent
-      // see https://github.com/rjsf-team/react-jsonschema-form/issues/255
-      return true;
-    }
-    return undefined; // fallback to default isEquals behavior
-  });
-}
+const deepEquals = createCustomEqual({
+  createCustomConfig: () => ({
+    // Assume all functions are equivalent
+    // see https://github.com/rjsf-team/react-jsonschema-form/issues/255
+    //
+    // Performance improvement: knowing that typeof a === function, so, only needs to check if typeof b === function.
+    // https://github.com/planttheidea/fast-equals/blob/c633c4e653cacf8fd5cbb309b6841df62322d74c/src/comparator.ts#L99
+    areFunctionsEqual(_a, b) {
+      return typeof b === 'function';
+    },
+  }),
+});
+
+export default deepEquals;


### PR DESCRIPTION
### Reasons for making this change
This PR replaces `lodash.isEqualWith` with `fast-equals.createCustomEqual` at `@rjsf/utils.deepEquals` as the second part of this approach https://github.com/rjsf-team/react-jsonschema-form/issues/4291#issuecomment-2569881383 .
first part https://github.com/rjsf-team/react-jsonschema-form/pull/4438 

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
