### PR TITLE
Validator should not refresh on clicking a Selector in playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Fixed issue with file accept attribute, fixing [#4404](https://github.com/rjsf-team/react-jsonschema-form/issues/4404).
 
+## Dev / docs / playground
+- Fixed issue with selector, where validator was getting refreshed on clicking on anything in selector. [#4472](https://github.com/rjsf-team/react-jsonschema-form/pull/4472)
+
 # 5.24.1
 
 ## @rjsf/utils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.24.3
+
+## Dev / docs / playground
+- Fixed issue with selector, where validator was getting refreshed on clicking on anything in selector. [#4472](https://github.com/rjsf-team/react-jsonschema-form/pull/4472)
+
 # 5.24.2
 
 ## @rjsf/utils
@@ -27,9 +32,6 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/mui
 
 - Fixed issue with file accept attribute, fixing [#4404](https://github.com/rjsf-team/react-jsonschema-form/issues/4404).
-
-## Dev / docs / playground
-- Fixed issue with selector, where validator was getting refreshed on clicking on anything in selector. [#4472](https://github.com/rjsf-team/react-jsonschema-form/pull/4472)
 
 # 5.24.1
 

--- a/packages/playground/src/components/Playground.tsx
+++ b/packages/playground/src/components/Playground.tsx
@@ -86,7 +86,9 @@ export default function Playground({ themes, validators }: PlaygroundProps) {
       setTheme(theTheme);
       setShowForm(true);
       setLiveSettings(liveSettings);
-      setValidator(validator);
+      if ('validator' in data) {
+        setValidator(validator);
+      }
       setOtherFormProps({ fields, templates, ...rest });
     },
     [theme, onThemeSelected, themes]


### PR DESCRIPTION
### Reasons for making this change
This is a playground bug. On changing the selector a second time, the validator gets set to undefined. PFA

 The validator should not be updated. Technically, none of the settings should reset on selection change. But, I have fixed the validator only as the validator is throwing an error. I am happy to raise more PRs if resetting of all fields should be stopped. The line causing the error is 

https://github.com/rjsf-team/react-jsonschema-form/blob/b12175679079be956570349771dddd65406b3773/packages/core/src/components/Form.tsx#L287

https://github.com/user-attachments/assets/c7cda460-ed4e-455e-bdfd-0ab6ba9e14ed

### Checklist

- [x] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
