### PR TITLE
Improved ESM support for all public packages for vitest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,5 @@ out/
 
 # typescript tsbuildinfo
 *.tsbuildinfo
+lodashReplacer.js
+

--- a/.gitignore
+++ b/.gitignore
@@ -141,4 +141,5 @@ out/
 # typescript tsbuildinfo
 *.tsbuildinfo
 lodashReplacer.js
+muiReplacer.js
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,13 @@ should change the heading of the (upcoming) version to include a major version b
 
 ## @rjsf/utils
 
-- fixed issue with customValidate errors are not cleared when the form is valid [4365](https://github.com/rjsf-team/react-jsonschema-form/pull/4365) due to regression
+- Fixed issue with customValidate errors are not cleared when the form is valid [4365](https://github.com/rjsf-team/react-jsonschema-form/pull/4365) due to regression
 - Add missing `experimental_customMergeAllOf` argument to `ensureFormDataMatchingSchema` introduced by [4388](https://github.com/rjsf-team/react-jsonschema-form/pull/4388)
+
+## Dev / docs / playground
+
+- Improved the ESM support for all public packages by adding explicit `exports` to each public `package.json`
+- Updated the ESM builds to use `tsc-alias` to add `.js` onto all ESM imports
 
 # 5.24.3
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "prettier": "^2.8.8",
         "rimraf": "^5.0.5",
         "ts-jest": "^29.1.2",
+        "tsc-alias": "^1.8.11",
         "tslib": "^2.6.2",
         "typescript": "^4.9.5"
       },
@@ -23905,6 +23906,20 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "node_modules/mylas": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.13.tgz",
+      "integrity": "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/raouldeheer"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
@@ -26116,6 +26131,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/plimit-lit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
+      "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "queue-lit": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/popmotion": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
@@ -27132,6 +27160,16 @@
       "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
       "dependencies": {
         "inherits": "~2.0.3"
+      }
+    },
+    "node_modules/queue-lit": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
+      "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/queue-microtask": {
@@ -31600,6 +31638,34 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/tsc-alias": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.11.tgz",
+      "integrity": "sha512-2DuEQ58A9Rj2NE2c1+/qaGKlshni9MCK95MJzRGhQG0CYLw0bE/ACgbhhTSf/p1svLelwqafOd8stQate2bYbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "commander": "^9.0.0",
+        "globby": "^11.0.4",
+        "mylas": "^2.1.9",
+        "normalize-path": "^3.0.0",
+        "plimit-lit": "^1.2.6"
+      },
+      "bin": {
+        "tsc-alias": "dist/bin/index.js"
+      }
+    },
+    "node_modules/tsc-alias/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "prettier": "^2.8.8",
     "rimraf": "^5.0.5",
     "ts-jest": "^29.1.2",
+    "tsc-alias": "^1.8.11",
     "tslib": "^2.6.2",
     "typescript": "^4.9.5"
   },
@@ -79,6 +80,5 @@
     "packages/validator-ajv6",
     "packages/validator-ajv8",
     "packages/snapshot-tests"
-  ],
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  ]
 }

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -5,8 +5,14 @@
   "main": "dist/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
+  "exports": {
+    "require": "./dist/index.js",
+    "import": "./lib/index.js",
+    "types": "./lib/index.d.ts"
+  },
   "scripts": {
-    "build:ts": "tsc -b",
+    "compileReplacer": "tsc -p tsconfig.replacer.json",
+    "build:ts": "npm run compileReplacer && rimraf ./lib && tsc -b tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:cjs": "esbuild ./src/index.ts --bundle --outfile=dist/index.js --sourcemap --packages=external --format=cjs",
     "build:esm": "esbuild ./src/index.ts --bundle --outfile=dist/antd.esm.js --sourcemap --packages=external --format=esm",
     "build:umd": "rollup dist/antd.esm.js --format=umd --file=dist/antd.umd.js --name=@rjsf/antd",

--- a/packages/antd/tsconfig.build.json
+++ b/packages/antd/tsconfig.build.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./lib"
+  },
+  "files": [],
+  "references": [
+    {
+      "path": "./src"
+    }
+  ],
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": true,
+    "replacers": {
+      "lodash": {
+        "enabled": true,
+        "file": "lodashReplacer.js"
+      }
+    }
+  }
+}

--- a/packages/antd/tsconfig.replacer.json
+++ b/packages/antd/tsconfig.replacer.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "outDir": "./",
+    "skipLibCheck": true,
+  },
+  "files": [
+    "../../tsc-alias-replacer/lodashReplacer.ts"
+  ],
+  "exclude": [
+    "./src",
+    "./test"
+  ]
+}

--- a/packages/bootstrap-4/package.json
+++ b/packages/bootstrap-4/package.json
@@ -4,6 +4,11 @@
   "main": "dist/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
+  "exports": {
+    "require": "./dist/index.js",
+    "import": "./lib/index.js",
+    "types": "./lib/index.d.ts"
+  },
   "description": "Bootstrap 4 theme, fields and widgets for react-jsonschema-form",
   "files": [
     "dist",
@@ -15,7 +20,7 @@
     "url": "git+https://github.com/rjsf-team/react-jsonschema-form.git"
   },
   "scripts": {
-    "build:ts": "tsc -b",
+    "build:ts": "tsc -b tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:cjs": "esbuild ./src/index.ts --bundle --outfile=dist/index.js --sourcemap --packages=external --format=cjs",
     "build:esm": "esbuild ./src/index.ts --bundle --outfile=dist/bootstrap-4.esm.js --sourcemap --packages=external --format=esm",
     "build:umd": "rollup dist/bootstrap-4.esm.js --format=umd --file=dist/bootstrap-4.umd.js --name=@rjsf/bootstrap-4",

--- a/packages/bootstrap-4/tsconfig.build.json
+++ b/packages/bootstrap-4/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./lib"
+  },
+  "files": [],
+  "references": [
+    {
+      "path": "./src"
+    }
+  ]
+}

--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -5,13 +5,18 @@
   "main": "dist/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
+  "exports": {
+    "require": "./dist/index.js",
+    "import": "./lib/index.js",
+    "types": "./lib/index.d.ts"
+  },
   "files": [
     "dist",
     "lib",
     "src"
   ],
   "scripts": {
-    "build:ts": "tsc -b",
+    "build:ts": "tsc -b tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:cjs": "esbuild ./src/index.ts --bundle --outfile=dist/index.js --sourcemap --packages=external --format=cjs",
     "build:esm": "esbuild ./src/index.ts --bundle --outfile=dist/chakra-ui.esm.js --sourcemap --packages=external --format=esm",
     "build:umd": "rollup dist/chakra-ui.esm.js --format=umd --file=dist/chakra-ui.umd.js --name=@rjsf/chakra-ui",

--- a/packages/chakra-ui/tsconfig.build.json
+++ b/packages/chakra-ui/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./lib"
+  },
+  "files": [],
+  "references": [
+    {
+      "path": "./src"
+    }
+  ],
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": true,
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,8 @@
   "version": "5.24.3",
   "description": "A simple React component capable of building HTML forms out of a JSON schema.",
   "scripts": {
-    "build:ts": "tsc -b",
+    "compileReplacer": "tsc -p tsconfig.replacer.json",
+    "build:ts": "npm run compileReplacer && rimraf ./lib && tsc -b tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:cjs": "esbuild ./src/index.ts --bundle --outfile=dist/index.js --sourcemap --packages=external --format=cjs",
     "build:esm": "esbuild ./src/index.ts --bundle --outfile=dist/index.esm.js --sourcemap --packages=external --format=esm",
     "build:umd": "rollup dist/index.esm.js --format=umd --file=dist/core.umd.js --name=JSONSchemaForm",
@@ -27,6 +28,11 @@
   "main": "dist/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
+  "exports": {
+    "require": "./dist/index.js",
+    "import": "./lib/index.js",
+    "types": "./lib/index.d.ts"
+  },
   "files": [
     "dist",
     "lib",

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./lib"
+  },
+  "files": [],
+  "references": [
+    {
+      "path": "./src"
+    }
+  ],
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": true,
+    "replacers": {
+      "lodash": {
+        "enabled": true,
+        "file": "lodashReplacer.js"
+      }
+    }
+  }
+}

--- a/packages/core/tsconfig.replacer.json
+++ b/packages/core/tsconfig.replacer.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "outDir": "./",
+    "skipLibCheck": true,
+  },
+  "files": [
+    "../../tsc-alias-replacer/lodashReplacer.ts"
+  ],
+  "exclude": [
+    "./src",
+    "./test"
+  ]
+}

--- a/packages/fluent-ui/package.json
+++ b/packages/fluent-ui/package.json
@@ -4,6 +4,11 @@
   "main": "dist/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
+  "exports": {
+    "require": "./dist/index.js",
+    "import": "./lib/index.js",
+    "types": "./lib/index.d.ts"
+  },
   "description": "Fluent UI theme, fields and widgets for react-jsonschema-form",
   "files": [
     "dist",
@@ -11,7 +16,7 @@
     "src"
   ],
   "scripts": {
-    "build:ts": "tsc -b",
+    "build:ts": "tsc -b tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:cjs": "esbuild ./src/index.ts --bundle --outfile=dist/index.js --sourcemap --packages=external --format=cjs",
     "build:esm": "esbuild ./src/index.ts --bundle --outfile=dist/fluent-ui.esm.js --sourcemap --packages=external --format=esm",
     "build:umd": "rollup dist/fluent-ui.esm.js --format=umd --file=dist/fluent-ui.umd.js --name=@rjsf/fluent-ui",

--- a/packages/fluent-ui/tsconfig.build.json
+++ b/packages/fluent-ui/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./lib"
+  },
+  "files": [],
+  "references": [
+    {
+      "path": "./src"
+    }
+  ],
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": true,
+  }
+}

--- a/packages/fluentui-rc/package.json
+++ b/packages/fluentui-rc/package.json
@@ -3,7 +3,7 @@
   "version": "5.24.3",
   "description": "FluentUI React Components theme, fields and widgets for react-jsonschema-form",
   "scripts": {
-    "build:ts": "tsc -b",
+    "build:ts": "tsc -b tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:cjs": "esbuild ./src/index.ts --bundle --outfile=dist/index.js --sourcemap --packages=external --format=cjs",
     "build:esm": "esbuild ./src/index.ts --bundle --outfile=dist/index.esm.js --sourcemap --packages=external --format=esm",
     "build:umd": "rollup dist/index.esm.js --format=umd --file=dist/core.umd.js --name=JSONSchemaForm",
@@ -27,6 +27,11 @@
   "main": "dist/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
+  "exports": {
+    "require": "./dist/index.js",
+    "import": "./lib/index.js",
+    "types": "./lib/index.d.ts"
+  },
   "files": [
     "dist",
     "lib",

--- a/packages/fluentui-rc/tsconfig.build.json
+++ b/packages/fluentui-rc/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./lib"
+  },
+  "files": [],
+  "references": [
+    {
+      "path": "./src"
+    }
+  ],
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": true,
+  }
+}

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -5,13 +5,18 @@
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "description": "Material UI 4 theme, fields and widgets for react-jsonschema-form",
+  "exports": {
+    "require": "./dist/index.js",
+    "import": "./lib/index.js",
+    "types": "./lib/index.d.ts"
+  },
   "files": [
     "dist",
     "lib",
     "src"
   ],
   "scripts": {
-    "build:ts": "tsc -b",
+    "build:ts": "tsc -b tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:cjs": "esbuild ./src/index.ts --bundle --outfile=dist/index.js --sourcemap --packages=external --format=cjs",
     "build:esm": "esbuild ./src/index.ts --bundle --outfile=dist/material-ui.esm.js --sourcemap --packages=external --format=esm",
     "build:umd": "rollup dist/material-ui.esm.js --format=umd --file=dist/material-ui.umd.js --name=@rjsf/material-ui",

--- a/packages/material-ui/tsconfig.build.json
+++ b/packages/material-ui/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./lib"
+  },
+  "files": [],
+  "references": [
+    {
+      "path": "./src"
+    }
+  ],
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": true,
+  }
+}

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -5,13 +5,18 @@
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "description": "Material UI 5 theme, fields and widgets for react-jsonschema-form",
+  "exports": {
+    "require": "./dist/index.js",
+    "import": "./lib/index.js",
+    "types": "./lib/index.d.ts"
+  },
   "files": [
     "dist",
     "lib",
     "src"
   ],
   "scripts": {
-    "build:ts": "tsc -b",
+    "build:ts": "tsc -b tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:cjs": "esbuild ./src/index.ts --bundle --outfile=dist/index.js --sourcemap --packages=external --format=cjs",
     "build:esm": "esbuild ./src/index.ts --bundle --outfile=dist/mui.esm.js --sourcemap --packages=external --format=esm",
     "build:umd": "rollup dist/mui.esm.js --format=umd --file=dist/mui.umd.js --name=@rjsf/mui",

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -16,7 +16,8 @@
     "src"
   ],
   "scripts": {
-    "build:ts": "tsc -b tsconfig.build.json && tsc-alias -p tsconfig.build.json",
+    "compileReplacer": "tsc -p tsconfig.replacer.json",
+    "build:ts": "npm run compileReplacer && rimraf ./lib && tsc -b tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:cjs": "esbuild ./src/index.ts --bundle --outfile=dist/index.js --sourcemap --packages=external --format=cjs",
     "build:esm": "esbuild ./src/index.ts --bundle --outfile=dist/mui.esm.js --sourcemap --packages=external --format=esm",
     "build:umd": "rollup dist/mui.esm.js --format=umd --file=dist/mui.umd.js --name=@rjsf/mui",

--- a/packages/mui/tsconfig.build.json
+++ b/packages/mui/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./lib"
+  },
+  "files": [],
+  "references": [
+    {
+      "path": "./src"
+    }
+  ],
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": true,
+  }
+}

--- a/packages/mui/tsconfig.build.json
+++ b/packages/mui/tsconfig.build.json
@@ -12,5 +12,11 @@
   "tsc-alias": {
     "resolveFullPaths": true,
     "verbose": true,
+    "replacers": {
+      "lodash": {
+        "enabled": true,
+        "file": "muiReplacer.js"
+      }
+    }
   }
 }

--- a/packages/mui/tsconfig.replacer.json
+++ b/packages/mui/tsconfig.replacer.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "outDir": "./",
+    "skipLibCheck": true,
+  },
+  "files": [
+    "../../tsc-alias-replacer/muiReplacer.ts"
+  ],
+  "exclude": [
+    "./src",
+    "./test"
+  ]
+}

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -5,6 +5,11 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "description": "Semantic UI theme, fields and widgets for react-jsonschema-form",
+  "exports": {
+    "require": "./dist/index.js",
+    "import": "./lib/index.js",
+    "types": "./lib/index.d.ts"
+  },
   "files": [
     "dist",
     "lib",
@@ -15,7 +20,7 @@
     "node": ">=14"
   },
   "scripts": {
-    "build:ts": "tsc -b",
+    "build:ts": "tsc -b tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:cjs": "esbuild ./src/index.ts --bundle --outfile=dist/index.js --sourcemap --packages=external --format=cjs",
     "build:esm": "esbuild ./src/index.ts --bundle --outfile=dist/semantic-ui.esm.js --sourcemap --packages=external --format=esm",
     "build:umd": "rollup dist/semantic-ui.esm.js --format=umd --file=dist/semantic-ui.umd.js --name=@rjsf/semantic-ui",

--- a/packages/semantic-ui/tsconfig.build.json
+++ b/packages/semantic-ui/tsconfig.build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./lib"
+  },
+  "files": [],
+  "references": [
+    {
+      "path": "./src"
+    }
+  ],
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": true,
+  }
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,6 +5,12 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "description": "Utility functions for @rjsf/core",
+  "exports": {
+    "require": "./dist/index.js",
+    "node": "./dist/index.js",
+    "import": "./lib/index.js",
+    "types": "./lib/index.d.ts"
+  },
   "files": [
     "dist",
     "lib",
@@ -15,7 +21,8 @@
     "node": ">=14"
   },
   "scripts": {
-    "build:ts": "tsc -b",
+    "compileReplacer": "tsc -p tsconfig.replacer.json",
+    "build:ts": "npm run compileReplacer && rimraf ./lib && tsc -b tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:cjs": "esbuild ./src/index.ts --bundle --outfile=dist/index.js --sourcemap --packages=external --format=cjs",
     "build:esm": "esbuild ./src/index.ts --bundle --outfile=dist/utils.esm.js --sourcemap --packages=external --format=esm",
     "build:umd": "rollup dist/utils.esm.js --format=umd --file=dist/utils.umd.js --name=@rjsf/utils",

--- a/packages/utils/tsconfig.build.json
+++ b/packages/utils/tsconfig.build.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./lib"
+  },
+  "files": [],
+  "references": [
+    {
+      "path": "./src"
+    }
+  ],
+  "exclude": [
+    "./test"
+  ],
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": true,
+    "replacers": {
+      "lodash": {
+        "enabled": true,
+        "file": "lodashReplacer.js"
+      }
+    }
+  }
+}

--- a/packages/utils/tsconfig.replacer.json
+++ b/packages/utils/tsconfig.replacer.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "outDir": "./",
+    "skipLibCheck": true,
+  },
+  "files": [
+    "../../tsc-alias-replacer/lodashReplacer.ts"
+  ],
+  "exclude": [
+    "./src",
+    "./test"
+  ]
+}

--- a/packages/validator-ajv6/package.json
+++ b/packages/validator-ajv6/package.json
@@ -15,7 +15,8 @@
     "node": ">=14"
   },
   "scripts": {
-    "build:ts": "tsc -b",
+    "compileReplacer": "tsc -p tsconfig.replacer.json",
+    "build:ts": "npm run compileReplacer && rimraf ./lib && tsc -b tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:cjs": "esbuild ./src/index.ts --bundle --outfile=dist/index.js --sourcemap --packages=external --format=cjs",
     "build:esm": "esbuild ./src/index.ts --bundle --outfile=dist/validator-ajv6.esm.js --sourcemap --packages=external --format=esm",
     "build:umd": "rollup dist/validator-ajv6.esm.js --format=umd --file=dist/validator-ajv6.umd.js --name=@rjsf/validator-ajv6",

--- a/packages/validator-ajv6/test/utilsTests/schema.test.ts
+++ b/packages/validator-ajv6/test/utilsTests/schema.test.ts
@@ -1,4 +1,4 @@
-// With Lerna active, the test world has access to the test suite via the symlink
+// The test world has access to the test suite via the direct import from the utils package
 import {
   getDefaultFormStateTest,
   getDisplayLabelTest,
@@ -12,7 +12,7 @@ import {
   sanitizeDataForNewSchemaTest,
   toIdSchemaTest,
   toPathSchemaTest,
-} from '@rjsf/utils/test/schema';
+} from '../../../utils/test/schema';
 import getTestValidator from './getTestValidator';
 
 const testValidator = getTestValidator({});

--- a/packages/validator-ajv6/tsconfig.build.json
+++ b/packages/validator-ajv6/tsconfig.build.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./lib"
+  },
+  "files": [],
+  "references": [
+    {
+      "path": "./src"
+    }
+  ],
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": true,
+    "replacers": {
+      "lodash": {
+        "enabled": true,
+        "file": "lodashReplacer.js"
+      }
+    }
+  }
+}

--- a/packages/validator-ajv6/tsconfig.replacer.json
+++ b/packages/validator-ajv6/tsconfig.replacer.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "outDir": "./",
+    "skipLibCheck": true,
+  },
+  "files": [
+    "../../tsc-alias-replacer/lodashReplacer.ts"
+  ],
+  "exclude": [
+    "./src",
+    "./test"
+  ]
+}

--- a/packages/validator-ajv8/package.json
+++ b/packages/validator-ajv8/package.json
@@ -5,6 +5,23 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "description": "The ajv-8 based validator for @rjsf/core",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./lib/index.js",
+      "types": "./lib/index.d.ts"
+    },
+    "./compileSchemaValidators": {
+      "require": "./dist/compileSchemaValidators.js",
+      "import": "./lib/compileSchemaValidators.js",
+      "types": "./lib/compileSchemaValidators.d.ts"
+    },
+    "./dist/compileSchemaValidators": {
+      "require": "./dist/compileSchemaValidators.js",
+      "import": "./lib/compileSchemaValidators.js",
+      "types": "./lib/compileSchemaValidators.d.ts"
+    }
+  },
   "files": [
     "dist",
     "lib",
@@ -15,7 +32,8 @@
     "node": ">=14"
   },
   "scripts": {
-    "build:ts": "tsc -b",
+    "compileReplacer": "tsc -p tsconfig.replacer.json",
+    "build:ts": "npm run compileReplacer && rimraf ./lib && tsc -b tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:cjs": "esbuild ./src/index.ts --bundle --outfile=dist/index.js --sourcemap --packages=external --format=cjs && esbuild ./src/compileSchemaValidators.ts --bundle --outfile=dist/compileSchemaValidators.js --sourcemap --packages=external --format=cjs",
     "build:esm": "esbuild ./src/index.ts --bundle --outfile=dist/validator-ajv8.esm.js --sourcemap --packages=external --format=esm  && esbuild ./src/compileSchemaValidators.ts --bundle --outfile=dist/compileSchemaValidators.esm.js --sourcemap --packages=external --format=esm",
     "build:umd": "rollup dist/validator-ajv8.esm.js --format=umd --file=dist/validator-ajv8.umd.js --name=@rjsf/validator-ajv8",

--- a/packages/validator-ajv8/test/utilsTests/schema.test.ts
+++ b/packages/validator-ajv8/test/utilsTests/schema.test.ts
@@ -1,6 +1,6 @@
-// With Lerna active, the test world has access to the test suite via the symlink
 import Ajv2019 from 'ajv/dist/2019';
 import Ajv2020 from 'ajv/dist/2020';
+// The test world has access to the test suite via the direct import from the utils package
 import {
   getDefaultFormStateTest,
   getDisplayLabelTest,
@@ -14,7 +14,7 @@ import {
   sanitizeDataForNewSchemaTest,
   toIdSchemaTest,
   toPathSchemaTest,
-} from '@rjsf/utils/test/schema';
+} from '../../../utils/test/schema';
 import getTestValidator from './getTestValidator';
 
 const testValidator = getTestValidator({});

--- a/packages/validator-ajv8/tsconfig.build.json
+++ b/packages/validator-ajv8/tsconfig.build.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./lib"
+  },
+  "files": [],
+  "references": [
+    {
+      "path": "./src"
+    }
+  ],
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": true,
+    "replacers": {
+      "lodash": {
+        "enabled": true,
+        "file": "lodashReplacer.js"
+      }
+    }
+  }
+}

--- a/packages/validator-ajv8/tsconfig.replacer.json
+++ b/packages/validator-ajv8/tsconfig.replacer.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "outDir": "./",
+    "skipLibCheck": true,
+  },
+  "files": [
+    "../../tsc-alias-replacer/lodashReplacer.ts"
+  ],
+  "exclude": [
+    "./src",
+    "./test"
+  ]
+}

--- a/tsc-alias-replacer/lodashReplacer.ts
+++ b/tsc-alias-replacer/lodashReplacer.ts
@@ -1,0 +1,15 @@
+import { AliasReplacerArguments } from 'tsc-alias';
+
+/** A `tsc-alias` replacer that fixes up the imports `from 'lodash/xxxx'` to be `from `lodash/xxxx.js`
+ *
+ * @param orig - The original import name
+ */
+export default function exampleReplacer({ orig }: AliasReplacerArguments): string {
+  if (orig.startsWith("from 'lodash/")) {
+    const origLodashEs = orig.substring(0, orig.length - 1).replace('lodash/', 'lodash-es/');
+    // console.log(origLodashEs);
+    return `${origLodashEs}.js'`;
+  }
+
+  return orig;
+}

--- a/tsc-alias-replacer/muiReplacer.ts
+++ b/tsc-alias-replacer/muiReplacer.ts
@@ -1,0 +1,15 @@
+import { AliasReplacerArguments } from 'tsc-alias';
+
+/** A `tsc-alias` replacer that fixes up the imports `from 'lodash/xxxx'` to be `from `lodash/xxxx.js`
+ *
+ * @param orig - The original import name
+ */
+export default function exampleReplacer({ orig }: AliasReplacerArguments): string {
+  if (orig.startsWith("from '@mui/material/")) {
+    const origMinusEndQuote = orig.substring(0, orig.length - 1);
+    // console.log(origMinusEndQuote);
+    return `${origMinusEndQuote}/index.js'`;
+  }
+
+  return orig;
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "lib": ["dom", "esnext"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedParameters": false,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true,
+  },
+  "include": [
+    "./src"
+  ],
+  "exclude": [
+    "./test"
+  ]
+}


### PR DESCRIPTION
### Reasons for making this change
According to this [vitest discussion](https://github.com/vitest-dev/vitest/discussions/4233) we needed to add `exports` to all `package.json` files
- Updated the building of ESM modules to run `tsc-alias` to append the `.js` extensions onto the imports for ESM builds
- For those builds that use `lodash` also added a replacer for the `tsc-alias` that switches things to use `lodash-es`

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
