### PR TITLE
Bug: The oneOf selector can be modified in readonly mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/utils
 
 - switch `lodash.isEqualWith` to `fast-equals.createCustomEqual` providing `areFunctionsEqual` assuming any functions are equal.
+- Fixed issue with oneOf selector can be modified in readonly mode, fixing [#4460](https://github.com/rjsf-team/react-jsonschema-form/issues/4460)
 
 # 5.24.1
 

--- a/packages/core/src/components/fields/MultiSchemaField.tsx
+++ b/packages/core/src/components/fields/MultiSchemaField.tsx
@@ -149,6 +149,7 @@ class AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
       formContext,
       onBlur,
       onFocus,
+      readonly,
       registry,
       schema,
       uiSchema,
@@ -237,7 +238,7 @@ class AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
             autofocus={autofocus}
             label={title ?? name}
             hideLabel={!displayLabel}
-            readonly={this.props.readonly}
+            readonly={readonly}
           />
         </div>
         {optionSchema && <_SchemaField {...this.props} schema={optionSchema} uiSchema={optionUiSchema} />}

--- a/packages/core/src/components/fields/MultiSchemaField.tsx
+++ b/packages/core/src/components/fields/MultiSchemaField.tsx
@@ -237,6 +237,7 @@ class AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
             autofocus={autofocus}
             label={title ?? name}
             hideLabel={!displayLabel}
+            readonly={this.props.readonly}
           />
         </div>
         {optionSchema && <_SchemaField {...this.props} schema={optionSchema} uiSchema={optionUiSchema} />}

--- a/packages/core/test/oneOf.test.jsx
+++ b/packages/core/test/oneOf.test.jsx
@@ -891,6 +891,80 @@ describe('oneOf', () => {
     });
   });
 
+  it('should select oneOf dropdown be disabled when the schema is readOnly', () => {
+    const schema = {
+      title: 'Example Schema',
+      type: 'object',
+      readOnly: true,
+      properties: {
+        contactPreference: {
+          oneOf: [
+            {
+              $ref: '#/definitions/phoneContact',
+            },
+            {
+              $ref: '#/definitions/emailContact',
+            },
+          ],
+        },
+      },
+      required: ['contactPreference'],
+      definitions: {
+        phoneContact: {
+          type: 'object',
+          properties: {
+            contactMethod: {
+              type: 'string',
+              enum: ['phone'],
+            },
+            phoneNumber: {
+              type: 'string',
+              pattern: '^[0-9]{10}$',
+            },
+          },
+          required: ['contactMethod', 'phoneNumber'],
+        },
+        emailContact: {
+          type: 'object',
+          properties: {
+            contactMethod: {
+              type: 'string',
+              enum: ['email'],
+            },
+            emailAddress: {
+              type: 'string',
+              format: 'email',
+            },
+          },
+          required: ['contactMethod', 'emailAddress'],
+        },
+      },
+    };
+
+    const { node } = createFormComponent({
+      schema,
+      formData: {
+        contactPreference: {
+          contactMethod: 'phone',
+          phoneNumber: '1231231231',
+        },
+      },
+    });
+
+    const $select = node.querySelector('select#root_contactPreference__oneof_select');
+
+    expect($select.value).eql('0');
+    expect($select).to.have.property('disabled', true);
+
+    act(() => {
+      fireEvent.change($select, {
+        target: { value: $select.options[1].value },
+      });
+    });
+
+    expect($select.value).eql('0');
+  });
+
   describe('Arrays', () => {
     it('should correctly render mixed types for oneOf inside array items', () => {
       const schema = {


### PR DESCRIPTION
### Reasons for making this change

Fixes #4460 

### Checklist

- [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR

