### PR TITLE
Implemented the GridTemplate for all themes

### DIFF
--- a/CHANGELOG_v6.md
+++ b/CHANGELOG_v6.md
@@ -21,11 +21,13 @@ should change the heading of the (upcoming) version to include a major version b
 
 - BREAKING CHANGE: Refactored `ArrayFieldItemTemplate` to use the new `ArrayFieldItemButtonsTemplate`
 - Updated the `ArrayFieldTemplate`, `ObjectFieldTemplate`, and `WrapIfAdditionalTemplate` to a unique id using the `buttonId()` function and adding consistent marker classes
+- Implemented the `GridTemplate` component, adding it to the `templates` for the theme 
 
 ## @rjsf/chakra-ui
 
 - BREAKING CHANGE: Refactored `ArrayFieldItemTemplate` to use the new `ArrayFieldItemButtonsTemplate`
 - Updated the `ArrayFieldTemplate`, `ObjectFieldTemplate`, and `WrapIfAdditionalTemplate` to a unique id using the `buttonId()` function and adding consistent marker classes
+- Implemented the `GridTemplate` component, adding it to the `templates` for the theme
 
 ## @rjsf/core
 
@@ -33,6 +35,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Added `ArrayFieldItemButtonsTemplate` component as a refactor of all the common buttons code from all the `ArrayFieldItemTemplate` implementations, adding a unique id using the `buttonId()` function
 - Refactored `ArrayFieldItemTemplate` to use the new `ArrayFieldItemButtonsTemplate`
 - Updated the `ArrayFieldTemplate`, `ObjectFieldTemplate`, and `WrapIfAdditionalTemplate` to a unique id using the `buttonId()` function and adding consistent marker classes
+- Implemented the `GridTemplate` component, adding it to the `templates` for the theme
 
 ## @rjsf/fluent-ui
 
@@ -42,16 +45,20 @@ should change the heading of the (upcoming) version to include a major version b
 
 - BREAKING CHANGE: Refactored `ArrayFieldItemTemplate` to use the new `ArrayFieldItemButtonsTemplate`
 - Updated the `ArrayFieldTemplate`, `ObjectFieldTemplate`, and `WrapIfAdditionalTemplate` to a unique id using the `buttonId()` function and adding consistent marker classes
+- Implemented the `GridTemplate` component, adding it to the `templates` for the theme
 
 ## @rjsf/mui
 
 - BREAKING CHANGE: Refactored `ArrayFieldItemTemplate` to use the new `ArrayFieldItemButtonsTemplate`
 - Updated the `ArrayFieldTemplate`, `ObjectFieldTemplate`, and `WrapIfAdditionalTemplate` to a unique id using the `buttonId()` function and adding consistent marker classes
+- Updated the theme to use `Grid2` instead of the deprecated `Grid`
+- Implemented the `GridTemplate` component, adding it to the `templates` for the theme
 
 ## @rjsf/semantic-ui
 
 - BREAKING CHANGE: Refactored `ArrayFieldItemTemplate` to use the new `ArrayFieldItemButtonsTemplate`
 - Updated the `ArrayFieldTemplate`, `ObjectFieldTemplate`, and `WrapIfAdditionalTemplate` to a unique id using the `buttonId()` function and adding consistent marker classes
+- Implemented the `GridTemplate` component, adding it to the `templates` for the theme
 
 ## @rjsf/utils
 

--- a/packages/antd/src/templates/GridTemplate/index.tsx
+++ b/packages/antd/src/templates/GridTemplate/index.tsx
@@ -1,0 +1,15 @@
+import { Col, Row } from 'antd';
+import { GridTemplateProps } from '@rjsf/utils';
+
+/** Renders a `GridTemplate` for antd, which is expecting the column sizing information coming in via the
+ * extra props provided by the caller, which are spread directly on the `Row`/`Col`.
+ *
+ * @param props - The GridTemplateProps, including the extra props containing the antd grid positioning details
+ */
+export default function GridTemplate(props: GridTemplateProps) {
+  const { children, column, ...rest } = props;
+  if (column) {
+    return <Col {...rest}>{children}</Col>;
+  }
+  return <Row {...rest}>{children}</Row>;
+}

--- a/packages/antd/src/templates/index.ts
+++ b/packages/antd/src/templates/index.ts
@@ -8,6 +8,7 @@ import ErrorList from './ErrorList';
 import { AddButton, CopyButton, MoveDownButton, MoveUpButton, RemoveButton } from './IconButton';
 import FieldErrorTemplate from './FieldErrorTemplate';
 import FieldTemplate from './FieldTemplate';
+import GridTemplate from './GridTemplate';
 import ObjectFieldTemplate from './ObjectFieldTemplate';
 import SubmitButton from './SubmitButton';
 import TitleField from './TitleField';
@@ -34,6 +35,7 @@ export function generateTemplates<
     ErrorListTemplate: ErrorList,
     FieldErrorTemplate,
     FieldTemplate,
+    GridTemplate,
     ObjectFieldTemplate,
     TitleFieldTemplate: TitleField,
     WrapIfAdditionalTemplate,

--- a/packages/chakra-ui/src/GridTemplate/GridTemplate.tsx
+++ b/packages/chakra-ui/src/GridTemplate/GridTemplate.tsx
@@ -1,0 +1,15 @@
+import { Grid, GridItem } from '@chakra-ui/react';
+import { GridTemplateProps } from '@rjsf/utils';
+
+/** Renders a `GridTemplate` for chakra-ui, which is expecting the column sizing information coming in via the
+ * extra props provided by the caller, which are spread directly on the `Grid`/`GridItem`.
+ *
+ * @param props - The GridTemplateProps, including the extra props containing the chakra-ui grid positioning details
+ */
+export default function GridTemplate(props: GridTemplateProps) {
+  const { children, column, ...rest } = props;
+  if (column) {
+    return <GridItem {...rest}>{children}</GridItem>;
+  }
+  return <Grid {...rest}>{children}</Grid>;
+}

--- a/packages/chakra-ui/src/GridTemplate/index.ts
+++ b/packages/chakra-ui/src/GridTemplate/index.ts
@@ -1,0 +1,2 @@
+export { default } from './GridTemplate';
+export * from './GridTemplate';

--- a/packages/chakra-ui/src/Templates/Templates.ts
+++ b/packages/chakra-ui/src/Templates/Templates.ts
@@ -8,6 +8,7 @@ import { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } from '../IconB
 import FieldErrorTemplate from '../FieldErrorTemplate';
 import FieldHelpTemplate from '../FieldHelpTemplate';
 import FieldTemplate from '../FieldTemplate';
+import GridTemplate from '../GridTemplate';
 import ObjectFieldTemplate from '../ObjectFieldTemplate';
 import SubmitButton from '../SubmitButton';
 import TitleField from '../TitleField';
@@ -36,6 +37,7 @@ export function generateTemplates<
     FieldErrorTemplate,
     FieldHelpTemplate,
     FieldTemplate,
+    GridTemplate,
     ObjectFieldTemplate,
     TitleFieldTemplate: TitleField,
     WrapIfAdditionalTemplate,

--- a/packages/core/src/components/templates/GridTemplate.tsx
+++ b/packages/core/src/components/templates/GridTemplate.tsx
@@ -1,13 +1,12 @@
 import { GridTemplateProps } from '@rjsf/utils';
 
-/** Renders a `GridTemplate` for bootstrap 3, which is expecting the column
- * information coming in via the `className` prop.
+/** Renders a `GridTemplate` for bootstrap 3, which is expecting the column information coming in via the `className`
+ * prop. Also spreads all the other props provided by the user directly on the div.
  *
- * @param props - The GridTemplateProps, including the expected className for
- *        the bootstrap 3 grid behavior
+ * @param props - The GridTemplateProps, including the expected className for the bootstrap 3 grid behavior
  */
 export default function GridTemplate(props: GridTemplateProps) {
-  const { children, overrides, column, className, ...rest } = props;
+  const { children, column, className, ...rest } = props;
   const classNames = column ? className : `row ${className}`;
   return (
     <div className={classNames} {...rest}>

--- a/packages/fluentui-rc/src/GridTemplate/GridTemplate.tsx
+++ b/packages/fluentui-rc/src/GridTemplate/GridTemplate.tsx
@@ -1,0 +1,12 @@
+import { Flex } from '@fluentui/react-migration-v0-v9';
+import { GridTemplateProps } from '@rjsf/utils';
+
+/** Renders a `GridTemplate` for fluentui-rc, which is expecting the column sizing information coming in via the
+ * extra props provided by the caller, which are spread directly on the `Flex`.
+ *
+ * @param props - The GridTemplateProps, including the extra props containing the fluentui-rc grid positioning details
+ */
+export default function GridTemplate(props: GridTemplateProps) {
+  const { children, column, ...rest } = props;
+  return <Flex {...rest}>{children}</Flex>;
+}

--- a/packages/fluentui-rc/src/GridTemplate/index.ts
+++ b/packages/fluentui-rc/src/GridTemplate/index.ts
@@ -1,0 +1,2 @@
+export { default } from './GridTemplate';
+export * from './GridTemplate';

--- a/packages/fluentui-rc/src/Templates/Templates.ts
+++ b/packages/fluentui-rc/src/Templates/Templates.ts
@@ -8,6 +8,7 @@ import { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } from '../IconB
 import FieldErrorTemplate from '../FieldErrorTemplate';
 import FieldHelpTemplate from '../FieldHelpTemplate';
 import FieldTemplate from '../FieldTemplate';
+import GridTemplate from '../GridTemplate';
 import ObjectFieldTemplate from '../ObjectFieldTemplate';
 import SubmitButton from '../SubmitButton';
 import TitleField from '../TitleField';
@@ -36,6 +37,7 @@ export function generateTemplates<
     FieldErrorTemplate,
     FieldHelpTemplate,
     FieldTemplate,
+    GridTemplate,
     ObjectFieldTemplate,
     TitleFieldTemplate: TitleField,
     WrapIfAdditionalTemplate,

--- a/packages/mui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
+++ b/packages/mui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
@@ -1,6 +1,6 @@
 import { CSSProperties } from 'react';
 import Box from '@mui/material/Box';
-import Grid from '@mui/material/Grid';
+import Grid2 from '@mui/material/Grid2';
 import Paper from '@mui/material/Paper';
 import {
   ArrayFieldTemplateItemType,
@@ -35,19 +35,19 @@ export default function ArrayFieldItemTemplate<
     minWidth: 0,
   };
   return (
-    <Grid container={true} alignItems='center'>
-      <Grid item={true} xs style={{ overflow: 'auto' }}>
+    <Grid2 container={true} alignItems='center'>
+      <Grid2 size='auto' style={{ overflow: 'auto' }}>
         <Box mb={2}>
           <Paper elevation={2}>
             <Box p={2}>{children}</Box>
           </Paper>
         </Box>
-      </Grid>
+      </Grid2>
       {hasToolbar && (
-        <Grid item={true}>
+        <Grid2>
           <ArrayFieldItemButtonsTemplate {...buttonsProps} style={btnStyle} />
-        </Grid>
+        </Grid2>
       )}
-    </Grid>
+    </Grid2>
   );
 }

--- a/packages/mui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/mui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -1,5 +1,5 @@
 import Box from '@mui/material/Box';
-import Grid from '@mui/material/Grid';
+import Grid2 from '@mui/material/Grid2';
 import Paper from '@mui/material/Paper';
 import {
   getTemplate,
@@ -66,8 +66,8 @@ export default function ArrayFieldTemplate<
             <ArrayFieldItemTemplate key={key} {...itemProps} />
           ))}
         {canAdd && (
-          <Grid container justifyContent='flex-end'>
-            <Grid item={true}>
+          <Grid2 container justifyContent='flex-end'>
+            <Grid2>
               <Box mt={2}>
                 <AddButton
                   id={buttonId<T>(idSchema, 'add')}
@@ -78,8 +78,8 @@ export default function ArrayFieldTemplate<
                   registry={registry}
                 />
               </Box>
-            </Grid>
-          </Grid>
+            </Grid2>
+          </Grid2>
         )}
       </Box>
     </Paper>

--- a/packages/mui/src/GridTemplate/GridTemplate.tsx
+++ b/packages/mui/src/GridTemplate/GridTemplate.tsx
@@ -1,0 +1,16 @@
+import Grid2 from '@mui/material/Grid2';
+import { GridTemplateProps } from '@rjsf/utils';
+
+/** Renders a `GridTemplate` for mui, which is expecting the column sizing information coming in via the
+ * extra props provided by the caller, which are spread directly on the `Grid2`.
+ *
+ * @param props - The GridTemplateProps, including the extra props containing the mui grid positioning details
+ */
+export default function GridTemplate(props: GridTemplateProps) {
+  const { children, column, ...rest } = props;
+  return (
+    <Grid2 container={!column} {...rest}>
+      {children}
+    </Grid2>
+  );
+}

--- a/packages/mui/src/GridTemplate/index.ts
+++ b/packages/mui/src/GridTemplate/index.ts
@@ -1,0 +1,2 @@
+export { default } from './GridTemplate';
+export * from './GridTemplate';

--- a/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -76,7 +76,7 @@ export default function ObjectFieldTemplate<
           element.hidden ? (
             element.content
           ) : (
-            <Grid2 size='auto' key={index} style={{ marginBottom: '10px' }}>
+            <Grid2 size={{ xs: 12 }} key={index} style={{ marginBottom: '10px' }}>
               {element.content}
             </Grid2>
           )

--- a/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -1,4 +1,4 @@
-import Grid from '@mui/material/Grid';
+import Grid2 from '@mui/material/Grid2';
 import {
   FormContextType,
   ObjectFieldTemplateProps,
@@ -69,21 +69,21 @@ export default function ObjectFieldTemplate<
           registry={registry}
         />
       )}
-      <Grid container={true} spacing={2} style={{ marginTop: '10px' }}>
+      <Grid2 container={true} spacing={2} style={{ marginTop: '10px' }}>
         {properties.map((element, index) =>
-          // Remove the <Grid> if the inner element is hidden as the <Grid>
+          // Remove the <Grid2> if the inner element is hidden as the <Grid2>
           // itself would otherwise still take up space.
           element.hidden ? (
             element.content
           ) : (
-            <Grid item={true} xs={12} key={index} style={{ marginBottom: '10px' }}>
+            <Grid2 size='auto' key={index} style={{ marginBottom: '10px' }}>
               {element.content}
-            </Grid>
+            </Grid2>
           )
         )}
         {canExpand<T, S, F>(schema, uiSchema, formData) && (
-          <Grid container justifyContent='flex-end'>
-            <Grid item={true}>
+          <Grid2 container justifyContent='flex-end'>
+            <Grid2>
               <AddButton
                 id={buttonId<T>(idSchema, 'add')}
                 className='object-property-expand'
@@ -92,10 +92,10 @@ export default function ObjectFieldTemplate<
                 uiSchema={uiSchema}
                 registry={registry}
               />
-            </Grid>
-          </Grid>
+            </Grid2>
+          </Grid2>
         )}
