### PR TITLE
Fix 3759 - uneditable & permanent defaults with additional properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.24.4
+
+## @rjsf/core
+
+- Added `initialDefaultsGenerated` flag to state, which indicates whether the initial generation of defaults has been completed
+- Added `ObjectField` tests for additionalProperties with defaults  
+
+## @rjsf/utils
+
+- Updated `getDefaultFormState` to add a new `initialDefaultsGenerated` prop flag, along with type definitions, fixing uneditable & permanent defaults with additional properties [3759](https://github.com/rjsf-team/react-jsonschema-form/issues/3759)
+- Updated `createSchemaUtils` definition to reflect addition of `initialDefaultsGenerated`
+- Updated existing tests where `getDefaultFormState` is used to reflect addition of `initialDefaultsGenerated`
+
+## @rjsf/docs 
+- Updated docs for `getDefaultFormState` to reflect addition of `initialDefaultsGenerated` prop
+
+## @rjsf/validator-ajv6 @rjsf/validator-avv8
+- Updated `getDefaultFormState` calls to reflect addition of `initialDefaultsGenerated`
+
 # 5.24.3
 
 ## @rjsf/utils

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -761,6 +761,7 @@ export default class Form<
       errors: [] as unknown,
       schemaValidationErrors: [] as unknown,
       schemaValidationErrorSchema: {},
+      initialDefaultsGenerated: false,
     } as FormState<T, S, F>;
 
     this.setState(state, () => onChange && onChange({ ...this.state, ...state }));

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -252,6 +252,8 @@ export interface FormState<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
   // Private
   /** @description result of schemaUtils.retrieveSchema(schema, formData). This a memoized value to avoid re calculate at internal functions (getStateFromProps, onChange) */
   retrievedSchema: S;
+  /** Flag indicating whether the form defaults have been generated */
+  initialDefaultsGenerated: boolean;
 }
 
 /** The event data passed when changes have been made to the form, includes everything from the `FormState` except
@@ -423,7 +425,15 @@ export default class Form<
         experimental_customMergeAllOf
       );
     }
-    const formData: T = schemaUtils.getDefaultFormState(schema, inputFormData) as T;
+
+    if (schema.title === 'console') {
+      console.log('schema', schema);
+      console.log('retrievedSchema', retrievedSchema);
+      console.log('edit', edit);
+      console.log('props', props);
+    }
+
+    const formData: T = schemaUtils.getDefaultFormState(schema, inputFormData, state.initialDefaultsGenerated) as T;
     const _retrievedSchema = this.updateRetrievedSchema(
       retrievedSchema ?? schemaUtils.retrieveSchema(schema, formData)
     );
@@ -505,6 +515,7 @@ export default class Form<
       schemaValidationErrors,
       schemaValidationErrorSchema,
       retrievedSchema: _retrievedSchema,
+      initialDefaultsGenerated: true,
     };
     return nextState;
   }

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -252,7 +252,7 @@ export interface FormState<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
   // Private
   /** @description result of schemaUtils.retrieveSchema(schema, formData). This a memoized value to avoid re calculate at internal functions (getStateFromProps, onChange) */
   retrievedSchema: S;
-  /** Flag indicating whether the form defaults have been generated */
+  /** Flag indicating whether the initial form defaults have been generated */
   initialDefaultsGenerated: boolean;
 }
 

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -426,13 +426,6 @@ export default class Form<
       );
     }
 
-    if (schema.title === 'console') {
-      console.log('schema', schema);
-      console.log('retrievedSchema', retrievedSchema);
-      console.log('edit', edit);
-      console.log('props', props);
-    }
-
     const formData: T = schemaUtils.getDefaultFormState(schema, inputFormData, state.initialDefaultsGenerated) as T;
     const _retrievedSchema = this.updateRetrievedSchema(
       retrievedSchema ?? schemaUtils.retrieveSchema(schema, formData)

--- a/packages/core/src/components/fields/MultiSchemaField.tsx
+++ b/packages/core/src/components/fields/MultiSchemaField.tsx
@@ -126,7 +126,7 @@ class AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
     if (newOption) {
       // Call getDefaultFormState to make sure defaults are populated on change. Pass "excludeObjectChildren"
       // so that only the root objects themselves are created without adding undefined children properties
-      newFormData = schemaUtils.getDefaultFormState(newOption, newFormData, 'excludeObjectChildren') as T;
+      newFormData = schemaUtils.getDefaultFormState(newOption, newFormData, false, 'excludeObjectChildren') as T;
     }
 
     this.setState({ selectedOption: intOption }, () => {

--- a/packages/core/test/Form.test.jsx
+++ b/packages/core/test/Form.test.jsx
@@ -147,6 +147,7 @@ describeRepeated('Form common', (createFormComponent) => {
           schemaValidationErrorSchema: undefined,
           schemaUtils: sinon.match.object,
           retrievedSchema: schema,
+          initialDefaultsGenerated: true,
         });
       });
     });
@@ -1512,6 +1513,7 @@ describeRepeated('Form common', (createFormComponent) => {
           schemaValidationErrorSchema: undefined,
           schemaUtils: sinon.match.object,
           retrievedSchema: formProps.schema,
+          initialDefaultsGenerated: true,
         });
       });
     });

--- a/packages/core/test/ObjectField.test.jsx
+++ b/packages/core/test/ObjectField.test.jsx
@@ -1142,6 +1142,165 @@ describe('ObjectField', () => {
       });
     });
 
+    it('should generate the specifed default key and value inputs if default is provided outside of additionalProperties schema', () => {
+      const customSchema = {
+        ...schema,
+        default: {
+          defaultKey: 'defaultValue',
+        },
+      };
+      const { onChange } = createFormComponent({
+        schema: customSchema,
+        formData: {},
+      });
+
+      sinon.assert.calledWithMatch(onChange.lastCall, {
+        formData: {
+          defaultKey: 'defaultValue',
+        },
+      });
+    });
+
+    it('should generate the specifed default key/value input with custom formData provided', () => {
+      const customSchema = {
+        ...schema,
+        default: {
+          defaultKey: 'defaultValue',
+        },
+      };
+      const { onChange } = createFormComponent({
+        schema: customSchema,
+        formData: {
+          someData: 'someValue',
+        },
+      });
+
+      sinon.assert.calledWithMatch(onChange.lastCall, {
+        formData: {
+          defaultKey: 'defaultValue',
+          someData: 'someValue',
+        },
+      });
+    });
+
+    it('should edit the specifed default key without duplicating', () => {
+      const customSchema = {
+        ...schema,
+        default: {
+          defaultKey: 'defaultValue',
+        },
+      };
+      const { node, onChange } = createFormComponent({
+        schema: customSchema,
+        formData: {},
+      });
+
+      fireEvent.blur(node.querySelector('#root_defaultKey-key'), { target: { value: 'newDefaultKey' } });
+
+      sinon.assert.calledWithMatch(onChange.lastCall, {
+        formData: {
+          newDefaultKey: 'defaultValue',
+        },
+      });
+    });
+
+    it('should remove the specifed default key/value input item', () => {
+      const customSchema = {
+        ...schema,
+        default: {
+          defaultKey: 'defaultValue',
+        },
+      };
+      const { node, onChange } = createFormComponent({
+        schema: customSchema,
+        formData: {},
+      });
+
+      fireEvent.click(node.querySelector('.array-item-remove'));
+
+      sinon.assert.calledWithMatch(onChange.lastCall, {
+        formData: {},
+      });
+    });
+
+    it('should handle nested additional property default key/value input generation', () => {
+      const customSchema = {
+        ...schema,
+        default: {
+          defaultKey: 'defaultValue',
+        },
+        properties: {
+          nested: {
+            type: 'object',
+            properties: {
+              bar: {
+                type: 'object',
+                additionalProperties: {
+                  type: 'string',
+                },
+                default: {
+                  baz: 'value',
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const { onChange } = createFormComponent({
+        schema: customSchema,
+        formData: {},
+      });
+
+      sinon.assert.calledWithMatch(onChange.lastCall, {
+        formData: {
+          defaultKey: 'defaultValue',
+          nested: {
+            bar: {
+              baz: 'value',
+            },
+          },
+        },
+      });
+    });
+
+    it('should remove nested additional property default key/value input', () => {
+      const customSchema = {
+        ...schema,
+        properties: {
+          nested: {
+            type: 'object',
+            properties: {
+              bar: {
+                type: 'object',
+                additionalProperties: {
+                  type: 'string',
+                },
+                default: {
+                  baz: 'value',
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const { node, onChange } = createFormComponent({
+        schema: customSchema,
+        formData: {},
+      });
+
+      fireEvent.click(node.querySelector('.array-item-remove'));
+
+      sinon.assert.calledWithMatch(onChange.lastCall, {
+        formData: {
+          nested: {
+            bar: {},
+          },
+        },
+      });
+    });
+
     it('should not provide an expand button if length equals maxProperties', () => {
       const { node } = createFormComponent({
         schema: { maxProperties: 1, ...schema },

--- a/packages/core/test/ObjectField.test.jsx
+++ b/packages/core/test/ObjectField.test.jsx
@@ -1142,7 +1142,7 @@ describe('ObjectField', () => {
       });
     });
 
-    it('should generate the specifed default key and value inputs if default is provided outside of additionalProperties schema', () => {
+    it('should generate the specified default key and value inputs if default is provided outside of additionalProperties schema', () => {
       const customSchema = {
         ...schema,
         default: {
@@ -1161,7 +1161,7 @@ describe('ObjectField', () => {
       });
     });
 
-    it('should generate the specifed default key/value input with custom formData provided', () => {
+    it('should generate the specified default key/value input with custom formData provided', () => {
       const customSchema = {
         ...schema,
         default: {
@@ -1183,7 +1183,7 @@ describe('ObjectField', () => {
       });
     });
 
-    it('should edit the specifed default key without duplicating', () => {
+    it('should edit the specified default key without duplicating', () => {
       const customSchema = {
         ...schema,
         default: {
@@ -1204,7 +1204,7 @@ describe('ObjectField', () => {
       });
     });
 
-    it('should remove the specifed default key/value input item', () => {
+    it('should remove the specified default key/value input item', () => {
       const customSchema = {
         ...schema,
         default: {

--- a/packages/docs/docs/api-reference/utility-functions.md
+++ b/packages/docs/docs/api-reference/utility-functions.md
@@ -921,6 +921,7 @@ Returns the superset of `formData` that includes the given set updated to includ
 - theSchema: S - The schema for which the default state is desired
 - [formData]: T | undefined - The current formData, if any, onto which to provide any missing defaults
 - [rootSchema]: S | undefined - The root schema, used to primarily to look up `$ref`s
+- [initialDefaultsGenerated]: boolean - Flag indicating whether the initial form defaults have been generated
 - [includeUndefinedValues=false]: boolean | "excludeObjectChildren" - Optional flag, if true, cause undefined values to be added as defaults. If "excludeObjectChildren", cause undefined values for this object and pass `includeUndefinedValues` as false when computing defaults for any nested object properties.
 - [experimental_defaultFormStateBehavior]: Experimental_DefaultFormStateBehavior - See `Form` documentation for the [experimental_defaultFormStateBehavior](./form-props.md#experimental_defaultFormStateBehavior) prop
 - [experimental_customMergeAllOf]: Experimental_CustomMergeAllOf&lt;S&gt; - See `Form` documentation for the [experimental_customMergeAllOf](./form-props.md#experimental_custommergeallof) prop

--- a/packages/utils/src/createSchemaUtils.ts
+++ b/packages/utils/src/createSchemaUtils.ts
@@ -103,7 +103,7 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
    *
    * @param schema - The schema for which the default state is desired
    * @param [formData] - The current formData, if any, onto which to provide any missing defaults
-   * @param initDefaultsGenerated - indicates whether or not initial defaults have been generated
+   * @param initialDefaultsGenerated - Indicates whether or not initial defaults have been generated
    * @param [includeUndefinedValues=false] - Optional flag, if true, cause undefined values to be added as defaults.
    *          If "excludeObjectChildren", pass `includeUndefinedValues` as false when computing defaults for any nested
    *          object properties.
@@ -112,7 +112,7 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
   getDefaultFormState(
     schema: S,
     formData?: T,
-    initDefaultsGenerated?: boolean,
+    initialDefaultsGenerated?: boolean,
     includeUndefinedValues: boolean | 'excludeObjectChildren' = false
   ): T | T[] | undefined {
     return getDefaultFormState<T, S, F>(
@@ -120,7 +120,7 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
       schema,
       formData,
       this.rootSchema,
-      initDefaultsGenerated,
+      initialDefaultsGenerated,
       includeUndefinedValues,
       this.experimental_defaultFormStateBehavior,
       this.experimental_customMergeAllOf

--- a/packages/utils/src/createSchemaUtils.ts
+++ b/packages/utils/src/createSchemaUtils.ts
@@ -103,7 +103,7 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
    *
    * @param schema - The schema for which the default state is desired
    * @param [formData] - The current formData, if any, onto which to provide any missing defaults
-   * @param initDefaultsGenerated - check for whether or not the defaults have been generated
+   * @param initDefaultsGenerated - indicates whether or not initial defaults have been generated
    * @param [includeUndefinedValues=false] - Optional flag, if true, cause undefined values to be added as defaults.
    *          If "excludeObjectChildren", pass `includeUndefinedValues` as false when computing defaults for any nested
    *          object properties.

--- a/packages/utils/src/createSchemaUtils.ts
+++ b/packages/utils/src/createSchemaUtils.ts
@@ -103,6 +103,7 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
    *
    * @param schema - The schema for which the default state is desired
    * @param [formData] - The current formData, if any, onto which to provide any missing defaults
+   * @param initDefaultsGenerated - check for whether or not the defaults have been generated
    * @param [includeUndefinedValues=false] - Optional flag, if true, cause undefined values to be added as defaults.
    *          If "excludeObjectChildren", pass `includeUndefinedValues` as false when computing defaults for any nested
    *          object properties.
@@ -111,6 +112,7 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
   getDefaultFormState(
     schema: S,
     formData?: T,
+    initDefaultsGenerated?: boolean,
     includeUndefinedValues: boolean | 'excludeObjectChildren' = false
   ): T | T[] | undefined {
     return getDefaultFormState<T, S, F>(
@@ -118,6 +120,7 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
       schema,
       formData,
       this.rootSchema,
+      initDefaultsGenerated,
       includeUndefinedValues,
       this.experimental_defaultFormStateBehavior,
       this.experimental_customMergeAllOf

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -178,8 +178,8 @@ interface ComputeDefaultsProps<T = any, S extends StrictRJSFSchema = RJSFSchema>
    *  The formData should take precedence unless it's not valid. This is useful when for example the value from formData does not exist in the schema 'enum' property, in such cases we take the value from the defaults because the value from the formData is not valid.
    */
   shouldMergeDefaultsIntoFormData?: boolean;
-  /** Indicates whether or not initial defaults have been generated */
-  initDefaultsGenerated?: boolean;
+  /** Indicates whether initial defaults have been generated */
+  initialDefaultsGenerated?: boolean;
 }
 
 /** Computes the defaults for the current `schema` given the `rawFormData` and `parentDefaults` if any. This drills into
@@ -205,7 +205,7 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
     experimental_customMergeAllOf = undefined,
     required,
     shouldMergeDefaultsIntoFormData = false,
-    initDefaultsGenerated,
+    initialDefaultsGenerated,
   } = computeDefaultsProps;
   const formData: T = (isObject(rawFormData) ? rawFormData : {}) as T;
   const schema: S = isObject(rawSchema) ? rawSchema : ({} as S);
@@ -326,7 +326,7 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
       rawFormData: formData as T,
       required,
       shouldMergeDefaultsIntoFormData,
-      initDefaultsGenerated,
+      initialDefaultsGenerated,
     });
   }
 
@@ -421,7 +421,7 @@ export function getObjectDefaults<T = any, S extends StrictRJSFSchema = RJSFSche
     experimental_customMergeAllOf = undefined,
     required,
     shouldMergeDefaultsIntoFormData,
-    initDefaultsGenerated,
+    initialDefaultsGenerated,
   }: ComputeDefaultsProps<T, S> = {},
   defaults?: T | T[] | undefined
 ): T {
@@ -457,7 +457,7 @@ export function getObjectDefaults<T = any, S extends StrictRJSFSchema = RJSFSche
           rawFormData: get(formData, [key]),
           required: retrievedSchema.required?.includes(key),
           shouldMergeDefaultsIntoFormData,
-          initDefaultsGenerated,
+          initialDefaultsGenerated,
         });
         maybeAddDefaultToObject<T>(
           acc,
@@ -473,7 +473,7 @@ export function getObjectDefaults<T = any, S extends StrictRJSFSchema = RJSFSche
       },
       {}
     ) as T;
-    if (retrievedSchema.additionalProperties && !initDefaultsGenerated) {
+    if (retrievedSchema.additionalProperties && !initialDefaultsGenerated) {
       // as per spec additionalProperties may be either schema or boolean
       const additionalPropertiesSchema = isObject(retrievedSchema.additionalProperties)
         ? retrievedSchema.additionalProperties
@@ -503,7 +503,7 @@ export function getObjectDefaults<T = any, S extends StrictRJSFSchema = RJSFSche
           rawFormData: get(formData, [key]),
           required: retrievedSchema.required?.includes(key),
           shouldMergeDefaultsIntoFormData,
-          initDefaultsGenerated,
+          initialDefaultsGenerated,
         });
         // Since these are additional properties we don't need to add the `experimental_defaultFormStateBehavior` prop
         maybeAddDefaultToObject<T>(
@@ -539,7 +539,7 @@ export function getArrayDefaults<T = any, S extends StrictRJSFSchema = RJSFSchem
     experimental_customMergeAllOf = undefined,
     required,
     shouldMergeDefaultsIntoFormData,
-    initDefaultsGenerated,
+    initialDefaultsGenerated,
   }: ComputeDefaultsProps<T, S> = {},
   defaults?: T | T[] | undefined
 ): T | T[] | undefined {
@@ -568,7 +568,7 @@ export function getArrayDefaults<T = any, S extends StrictRJSFSchema = RJSFSchem
         parentDefaults: item,
         required,
         shouldMergeDefaultsIntoFormData,
-        initDefaultsGenerated,
+        initialDefaultsGenerated,
       });
     }) as T[];
   }
@@ -589,7 +589,7 @@ export function getArrayDefaults<T = any, S extends StrictRJSFSchema = RJSFSchem
           parentDefaults: get(defaults, [idx]),
           required,
           shouldMergeDefaultsIntoFormData,
-          initDefaultsGenerated,
+          initialDefaultsGenerated,
         });
       }) as T[];
 
@@ -639,7 +639,7 @@ export function getArrayDefaults<T = any, S extends StrictRJSFSchema = RJSFSchem
       experimental_customMergeAllOf,
       required,
       shouldMergeDefaultsIntoFormData,
-      initDefaultsGenerated,
+      initialDefaultsGenerated,
     })
   ) as T[];
   // then fill up the rest with either the item default or empty, up to minItems
@@ -682,7 +682,7 @@ export function getDefaultBasedOnSchemaType<
  * @param theSchema - The schema for which the default state is desired
  * @param [formData] - The current formData, if any, onto which to provide any missing defaults
  * @param [rootSchema] - The root schema, used to primarily to look up `$ref`s
- * @param initDefaultsGenerated - indicates whether or not initial defaults have been generated
+ * @param initialDefaultsGenerated - Indicates whether or not initial defaults have been generated
  * @param [includeUndefinedValues=false] - Optional flag, if true, cause undefined values to be added as defaults.
  *          If "excludeObjectChildren", cause undefined values for this object and pass `includeUndefinedValues` as
  *          false when computing defaults for any nested object properties.
@@ -699,7 +699,7 @@ export default function getDefaultFormState<
   theSchema: S,
   formData?: T,
   rootSchema?: S,
-  initDefaultsGenerated?: boolean,
+  initialDefaultsGenerated?: boolean,
   includeUndefinedValues: boolean | 'excludeObjectChildren' = false,
   experimental_defaultFormStateBehavior?: Experimental_DefaultFormStateBehavior,
   experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>
@@ -719,7 +719,7 @@ export default function getDefaultFormState<
     experimental_customMergeAllOf,
     rawFormData: formData,
     shouldMergeDefaultsIntoFormData: true,
-    initDefaultsGenerated,
+    initialDefaultsGenerated,
   });
 
   // If the formData is an object or an array, add additional properties from formData and override formData with

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -178,7 +178,7 @@ interface ComputeDefaultsProps<T = any, S extends StrictRJSFSchema = RJSFSchema>
    *  The formData should take precedence unless it's not valid. This is useful when for example the value from formData does not exist in the schema 'enum' property, in such cases we take the value from the defaults because the value from the formData is not valid.
    */
   shouldMergeDefaultsIntoFormData?: boolean;
-  /** Optional flag, if true, indicates that defaults have already been generated */
+  /** Indicates whether or not initial defaults have been generated */
   initDefaultsGenerated?: boolean;
 }
 
@@ -682,6 +682,7 @@ export function getDefaultBasedOnSchemaType<
  * @param theSchema - The schema for which the default state is desired
  * @param [formData] - The current formData, if any, onto which to provide any missing defaults
  * @param [rootSchema] - The root schema, used to primarily to look up `$ref`s
+ * @param initDefaultsGenerated - indicates whether or not initial defaults have been generated
  * @param [includeUndefinedValues=false] - Optional flag, if true, cause undefined values to be added as defaults.
  *          If "excludeObjectChildren", cause undefined values for this object and pass `includeUndefinedValues` as
  *          false when computing defaults for any nested object properties.

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1074,7 +1074,7 @@ export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchem
    *
    * @param schema - The schema for which the default state is desired
    * @param [formData] - The current formData, if any, onto which to provide any missing defaults
-   * @param initDefaultsGenerated - indicates whether or not initial defaults have been generated
+   * @param initialDefaultsGenerated - Indicates whether or not initial defaults have been generated
    * @param [includeUndefinedValues=false] - Optional flag, if true, cause undefined values to be added as defaults.
    *          If "excludeObjectChildren", cause undefined values for this object and pass `includeUndefinedValues` as
    *          false when computing defaults for any nested object properties.
@@ -1083,7 +1083,7 @@ export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchem
   getDefaultFormState(
     schema: S,
     formData?: T,
-    initDefaultsGenerated?: boolean,
+    initialDefaultsGenerated?: boolean,
     includeUndefinedValues?: boolean | 'excludeObjectChildren'
   ): T | T[] | undefined;
   /** Determines whether the combination of `schema` and `uiSchema` properties indicates that the label for the `schema`

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1074,6 +1074,7 @@ export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchem
    *
    * @param schema - The schema for which the default state is desired
    * @param [formData] - The current formData, if any, onto which to provide any missing defaults
+   * @param initDefaultsGenerated - indicates whether or not initial defaults have been generated
    * @param [includeUndefinedValues=false] - Optional flag, if true, cause undefined values to be added as defaults.
    *          If "excludeObjectChildren", cause undefined values for this object and pass `includeUndefinedValues` as
    *          false when computing defaults for any nested object properties.

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1082,6 +1082,7 @@ export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchem
   getDefaultFormState(
     schema: S,
     formData?: T,
+    initDefaultsGenerated?: boolean,
     includeUndefinedValues?: boolean | 'excludeObjectChildren'
   ): T | T[] | undefined;
   /** Determines whether the combination of `schema` and `uiSchema` properties indicates that the label for the `schema`

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -121,6 +121,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
                 undefined,
                 schema,
                 undefined,
+                false,
                 experimental_defaultFormStateBehavior
               )
             ).toEqual(expected);
@@ -348,7 +349,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         };
 
         test('getDefaultFormState', () => {
-          expect(getDefaultFormState(testValidator, schema, undefined, schema, includeUndefinedValues)).toEqual(
+          expect(getDefaultFormState(testValidator, schema, undefined, schema, false, includeUndefinedValues)).toEqual(
             expected
           );
         });
@@ -458,7 +459,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         };
 
         test('getDefaultFormState', () => {
-          expect(getDefaultFormState(testValidator, schema, undefined, schema, includeUndefinedValues)).toEqual(
+          expect(getDefaultFormState(testValidator, schema, undefined, schema, false, includeUndefinedValues)).toEqual(
             expected
           );
         });
@@ -794,7 +795,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
 
           test('getDefaultFormState', () => {
             expect(
-              getDefaultFormState(testValidator, schema, rawFormData, schema, false, {
+              getDefaultFormState(testValidator, schema, rawFormData, schema, false, false, {
                 emptyObjectFields: 'populateAllDefaults',
                 allOf: 'skipDefaults',
                 arrayMinItems: {
@@ -873,9 +874,9 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           const expected = {};
 
           test('getDefaultFormState', () => {
-            expect(getDefaultFormState(testValidator, schema, undefined, schema, includeUndefinedValues)).toEqual(
-              expected
-            );
+            expect(
+              getDefaultFormState(testValidator, schema, undefined, schema, false, includeUndefinedValues)
+            ).toEqual(expected);
           });
 
           test('computeDefaults', () => {
@@ -1050,6 +1051,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
                 rawFormData,
                 schema,
                 includeUndefinedValues,
+                false,
                 experimental_defaultFormStateBehavior
               )
             ).toEqual({
@@ -1131,6 +1133,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
                   rawFormData,
                   schema,
                   includeUndefinedValues,
+                  false,
                   experimental_defaultFormStateBehavior
                 )
               ).toEqual({
@@ -1298,6 +1301,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
                 rawFormData,
                 schema,
                 undefined,
+                false,
                 experimental_defaultFormStateBehavior
               )
             ).toEqual(expected);
@@ -1380,6 +1384,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
                 undefined,
                 schema,
                 undefined,
+                false,
                 experimental_defaultFormStateBehavior
               )
             ).toEqual(expected);
@@ -1427,6 +1432,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
                 undefined,
                 schema,
                 undefined,
+                false,
                 experimental_defaultFormStateBehavior
               )
             ).toEqual(expected);
@@ -1474,6 +1480,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
                 undefined,
                 schema,
                 undefined,
+                false,
                 experimental_defaultFormStateBehavior
               )
             ).toEqual(expected);
@@ -1536,6 +1543,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
               rawFormData,
               schema,
               undefined,
+              false,
               experimental_defaultFormStateBehavior
             )
           ).toEqual(expected);
@@ -1588,7 +1596,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         const expected = ['Raphael', 'Michaelangelo', 'Unknown', 'Unknown'];
 
         test('getDefaultFormState', () => {
-          expect(getDefaultFormState(testValidator, schema, undefined, schema, includeUndefinedValues)).toEqual(
+          expect(getDefaultFormState(testValidator, schema, undefined, schema, false, includeUndefinedValues)).toEqual(
             expected
           );
         });
@@ -1647,6 +1655,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
                 schema,
                 undefined,
                 schema,
+                false,
                 includeUndefinedValues,
                 experimental_defaultFormStateBehavior
               )
@@ -1710,7 +1719,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         const expected: undefined[] = [undefined, undefined, undefined, undefined];
 
         test('getDefaultFormState', () => {
-          expect(getDefaultFormState(testValidator, schema, undefined, schema, includeUndefinedValues)).toEqual(
+          expect(getDefaultFormState(testValidator, schema, undefined, schema, false, includeUndefinedValues)).toEqual(
             expected
           );
         });
@@ -1757,7 +1766,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         const expected = ['ConstFromRoot', 'ConstFromRoot', 'Constant', 'Constant'];
 
         test('getDefaultFormState', () => {
-          expect(getDefaultFormState(testValidator, schema, undefined, schema, includeUndefinedValues)).toEqual(
+          expect(getDefaultFormState(testValidator, schema, undefined, schema, false, includeUndefinedValues)).toEqual(
             expected
           );
         });
@@ -1809,7 +1818,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         const expected: never[] = [];
 
         test('getDefaultFormState', () => {
-          expect(getDefaultFormState(testValidator, schema, undefined, schema, includeUndefinedValues)).toEqual(
+          expect(getDefaultFormState(testValidator, schema, undefined, schema, false, includeUndefinedValues)).toEqual(
             expected
           );
         });
@@ -3855,7 +3864,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           },
         };
         expect(
-          getDefaultFormState(testValidator, schema, {}, undefined, undefined, {
+          getDefaultFormState(testValidator, schema, {}, undefined, undefined, false, {
             emptyObjectFields: 'populateRequiredDefaults',
           })
         ).toEqual({ name: {} });
@@ -3886,7 +3895,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           },
         };
         expect(
-          getDefaultFormState(testValidator, schema, {}, undefined, undefined, {
+          getDefaultFormState(testValidator, schema, {}, undefined, undefined, false, {
             emptyObjectFields: 'populateRequiredDefaults',
           })
         ).toEqual({
@@ -3920,7 +3929,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           ],
         };
         expect(
-          getDefaultFormState(testValidator, schema, {}, undefined, undefined, {
+          getDefaultFormState(testValidator, schema, {}, undefined, undefined, false, {
             emptyObjectFields: 'populateRequiredDefaults',
           })
         ).toEqual({ foo: 'fooVal', baz: 'bazIsRequired' });
@@ -4052,7 +4061,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           },
         };
         expect(
-          getDefaultFormState(testValidator, schema, {}, undefined, undefined, {
+          getDefaultFormState(testValidator, schema, {}, undefined, undefined, false, {
             emptyObjectFields: 'populateRequiredDefaults',
           })
         ).toEqual({ name: {} });
@@ -4083,7 +4092,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           },
         };
         expect(
-          getDefaultFormState(testValidator, schema, {}, undefined, undefined, {
+          getDefaultFormState(testValidator, schema, {}, undefined, undefined, false, {
             emptyObjectFields: 'populateRequiredDefaults',
           })
         ).toEqual({
@@ -4117,7 +4126,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           ],
         };
         expect(
-          getDefaultFormState(testValidator, schema, {}, undefined, undefined, {
+          getDefaultFormState(testValidator, schema, {}, undefined, undefined, false, {
             emptyObjectFields: 'populateRequiredDefaults',
           })
         ).toEqual({ foo: 'fooVal', baz: 'bazIsRequired' });
@@ -4635,7 +4644,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
       it('returns field value of default when formData has undefined for field and `useDefaultIfFormDataUndefined`', () => {
         const formData = { field: undefined };
         expect(
-          getDefaultFormState(testValidator, schema, formData, undefined, undefined, {
+          getDefaultFormState(testValidator, schema, formData, undefined, undefined, false, {
             mergeDefaultsIntoFormData: 'useDefaultIfFormDataUndefined',
           })
         ).toEqual(defaultedFormData);
@@ -4683,7 +4692,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         },
       };
       expect(
-        getDefaultFormState(testValidator, schema, { requiredArray: ['raw0'] }, schema, false, {
+        getDefaultFormState(testValidator, schema, { requiredArray: ['raw0'] }, schema, false, false, {
           arrayMinItems: { mergeExtraDefaults: true },
         })
       ).toEqual({
@@ -4703,7 +4712,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         required: ['requiredArray'],
       };
       expect(
-        getDefaultFormState(testValidator, schema, undefined, schema, false, {
+        getDefaultFormState(testValidator, schema, undefined, schema, false, false, {
           arrayMinItems: { populate: 'requiredOnly' },
         })
       ).toEqual({ requiredArray: ['default0', 'default0'] });
@@ -4721,7 +4730,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         required: ['requiredArray'],
       };
       expect(
-        getDefaultFormState(testValidator, schema, { requiredArray: ['raw0'] }, schema, false, {
+        getDefaultFormState(testValidator, schema, { requiredArray: ['raw0'] }, schema, false, false, {
           arrayMinItems: { populate: 'requiredOnly' },
         })
       ).toEqual({ requiredArray: ['raw0'] });
@@ -4739,7 +4748,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         required: ['requiredArray'],
       };
       expect(
-        getDefaultFormState(testValidator, schema, { requiredArray: ['raw0'] }, schema, false, {
+        getDefaultFormState(testValidator, schema, { requiredArray: ['raw0'] }, schema, false, false, {
           arrayMinItems: { populate: 'requiredOnly', mergeExtraDefaults: true },
         })
       ).toEqual({ requiredArray: ['raw0', 'default0'] });
@@ -4762,7 +4771,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         required: ['stringArray', 'numberArray'],
       };
       expect(
-        getDefaultFormState(testValidator, schema, {}, schema, false, {
+        getDefaultFormState(testValidator, schema, {}, schema, false, false, {
           arrayMinItems: {
             computeSkipPopulate: (_, schema) =>
               !Array.isArray(schema?.items) && typeof schema?.items !== 'boolean' && schema?.items?.type === 'number',

--- a/packages/validator-ajv6/src/validator.ts
+++ b/packages/validator-ajv6/src/validator.ts
@@ -152,7 +152,7 @@ export default class AJV6Validator<T = any, S extends StrictRJSFSchema = RJSFSch
     }
 
     // Include form data with undefined values, which is required for custom validation.
-    const newFormData = getDefaultFormState<T, S, F>(this, schema, formData, rootSchema, true) as T;
+    const newFormData = getDefaultFormState<T, S, F>(this, schema, formData, rootSchema, false, true) as T;
 
     const errorHandler = customValidate(newFormData, createErrorHandler<T>(newFormData), uiSchema);
     const userErrorSchema = unwrapErrorHandler<T>(errorHandler);

--- a/packages/validator-ajv8/src/processRawValidationErrors.ts
+++ b/packages/validator-ajv8/src/processRawValidationErrors.ts
@@ -150,7 +150,7 @@ export default function processRawValidationErrors<
   }
 
   // Include form data with undefined values, which is required for custom validation.
-  const newFormData = getDefaultFormState<T, S, F>(validator, schema, formData, schema, true) as T;
+  const newFormData = getDefaultFormState<T, S, F>(validator, schema, formData, schema, false, true) as T;
 
   const errorHandler = customValidate(newFormData, createErrorHandler<T>(newFormData), uiSchema);
   const userErrorSchema = unwrapErrorHandler<T>(errorHandler);


### PR DESCRIPTION
### Reasons for making this change

Fixes [#3759](https://github.com/rjsf-team/react-jsonschema-form/issues/3759)

Additional properties with defaults set currently creates a permanent key-value pair that is essentially uneditable.
Trying to edit the key creates an entirely new key value entry on blur while still keeping the default key-value pair. The default key-value pair is also not deletable. Solution here generates defaults for additional properties once on form initialization, and then skips regeneration on any form update

This solution works for root & nested additionalProperties (see tests)
Allows for 'reset' form to regenerate defaults
Also fixes the issue I mentioned in the [Closed PR](https://github.com/rjsf-team/react-jsonschema-form/pull/4440) with custom formData not being applied when generating additionalProperties defaults

I wanted to avoid prop drilling, but there wasn't an obvious way to get root form state into getDefaultFormState

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [x] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature