### PR TITLE
Fixed core ESM builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.24.6
+
+## @rjsf/core
+
+- Fixed `src/tsconfig.json` to add the `tsc-alias` block to support proper fixing up of ESM import
+
 # 5.24.5
 
 ## @rjsf/utils

--- a/packages/core/src/tsconfig.json
+++ b/packages/core/src/tsconfig.json
@@ -19,5 +19,15 @@
     {
       "path": "../../validator-ajv8"
     }
-  ]
+  ],
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": true,
+    "replacers": {
+      "lodash": {
+        "enabled": true,
+        "file": "lodashReplacer.js"
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Reasons for making this change

There are two `tsconfig.json` files in core and the second one in `src` also needed the `tsc-alias` block
- Updated the `src/tsconfig.json` to add the `tsc-alias` block to support proper building of the ESM version


### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