-      </Grid>
+      </Grid2>
     </>
   );
 }

--- a/packages/mui/src/Templates/Templates.ts
+++ b/packages/mui/src/Templates/Templates.ts
@@ -10,6 +10,7 @@ import { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } from '../IconB
 import FieldErrorTemplate from '../FieldErrorTemplate';
 import FieldHelpTemplate from '../FieldHelpTemplate';
 import FieldTemplate from '../FieldTemplate';
+import GridTemplate from '../GridTemplate';
 import ObjectFieldTemplate from '../ObjectFieldTemplate';
 import SubmitButton from '../SubmitButton';
 import TitleField from '../TitleField';
@@ -37,6 +38,7 @@ export function generateTemplates<
     FieldErrorTemplate,
     FieldHelpTemplate,
     FieldTemplate,
+    GridTemplate,
     ObjectFieldTemplate,
     TitleFieldTemplate: TitleField,
     WrapIfAdditionalTemplate,

--- a/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -1,5 +1,5 @@
 import { CSSProperties, FocusEvent } from 'react';
-import Grid from '@mui/material/Grid';
+import Grid2 from '@mui/material/Grid2';
 import TextField from '@mui/material/TextField';
 import {
   ADDITIONAL_PROPERTY_FLAG,
@@ -59,8 +59,8 @@ export default function WrapIfAdditionalTemplate<
   const handleBlur = ({ target }: FocusEvent<HTMLInputElement>) => onKeyChange(target && target.value);
 
   return (
-    <Grid container key={`${id}-key`} alignItems='center' spacing={2} className={classNames} style={style}>
-      <Grid item xs>
+    <Grid2 container key={`${id}-key`} alignItems='center' spacing={2} className={classNames} style={style}>
+      <Grid2 size='auto'>
         <TextField
           fullWidth={true}
           required={required}
@@ -72,11 +72,9 @@ export default function WrapIfAdditionalTemplate<
           onBlur={!readonly ? handleBlur : undefined}
           type='text'
         />
-      </Grid>
-      <Grid item={true} xs>
-        {children}
-      </Grid>
-      <Grid item={true}>
+      </Grid2>
+      <Grid2 size='auto'>{children}</Grid2>
+      <Grid2>
         <RemoveButton
           id={buttonId<T>(id, 'remove')}
           className='array-item-remove'
@@ -87,7 +85,7 @@ export default function WrapIfAdditionalTemplate<
           uiSchema={uiSchema}
           registry={registry}
         />
-      </Grid>
-    </Grid>
+      </Grid2>
+    </Grid2>
   );
 }

--- a/packages/mui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Array.test.tsx.snap
@@ -30,28 +30,41 @@ exports[`array fields array 1`] = `
 }
 
 .emotion-3 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
   justify-content: flex-end;
 }
 
+.emotion-3>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-3>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-3>* {
+  --Grid-parent-rowSpacing: 0px;
+}
+
 .emotion-4 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-5 {
@@ -286,10 +299,10 @@ exports[`array fields array 1`] = `
           className="MuiBox-root emotion-2"
         >
           <div
-            className="MuiGrid-root MuiGrid-container emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-item emotion-4"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-4"
             >
               <div
                 className="MuiBox-root emotion-5"
