### PR TITLE
Bug: schema combinators(allOf, anyOf, oneOf) cannot be modified when defaults were set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Fixed issue in BaseInputTemplate where input props were passed to `slotProps.htmlInput`, which does not work in MUI v5.
 
+## @rjsf/utils
+
+- Fixed issue with schema combinators(allOf, anyOf, oneOf) could not be modified when defaults were set, fixing [#4555](https://github.com/rjsf-team/react-jsonschema-form/issues/4555)
+
 ## Dev / docs / playground
 
 - Updated docs for ArrayFieldItemTemplate to include prop `onCopyIndexClick`, fixing [#4507](https://github.com/rjsf-team/react-jsonschema-form/issues/4507)

--- a/packages/core/test/Form.test.jsx
+++ b/packages/core/test/Form.test.jsx
@@ -1261,6 +1261,174 @@ describeRepeated('Form common', (createFormComponent) => {
       sinon.assert.callCount(onChange, 1);
       sinon.assert.callCount(secondOnChange, 1);
     });
+    it('should modify an allOf field when the defaults are set', () => {
+      const schema = {
+        properties: {
+          all_of_field: {
+            allOf: [
+              {
+                properties: {
+                  first: {
+                    type: 'string',
+                  },
+                },
+              },
+              {
+                properties: {
+                  second: {
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+            default: {
+              second: 'second!',
+            },
+          },
+        },
+        type: 'object',
+      };
+
+      const { node, onChange } = createFormComponent({
+        schema,
+      });
+
+      const secondInputID = '#root_all_of_field_second';
+      expect(node.querySelector(secondInputID).value).to.equal('second!');
+
+      act(() => {
+        fireEvent.change(node.querySelector(secondInputID), {
+          target: { value: 'changed!' },
+        });
+      });
+
+      sinon.assert.calledWithMatch(
+        onChange.lastCall,
+        {
+          formData: {
+            all_of_field: {
+              second: 'changed!',
+            },
+          },
+          schema,
+        },
+        'root_all_of_field_second'
+      );
+
+      expect(node.querySelector(secondInputID).value).to.equal('changed!');
+    });
+    it('should modify an oneOf field when the defaults are set', () => {
+      const schema = {
+        properties: {
+          one_of_field: {
+            oneOf: [
+              {
+                properties: {
+                  first: {
+                    type: 'string',
+                  },
+                },
+              },
+              {
+                properties: {
+                  second: {
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+            default: {
+              second: 'second!',
+            },
+          },
+        },
+        type: 'object',
+      };
+
+      const { node, onChange } = createFormComponent({
+        schema,
+      });
+
+      const secondInputID = '#root_one_of_field_second';
+      expect(node.querySelector(secondInputID).value).to.equal('second!');
+
+      act(() => {
+        fireEvent.change(node.querySelector(secondInputID), {
+          target: { value: 'changed!' },
+        });
+      });
+
+      sinon.assert.calledWithMatch(
+        onChange.lastCall,
+        {
+          formData: {
+            one_of_field: {
+              second: 'changed!',
+            },
+          },
+          schema,
+        },
+        'root_one_of_field_second'
+      );
+
+      expect(node.querySelector(secondInputID).value).to.equal('changed!');
+    });
+    it('should modify an anyOf field when the defaults are set', () => {
+      const schema = {
+        properties: {
+          any_of_field: {
+            anyOf: [
+              {
+                properties: {
+                  first: {
+                    type: 'string',
+                  },
+                },
+              },
+              {
+                properties: {
+                  second: {
+                    type: 'string',
+                  },
+                },
+              },
+            ],
+            default: {
+              second: 'second!',
+            },
+          },
+        },
+        type: 'object',
+      };
+
+      const { node, onChange } = createFormComponent({
+        schema,
+      });
+
+      const secondInputID = '#root_any_of_field_second';
+      expect(node.querySelector(secondInputID).value).to.equal('second!');
+
+      act(() => {
+        fireEvent.change(node.querySelector(secondInputID), {
+          target: { value: 'changed!' },
+        });
+      });
+
+      sinon.assert.calledWithMatch(
+        onChange.lastCall,
+        {
+          formData: {
+            any_of_field: {
+              second: 'changed!',
+            },
+          },
+          schema,
+        },
+        'root_any_of_field_second'
+      );
+
+      expect(node.querySelector(secondInputID).value).to.equal('changed!');
+    });
   });
 
   describe('Blur handler', () => {

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -3835,7 +3835,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           ],
         });
 
-        expect(getDefaultFormState(testValidator, schema, {})).toEqual({
+        expect(getDefaultFormState(testValidator, schema)).toEqual({
           second: 'Second 2!',
         });
       });
@@ -4094,7 +4094,7 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
           ],
         });
 
-        expect(getDefaultFormState(testValidator, schema, {})).toEqual({
+        expect(getDefaultFormState(testValidator, schema)).toEqual({
           second: 'Second 2!',
         });
       });


### PR DESCRIPTION
### Reasons for making this change

Fixes #4555 

### Checklist


- [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
