### PR TITLE
Bug : Fields inside an array can't be set to empty when default is set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/utils
 
 - switch `lodash.isEqualWith` to `fast-equals.createCustomEqual` providing `areFunctionsEqual` assuming any functions are equal.
+- Fixed issue with fields inside an array can't be set to empty when a default is set, fixing [#4456](https://github.com/rjsf-team/react-jsonschema-form/issues/4456)
 
 # 5.24.1
 

--- a/packages/utils/src/mergeDefaultsWithFormData.ts
+++ b/packages/utils/src/mergeDefaultsWithFormData.ts
@@ -41,7 +41,7 @@ export default function mergeDefaultsWithFormData<T = any>(
     const overrideOppositeArray = overrideFormDataWithDefaults ? formData : defaultsArray;
 
     const mapped = overrideArray.map((value, idx) => {
-      if (overrideOppositeArray[idx]) {
+      if (typeof overrideOppositeArray[idx] !== 'undefined') {
         return mergeDefaultsWithFormData<any>(
           defaultsArray[idx],
           formData[idx],

--- a/packages/utils/src/mergeDefaultsWithFormData.ts
+++ b/packages/utils/src/mergeDefaultsWithFormData.ts
@@ -41,7 +41,7 @@ export default function mergeDefaultsWithFormData<T = any>(
     const overrideOppositeArray = overrideFormDataWithDefaults ? formData : defaultsArray;
 
     const mapped = overrideArray.map((value, idx) => {
-     // We want to explicitly make sure that the value is NOT undefined since null, 0 and empty space are valid values
+      // We want to explicitly make sure that the value is NOT undefined since null, 0 and empty space are valid values
       if (overrideOppositeArray[idx] !== undefined) {
         return mergeDefaultsWithFormData<any>(
           defaultsArray[idx],

--- a/packages/utils/src/mergeDefaultsWithFormData.ts
+++ b/packages/utils/src/mergeDefaultsWithFormData.ts
@@ -41,7 +41,8 @@ export default function mergeDefaultsWithFormData<T = any>(
     const overrideOppositeArray = overrideFormDataWithDefaults ? formData : defaultsArray;
 
     const mapped = overrideArray.map((value, idx) => {
-      if (typeof overrideOppositeArray[idx] !== 'undefined') {
+     // We want to explicitly make sure that the value is NOT undefined since null, 0 and empty space are valid values
+      if (overrideOppositeArray[idx] !== undefined) {
         return mergeDefaultsWithFormData<any>(
           defaultsArray[idx],
           formData[idx],

--- a/packages/utils/test/mergeDefaultsWithFormData.test.ts
+++ b/packages/utils/test/mergeDefaultsWithFormData.test.ts
@@ -150,6 +150,38 @@ describe('mergeDefaultsWithFormData()', () => {
       expect(mergeDefaultsWithFormData({}, undefined, undefined, undefined, true)).toEqual(undefined);
     });
 
+    it('should deeply merge and return formData when formData is undefined and defaultSupercedesUndefined false', () => {
+      expect(
+        mergeDefaultsWithFormData(
+          {
+            arrayWithDefaults: ['Hello World'],
+            objectWidthDefaults: {
+              nestedField: 'Hello World!',
+            },
+            stringField: 'Hello World!!',
+          },
+          {
+            arrayWithDefaults: [null],
+            objectWidthDefaults: {
+              nestedField: undefined,
+            },
+            stringField: undefined,
+            nonEmptyField: 'Hello World!!!',
+          },
+          undefined,
+          undefined,
+          true
+        )
+      ).toEqual({
+        arrayWithDefaults: [null],
+        objectWidthDefaults: {
+          nestedField: undefined,
+        },
+        stringField: undefined,
+        nonEmptyField: 'Hello World!!!',
+      });
+    });
+
     it('should return default when formData is undefined and defaultSupercedesUndefined true', () => {
       expect(mergeDefaultsWithFormData({}, undefined, undefined, true, true)).toEqual({});
     });


### PR DESCRIPTION
### Reasons for making this change

Fixes #4456 


### Checklist

- [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR

