### PR TITLE
Fixed ESM support in @rjsf/utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.24.5
+
+## @rjsf/utils
+
+- Fixed `package.json` to remove `node` from the `exports` block to fix ESM support
+
 # 5.24.4
 
 ## @rjsf/utils
@@ -34,6 +40,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Rollback [4446](https://github.com/rjsf-team/react-jsonschema-form/pull/4446) due to regression
 
 ## Dev / docs / playground
+
 - Fixed issue with selector, where validator was getting refreshed on clicking on anything in selector. [#4472](https://github.com/rjsf-team/react-jsonschema-form/pull/4472)
 
 # 5.24.2

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -7,7 +7,6 @@
   "description": "Utility functions for @rjsf/core",
   "exports": {
     "require": "./dist/index.js",
-    "node": "./dist/index.js",
     "import": "./lib/index.js",
     "types": "./lib/index.d.ts"
   },


### PR DESCRIPTION
ESM support for `@rjsf/utils` is broken due to a `node` line being added in the `exports` block
- Updated `@rjsf/utils` package.json to fix ESM issue

### Reasons for making this change

ESM support for `@rjsf/utils` is broken due to a `node` line being added in the `exports` block
- Updated `@rjsf/utils` package.json to fix ESM issue

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
