### PR TITLE
Bug: Antd radio is not disabled when disabled is set in ui schema

### DIFF
--- a/packages/antd/src/widgets/RadioWidget/index.tsx
+++ b/packages/antd/src/widgets/RadioWidget/index.tsx
@@ -61,7 +61,7 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
             id={optionId(id, i)}
             name={id}
             autoFocus={i === 0 ? autofocus : false}
-            disabled={Array.isArray(enumDisabled) && enumDisabled.indexOf(option.value) !== -1}
+            disabled={disabled || (Array.isArray(enumDisabled) && enumDisabled.indexOf(option.value) !== -1)}
             key={i}
             value={String(i)}
           >


### PR DESCRIPTION
### Reasons for making this change

Antd radio is not disabled when disabled is set in ui schema

Fixes [#4481](https://github.com/rjsf-team/react-jsonschema-form/issues/4481)


### Checklist

- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
