### PR TITLE
Pass experimental_customMergeAllOf to ensureFormDataMatchingSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/utils
 
 - fixed issue with customValidate errors are not cleared when the form is valid [4365](https://github.com/rjsf-team/react-jsonschema-form/pull/4365) due to regression
+- Add missing `experimental_customMergeAllOf` argument to `ensureFormDataMatchingSchema` introduced by [4388](https://github.com/rjsf-team/react-jsonschema-form/pull/4388)
 
 # 5.24.3
 

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -344,7 +344,8 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
       schema,
       rootSchema,
       rawFormData,
-      experimental_defaultFormStateBehavior
+      experimental_defaultFormStateBehavior,
+      experimental_customMergeAllOf
     );
     if (!isObject(rawFormData)) {
       defaultsWithFormData = mergeDefaultsWithFormData<T>(
@@ -366,7 +367,8 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
  * @param schema - The schema for which the formData state is desired
  * @param rootSchema - The root schema, used to primarily to look up `$ref`s
  * @param formData - The current formData
- * @param experimental_defaultFormStateBehavior - Optional configuration object, if provided, allows users to override default form state behavior
+ * @param [experimental_defaultFormStateBehavior] - Optional configuration object, if provided, allows users to override default form state behavior
+ * @param [experimental_customMergeAllOf] - Optional function that allows for custom merging of `allOf` schemas
  * @returns - valid formData that matches schema
  */
 export function ensureFormDataMatchingSchema<
@@ -378,9 +380,10 @@ export function ensureFormDataMatchingSchema<
   schema: S,
   rootSchema: S,
   formData: T | undefined,
-  experimental_defaultFormStateBehavior?: Experimental_DefaultFormStateBehavior
+  experimental_defaultFormStateBehavior?: Experimental_DefaultFormStateBehavior,
+  experimental_customMergeAllOf?: Experimental_CustomMergeAllOf<S>
 ): T | T[] | undefined {
-  const isSelectField = !isConstant(schema) && isSelect(validator, schema, rootSchema);
+  const isSelectField = !isConstant(schema) && isSelect(validator, schema, rootSchema, experimental_customMergeAllOf);
   let validFormData: T | T[] | undefined = formData;
   if (isSelectField) {
     const getOptionsList = optionsList(schema);


### PR DESCRIPTION
### Reasons for making this change

Change introduced by #4388 doesn't pass `experimental_customMergeAllOf` to `ensureFormDataMatchingSchema`.

As discussed in #4385, I don't have a capacity to more than fix this now.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