@@ -392,88 +405,53 @@ exports[`array fields array icons 1`] = `
 }
 
 .emotion-3 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
+.emotion-3>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-3>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-3>* {
+  --Grid-parent-rowSpacing: 0px;
+}
+
 .emotion-4 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
 }
 
 .emotion-5 {
@@ -664,11 +642,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
 }
 
 .emotion-14 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-15 {
@@ -839,20 +814,36 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
 }
 
 .emotion-43 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
   justify-content: flex-end;
+}
+
+.emotion-43>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-43>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-43>* {
+  --Grid-parent-rowSpacing: 0px;
 }
 
 .emotion-45 {
@@ -1087,10 +1078,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           className="MuiBox-root emotion-2"
         >
           <div
-            className="MuiGrid-root MuiGrid-container emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
               style={
                 {
                   "overflow": "auto",
@@ -1165,7 +1156,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-14"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-14"
             >
               <button
                 className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall array-item-move-up emotion-15"
@@ -1302,10 +1293,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
             </div>
           </div>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
               style={
                 {
                   "overflow": "auto",
@@ -1380,7 +1371,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-14"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-14"
             >
               <button
                 className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-move-up emotion-15"
@@ -1517,10 +1508,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
             </div>
           </div>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-43"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-43"
           >
             <div
-              className="MuiGrid-root MuiGrid-item emotion-14"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-14"
             >
               <div
                 className="MuiBox-root emotion-45"
@@ -2107,94 +2098,49 @@ exports[`array fields empty errors array 1`] = `
 }
 
 .emotion-1 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-1>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-1>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-1>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-2 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -2557,7 +2503,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
         style={
           {
             "marginTop": "10px",
@@ -2565,7 +2511,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -2688,88 +2634,53 @@ exports[`array fields fixed array 1`] = `
 }
 
 .emotion-3 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
+.emotion-3>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-3>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-3>* {
+  --Grid-parent-rowSpacing: 0px;
+}
+
 .emotion-4 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
 }
 
 .emotion-5 {
@@ -3095,10 +3006,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           className="MuiBox-root emotion-2"
         >
           <div
-            className="MuiGrid-root MuiGrid-container emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
               style={
                 {
                   "overflow": "auto",
@@ -3174,10 +3085,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
             </div>
           </div>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
               style={
                 {
                   "overflow": "auto",
@@ -3409,94 +3320,49 @@ exports[`array fields has errors 1`] = `
 }
 
 .emotion-10 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-10>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-10>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-10>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-10>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-10>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-11 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-11 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-11 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-11 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-11 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-13 {
@@ -3960,7 +3826,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-16:focus::-ms-input-
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-9"
     >
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-10"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-10"
         style={
           {
             "marginTop": "10px",
@@ -3968,7 +3834,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-16:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-11"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-11"
           style={
             {
               "marginBottom": "10px",
@@ -4092,94 +3958,49 @@ exports[`array fields no errors 1`] = `
 }
 
 .emotion-1 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-1>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-1>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-1>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-2 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -4542,7 +4363,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
         style={
           {
             "marginTop": "10px",
@@ -4550,7 +4371,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -4707,28 +4528,41 @@ exports[`with title and description array 1`] = `
 }
 
 .emotion-7 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
   justify-content: flex-end;
 }
 
+.emotion-7>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-7>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-7>* {
+  --Grid-parent-rowSpacing: 0px;
+}
+
 .emotion-8 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-9 {
@@ -4988,10 +4822,10 @@ exports[`with title and description array 1`] = `
             a test description
           </h6>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-8"
             >
               <div
                 className="MuiBox-root emotion-9"
@@ -5128,88 +4962,53 @@ exports[`with title and description array icons 1`] = `
 }
 
 .emotion-7 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
+.emotion-7>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-7>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-7>* {
+  --Grid-parent-rowSpacing: 0px;
+}
+
 .emotion-8 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
 }
 
 .emotion-9 {
@@ -5470,11 +5269,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
 }
 
 .emotion-22 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-23 {
@@ -5645,20 +5441,36 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
 }
 
 .emotion-55 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
   justify-content: flex-end;
+}
+
+.emotion-55>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-55>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-55>* {
+  --Grid-parent-rowSpacing: 0px;
 }
 
 .emotion-57 {
@@ -5918,10 +5730,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
             a test description
           </h6>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
               style={
                 {
                   "overflow": "auto",
@@ -6026,7 +5838,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-22"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-22"
             >
               <button
                 className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall array-item-move-up emotion-23"
@@ -6163,10 +5975,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
             </div>
           </div>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
               style={
                 {
                   "overflow": "auto",
@@ -6271,7 +6083,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-22"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-22"
             >
               <button
                 className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-move-up emotion-23"
@@ -6408,10 +6220,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
             </div>
           </div>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-55"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-55"
           >
             <div
-              className="MuiGrid-root MuiGrid-item emotion-22"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-22"
             >
               <div
                 className="MuiBox-root emotion-57"
@@ -7138,88 +6950,53 @@ exports[`with title and description fixed array 1`] = `
 }
 
 .emotion-7 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
+.emotion-7>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-7>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-7>* {
+  --Grid-parent-rowSpacing: 0px;
+}
+
 .emotion-8 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
 }
 
 .emotion-9 {
@@ -7636,10 +7413,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
             a test description
           </h6>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
               style={
                 {
                   "overflow": "auto",
@@ -7745,10 +7522,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
             </div>
           </div>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
               style={
                 {
                   "overflow": "auto",
@@ -7950,28 +7727,41 @@ exports[`with title and description from both array 1`] = `
 }
 
 .emotion-7 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
   justify-content: flex-end;
 }
 
+.emotion-7>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-7>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-7>* {
+  --Grid-parent-rowSpacing: 0px;
+}
+
 .emotion-8 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-9 {
@@ -8231,10 +8021,10 @@ exports[`with title and description from both array 1`] = `
             a fancier description
           </h6>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-8"
             >
               <div
                 className="MuiBox-root emotion-9"
@@ -8371,88 +8161,53 @@ exports[`with title and description from both array icons 1`] = `
 }
 
 .emotion-7 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
+.emotion-7>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-7>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-7>* {
+  --Grid-parent-rowSpacing: 0px;
+}
+
 .emotion-8 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
 }
 
 .emotion-9 {
@@ -8713,11 +8468,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
 }
 
 .emotion-22 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-23 {
@@ -8888,20 +8640,36 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
 }
 
 .emotion-55 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
   justify-content: flex-end;
+}
+
+.emotion-55>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-55>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-55>* {
+  --Grid-parent-rowSpacing: 0px;
 }
 
 .emotion-57 {
@@ -9161,10 +8929,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
             a fancier description
           </h6>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
               style={
                 {
                   "overflow": "auto",
@@ -9269,7 +9037,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-22"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-22"
             >
               <button
                 className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall array-item-move-up emotion-23"
@@ -9406,10 +9174,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
             </div>
           </div>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
               style={
                 {
                   "overflow": "auto",
@@ -9514,7 +9282,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-22"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-22"
             >
               <button
                 className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-move-up emotion-23"
@@ -9651,10 +9419,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
             </div>
           </div>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-55"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-55"
           >
             <div
-              className="MuiGrid-root MuiGrid-item emotion-22"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-22"
             >
               <div
                 className="MuiBox-root emotion-57"
@@ -10381,88 +10149,53 @@ exports[`with title and description from both fixed array 1`] = `
 }
 
 .emotion-7 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
+.emotion-7>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-7>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-7>* {
+  --Grid-parent-rowSpacing: 0px;
+}
+
 .emotion-8 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
 }
 
 .emotion-9 {
@@ -10879,10 +10612,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
             a fancier description
           </h6>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
               style={
                 {
                   "overflow": "auto",
@@ -10988,10 +10721,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
             </div>
           </div>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
               style={
                 {
                   "overflow": "auto",
@@ -11193,28 +10926,41 @@ exports[`with title and description from uiSchema array 1`] = `
 }
 
 .emotion-7 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
   justify-content: flex-end;
 }
 
+.emotion-7>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-7>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-7>* {
+  --Grid-parent-rowSpacing: 0px;
+}
+
 .emotion-8 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-9 {
@@ -11474,10 +11220,10 @@ exports[`with title and description from uiSchema array 1`] = `
             a fancier description
           </h6>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-8"
             >
               <div
                 className="MuiBox-root emotion-9"
@@ -11614,88 +11360,53 @@ exports[`with title and description from uiSchema array icons 1`] = `
 }
 
 .emotion-7 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
+.emotion-7>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-7>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-7>* {
+  --Grid-parent-rowSpacing: 0px;
+}
+
 .emotion-8 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
 }
 
 .emotion-9 {
@@ -11956,11 +11667,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
 }
 
 .emotion-22 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-23 {
@@ -12131,20 +11839,36 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
 }
 
 .emotion-55 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
   justify-content: flex-end;
+}
+
+.emotion-55>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-55>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-55>* {
+  --Grid-parent-rowSpacing: 0px;
 }
 
 .emotion-57 {
@@ -12404,10 +12128,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
             a fancier description
           </h6>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
               style={
                 {
                   "overflow": "auto",
@@ -12512,7 +12236,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-22"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-22"
             >
               <button
                 className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall array-item-move-up emotion-23"
@@ -12649,10 +12373,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
             </div>
           </div>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
               style={
                 {
                   "overflow": "auto",
@@ -12757,7 +12481,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-22"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-22"
             >
               <button
                 className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-move-up emotion-23"
@@ -12894,10 +12618,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
             </div>
           </div>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-55"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-55"
           >
             <div
-              className="MuiGrid-root MuiGrid-item emotion-22"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-22"
             >
               <div
                 className="MuiBox-root emotion-57"
@@ -13624,88 +13348,53 @@ exports[`with title and description from uiSchema fixed array 1`] = `
 }
 
 .emotion-7 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
+.emotion-7>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-7>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-7>* {
+  --Grid-parent-rowSpacing: 0px;
+}
+
 .emotion-8 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
 }
 
 .emotion-9 {
@@ -14122,10 +13811,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
             a fancier description
           </h6>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
               style={
                 {
                   "overflow": "auto",
@@ -14231,10 +13920,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
             </div>
           </div>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
               style={
                 {
                   "overflow": "auto",
@@ -14402,28 +14091,41 @@ exports[`with title and description with global label off array 1`] = `
 }
 
 .emotion-3 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
   justify-content: flex-end;
 }
 
+.emotion-3>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-3>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-3>* {
+  --Grid-parent-rowSpacing: 0px;
+}
+
 .emotion-4 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-5 {
@@ -14658,10 +14360,10 @@ exports[`with title and description with global label off array 1`] = `
           className="MuiBox-root emotion-2"
         >
           <div
-            className="MuiGrid-root MuiGrid-container emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-item emotion-4"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-4"
             >
               <div
                 className="MuiBox-root emotion-5"
@@ -14764,88 +14466,53 @@ exports[`with title and description with global label off array icons 1`] = `
 }
 
 .emotion-3 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
+.emotion-3>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-3>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-3>* {
+  --Grid-parent-rowSpacing: 0px;
+}
+
 .emotion-4 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
 }
 
 .emotion-5 {
@@ -15036,11 +14703,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
 }
 
 .emotion-14 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-15 {
@@ -15211,20 +14875,36 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
 }
 
 .emotion-43 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
   justify-content: flex-end;
+}
+
+.emotion-43>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-43>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-43>* {
+  --Grid-parent-rowSpacing: 0px;
 }
 
 .emotion-45 {
@@ -15459,10 +15139,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           className="MuiBox-root emotion-2"
         >
           <div
-            className="MuiGrid-root MuiGrid-container emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
               style={
                 {
                   "overflow": "auto",
@@ -15537,7 +15217,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-14"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-14"
             >
               <button
                 className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall array-item-move-up emotion-15"
@@ -15674,10 +15354,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
             </div>
           </div>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
               style={
                 {
                   "overflow": "auto",
@@ -15752,7 +15432,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-14"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-14"
             >
               <button
                 className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-move-up emotion-15"
@@ -15889,10 +15569,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
             </div>
           </div>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-43"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-43"
           >
             <div
-              className="MuiGrid-root MuiGrid-item emotion-14"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-14"
             >
               <div
                 className="MuiBox-root emotion-45"
@@ -16585,88 +16265,53 @@ exports[`with title and description with global label off fixed array 1`] = `
 }
 
 .emotion-3 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 0px;
+  --Grid-rowSpacing: 0px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
+.emotion-3>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-3>* {
+  --Grid-parent-columnSpacing: 0px;
+}
+
+.emotion-3>* {
+  --Grid-parent-rowSpacing: 0px;
+}
+
 .emotion-4 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
 }
 
 .emotion-5 {
@@ -16992,10 +16637,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           className="MuiBox-root emotion-2"
         >
           <div
-            className="MuiGrid-root MuiGrid-container emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
               style={
                 {
                   "overflow": "auto",
@@ -17071,10 +16716,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
             </div>
           </div>
           <div
-            className="MuiGrid-root MuiGrid-container emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
               style={
                 {
                   "overflow": "auto",

--- a/packages/mui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Array.test.tsx.snap
@@ -2127,18 +2127,14 @@ exports[`array fields empty errors array 1`] = `
 }
 
 .emotion-2 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -2511,7 +2507,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -3349,18 +3345,14 @@ exports[`array fields has errors 1`] = `
 }
 
 .emotion-11 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -3834,7 +3826,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-16:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-11"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-11"
           style={
             {
               "marginBottom": "10px",
@@ -3987,18 +3979,14 @@ exports[`array fields no errors 1`] = `
 }
 
 .emotion-2 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -4371,7 +4359,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-2"
           style={
             {
               "marginBottom": "10px",

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -1253,94 +1253,49 @@ exports[`single fields field with description 1`] = `
 }
 
 .emotion-1 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-1>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-1>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-1>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-2 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -1722,7 +1677,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
         style={
           {
             "marginTop": "10px",
@@ -1730,7 +1685,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -1855,94 +1810,49 @@ exports[`single fields field with description in uiSchema 1`] = `
 }
 
 .emotion-1 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-1>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-1>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-1>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-2 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -2324,7 +2234,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
         style={
           {
             "marginTop": "10px",
@@ -2332,7 +2242,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -4652,26 +4562,32 @@ exports[`single fields hidden field 1`] = `
 }
 
 .emotion-1 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-1>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-1>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-1>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-2 {
@@ -4799,7 +4715,7 @@ exports[`single fields hidden field 1`] = `
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
         style={
           {
             "marginTop": "10px",
@@ -14987,94 +14903,49 @@ exports[`single fields title field 1`] = `
 }
 
 .emotion-4 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-4>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-4>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-4>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-4>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-4>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-5 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-5 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-5 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-5 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-5 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-7 {
@@ -15451,7 +15322,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-10:focus::-ms-input-
         />
       </div>
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-4"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-4"
         style={
           {
             "marginTop": "10px",
@@ -15459,7 +15330,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-10:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-5"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-5"
           style={
             {
               "marginBottom": "10px",

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -1282,18 +1282,14 @@ exports[`single fields field with description 1`] = `
 }
 
 .emotion-2 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -1685,7 +1681,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -1839,18 +1835,14 @@ exports[`single fields field with description in uiSchema 1`] = `
 }
 
 .emotion-2 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -2242,7 +2234,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -14932,18 +14924,14 @@ exports[`single fields title field 1`] = `
 }
 
 .emotion-5 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -15330,7 +15318,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-10:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-5"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-5"
           style={
             {
               "marginBottom": "10px",

--- a/packages/mui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Object.test.tsx.snap
@@ -45,18 +45,14 @@ exports[`object fields additionalProperties 1`] = `
 }
 
 .emotion-2 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -92,6 +88,23 @@ exports[`object fields additionalProperties 1`] = `
 
 .emotion-3>* {
   --Grid-parent-rowSpacing: 16px;
+}
+
+.emotion-4 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-5 {
@@ -721,7 +734,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -732,7 +745,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
             className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-3"
           >
             <div
-              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-5"
@@ -780,7 +793,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               </div>
             </div>
             <div
-              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -997,18 +1010,14 @@ exports[`object fields object 1`] = `
 }
 
 .emotion-2 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -1381,7 +1390,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -1444,7 +1453,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
           </div>
         </div>
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -1583,18 +1592,14 @@ exports[`object fields show add button and fields if additionalProperties is tru
 }
 
 .emotion-2 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -1630,6 +1635,23 @@ exports[`object fields show add button and fields if additionalProperties is tru
 
 .emotion-3>* {
   --Grid-parent-rowSpacing: 16px;
+}
+
+.emotion-4 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-5 {
@@ -2255,7 +2277,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -2266,7 +2288,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
             className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-3"
           >
             <div
-              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-5"
@@ -2314,7 +2336,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               </div>
             </div>
             <div
-              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2565,18 +2587,14 @@ exports[`object fields with title and description additionalProperties 1`] = `
 }
 
 .emotion-6 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -2612,6 +2630,23 @@ exports[`object fields with title and description additionalProperties 1`] = `
 
 .emotion-7>* {
   --Grid-parent-rowSpacing: 16px;
+}
+
+.emotion-8 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-9 {
@@ -3266,7 +3301,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -3277,7 +3312,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
             className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-7"
           >
             <div
-              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-9"
@@ -3325,7 +3360,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3576,18 +3611,14 @@ exports[`object fields with title and description from both additionalProperties
 }
 
 .emotion-6 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -3623,6 +3654,23 @@ exports[`object fields with title and description from both additionalProperties
 
 .emotion-7>* {
   --Grid-parent-rowSpacing: 16px;
+}
+
+.emotion-8 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-9 {
@@ -4277,7 +4325,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -4288,7 +4336,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
             className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-7"
           >
             <div
-              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-9"
@@ -4336,7 +4384,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4587,18 +4635,14 @@ exports[`object fields with title and description from both object 1`] = `
 }
 
 .emotion-6 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -5006,7 +5050,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -5085,7 +5129,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           </div>
         </div>
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -5274,18 +5318,14 @@ exports[`object fields with title and description from uiSchema additionalProper
 }
 
 .emotion-6 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -5321,6 +5361,23 @@ exports[`object fields with title and description from uiSchema additionalProper
 
 .emotion-7>* {
   --Grid-parent-rowSpacing: 16px;
+}
+
+.emotion-8 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-9 {
@@ -5975,7 +6032,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -5986,7 +6043,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
             className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-7"
           >
             <div
-              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-9"
@@ -6034,7 +6091,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6285,18 +6342,14 @@ exports[`object fields with title and description from uiSchema object 1`] = `
 }
 
 .emotion-6 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -6704,7 +6757,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -6783,7 +6836,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           </div>
         </div>
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -6972,18 +7025,14 @@ exports[`object fields with title and description from uiSchema show add button 
 }
 
 .emotion-6 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -7019,6 +7068,23 @@ exports[`object fields with title and description from uiSchema show add button 
 
 .emotion-7>* {
   --Grid-parent-rowSpacing: 16px;
+}
+
+.emotion-8 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-9 {
@@ -7669,7 +7735,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -7680,7 +7746,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
             className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-7"
           >
             <div
-              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-9"
@@ -7728,7 +7794,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7979,18 +8045,14 @@ exports[`object fields with title and description object 1`] = `
 }
 
 .emotion-6 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -8398,7 +8460,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -8477,7 +8539,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           </div>
         </div>
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -8666,18 +8728,14 @@ exports[`object fields with title and description show add button and fields if 
 }
 
 .emotion-6 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -8713,6 +8771,23 @@ exports[`object fields with title and description show add button and fields if 
 
 .emotion-7>* {
   --Grid-parent-rowSpacing: 16px;
+}
+
+.emotion-8 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-9 {
@@ -9363,7 +9438,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -9374,7 +9449,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
             className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-7"
           >
             <div
-              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-9"
@@ -9422,7 +9497,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9639,18 +9714,14 @@ exports[`object fields with title and description with global label off addition
 }
 
 .emotion-2 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -9686,6 +9757,23 @@ exports[`object fields with title and description with global label off addition
 
 .emotion-3>* {
   --Grid-parent-rowSpacing: 16px;
+}
+
+.emotion-4 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-5 {
@@ -10321,7 +10409,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -10332,7 +10420,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
             className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-3"
           >
             <div
-              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-5"
@@ -10380,7 +10468,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               </div>
             </div>
             <div
-              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10592,18 +10680,14 @@ exports[`object fields with title and description with global label off object 1
 }
 
 .emotion-2 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -10924,7 +11008,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -10982,7 +11066,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
           </div>
         </div>
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -11116,18 +11200,14 @@ exports[`object fields with title and description with global label off show add
 }
 
 .emotion-2 {
-  -webkit-flex-basis: auto;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  max-width: none;
-  width: auto;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
   min-width: 0;
   box-sizing: border-box;
 }
@@ -11163,6 +11243,23 @@ exports[`object fields with title and description with global label off show add
 
 .emotion-3>* {
   --Grid-parent-rowSpacing: 16px;
+}
+
+.emotion-4 {
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-5 {
@@ -11798,7 +11895,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -11809,7 +11906,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
             className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-3"
           >
             <div
-              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-5"
@@ -11857,7 +11954,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               </div>
             </div>
             <div
-              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"

--- a/packages/mui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Object.test.tsx.snap
@@ -16,189 +16,82 @@ exports[`object fields additionalProperties 1`] = `
 }
 
 .emotion-1 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-1>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-1>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-1>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-2 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-3 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-3>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-3>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-3>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-3>* {
+  --Grid-parent-columnSpacing: 16px;
 }
 
-.emotion-4 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
+.emotion-3>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-5 {
@@ -505,11 +398,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
 }
 
 .emotion-19 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-20 {
@@ -605,16 +495,18 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
 }
 
 .emotion-22 {
+  --Grid-columns: 12;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
@@ -821,7 +713,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
         style={
           {
             "marginTop": "10px",
@@ -829,7 +721,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -837,10 +729,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
           }
         >
           <div
-            className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 form-group field field-string emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-5"
@@ -888,7 +780,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -942,7 +834,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-19"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-19"
             >
               <button
                 className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-20"
@@ -989,10 +881,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
           </div>
         </div>
         <div
-          className="MuiGrid-root MuiGrid-container emotion-22"
+          className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-22"
         >
           <div
-            className="MuiGrid-root MuiGrid-item emotion-19"
+            className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-19"
           >
             <button
               className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium object-property-expand emotion-24"
@@ -1076,94 +968,49 @@ exports[`object fields object 1`] = `
 }
 
 .emotion-1 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-1>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-1>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-1>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-2 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -1526,7 +1373,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
         style={
           {
             "marginTop": "10px",
@@ -1534,7 +1381,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -1597,7 +1444,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
           </div>
         </div>
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -1707,189 +1554,82 @@ exports[`object fields show add button and fields if additionalProperties is tru
 }
 
 .emotion-1 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-1>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-1>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-1>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-2 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-3 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-3>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-3>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-3>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-3>* {
+  --Grid-parent-columnSpacing: 16px;
 }
 
-.emotion-4 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
+.emotion-3>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-5 {
@@ -2192,11 +1932,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
 }
 
 .emotion-19 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-20 {
@@ -2292,16 +2029,18 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
 }
 
 .emotion-22 {
+  --Grid-columns: 12;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
@@ -2508,7 +2247,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
         style={
           {
             "marginTop": "10px",
@@ -2516,7 +2255,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -2524,10 +2263,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
           }
         >
           <div
-            className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 form-group field field-string emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-5"
@@ -2575,7 +2314,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2629,7 +2368,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-19"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-19"
             >
               <button
                 className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-20"
@@ -2676,10 +2415,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
           </div>
         </div>
         <div
-          className="MuiGrid-root MuiGrid-container emotion-22"
+          className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-22"
         >
           <div
-            className="MuiGrid-root MuiGrid-item emotion-19"
+            className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-19"
           >
             <button
               className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium object-property-expand emotion-24"
@@ -2797,189 +2536,82 @@ exports[`object fields with title and description additionalProperties 1`] = `
 }
 
 .emotion-5 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-5>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-5>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-5>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-5>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-5>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-6 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-7 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-7>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-7>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-7>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-7>* {
+  --Grid-parent-columnSpacing: 16px;
 }
 
-.emotion-8 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
+.emotion-7>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-9 {
@@ -3286,11 +2918,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
 }
 
 .emotion-23 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-24 {
@@ -3386,16 +3015,18 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
 }
 
 .emotion-26 {
+  --Grid-columns: 12;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
@@ -3627,7 +3258,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
         a test description
       </h6>
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-5"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-5"
         style={
           {
             "marginTop": "10px",
@@ -3635,7 +3266,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -3643,10 +3274,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           }
         >
           <div
-            className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 form-group field field-string emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-9"
@@ -3694,7 +3325,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3748,7 +3379,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-23"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
             >
               <button
                 className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-24"
@@ -3795,10 +3426,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           </div>
         </div>
         <div
-          className="MuiGrid-root MuiGrid-container emotion-26"
+          className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-26"
         >
           <div
-            className="MuiGrid-root MuiGrid-item emotion-23"
+            className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
           >
             <button
               className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium object-property-expand emotion-28"
@@ -3916,189 +3547,82 @@ exports[`object fields with title and description from both additionalProperties
 }
 
 .emotion-5 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-5>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-5>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-5>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-5>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-5>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-6 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-7 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-7>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-7>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-7>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-7>* {
+  --Grid-parent-columnSpacing: 16px;
 }
 
-.emotion-8 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
+.emotion-7>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-9 {
@@ -4405,11 +3929,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
 }
 
 .emotion-23 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-24 {
@@ -4505,16 +4026,18 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
 }
 
 .emotion-26 {
+  --Grid-columns: 12;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
@@ -4746,7 +4269,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
         a fancier description
       </h6>
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-5"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-5"
         style={
           {
             "marginTop": "10px",
@@ -4754,7 +4277,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -4762,10 +4285,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           }
         >
           <div
-            className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 form-group field field-string emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-9"
@@ -4813,7 +4336,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4867,7 +4390,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-23"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
             >
               <button
                 className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-24"
@@ -4914,10 +4437,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           </div>
         </div>
         <div
-          className="MuiGrid-root MuiGrid-container emotion-26"
+          className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-26"
         >
           <div
-            className="MuiGrid-root MuiGrid-item emotion-23"
+            className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
           >
             <button
               className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium object-property-expand emotion-28"
@@ -5035,94 +4558,49 @@ exports[`object fields with title and description from both object 1`] = `
 }
 
 .emotion-5 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-5>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-5>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-5>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-5>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-5>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-6 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-8 {
@@ -5520,7 +4998,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
         a fancier description
       </h6>
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-5"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-5"
         style={
           {
             "marginTop": "10px",
@@ -5528,7 +5006,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -5607,7 +5085,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           </div>
         </div>
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -5767,189 +5245,82 @@ exports[`object fields with title and description from uiSchema additionalProper
 }
 
 .emotion-5 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-5>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-5>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-5>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-5>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-5>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-6 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-7 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-7>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-7>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-7>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-7>* {
+  --Grid-parent-columnSpacing: 16px;
 }
 
-.emotion-8 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
+.emotion-7>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-9 {
@@ -6256,11 +5627,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
 }
 
 .emotion-23 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-24 {
@@ -6356,16 +5724,18 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
 }
 
 .emotion-26 {
+  --Grid-columns: 12;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
@@ -6597,7 +5967,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
         a fancier description
       </h6>
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-5"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-5"
         style={
           {
             "marginTop": "10px",
@@ -6605,7 +5975,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -6613,10 +5983,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           }
         >
           <div
-            className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 form-group field field-string emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-9"
@@ -6664,7 +6034,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6718,7 +6088,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-23"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
             >
               <button
                 className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-24"
@@ -6765,10 +6135,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           </div>
         </div>
         <div
-          className="MuiGrid-root MuiGrid-container emotion-26"
+          className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-26"
         >
           <div
-            className="MuiGrid-root MuiGrid-item emotion-23"
+            className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
           >
             <button
               className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium object-property-expand emotion-28"
@@ -6886,94 +6256,49 @@ exports[`object fields with title and description from uiSchema object 1`] = `
 }
 
 .emotion-5 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-5>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-5>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-5>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-5>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-5>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-6 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-8 {
@@ -7371,7 +6696,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
         a fancier description
       </h6>
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-5"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-5"
         style={
           {
             "marginTop": "10px",
@@ -7379,7 +6704,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -7458,7 +6783,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           </div>
         </div>
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -7618,189 +6943,82 @@ exports[`object fields with title and description from uiSchema show add button 
 }
 
 .emotion-5 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-5>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-5>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-5>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-5>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-5>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-6 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-7 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-7>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-7>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-7>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-7>* {
+  --Grid-parent-columnSpacing: 16px;
 }
 
-.emotion-8 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
+.emotion-7>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-9 {
@@ -8103,11 +7321,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
 }
 
 .emotion-23 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-24 {
@@ -8203,16 +7418,18 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
 }
 
 .emotion-26 {
+  --Grid-columns: 12;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
@@ -8444,7 +7661,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
         a fancier description
       </h6>
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-5"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-5"
         style={
           {
             "marginTop": "10px",
@@ -8452,7 +7669,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -8460,10 +7677,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           }
         >
           <div
-            className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 form-group field field-string emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-9"
@@ -8511,7 +7728,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -8565,7 +7782,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-23"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
             >
               <button
                 className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-24"
@@ -8612,10 +7829,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           </div>
         </div>
         <div
-          className="MuiGrid-root MuiGrid-container emotion-26"
+          className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-26"
         >
           <div
-            className="MuiGrid-root MuiGrid-item emotion-23"
+            className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
           >
             <button
               className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium object-property-expand emotion-28"
@@ -8733,94 +7950,49 @@ exports[`object fields with title and description object 1`] = `
 }
 
 .emotion-5 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-5>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-5>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-5>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-5>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-5>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-6 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-8 {
@@ -9218,7 +8390,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
         a test description
       </h6>
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-5"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-5"
         style={
           {
             "marginTop": "10px",
@@ -9226,7 +8398,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -9305,7 +8477,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           </div>
         </div>
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -9465,189 +8637,82 @@ exports[`object fields with title and description show add button and fields if 
 }
 
 .emotion-5 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-5>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-5>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-5>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-5>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-5>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-6 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-6 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-7 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-7>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-7>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-7>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-7>* {
+  --Grid-parent-columnSpacing: 16px;
 }
 
-.emotion-8 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-8 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
+.emotion-7>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-9 {
@@ -9950,11 +9015,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
 }
 
 .emotion-23 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-24 {
@@ -10050,16 +9112,18 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
 }
 
 .emotion-26 {
+  --Grid-columns: 12;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
@@ -10291,7 +9355,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
         a test description
       </h6>
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-5"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-5"
         style={
           {
             "marginTop": "10px",
@@ -10299,7 +9363,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-6"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
           style={
             {
               "marginBottom": "10px",
@@ -10307,10 +9371,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           }
         >
           <div
-            className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 form-group field field-string emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-7"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-9"
@@ -10358,7 +9422,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-8"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-6"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10412,7 +9476,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-23"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
             >
               <button
                 className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-24"
@@ -10459,10 +9523,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           </div>
         </div>
         <div
-          className="MuiGrid-root MuiGrid-container emotion-26"
+          className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-26"
         >
           <div
-            className="MuiGrid-root MuiGrid-item emotion-23"
+            className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
           >
             <button
               className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium object-property-expand emotion-28"
@@ -10546,189 +9610,82 @@ exports[`object fields with title and description with global label off addition
 }
 
 .emotion-1 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-1>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-1>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-1>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-2 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-3 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-3>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-3>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-3>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-3>* {
+  --Grid-parent-columnSpacing: 16px;
 }
 
-.emotion-4 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
+.emotion-3>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-5 {
@@ -11041,11 +9998,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
 }
 
 .emotion-18 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-19 {
@@ -11141,16 +10095,18 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
 }
 
 .emotion-21 {
+  --Grid-columns: 12;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
@@ -11357,7 +10313,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
         style={
           {
             "marginTop": "10px",
@@ -11365,7 +10321,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -11373,10 +10329,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
           }
         >
           <div
-            className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 form-group field field-string emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-5"
@@ -11424,7 +10380,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11473,7 +10429,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-18"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-18"
             >
               <button
                 className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-19"
@@ -11520,10 +10476,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
           </div>
         </div>
         <div
-          className="MuiGrid-root MuiGrid-container emotion-21"
+          className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-21"
         >
           <div
-            className="MuiGrid-root MuiGrid-item emotion-18"
+            className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-18"
           >
             <button
               className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium object-property-expand emotion-23"
@@ -11607,94 +10563,49 @@ exports[`object fields with title and description with global label off object 1
 }
 
 .emotion-1 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-1>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-1>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-1>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-2 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-4 {
@@ -12005,7 +10916,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
         style={
           {
             "marginTop": "10px",
@@ -12013,7 +10924,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -12071,7 +10982,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
           </div>
         </div>
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -12176,189 +11087,82 @@ exports[`object fields with title and description with global label off show add
 }
 
 .emotion-1 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-1>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-1>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-1>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-1>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-2 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 100%;
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-2 {
-    -webkit-flex-basis: 100%;
-    -ms-flex-preferred-size: 100%;
-    flex-basis: 100%;
-    -webkit-box-flex: 0;
-    -webkit-flex-grow: 0;
-    -ms-flex-positive: 0;
-    flex-grow: 0;
-    max-width: 100%;
-  }
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: none;
+  width: auto;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .emotion-3 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: calc(100% + 16px);
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  margin-top: calc(-1 * 16px);
-  margin-left: calc(-1 * 16px);
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
 }
 
-.emotion-3>.MuiGrid-item {
-  padding-top: 16px;
+.emotion-3>* {
+  --Grid-parent-columns: 12;
 }
 
-.emotion-3>.MuiGrid-item {
-  padding-left: 16px;
+.emotion-3>* {
+  --Grid-parent-columnSpacing: 16px;
 }
 
-.emotion-4 {
-  box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-basis: 0;
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  max-width: 100%;
-}
-
-@media (min-width:600px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:900px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1200px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-}
-
-@media (min-width:1536px) {
-  .emotion-4 {
-    -webkit-flex-basis: 0;
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -webkit-box-flex: 1;
-    -webkit-flex-grow: 1;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%;
-  }
+.emotion-3>* {
+  --Grid-parent-rowSpacing: 16px;
 }
 
 .emotion-5 {
@@ -12671,11 +11475,8 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
 }
 
 .emotion-18 {
+  min-width: 0;
   box-sizing: border-box;
-  margin: 0;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
 }
 
 .emotion-19 {
@@ -12771,16 +11572,18 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
 }
 
 .emotion-21 {
+  --Grid-columns: 12;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
   box-sizing: border-box;
   display: flex;
   -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
-  width: 100%;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
   -webkit-box-pack: end;
   -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
@@ -12987,7 +11790,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
     >
       <div
-        className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 emotion-1"
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
         style={
           {
             "marginTop": "10px",
@@ -12995,7 +11798,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
         }
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 emotion-2"
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
           style={
             {
               "marginBottom": "10px",
@@ -13003,10 +11806,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
           }
         >
           <div
-            className="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 form-group field field-string emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-3"
           >
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root emotion-5"
@@ -13054,7 +11857,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-true emotion-4"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-2"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13103,7 +11906,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               </div>
             </div>
             <div
-              className="MuiGrid-root MuiGrid-item emotion-18"
+              className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-18"
             >
               <button
                 className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-19"
@@ -13150,10 +11953,10 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
           </div>
         </div>
         <div
-          className="MuiGrid-root MuiGrid-container emotion-21"
+          className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row emotion-21"
         >
           <div
-            className="MuiGrid-root MuiGrid-item emotion-18"
+            className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-18"
           >
             <button
               className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium object-property-expand emotion-23"

--- a/packages/react-bootstrap/src/GridTemplate/GridTemplate.tsx
+++ b/packages/react-bootstrap/src/GridTemplate/GridTemplate.tsx
@@ -1,0 +1,16 @@
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import { GridTemplateProps } from '@rjsf/utils';
+
+/** Renders a `GridTemplate` for react-bootstrap, which is expecting the column sizing information coming in via the
+ * extra props provided by the caller, which are spread directly on the `Row`/`Col`.
+ *
+ * @param props - The GridTemplateProps, including the extra props containing the react-bootstrap grid positioning details
+ */
+export default function GridTemplate(props: GridTemplateProps) {
+  const { children, column, ...rest } = props;
+  if (column) {
+    return <Col {...rest}>{children}</Col>;
+  }
+  return <Row {...rest}>{children}</Row>;
+}

--- a/packages/react-bootstrap/src/GridTemplate/index.ts
+++ b/packages/react-bootstrap/src/GridTemplate/index.ts
@@ -1,0 +1,2 @@
+export { default } from './GridTemplate';
+export * from './GridTemplate';

--- a/packages/react-bootstrap/src/Templates/Templates.ts
+++ b/packages/react-bootstrap/src/Templates/Templates.ts
@@ -8,6 +8,7 @@ import { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } from '../IconB
 import FieldErrorTemplate from '../FieldErrorTemplate';
 import FieldHelpTemplate from '../FieldHelpTemplate';
 import FieldTemplate from '../FieldTemplate';
+import GridTemplate from '../GridTemplate';
 import ObjectFieldTemplate from '../ObjectFieldTemplate';
 import SubmitButton from '../SubmitButton';
 import TitleField from '../TitleField';
@@ -36,6 +37,7 @@ export function generateTemplates<
     FieldErrorTemplate,
     FieldHelpTemplate,
     FieldTemplate,
+    GridTemplate,
     ObjectFieldTemplate,
     TitleFieldTemplate: TitleField,
     WrapIfAdditionalTemplate,

--- a/packages/semantic-ui/src/GridTemplate/GridTemplate.tsx
+++ b/packages/semantic-ui/src/GridTemplate/GridTemplate.tsx
@@ -1,0 +1,15 @@
+import { Grid } from 'semantic-ui-react';
+import { GridTemplateProps } from '@rjsf/utils';
+
+/** Renders a `GridTemplate` for semantic-ui, which is expecting the column sizing information coming in via the
+ * extra props provided by the caller, which are spread directly on the `Flex`.
+ *
+ * @param props - The GridTemplateProps, including the extra props containing the semantic-ui grid positioning details
+ */
+export default function GridTemplate(props: GridTemplateProps) {
+  const { children, column, ...rest } = props;
+  if (column) {
+    return <Grid.Column {...rest}>{children}</Grid.Column>;
+  }
+  return <Grid {...rest}>{children}</Grid>;
+}

--- a/packages/semantic-ui/src/GridTemplate/index.ts
+++ b/packages/semantic-ui/src/GridTemplate/index.ts
@@ -1,0 +1,2 @@
+export { default } from './GridTemplate';
+export * from './GridTemplate';

--- a/packages/semantic-ui/src/Templates/Templates.ts
+++ b/packages/semantic-ui/src/Templates/Templates.ts
@@ -10,6 +10,7 @@ import { CopyButton, MoveDownButton, MoveUpButton, RemoveButton } from '../IconB
 import FieldErrorTemplate from '../FieldErrorTemplate';
 import FieldHelpTemplate from '../FieldHelpTemplate';
 import FieldTemplate from '../FieldTemplate';
+import GridTemplate from '../GridTemplate';
 import ObjectFieldTemplate from '../ObjectFieldTemplate';
 import SubmitButton from '../SubmitButton';
 import TitleField from '../TitleField';
@@ -37,6 +38,7 @@ export function generateTemplates<
     FieldErrorTemplate,
     FieldHelpTemplate,
     FieldTemplate,
+    GridTemplate,
     ObjectFieldTemplate,
     TitleFieldTemplate: TitleField,
     WrapIfAdditionalTemplate,


### PR DESCRIPTION
### Reasons for making this change

- In all themes except `@rjsf/core`:
  - Implemented the `GridTemplate` using the theme specific grid, adding them to the `templates` in the Registry
- In `@rjsf/core` cleaned up the documentation for the already implemented `GridTemplate`
- In `@rjsf/mui` switched to using the `Grid2` component instead of the deprecated `Grid`
- Updated the `CHANGELOG_V6.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
