### PR TITLE
Fix 2280 by moving the bootstrap 3 classes out of SchemaField

### DIFF
--- a/CHANGELOG_v6.md
+++ b/CHANGELOG_v6.md
@@ -25,6 +25,7 @@ should change the heading of the (upcoming) version to include a major version b
 - BREAKING CHANGE: Removed support for version 4 of `antd`
 - Updated `ArrayFieldItemTemplate` to replace `Button.Group` with `Space.Compact` since `Button.Group` is deprecated in `antd` version 5
 - Upgraded to `@ant-design/icon@5`
+- BREAKING CHANGE: Removed the addition of `Bootstrap 3` marker classes from the `SchemaField`, thereby changing theme `FieldTemplate` className prop output and associated snapshots
 
 ## @rjsf/chakra-ui
 
@@ -33,6 +34,7 @@ should change the heading of the (upcoming) version to include a major version b
 - BREAKING CHANGE: Refactored `ArrayFieldItemTemplate` to use the new `ArrayFieldItemButtonsTemplate`
 - Updated the `ArrayFieldTemplate`, `ObjectFieldTemplate`, and `WrapIfAdditionalTemplate` to a unique id using the `buttonId()` function and adding consistent marker classes
 - Implemented the `GridTemplate` component, adding it to the `templates` for the theme
+- BREAKING CHANGE: Removed the addition of `Bootstrap 3` marker classes from the `SchemaField`, thereby changing theme `FieldTemplate` className prop output and associated snapshots
 
 ## @rjsf/core
 
@@ -43,6 +45,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Implemented the `GridTemplate` component, adding it to the `templates` for the theme
 - Implemented the new `LayoutGridField`, `LayoutMultiSchemaField` and `LayoutHeaderField` fields, adding them to the `fields` list
 - BREAKING CHANGE: Removed support for the deprecated `schema.enumNames` and `uiSchema.classNames` as well as the deprecated `acceptcharset` prop on `Form`
+- BREAKING CHANGE: Moved the addition of `Bootstrap 3` marker classes from the `SchemaField` to the `WrapIfAdditionalTemplate`, thereby affecting all of the other themes, fixing [#2280](https://github.com/rjsf-team/react-jsonschema-form/issues/2280)
 
 ## @rjsf/daisyui
 
@@ -57,6 +60,11 @@ should change the heading of the (upcoming) version to include a major version b
 - BREAKING CHANGE: Refactored `ArrayFieldItemTemplate` to use the new `ArrayFieldItemButtonsTemplate`
 - Updated the `ArrayFieldTemplate`, `ObjectFieldTemplate`, and `WrapIfAdditionalTemplate` to a unique id using the `buttonId()` function and adding consistent marker classes
 - Implemented the `GridTemplate` component, adding it to the `templates` for the theme
+- BREAKING CHANGE: Removed the addition of `Bootstrap 3` marker classes from the `SchemaField`, thereby changing theme `FieldTemplate` className prop output and associated snapshots
+
+## @rjsf/material-ui
+
+- BREAKING CHANGE: Deleted this theme in favor of `mui`
 
 ## @rjsf/mui
 
@@ -64,12 +72,15 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated the `ArrayFieldTemplate`, `ObjectFieldTemplate`, and `WrapIfAdditionalTemplate` to a unique id using the `buttonId()` function and adding consistent marker classes
 - Updated the theme to use `Grid2` instead of the deprecated `Grid`
 - Implemented the `GridTemplate` component, adding it to the `templates` for the theme
+- BREAKING CHANGE: Removed the addition of `Bootstrap 3` marker classes from the `SchemaField`, thereby changing theme `FieldTemplate` className prop output and associated snapshots
 
 ## @rjsf/semantic-ui
 
 - BREAKING CHANGE: Refactored `ArrayFieldItemTemplate` to use the new `ArrayFieldItemButtonsTemplate`
 - Updated the `ArrayFieldTemplate`, `ObjectFieldTemplate`, and `WrapIfAdditionalTemplate` to a unique id using the `buttonId()` function and adding consistent marker classes
 - Implemented the `GridTemplate` component, adding it to the `templates` for the theme
+- BREAKING CHANGE: Removed the addition of `Bootstrap 3` marker classes from the `SchemaField`, thereby changing theme `FieldTemplate` className prop output and associated snapshots
+- BREAKING CHANGE: Removed the addition of `Bootstrap 3` marker classes from the `SchemaField`, thereby changing theme `FieldTemplate` className prop output and associated snapshots
 
 ## @rjsf/shadcn
 
@@ -98,6 +109,7 @@ should change the heading of the (upcoming) version to include a major version b
 - BREAKING CHANGE: Removed the deprecated `getMatchingOption()` and `mergeValidationData()` from the library export and the `SchemaUtilsType` interface
 - BREAKING CHANGE: Removed the deprecated `toErrorList()` function from the `ValidatorType` interface
 - BREAKING CHANGE: Removed the deprecated `RJSF_ADDITONAL_PROPERTIES_FLAG` constant
+- Updated the `WrapIfAdditionalTemplateProps` to include `hideError` and `rawErrors` in support of moving `Bootstrap 3` marker classes out of `SchemaField`
 
 ## @rjsf/validator-ajv6
 

--- a/CHANGELOG_v6.md
+++ b/CHANGELOG_v6.md
@@ -25,7 +25,7 @@ should change the heading of the (upcoming) version to include a major version b
 - BREAKING CHANGE: Removed support for version 4 of `antd`
 - Updated `ArrayFieldItemTemplate` to replace `Button.Group` with `Space.Compact` since `Button.Group` is deprecated in `antd` version 5
 - Upgraded to `@ant-design/icon@5`
-- BREAKING CHANGE: Removed the addition of `Bootstrap 3` marker classes from the `SchemaField`, thereby changing theme `FieldTemplate` className prop output and associated snapshots
+- BREAKING CHANGE: Removed the addition of `Bootstrap 3` classes from the `SchemaField` and added `rjsf-` prefix to marker classes, thereby changing theme `FieldTemplate` className prop output and associated snapshots
 
 ## @rjsf/chakra-ui
 
@@ -34,7 +34,7 @@ should change the heading of the (upcoming) version to include a major version b
 - BREAKING CHANGE: Refactored `ArrayFieldItemTemplate` to use the new `ArrayFieldItemButtonsTemplate`
 - Updated the `ArrayFieldTemplate`, `ObjectFieldTemplate`, and `WrapIfAdditionalTemplate` to a unique id using the `buttonId()` function and adding consistent marker classes
 - Implemented the `GridTemplate` component, adding it to the `templates` for the theme
-- BREAKING CHANGE: Removed the addition of `Bootstrap 3` marker classes from the `SchemaField`, thereby changing theme `FieldTemplate` className prop output and associated snapshots
+- BREAKING CHANGE: Removed the addition of `Bootstrap 3` classes from the `SchemaField` and added `rjsf-` prefix to marker classes, thereby changing theme `FieldTemplate` className prop output and associated snapshots
 
 ## @rjsf/core
 
@@ -45,7 +45,9 @@ should change the heading of the (upcoming) version to include a major version b
 - Implemented the `GridTemplate` component, adding it to the `templates` for the theme
 - Implemented the new `LayoutGridField`, `LayoutMultiSchemaField` and `LayoutHeaderField` fields, adding them to the `fields` list
 - BREAKING CHANGE: Removed support for the deprecated `schema.enumNames` and `uiSchema.classNames` as well as the deprecated `acceptcharset` prop on `Form`
-- BREAKING CHANGE: Moved the addition of `Bootstrap 3` marker classes from the `SchemaField` to the `WrapIfAdditionalTemplate`, thereby affecting all of the other themes, fixing [#2280](https://github.com/rjsf-team/react-jsonschema-form/issues/2280)
+- BREAKING CHANGE: Moved the addition of `Bootstrap 3` classes from the `SchemaField` to the `WrapIfAdditionalTemplate`, thereby affecting all the other themes, fixing [#2280](https://github.com/rjsf-team/react-jsonschema-form/issues/2280)
+- BREAKING CHANGE: Added `rjsf-` prefix onto the following marker classes used in the fields and templates:
+  - `field`, `field-<schema.type>`, `field-error`, `field-array`, `field-array-of-<schema.type>`, `field-array-fixed-items`, `array-item`, `config-error`, `array-item-add`, `array-item-copy`, `array-item-move-down`, `array-item-move-up`, `array-item-remove`, `object-property-expand`
 
 ## @rjsf/daisyui
 
@@ -60,7 +62,7 @@ should change the heading of the (upcoming) version to include a major version b
 - BREAKING CHANGE: Refactored `ArrayFieldItemTemplate` to use the new `ArrayFieldItemButtonsTemplate`
 - Updated the `ArrayFieldTemplate`, `ObjectFieldTemplate`, and `WrapIfAdditionalTemplate` to a unique id using the `buttonId()` function and adding consistent marker classes
 - Implemented the `GridTemplate` component, adding it to the `templates` for the theme
-- BREAKING CHANGE: Removed the addition of `Bootstrap 3` marker classes from the `SchemaField`, thereby changing theme `FieldTemplate` className prop output and associated snapshots
+- BREAKING CHANGE: Removed the addition of `Bootstrap 3` classes from the `SchemaField` and added `rjsf-` prefix to marker classes, thereby changing theme `FieldTemplate` className prop output and associated snapshots
 
 ## @rjsf/material-ui
 
@@ -72,15 +74,14 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated the `ArrayFieldTemplate`, `ObjectFieldTemplate`, and `WrapIfAdditionalTemplate` to a unique id using the `buttonId()` function and adding consistent marker classes
 - Updated the theme to use `Grid2` instead of the deprecated `Grid`
 - Implemented the `GridTemplate` component, adding it to the `templates` for the theme
-- BREAKING CHANGE: Removed the addition of `Bootstrap 3` marker classes from the `SchemaField`, thereby changing theme `FieldTemplate` className prop output and associated snapshots
+- BREAKING CHANGE: Removed the addition of `Bootstrap 3` classes from the `SchemaField` and added `rjsf-` prefix to marker classes, thereby changing theme `FieldTemplate` className prop output and associated snapshots
 
 ## @rjsf/semantic-ui
 
 - BREAKING CHANGE: Refactored `ArrayFieldItemTemplate` to use the new `ArrayFieldItemButtonsTemplate`
 - Updated the `ArrayFieldTemplate`, `ObjectFieldTemplate`, and `WrapIfAdditionalTemplate` to a unique id using the `buttonId()` function and adding consistent marker classes
 - Implemented the `GridTemplate` component, adding it to the `templates` for the theme
-- BREAKING CHANGE: Removed the addition of `Bootstrap 3` marker classes from the `SchemaField`, thereby changing theme `FieldTemplate` className prop output and associated snapshots
-- BREAKING CHANGE: Removed the addition of `Bootstrap 3` marker classes from the `SchemaField`, thereby changing theme `FieldTemplate` className prop output and associated snapshots
+- BREAKING CHANGE: Removed the addition of `Bootstrap 3` classes from the `SchemaField` and added `rjsf-` prefix to marker classes, thereby changing theme `FieldTemplate` className prop output and associated snapshots
 
 ## @rjsf/shadcn
 

--- a/CHANGELOG_v6.md
+++ b/CHANGELOG_v6.md
@@ -47,7 +47,7 @@ should change the heading of the (upcoming) version to include a major version b
 - BREAKING CHANGE: Removed support for the deprecated `schema.enumNames` and `uiSchema.classNames` as well as the deprecated `acceptcharset` prop on `Form`
 - BREAKING CHANGE: Moved the addition of `Bootstrap 3` classes from the `SchemaField` to the `WrapIfAdditionalTemplate`, thereby affecting all the other themes, fixing [#2280](https://github.com/rjsf-team/react-jsonschema-form/issues/2280)
 - BREAKING CHANGE: Added `rjsf-` prefix onto the following marker classes used in the fields and templates:
-  - `field`, `field-<schema.type>`, `field-error`, `field-array`, `field-array-of-<schema.type>`, `field-array-fixed-items`, `array-item`, `config-error`, `array-item-add`, `array-item-copy`, `array-item-move-down`, `array-item-move-up`, `array-item-remove`, `object-property-expand`
+  - `field`, `field-<schema.type>`, `field-error`, `field-hidden`, `field-array`, `field-array-of-<schema.type>`, `field-array-fixed-items`, `array-item`, `config-error`, `array-item-add`, `array-item-copy`, `array-item-move-down`, `array-item-move-up`, `array-item-remove`, `object-property-expand`
 
 ## @rjsf/daisyui
 

--- a/packages/antd/src/templates/ArrayFieldItemTemplate/index.tsx
+++ b/packages/antd/src/templates/ArrayFieldItemTemplate/index.tsx
@@ -35,7 +35,7 @@ export default function ArrayFieldItemTemplate<
   const { rowGutter = 24, toolbarAlign = 'top' } = registry.formContext;
 
   return (
-    <Row align={toolbarAlign} key={`array-item-${index}`} gutter={rowGutter}>
+    <Row align={toolbarAlign} key={`rjsf-array-item-${index}`} gutter={rowGutter}>
       <Col flex='1'>{children}</Col>
 
       {hasToolbar && (

--- a/packages/antd/src/templates/ArrayFieldTemplate/index.tsx
+++ b/packages/antd/src/templates/ArrayFieldTemplate/index.tsx
@@ -111,7 +111,7 @@ export default function ArrayFieldTemplate<
               <Col flex='192px'>
                 <AddButton
                   id={buttonId<T>(idSchema, 'add')}
-                  className='array-item-add'
+                  className='rjsf-array-item-add'
                   disabled={disabled || readonly}
                   onClick={onAddClick}
                   uiSchema={uiSchema}

--- a/packages/antd/src/templates/FieldTemplate/index.tsx
+++ b/packages/antd/src/templates/FieldTemplate/index.tsx
@@ -62,7 +62,7 @@ export default function FieldTemplate<
   );
 
   if (hidden) {
-    return <div className='field-hidden'>{children}</div>;
+    return <div className='rjsf-field-hidden'>{children}</div>;
   }
 
   // check to see if there is rawDescription(string) before using description(ReactNode)

--- a/packages/antd/src/templates/ObjectFieldTemplate/index.tsx
+++ b/packages/antd/src/templates/ObjectFieldTemplate/index.tsx
@@ -155,7 +155,7 @@ export default function ObjectFieldTemplate<
             <Col flex='192px'>
               <AddButton
                 id={buttonId<T>(idSchema, 'add')}
-                className='object-property-expand'
+                className='rjsf-object-property-expand'
                 disabled={disabled || readonly}
                 onClick={onAddClick(schema)}
                 uiSchema={uiSchema}

--- a/packages/antd/src/templates/WrapIfAdditionalTemplate/index.tsx
+++ b/packages/antd/src/templates/WrapIfAdditionalTemplate/index.tsx
@@ -110,7 +110,7 @@ export default function WrapIfAdditionalTemplate<
         <Col flex='192px'>
           <RemoveButton
             id={buttonId<T>(id, 'remove')}
-            className='array-item-remove'
+            className='rjsf-object-property-remove'
             disabled={disabled || readonly}
             onClick={onDropPropertyClick(label)}
             uiSchema={buttonUiOptions}

--- a/packages/antd/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Array.test.tsx.snap
@@ -1533,7 +1533,7 @@ exports[`array fields has errors 1`] = `
                     }
                   >
                     <div
-                      className="rjsf-field rjsf-field-string"
+                      className="rjsf-field rjsf-field-string rjsf-field-error"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2 ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"

--- a/packages/antd/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Array.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -31,7 +31,7 @@ exports[`array fields array 1`] = `
               className="ant-form-item-control-input-content"
             >
               <fieldset
-                className="field field-array field-array-of-string"
+                className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
                 id="root"
               >
                 <div
@@ -83,7 +83,7 @@ exports[`array fields array 1`] = `
                         }
                       >
                         <button
-                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-add"
+                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-array-item-add"
                           disabled={false}
                           id="root__add"
                           onClick={[Function]}
@@ -151,7 +151,7 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -175,7 +175,7 @@ exports[`array fields array icons 1`] = `
               className="ant-form-item-control-input-content"
             >
               <fieldset
-                className="field field-array field-array-of-string"
+                className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
                 id="root"
               >
                 <div
@@ -218,7 +218,7 @@ exports[`array fields array icons 1`] = `
                         }
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -297,7 +297,7 @@ exports[`array fields array icons 1`] = `
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-up"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-up"
                             disabled={true}
                             id="root_0__moveUp"
                             onClick={[Function]}
@@ -331,7 +331,7 @@ exports[`array fields array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-down"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-down"
                             disabled={false}
                             id="root_0__moveDown"
                             onClick={[Function]}
@@ -365,7 +365,7 @@ exports[`array fields array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-copy"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-copy"
                             disabled={false}
                             id="root_0__copy"
                             onClick={[Function]}
@@ -399,7 +399,7 @@ exports[`array fields array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-remove"
                             disabled={false}
                             id="root_0__remove"
                             onClick={[Function]}
@@ -456,7 +456,7 @@ exports[`array fields array icons 1`] = `
                         }
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -535,7 +535,7 @@ exports[`array fields array icons 1`] = `
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-up"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-up"
                             disabled={false}
                             id="root_1__moveUp"
                             onClick={[Function]}
@@ -569,7 +569,7 @@ exports[`array fields array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-down"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-down"
                             disabled={true}
                             id="root_1__moveDown"
                             onClick={[Function]}
@@ -603,7 +603,7 @@ exports[`array fields array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-copy"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-copy"
                             disabled={false}
                             id="root_1__copy"
                             onClick={[Function]}
@@ -637,7 +637,7 @@ exports[`array fields array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-remove"
                             disabled={false}
                             id="root_1__remove"
                             onClick={[Function]}
@@ -704,7 +704,7 @@ exports[`array fields array icons 1`] = `
                         }
                       >
                         <button
-                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-add"
+                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-array-item-add"
                           disabled={false}
                           id="root__add"
                           onClick={[Function]}
@@ -772,7 +772,7 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -948,7 +948,7 @@ exports[`array fields empty errors array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -994,7 +994,7 @@ exports[`array fields empty errors array 1`] = `
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1095,7 +1095,7 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1119,7 +1119,7 @@ exports[`array fields fixed array 1`] = `
               className="ant-form-item-control-input-content"
             >
               <fieldset
-                className="field field-array field-array-fixed-items"
+                className="rjsf-field rjsf-field-array rjsf-field-array-fixed-items"
                 id="root"
               >
                 <div
@@ -1162,7 +1162,7 @@ exports[`array fields fixed array 1`] = `
                         }
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1244,7 +1244,7 @@ exports[`array fields fixed array 1`] = `
                         }
                       >
                         <div
-                          className="field-number"
+                          className="rjsf-field rjsf-field-number"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1487,7 +1487,7 @@ exports[`array fields has errors 1`] = `
     </div>
   </div>
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1533,7 +1533,7 @@ exports[`array fields has errors 1`] = `
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2 ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
@@ -1659,7 +1659,7 @@ exports[`array fields no errors 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1705,7 +1705,7 @@ exports[`array fields no errors 1`] = `
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1806,7 +1806,7 @@ exports[`with title and description array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1830,7 +1830,7 @@ exports[`with title and description array 1`] = `
               className="ant-form-item-control-input-content"
             >
               <fieldset
-                className="field field-array field-array-of-string"
+                className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
                 id="root"
               >
                 <div
@@ -1916,7 +1916,7 @@ exports[`with title and description array 1`] = `
                         }
                       >
                         <button
-                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-add"
+                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-array-item-add"
                           disabled={false}
                           id="root__add"
                           onClick={[Function]}
@@ -1998,7 +1998,7 @@ exports[`with title and description array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2022,7 +2022,7 @@ exports[`with title and description array icons 1`] = `
               className="ant-form-item-control-input-content"
             >
               <fieldset
-                className="field field-array field-array-of-string"
+                className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
                 id="root"
               >
                 <div
@@ -2099,7 +2099,7 @@ exports[`with title and description array icons 1`] = `
                         }
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2204,7 +2204,7 @@ exports[`with title and description array icons 1`] = `
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-up"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-up"
                             disabled={true}
                             id="root_0__moveUp"
                             onClick={[Function]}
@@ -2238,7 +2238,7 @@ exports[`with title and description array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-down"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-down"
                             disabled={false}
                             id="root_0__moveDown"
                             onClick={[Function]}
@@ -2272,7 +2272,7 @@ exports[`with title and description array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-copy"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-copy"
                             disabled={false}
                             id="root_0__copy"
                             onClick={[Function]}
@@ -2306,7 +2306,7 @@ exports[`with title and description array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-remove"
                             disabled={false}
                             id="root_0__remove"
                             onClick={[Function]}
@@ -2363,7 +2363,7 @@ exports[`with title and description array icons 1`] = `
                         }
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2468,7 +2468,7 @@ exports[`with title and description array icons 1`] = `
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-up"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-up"
                             disabled={false}
                             id="root_1__moveUp"
                             onClick={[Function]}
@@ -2502,7 +2502,7 @@ exports[`with title and description array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-down"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-down"
                             disabled={true}
                             id="root_1__moveDown"
                             onClick={[Function]}
@@ -2536,7 +2536,7 @@ exports[`with title and description array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-copy"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-copy"
                             disabled={false}
                             id="root_1__copy"
                             onClick={[Function]}
@@ -2570,7 +2570,7 @@ exports[`with title and description array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-remove"
                             disabled={false}
                             id="root_1__remove"
                             onClick={[Function]}
@@ -2637,7 +2637,7 @@ exports[`with title and description array icons 1`] = `
                         }
                       >
                         <button
-                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-add"
+                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-array-item-add"
                           disabled={false}
                           id="root__add"
                           onClick={[Function]}
@@ -2719,7 +2719,7 @@ exports[`with title and description checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2921,7 +2921,7 @@ exports[`with title and description fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2945,7 +2945,7 @@ exports[`with title and description fixed array 1`] = `
               className="ant-form-item-control-input-content"
             >
               <fieldset
-                className="field field-array field-array-fixed-items"
+                className="rjsf-field rjsf-field-array rjsf-field-array-fixed-items"
                 id="root"
               >
                 <div
@@ -3022,7 +3022,7 @@ exports[`with title and description fixed array 1`] = `
                         }
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3130,7 +3130,7 @@ exports[`with title and description fixed array 1`] = `
                         }
                       >
                         <div
-                          className="field-number"
+                          className="rjsf-field rjsf-field-number"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3340,7 +3340,7 @@ exports[`with title and description from both array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3364,7 +3364,7 @@ exports[`with title and description from both array 1`] = `
               className="ant-form-item-control-input-content"
             >
               <fieldset
-                className="field field-array field-array-of-string"
+                className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
                 id="root"
               >
                 <div
@@ -3450,7 +3450,7 @@ exports[`with title and description from both array 1`] = `
                         }
                       >
                         <button
-                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-add"
+                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-array-item-add"
                           disabled={false}
                           id="root__add"
                           onClick={[Function]}
@@ -3532,7 +3532,7 @@ exports[`with title and description from both array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3556,7 +3556,7 @@ exports[`with title and description from both array icons 1`] = `
               className="ant-form-item-control-input-content"
             >
               <fieldset
-                className="field field-array field-array-of-string"
+                className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
                 id="root"
               >
                 <div
@@ -3633,7 +3633,7 @@ exports[`with title and description from both array icons 1`] = `
                         }
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3738,7 +3738,7 @@ exports[`with title and description from both array icons 1`] = `
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-up"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-up"
                             disabled={true}
                             id="root_0__moveUp"
                             onClick={[Function]}
@@ -3772,7 +3772,7 @@ exports[`with title and description from both array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-down"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-down"
                             disabled={false}
                             id="root_0__moveDown"
                             onClick={[Function]}
@@ -3806,7 +3806,7 @@ exports[`with title and description from both array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-copy"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-copy"
                             disabled={false}
                             id="root_0__copy"
                             onClick={[Function]}
@@ -3840,7 +3840,7 @@ exports[`with title and description from both array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-remove"
                             disabled={false}
                             id="root_0__remove"
                             onClick={[Function]}
@@ -3897,7 +3897,7 @@ exports[`with title and description from both array icons 1`] = `
                         }
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4002,7 +4002,7 @@ exports[`with title and description from both array icons 1`] = `
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-up"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-up"
                             disabled={false}
                             id="root_1__moveUp"
                             onClick={[Function]}
@@ -4036,7 +4036,7 @@ exports[`with title and description from both array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-down"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-down"
                             disabled={true}
                             id="root_1__moveDown"
                             onClick={[Function]}
@@ -4070,7 +4070,7 @@ exports[`with title and description from both array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-copy"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-copy"
                             disabled={false}
                             id="root_1__copy"
                             onClick={[Function]}
@@ -4104,7 +4104,7 @@ exports[`with title and description from both array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-remove"
                             disabled={false}
                             id="root_1__remove"
                             onClick={[Function]}
@@ -4171,7 +4171,7 @@ exports[`with title and description from both array icons 1`] = `
                         }
                       >
                         <button
-                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-add"
+                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-array-item-add"
                           disabled={false}
                           id="root__add"
                           onClick={[Function]}
@@ -4253,7 +4253,7 @@ exports[`with title and description from both checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4455,7 +4455,7 @@ exports[`with title and description from both fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4479,7 +4479,7 @@ exports[`with title and description from both fixed array 1`] = `
               className="ant-form-item-control-input-content"
             >
               <fieldset
-                className="field field-array field-array-fixed-items"
+                className="rjsf-field rjsf-field-array rjsf-field-array-fixed-items"
                 id="root"
               >
                 <div
@@ -4556,7 +4556,7 @@ exports[`with title and description from both fixed array 1`] = `
                         }
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4664,7 +4664,7 @@ exports[`with title and description from both fixed array 1`] = `
                         }
                       >
                         <div
-                          className="field-number"
+                          className="rjsf-field rjsf-field-number"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4874,7 +4874,7 @@ exports[`with title and description from uiSchema array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4898,7 +4898,7 @@ exports[`with title and description from uiSchema array 1`] = `
               className="ant-form-item-control-input-content"
             >
               <fieldset
-                className="field field-array field-array-of-string"
+                className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
                 id="root"
               >
                 <div
@@ -4984,7 +4984,7 @@ exports[`with title and description from uiSchema array 1`] = `
                         }
                       >
                         <button
-                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-add"
+                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-array-item-add"
                           disabled={false}
                           id="root__add"
                           onClick={[Function]}
@@ -5066,7 +5066,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5090,7 +5090,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
               className="ant-form-item-control-input-content"
             >
               <fieldset
-                className="field field-array field-array-of-string"
+                className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
                 id="root"
               >
                 <div
@@ -5167,7 +5167,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                         }
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5272,7 +5272,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-up"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-up"
                             disabled={true}
                             id="root_0__moveUp"
                             onClick={[Function]}
@@ -5306,7 +5306,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-down"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-down"
                             disabled={false}
                             id="root_0__moveDown"
                             onClick={[Function]}
@@ -5340,7 +5340,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-copy"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-copy"
                             disabled={false}
                             id="root_0__copy"
                             onClick={[Function]}
@@ -5374,7 +5374,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-remove"
                             disabled={false}
                             id="root_0__remove"
                             onClick={[Function]}
@@ -5431,7 +5431,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                         }
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5536,7 +5536,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-up"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-up"
                             disabled={false}
                             id="root_1__moveUp"
                             onClick={[Function]}
@@ -5570,7 +5570,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-down"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-down"
                             disabled={true}
                             id="root_1__moveDown"
                             onClick={[Function]}
@@ -5604,7 +5604,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-copy"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-copy"
                             disabled={false}
                             id="root_1__copy"
                             onClick={[Function]}
@@ -5638,7 +5638,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-remove"
                             disabled={false}
                             id="root_1__remove"
                             onClick={[Function]}
@@ -5705,7 +5705,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                         }
                       >
                         <button
-                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-add"
+                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-array-item-add"
                           disabled={false}
                           id="root__add"
                           onClick={[Function]}
@@ -5787,7 +5787,7 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5989,7 +5989,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6013,7 +6013,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
               className="ant-form-item-control-input-content"
             >
               <fieldset
-                className="field field-array field-array-fixed-items"
+                className="rjsf-field rjsf-field-array rjsf-field-array-fixed-items"
                 id="root"
               >
                 <div
@@ -6090,7 +6090,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                         }
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6198,7 +6198,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                         }
                       >
                         <div
-                          className="field-number"
+                          className="rjsf-field rjsf-field-number"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6408,7 +6408,7 @@ exports[`with title and description with global label off array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6432,7 +6432,7 @@ exports[`with title and description with global label off array 1`] = `
               className="ant-form-item-control-input-content"
             >
               <fieldset
-                className="field field-array field-array-of-string"
+                className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
                 id="root"
               >
                 <div
@@ -6503,7 +6503,7 @@ exports[`with title and description with global label off array 1`] = `
                         }
                       >
                         <button
-                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-add"
+                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-array-item-add"
                           disabled={false}
                           id="root__add"
                           onClick={[Function]}
@@ -6585,7 +6585,7 @@ exports[`with title and description with global label off array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6609,7 +6609,7 @@ exports[`with title and description with global label off array icons 1`] = `
               className="ant-form-item-control-input-content"
             >
               <fieldset
-                className="field field-array field-array-of-string"
+                className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
                 id="root"
               >
                 <div
@@ -6671,7 +6671,7 @@ exports[`with title and description with global label off array icons 1`] = `
                         }
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6764,7 +6764,7 @@ exports[`with title and description with global label off array icons 1`] = `
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-up"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-up"
                             disabled={true}
                             id="root_0__moveUp"
                             onClick={[Function]}
@@ -6798,7 +6798,7 @@ exports[`with title and description with global label off array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-down"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-down"
                             disabled={false}
                             id="root_0__moveDown"
                             onClick={[Function]}
@@ -6832,7 +6832,7 @@ exports[`with title and description with global label off array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-copy"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-copy"
                             disabled={false}
                             id="root_0__copy"
                             onClick={[Function]}
@@ -6866,7 +6866,7 @@ exports[`with title and description with global label off array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-remove"
                             disabled={false}
                             id="root_0__remove"
                             onClick={[Function]}
@@ -6923,7 +6923,7 @@ exports[`with title and description with global label off array icons 1`] = `
                         }
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7016,7 +7016,7 @@ exports[`with title and description with global label off array icons 1`] = `
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-up"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-up"
                             disabled={false}
                             id="root_1__moveUp"
                             onClick={[Function]}
@@ -7050,7 +7050,7 @@ exports[`with title and description with global label off array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-move-down"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-move-down"
                             disabled={true}
                             id="root_1__moveDown"
                             onClick={[Function]}
@@ -7084,7 +7084,7 @@ exports[`with title and description with global label off array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-copy"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-default ant-btn-color-default ant-btn-variant-outlined ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-copy"
                             disabled={false}
                             id="root_1__copy"
                             onClick={[Function]}
@@ -7118,7 +7118,7 @@ exports[`with title and description with global label off array icons 1`] = `
                             </span>
                           </button>
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-compact-item ant-btn-compact-first-item ant-btn-compact-last-item rjsf-array-item-remove"
                             disabled={false}
                             id="root_1__remove"
                             onClick={[Function]}
@@ -7185,7 +7185,7 @@ exports[`with title and description with global label off array icons 1`] = `
                         }
                       >
                         <button
-                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-add"
+                          className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-array-item-add"
                           disabled={false}
                           id="root__add"
                           onClick={[Function]}
@@ -7267,7 +7267,7 @@ exports[`with title and description with global label off checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7469,7 +7469,7 @@ exports[`with title and description with global label off fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7493,7 +7493,7 @@ exports[`with title and description with global label off fixed array 1`] = `
               className="ant-form-item-control-input-content"
             >
               <fieldset
-                className="field field-array field-array-fixed-items"
+                className="rjsf-field rjsf-field-array rjsf-field-array-fixed-items"
                 id="root"
               >
                 <div
@@ -7555,7 +7555,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                         }
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7651,7 +7651,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                         }
                       >
                         <div
-                          className="field-number"
+                          className="rjsf-field rjsf-field-number"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"

--- a/packages/antd/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Array.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -151,7 +151,7 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -218,7 +218,7 @@ exports[`array fields array icons 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -456,7 +456,7 @@ exports[`array fields array icons 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -772,7 +772,7 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -948,7 +948,7 @@ exports[`array fields empty errors array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -994,7 +994,7 @@ exports[`array fields empty errors array 1`] = `
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1095,7 +1095,7 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1162,7 +1162,7 @@ exports[`array fields fixed array 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1244,7 +1244,7 @@ exports[`array fields fixed array 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-number"
+                          className="field-number"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1487,7 +1487,7 @@ exports[`array fields has errors 1`] = `
     </div>
   </div>
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1533,7 +1533,7 @@ exports[`array fields has errors 1`] = `
                     }
                   >
                     <div
-                      className="form-group field field-string field-error has-error has-danger"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2 ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
@@ -1659,7 +1659,7 @@ exports[`array fields no errors 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1705,7 +1705,7 @@ exports[`array fields no errors 1`] = `
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1806,7 +1806,7 @@ exports[`with title and description array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1998,7 +1998,7 @@ exports[`with title and description array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2099,7 +2099,7 @@ exports[`with title and description array icons 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2363,7 +2363,7 @@ exports[`with title and description array icons 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2719,7 +2719,7 @@ exports[`with title and description checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2921,7 +2921,7 @@ exports[`with title and description fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3022,7 +3022,7 @@ exports[`with title and description fixed array 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3130,7 +3130,7 @@ exports[`with title and description fixed array 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-number"
+                          className="field-number"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3340,7 +3340,7 @@ exports[`with title and description from both array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3532,7 +3532,7 @@ exports[`with title and description from both array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3633,7 +3633,7 @@ exports[`with title and description from both array icons 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3897,7 +3897,7 @@ exports[`with title and description from both array icons 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4253,7 +4253,7 @@ exports[`with title and description from both checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4455,7 +4455,7 @@ exports[`with title and description from both fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4556,7 +4556,7 @@ exports[`with title and description from both fixed array 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4664,7 +4664,7 @@ exports[`with title and description from both fixed array 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-number"
+                          className="field-number"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4874,7 +4874,7 @@ exports[`with title and description from uiSchema array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5066,7 +5066,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5167,7 +5167,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5431,7 +5431,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5787,7 +5787,7 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5989,7 +5989,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6090,7 +6090,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6198,7 +6198,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-number"
+                          className="field-number"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6408,7 +6408,7 @@ exports[`with title and description with global label off array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6585,7 +6585,7 @@ exports[`with title and description with global label off array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6671,7 +6671,7 @@ exports[`with title and description with global label off array icons 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6923,7 +6923,7 @@ exports[`with title and description with global label off array icons 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7267,7 +7267,7 @@ exports[`with title and description with global label off checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7469,7 +7469,7 @@ exports[`with title and description with global label off fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7555,7 +7555,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7651,7 +7651,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                         }
                       >
                         <div
-                          className="form-group field field-number"
+                          className="field-number"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"

--- a/packages/antd/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Form.test.tsx.snap
@@ -1310,7 +1310,7 @@ exports[`single fields help and error display 1`] = `
     </div>
   </div>
   <div
-    className="rjsf-field rjsf-field-string"
+    className="rjsf-field rjsf-field-string rjsf-field-error"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2 ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"

--- a/packages/antd/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Form.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`antd specific tests descriptionLocation tooltip in formContext 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -53,7 +53,7 @@ exports[`antd specific tests descriptionLocation tooltip in formContext 1`] = `
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -184,7 +184,7 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -264,7 +264,7 @@ exports[`single fields checkbox field with label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -346,7 +346,7 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -549,7 +549,7 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -595,7 +595,7 @@ exports[`single fields field with description 1`] = `
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -710,7 +710,7 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -756,7 +756,7 @@ exports[`single fields field with description in uiSchema 1`] = `
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -871,7 +871,7 @@ exports[`single fields format color 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -951,7 +951,7 @@ exports[`single fields format date 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1054,7 +1054,7 @@ exports[`single fields format datetime 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1157,7 +1157,7 @@ exports[`single fields format time 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1310,7 +1310,7 @@ exports[`single fields help and error display 1`] = `
     </div>
   </div>
   <div
-    className="form-group field field-string field-error has-error has-danger"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2 ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
@@ -1415,7 +1415,7 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1479,7 +1479,7 @@ exports[`single fields hidden label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1559,7 +1559,7 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-null"
+    className="field-null"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1608,7 +1608,7 @@ exports[`single fields number field 0 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1767,7 +1767,7 @@ exports[`single fields number field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1926,7 +1926,7 @@ exports[`single fields password field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2029,7 +2029,7 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2147,7 +2147,7 @@ exports[`single fields schema examples 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2247,7 +2247,7 @@ exports[`single fields select field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2392,7 +2392,7 @@ exports[`single fields select field multiple choice 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2568,7 +2568,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2744,7 +2744,7 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2935,7 +2935,7 @@ exports[`single fields select field multiple choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3224,7 +3224,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3400,7 +3400,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3545,7 +3545,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3663,7 +3663,7 @@ exports[`single fields select field single choice form disabled using radio widg
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3781,7 +3781,7 @@ exports[`single fields select field single choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3929,7 +3929,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4047,7 +4047,7 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-integer"
+    className="field-integer"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4149,7 +4149,7 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4231,7 +4231,7 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4311,7 +4311,7 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4391,7 +4391,7 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4471,7 +4471,7 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4551,7 +4551,7 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4641,7 +4641,7 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4705,7 +4705,7 @@ exports[`single fields title field 1`] = `
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4806,7 +4806,7 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-undefined"
+    className="field-undefined"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4876,7 +4876,7 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5035,7 +5035,7 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"

--- a/packages/antd/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Form.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`antd specific tests descriptionLocation tooltip in formContext 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -53,7 +53,7 @@ exports[`antd specific tests descriptionLocation tooltip in formContext 1`] = `
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -184,7 +184,7 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -264,7 +264,7 @@ exports[`single fields checkbox field with label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -346,7 +346,7 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -549,7 +549,7 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -595,7 +595,7 @@ exports[`single fields field with description 1`] = `
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -710,7 +710,7 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -756,7 +756,7 @@ exports[`single fields field with description in uiSchema 1`] = `
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -871,7 +871,7 @@ exports[`single fields format color 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -951,7 +951,7 @@ exports[`single fields format date 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1054,7 +1054,7 @@ exports[`single fields format datetime 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1157,7 +1157,7 @@ exports[`single fields format time 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1310,7 +1310,7 @@ exports[`single fields help and error display 1`] = `
     </div>
   </div>
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2 ant-form-item-with-help ant-form-item-has-feedback ant-form-item-has-error"
@@ -1415,7 +1415,7 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1479,7 +1479,7 @@ exports[`single fields hidden label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1559,7 +1559,7 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-null"
+    className="rjsf-field rjsf-field-null"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1608,7 +1608,7 @@ exports[`single fields number field 0 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1767,7 +1767,7 @@ exports[`single fields number field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1926,7 +1926,7 @@ exports[`single fields password field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2029,7 +2029,7 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2147,7 +2147,7 @@ exports[`single fields schema examples 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2247,7 +2247,7 @@ exports[`single fields select field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2392,7 +2392,7 @@ exports[`single fields select field multiple choice 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2568,7 +2568,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2744,7 +2744,7 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2935,7 +2935,7 @@ exports[`single fields select field multiple choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3224,7 +3224,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3400,7 +3400,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3545,7 +3545,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3663,7 +3663,7 @@ exports[`single fields select field single choice form disabled using radio widg
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3781,7 +3781,7 @@ exports[`single fields select field single choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3929,7 +3929,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4047,7 +4047,7 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-integer"
+    className="rjsf-field rjsf-field-integer"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4149,7 +4149,7 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4231,7 +4231,7 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4311,7 +4311,7 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4391,7 +4391,7 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4471,7 +4471,7 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4551,7 +4551,7 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4641,7 +4641,7 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4705,7 +4705,7 @@ exports[`single fields title field 1`] = `
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4806,7 +4806,7 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-undefined"
+    className="rjsf-field rjsf-field-undefined"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4876,7 +4876,7 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5035,7 +5035,7 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"

--- a/packages/antd/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/GridSnap.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -54,7 +54,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     style={{}}
                   >
                     <div
-                      className="form-group field field-object"
+                      className="field-object"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -115,7 +115,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -198,7 +198,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -281,7 +281,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -376,7 +376,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -482,7 +482,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-array"
+                      className="field-array"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -735,7 +735,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-object"
+                      className="field-object"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -773,7 +773,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="form-group field field-string"
+                                      className="field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -851,7 +851,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="form-group field field-string"
+                                      className="field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -929,7 +929,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="form-group field field-string"
+                                      className="field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1023,7 +1023,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                       }
                                     >
                                       <div
-                                        className="form-group field field-string"
+                                        className="field-string"
                                       >
                                         <div
                                           className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1171,7 +1171,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                       }
                                     >
                                       <div
-                                        className="form-group field field-string"
+                                        className="field-string"
                                       >
                                         <div
                                           className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1425,7 +1425,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         style={{}}
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1503,7 +1503,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         style={{}}
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1597,7 +1597,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                           }
                         >
                           <div
-                            className="form-group field field-string"
+                            className="field-string"
                           >
                             <div
                               className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1680,7 +1680,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                           }
                         >
                           <div
-                            className="form-group field field-string"
+                            className="field-string"
                           >
                             <div
                               className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1849,7 +1849,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1896,7 +1896,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     style={{}}
                   >
                     <div
-                      className="form-group field field-object"
+                      className="field-object"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1957,7 +1957,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2040,7 +2040,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2123,7 +2123,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2218,7 +2218,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2324,7 +2324,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-array"
+                      className="field-array"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2577,7 +2577,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-object"
+                      className="field-object"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2615,7 +2615,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="form-group field field-string"
+                                      className="field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2693,7 +2693,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="form-group field field-string"
+                                      className="field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2771,7 +2771,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="form-group field field-string"
+                                      className="field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2865,7 +2865,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                       }
                                     >
                                       <div
-                                        className="form-group field field-string"
+                                        className="field-string"
                                       >
                                         <div
                                           className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3013,7 +3013,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                       }
                                     >
                                       <div
-                                        className="form-group field field-string"
+                                        className="field-string"
                                       >
                                         <div
                                           className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3267,7 +3267,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         style={{}}
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3345,7 +3345,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         style={{}}
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3423,7 +3423,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         style={{}}
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3517,7 +3517,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                           }
                         >
                           <div
-                            className="form-group field field-string"
+                            className="field-string"
                           >
                             <div
                               className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3600,7 +3600,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                           }
                         >
                           <div
-                            className="form-group field field-string"
+                            className="field-string"
                           >
                             <div
                               className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3769,7 +3769,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3816,7 +3816,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     style={{}}
                   >
                     <div
-                      className="form-group field field-object"
+                      className="field-object"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3877,7 +3877,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3960,7 +3960,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4043,7 +4043,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4138,7 +4138,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4244,7 +4244,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-array"
+                      className="field-array"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4497,7 +4497,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-object"
+                      className="field-object"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4535,7 +4535,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="form-group field field-string"
+                                      className="field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4613,7 +4613,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="form-group field field-string"
+                                      className="field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4691,7 +4691,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="form-group field field-string"
+                                      className="field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4785,7 +4785,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                       }
                                     >
                                       <div
-                                        className="form-group field field-string"
+                                        className="field-string"
                                       >
                                         <div
                                           className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4933,7 +4933,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                       }
                                     >
                                       <div
-                                        className="form-group field field-string"
+                                        className="field-string"
                                       >
                                         <div
                                           className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5187,7 +5187,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         style={{}}
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5300,7 +5300,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5347,7 +5347,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     style={{}}
                   >
                     <div
-                      className="form-group field field-object"
+                      className="field-object"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5408,7 +5408,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5491,7 +5491,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5574,7 +5574,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5669,7 +5669,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5775,7 +5775,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-array"
+                      className="field-array"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6028,7 +6028,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-object"
+                      className="field-object"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6066,7 +6066,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="form-group field field-string"
+                                      className="field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6144,7 +6144,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="form-group field field-string"
+                                      className="field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6222,7 +6222,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="form-group field field-string"
+                                      className="field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6316,7 +6316,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                       }
                                     >
                                       <div
-                                        className="form-group field field-string"
+                                        className="field-string"
                                       >
                                         <div
                                           className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6464,7 +6464,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                       }
                                     >
                                       <div
-                                        className="form-group field field-string"
+                                        className="field-string"
                                       >
                                         <div
                                           className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6718,7 +6718,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         style={{}}
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6796,7 +6796,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         style={{}}
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6890,7 +6890,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                           }
                         >
                           <div
-                            className="form-group field field-string"
+                            className="field-string"
                           >
                             <div
                               className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6973,7 +6973,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                           }
                         >
                           <div
-                            className="form-group field field-string"
+                            className="field-string"
                           >
                             <div
                               className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7142,7 +7142,7 @@ exports[`Three even column grid renders person and address in three columns, no 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7180,7 +7180,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="form-group field field-object"
+                    className="field-object"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7224,7 +7224,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7302,7 +7302,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7380,7 +7380,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7458,7 +7458,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7559,7 +7559,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="form-group field field-array"
+                    className="field-array"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7795,7 +7795,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7873,7 +7873,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7951,7 +7951,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8029,7 +8029,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8199,7 +8199,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8237,7 +8237,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="form-group field field-object"
+                    className="field-object"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8281,7 +8281,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8359,7 +8359,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8437,7 +8437,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8515,7 +8515,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8616,7 +8616,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="form-group field field-array"
+                    className="field-array"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8852,7 +8852,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8930,7 +8930,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -9008,7 +9008,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -9086,7 +9086,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"

--- a/packages/antd/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/GridSnap.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -54,7 +54,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     style={{}}
                   >
                     <div
-                      className="field-object"
+                      className="rjsf-field rjsf-field-object"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -115,7 +115,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -198,7 +198,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -281,7 +281,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -376,7 +376,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -482,7 +482,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-array"
+                      className="rjsf-field rjsf-field-array"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -735,7 +735,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-object"
+                      className="rjsf-field rjsf-field-object"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -773,7 +773,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="field-string"
+                                      className="rjsf-field rjsf-field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -851,7 +851,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="field-string"
+                                      className="rjsf-field rjsf-field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -929,7 +929,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="field-string"
+                                      className="rjsf-field rjsf-field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1023,7 +1023,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                       }
                                     >
                                       <div
-                                        className="field-string"
+                                        className="rjsf-field rjsf-field-string"
                                       >
                                         <div
                                           className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1171,7 +1171,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                       }
                                     >
                                       <div
-                                        className="field-string"
+                                        className="rjsf-field rjsf-field-string"
                                       >
                                         <div
                                           className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1425,7 +1425,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         style={{}}
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1503,7 +1503,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         style={{}}
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1597,7 +1597,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                           }
                         >
                           <div
-                            className="field-string"
+                            className="rjsf-field rjsf-field-string"
                           >
                             <div
                               className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1680,7 +1680,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                           }
                         >
                           <div
-                            className="field-string"
+                            className="rjsf-field rjsf-field-string"
                           >
                             <div
                               className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1849,7 +1849,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1896,7 +1896,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     style={{}}
                   >
                     <div
-                      className="field-object"
+                      className="rjsf-field rjsf-field-object"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1957,7 +1957,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2040,7 +2040,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2123,7 +2123,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2218,7 +2218,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2324,7 +2324,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-array"
+                      className="rjsf-field rjsf-field-array"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2577,7 +2577,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-object"
+                      className="rjsf-field rjsf-field-object"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2615,7 +2615,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="field-string"
+                                      className="rjsf-field rjsf-field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2693,7 +2693,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="field-string"
+                                      className="rjsf-field rjsf-field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2771,7 +2771,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="field-string"
+                                      className="rjsf-field rjsf-field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2865,7 +2865,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                       }
                                     >
                                       <div
-                                        className="field-string"
+                                        className="rjsf-field rjsf-field-string"
                                       >
                                         <div
                                           className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3013,7 +3013,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                       }
                                     >
                                       <div
-                                        className="field-string"
+                                        className="rjsf-field rjsf-field-string"
                                       >
                                         <div
                                           className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3267,7 +3267,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         style={{}}
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3345,7 +3345,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         style={{}}
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3423,7 +3423,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         style={{}}
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3517,7 +3517,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                           }
                         >
                           <div
-                            className="field-string"
+                            className="rjsf-field rjsf-field-string"
                           >
                             <div
                               className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3600,7 +3600,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                           }
                         >
                           <div
-                            className="field-string"
+                            className="rjsf-field rjsf-field-string"
                           >
                             <div
                               className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3769,7 +3769,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3816,7 +3816,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     style={{}}
                   >
                     <div
-                      className="field-object"
+                      className="rjsf-field rjsf-field-object"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3877,7 +3877,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3960,7 +3960,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4043,7 +4043,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4138,7 +4138,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4244,7 +4244,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-array"
+                      className="rjsf-field rjsf-field-array"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4497,7 +4497,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-object"
+                      className="rjsf-field rjsf-field-object"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4535,7 +4535,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="field-string"
+                                      className="rjsf-field rjsf-field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4613,7 +4613,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="field-string"
+                                      className="rjsf-field rjsf-field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4691,7 +4691,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="field-string"
+                                      className="rjsf-field rjsf-field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4785,7 +4785,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                       }
                                     >
                                       <div
-                                        className="field-string"
+                                        className="rjsf-field rjsf-field-string"
                                       >
                                         <div
                                           className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4933,7 +4933,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                       }
                                     >
                                       <div
-                                        className="field-string"
+                                        className="rjsf-field rjsf-field-string"
                                       >
                                         <div
                                           className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5187,7 +5187,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         style={{}}
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5300,7 +5300,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5347,7 +5347,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     style={{}}
                   >
                     <div
-                      className="field-object"
+                      className="rjsf-field rjsf-field-object"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5408,7 +5408,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5491,7 +5491,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5574,7 +5574,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5669,7 +5669,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -5775,7 +5775,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-array"
+                      className="rjsf-field rjsf-field-array"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6028,7 +6028,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-object"
+                      className="rjsf-field rjsf-field-object"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6066,7 +6066,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="field-string"
+                                      className="rjsf-field rjsf-field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6144,7 +6144,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="field-string"
+                                      className="rjsf-field rjsf-field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6222,7 +6222,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     style={{}}
                                   >
                                     <div
-                                      className="field-string"
+                                      className="rjsf-field rjsf-field-string"
                                     >
                                       <div
                                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6316,7 +6316,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                       }
                                     >
                                       <div
-                                        className="field-string"
+                                        className="rjsf-field rjsf-field-string"
                                       >
                                         <div
                                           className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6464,7 +6464,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                       }
                                     >
                                       <div
-                                        className="field-string"
+                                        className="rjsf-field rjsf-field-string"
                                       >
                                         <div
                                           className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6718,7 +6718,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         style={{}}
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6796,7 +6796,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         style={{}}
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <div
                             className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6890,7 +6890,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                           }
                         >
                           <div
-                            className="field-string"
+                            className="rjsf-field rjsf-field-string"
                           >
                             <div
                               className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -6973,7 +6973,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                           }
                         >
                           <div
-                            className="field-string"
+                            className="rjsf-field rjsf-field-string"
                           >
                             <div
                               className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7142,7 +7142,7 @@ exports[`Three even column grid renders person and address in three columns, no 
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7180,7 +7180,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="field-object"
+                    className="rjsf-field rjsf-field-object"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7224,7 +7224,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7302,7 +7302,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7380,7 +7380,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7458,7 +7458,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7559,7 +7559,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="field-array"
+                    className="rjsf-field rjsf-field-array"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7795,7 +7795,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7873,7 +7873,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -7951,7 +7951,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8029,7 +8029,7 @@ exports[`Three even column grid renders person and address in three columns, no 
                   style={{}}
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8199,7 +8199,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8237,7 +8237,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="field-object"
+                    className="rjsf-field rjsf-field-object"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8281,7 +8281,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8359,7 +8359,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8437,7 +8437,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8515,7 +8515,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8616,7 +8616,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="field-array"
+                    className="rjsf-field rjsf-field-array"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8852,7 +8852,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -8930,7 +8930,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -9008,7 +9008,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -9086,7 +9086,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
                   style={{}}
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"

--- a/packages/antd/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Object.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -53,7 +53,7 @@ exports[`object fields additionalProperties 1`] = `
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-row ant-row-top css-dev-only-do-not-override-1d4w9r2"
@@ -366,7 +366,7 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -412,7 +412,7 @@ exports[`object fields object 1`] = `
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -494,7 +494,7 @@ exports[`object fields object 1`] = `
                     }
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -674,7 +674,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -720,7 +720,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-row ant-row-top css-dev-only-do-not-override-1d4w9r2"
@@ -1033,7 +1033,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1113,7 +1113,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-row ant-row-top css-dev-only-do-not-override-1d4w9r2"
@@ -1440,7 +1440,7 @@ exports[`object fields with title and description from both additionalProperties
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1520,7 +1520,7 @@ exports[`object fields with title and description from both additionalProperties
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-row ant-row-top css-dev-only-do-not-override-1d4w9r2"
@@ -1847,7 +1847,7 @@ exports[`object fields with title and description from both object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1927,7 +1927,7 @@ exports[`object fields with title and description from both object 1`] = `
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2023,7 +2023,7 @@ exports[`object fields with title and description from both object 1`] = `
                     }
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2231,7 +2231,7 @@ exports[`object fields with title and description from uiSchema additionalProper
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2311,7 +2311,7 @@ exports[`object fields with title and description from uiSchema additionalProper
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-row ant-row-top css-dev-only-do-not-override-1d4w9r2"
@@ -2638,7 +2638,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2718,7 +2718,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2814,7 +2814,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
                     }
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3022,7 +3022,7 @@ exports[`object fields with title and description from uiSchema show add button 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3102,7 +3102,7 @@ exports[`object fields with title and description from uiSchema show add button 
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-row ant-row-top css-dev-only-do-not-override-1d4w9r2"
@@ -3429,7 +3429,7 @@ exports[`object fields with title and description object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3509,7 +3509,7 @@ exports[`object fields with title and description object 1`] = `
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3605,7 +3605,7 @@ exports[`object fields with title and description object 1`] = `
                     }
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3813,7 +3813,7 @@ exports[`object fields with title and description show add button and fields if 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3893,7 +3893,7 @@ exports[`object fields with title and description show add button and fields if 
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-row ant-row-top css-dev-only-do-not-override-1d4w9r2"
@@ -4220,7 +4220,7 @@ exports[`object fields with title and description with global label off addition
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4266,7 +4266,7 @@ exports[`object fields with title and description with global label off addition
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-row ant-row-top css-dev-only-do-not-override-1d4w9r2"
@@ -4581,7 +4581,7 @@ exports[`object fields with title and description with global label off object 1
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4627,7 +4627,7 @@ exports[`object fields with title and description with global label off object 1
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4711,7 +4711,7 @@ exports[`object fields with title and description with global label off object 1
                     }
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4907,7 +4907,7 @@ exports[`object fields with title and description with global label off show add
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4953,7 +4953,7 @@ exports[`object fields with title and description with global label off show add
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="ant-row ant-row-top css-dev-only-do-not-override-1d4w9r2"

--- a/packages/antd/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Object.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -53,7 +53,7 @@ exports[`object fields additionalProperties 1`] = `
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-row ant-row-top css-dev-only-do-not-override-1d4w9r2"
@@ -236,7 +236,7 @@ exports[`object fields additionalProperties 1`] = `
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-object-property-remove"
                             disabled={false}
                             id="root_foo__remove"
                             onClick={[Function]}
@@ -299,7 +299,7 @@ exports[`object fields additionalProperties 1`] = `
                       }
                     >
                       <button
-                        className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block object-property-expand"
+                        className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-object-property-expand"
                         disabled={false}
                         id="root__add"
                         onClick={[Function]}
@@ -366,7 +366,7 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -412,7 +412,7 @@ exports[`object fields object 1`] = `
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -494,7 +494,7 @@ exports[`object fields object 1`] = `
                     }
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -674,7 +674,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -720,7 +720,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-row ant-row-top css-dev-only-do-not-override-1d4w9r2"
@@ -903,7 +903,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-object-property-remove"
                             disabled={false}
                             id="root_additionalProperty__remove"
                             onClick={[Function]}
@@ -966,7 +966,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
                       }
                     >
                       <button
-                        className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block object-property-expand"
+                        className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-object-property-expand"
                         disabled={false}
                         id="root__add"
                         onClick={[Function]}
@@ -1033,7 +1033,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1113,7 +1113,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-row ant-row-top css-dev-only-do-not-override-1d4w9r2"
@@ -1296,7 +1296,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-object-property-remove"
                             disabled={false}
                             id="root_foo__remove"
                             onClick={[Function]}
@@ -1359,7 +1359,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
                       }
                     >
                       <button
-                        className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block object-property-expand"
+                        className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-object-property-expand"
                         disabled={false}
                         id="root__add"
                         onClick={[Function]}
@@ -1440,7 +1440,7 @@ exports[`object fields with title and description from both additionalProperties
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1520,7 +1520,7 @@ exports[`object fields with title and description from both additionalProperties
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-row ant-row-top css-dev-only-do-not-override-1d4w9r2"
@@ -1703,7 +1703,7 @@ exports[`object fields with title and description from both additionalProperties
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-object-property-remove"
                             disabled={false}
                             id="root_foo__remove"
                             onClick={[Function]}
@@ -1766,7 +1766,7 @@ exports[`object fields with title and description from both additionalProperties
                       }
                     >
                       <button
-                        className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block object-property-expand"
+                        className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-object-property-expand"
                         disabled={false}
                         id="root__add"
                         onClick={[Function]}
@@ -1847,7 +1847,7 @@ exports[`object fields with title and description from both object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -1927,7 +1927,7 @@ exports[`object fields with title and description from both object 1`] = `
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2023,7 +2023,7 @@ exports[`object fields with title and description from both object 1`] = `
                     }
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2231,7 +2231,7 @@ exports[`object fields with title and description from uiSchema additionalProper
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2311,7 +2311,7 @@ exports[`object fields with title and description from uiSchema additionalProper
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-row ant-row-top css-dev-only-do-not-override-1d4w9r2"
@@ -2494,7 +2494,7 @@ exports[`object fields with title and description from uiSchema additionalProper
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-object-property-remove"
                             disabled={false}
                             id="root_foo__remove"
                             onClick={[Function]}
@@ -2557,7 +2557,7 @@ exports[`object fields with title and description from uiSchema additionalProper
                       }
                     >
                       <button
-                        className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block object-property-expand"
+                        className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-object-property-expand"
                         disabled={false}
                         id="root__add"
                         onClick={[Function]}
@@ -2638,7 +2638,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2718,7 +2718,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -2814,7 +2814,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
                     }
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3022,7 +3022,7 @@ exports[`object fields with title and description from uiSchema show add button 
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3102,7 +3102,7 @@ exports[`object fields with title and description from uiSchema show add button 
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-row ant-row-top css-dev-only-do-not-override-1d4w9r2"
@@ -3285,7 +3285,7 @@ exports[`object fields with title and description from uiSchema show add button 
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-object-property-remove"
                             disabled={false}
                             id="root_additionalProperty__remove"
                             onClick={[Function]}
@@ -3348,7 +3348,7 @@ exports[`object fields with title and description from uiSchema show add button 
                       }
                     >
                       <button
-                        className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block object-property-expand"
+                        className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-object-property-expand"
                         disabled={false}
                         id="root__add"
                         onClick={[Function]}
@@ -3429,7 +3429,7 @@ exports[`object fields with title and description object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3509,7 +3509,7 @@ exports[`object fields with title and description object 1`] = `
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3605,7 +3605,7 @@ exports[`object fields with title and description object 1`] = `
                     }
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3813,7 +3813,7 @@ exports[`object fields with title and description show add button and fields if 
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -3893,7 +3893,7 @@ exports[`object fields with title and description show add button and fields if 
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-row ant-row-top css-dev-only-do-not-override-1d4w9r2"
@@ -4076,7 +4076,7 @@ exports[`object fields with title and description show add button and fields if 
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-object-property-remove"
                             disabled={false}
                             id="root_additionalProperty__remove"
                             onClick={[Function]}
@@ -4139,7 +4139,7 @@ exports[`object fields with title and description show add button and fields if 
                       }
                     >
                       <button
-                        className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block object-property-expand"
+                        className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-object-property-expand"
                         disabled={false}
                         id="root__add"
                         onClick={[Function]}
@@ -4220,7 +4220,7 @@ exports[`object fields with title and description with global label off addition
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4266,7 +4266,7 @@ exports[`object fields with title and description with global label off addition
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-row ant-row-top css-dev-only-do-not-override-1d4w9r2"
@@ -4437,7 +4437,7 @@ exports[`object fields with title and description with global label off addition
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-object-property-remove"
                             disabled={false}
                             id="root_foo__remove"
                             onClick={[Function]}
@@ -4500,7 +4500,7 @@ exports[`object fields with title and description with global label off addition
                       }
                     >
                       <button
-                        className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block object-property-expand"
+                        className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-object-property-expand"
                         disabled={false}
                         id="root__add"
                         onClick={[Function]}
@@ -4581,7 +4581,7 @@ exports[`object fields with title and description with global label off object 1
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4627,7 +4627,7 @@ exports[`object fields with title and description with global label off object 1
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4711,7 +4711,7 @@ exports[`object fields with title and description with global label off object 1
                     }
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div
                         className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4907,7 +4907,7 @@ exports[`object fields with title and description with global label off show add
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="ant-form-item css-dev-only-do-not-override-1d4w9r2"
@@ -4953,7 +4953,7 @@ exports[`object fields with title and description with global label off show add
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="ant-row ant-row-top css-dev-only-do-not-override-1d4w9r2"
@@ -5124,7 +5124,7 @@ exports[`object fields with title and description with global label off show add
                           }
                         >
                           <button
-                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-block array-item-remove"
+                            className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-dangerous ant-btn-color-dangerous ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-object-property-remove"
                             disabled={false}
                             id="root_additionalProperty__remove"
                             onClick={[Function]}
@@ -5187,7 +5187,7 @@ exports[`object fields with title and description with global label off show add
                       }
                     >
                       <button
-                        className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block object-property-expand"
+                        className="ant-btn css-dev-only-do-not-override-1d4w9r2 ant-btn-primary ant-btn-color-primary ant-btn-variant-solid ant-btn-icon-only ant-btn-block rjsf-object-property-expand"
                         disabled={false}
                         id="root__add"
                         onClick={[Function]}

--- a/packages/chakra-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/chakra-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -66,7 +66,7 @@ export default function ArrayFieldTemplate<
             <Box mt={2}>
               <AddButton
                 id={buttonId<T>(idSchema, 'add')}
-                className='array-item-add'
+                className='rjsf-array-item-add'
                 onClick={onAddClick}
                 disabled={disabled || readonly}
                 uiSchema={uiSchema}

--- a/packages/chakra-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/chakra-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -76,7 +76,7 @@ export default function ObjectFieldTemplate<
           <GridItem justifySelf='flex-end'>
             <AddButton
               id={buttonId<T>(idSchema, 'add')}
-              className='object-property-expand'
+              className='rjsf-object-property-expand'
               onClick={onAddClick(schema)}
               disabled={disabled || readonly}
               uiSchema={uiSchema}

--- a/packages/chakra-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/chakra-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -66,7 +66,7 @@ export default function WrapIfAdditionalTemplate<
       <GridItem>
         <RemoveButton
           id={buttonId<T>(id, 'remove')}
-          className='array-item-remove'
+          className='rjsf-object-property-remove'
           disabled={disabled || readonly}
           onClick={onDropPropertyClick(label)}
           uiSchema={uiSchema}

--- a/packages/chakra-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Array.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -163,7 +163,7 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -190,7 +190,7 @@ exports[`array fields array icons 1`] = `
                   className="emotion-6"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -372,7 +372,7 @@ exports[`array fields array icons 1`] = `
                   className="emotion-6"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -633,7 +633,7 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -954,7 +954,7 @@ exports[`array fields empty errors array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -972,7 +972,7 @@ exports[`array fields empty errors array 1`] = `
             className="emotion-3"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -1076,7 +1076,7 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1103,7 +1103,7 @@ exports[`array fields fixed array 1`] = `
                   className="emotion-6"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -1153,7 +1153,7 @@ exports[`array fields fixed array 1`] = `
                   className="emotion-6"
                 >
                   <div
-                    className="form-group field field-number"
+                    className="field-number"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -1320,7 +1320,7 @@ exports[`array fields has errors 1`] = `
     </div>
   </div>
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-9"
@@ -1338,7 +1338,7 @@ exports[`array fields has errors 1`] = `
             className="emotion-12"
           >
             <div
-              className="form-group field field-string field-error has-error has-danger"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-9"
@@ -1455,7 +1455,7 @@ exports[`array fields no errors 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1473,7 +1473,7 @@ exports[`array fields no errors 1`] = `
             className="emotion-3"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -1573,7 +1573,7 @@ exports[`with title and description array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1747,7 +1747,7 @@ exports[`with title and description array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1795,7 +1795,7 @@ exports[`with title and description array icons 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -2004,7 +2004,7 @@ exports[`with title and description array icons 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -2300,7 +2300,7 @@ exports[`with title and description checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2670,7 +2670,7 @@ exports[`with title and description fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2718,7 +2718,7 @@ exports[`with title and description fixed array 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -2795,7 +2795,7 @@ exports[`with title and description fixed array 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="form-group field field-number"
+                    className="field-number"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -2918,7 +2918,7 @@ exports[`with title and description from both array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -3092,7 +3092,7 @@ exports[`with title and description from both array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -3140,7 +3140,7 @@ exports[`with title and description from both array icons 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -3349,7 +3349,7 @@ exports[`with title and description from both array icons 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -3645,7 +3645,7 @@ exports[`with title and description from both checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -4015,7 +4015,7 @@ exports[`with title and description from both fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -4063,7 +4063,7 @@ exports[`with title and description from both fixed array 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -4140,7 +4140,7 @@ exports[`with title and description from both fixed array 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="form-group field field-number"
+                    className="field-number"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -4263,7 +4263,7 @@ exports[`with title and description from uiSchema array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -4437,7 +4437,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -4485,7 +4485,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -4694,7 +4694,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -4990,7 +4990,7 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5360,7 +5360,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5408,7 +5408,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -5485,7 +5485,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="form-group field field-number"
+                    className="field-number"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -5599,7 +5599,7 @@ exports[`with title and description with global label off array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5739,7 +5739,7 @@ exports[`with title and description with global label off array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5766,7 +5766,7 @@ exports[`with title and description with global label off array icons 1`] = `
                   className="emotion-6"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -5948,7 +5948,7 @@ exports[`with title and description with global label off array icons 1`] = `
                   className="emotion-6"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -6217,7 +6217,7 @@ exports[`with title and description with global label off checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -6574,7 +6574,7 @@ exports[`with title and description with global label off fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -6601,7 +6601,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                   className="emotion-6"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -6651,7 +6651,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                   className="emotion-6"
                 >
                   <div
-                    className="form-group field field-number"
+                    className="field-number"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"

--- a/packages/chakra-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Array.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -50,7 +50,7 @@ exports[`array fields array 1`] = `
                 className="emotion-6"
               >
                 <button
-                  className="chakra-button array-item-add emotion-7"
+                  className="chakra-button rjsf-array-item-add emotion-7"
                   disabled={false}
                   id="root__add"
                   onClick={[Function]}
@@ -163,7 +163,7 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -190,7 +190,7 @@ exports[`array fields array icons 1`] = `
                   className="emotion-6"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -240,7 +240,7 @@ exports[`array fields array icons 1`] = `
                   >
                     <button
                       aria-label="Move up"
-                      className="chakra-button array-item-move-up emotion-13"
+                      className="chakra-button rjsf-array-item-move-up emotion-13"
                       disabled={true}
                       id="root_0__moveUp"
                       onClick={[Function]}
@@ -269,7 +269,7 @@ exports[`array fields array icons 1`] = `
                     </button>
                     <button
                       aria-label="Move down"
-                      className="chakra-button array-item-move-down emotion-13"
+                      className="chakra-button rjsf-array-item-move-down emotion-13"
                       disabled={false}
                       id="root_0__moveDown"
                       onClick={[Function]}
@@ -298,7 +298,7 @@ exports[`array fields array icons 1`] = `
                     </button>
                     <button
                       aria-label="Copy"
-                      className="chakra-button array-item-copy emotion-13"
+                      className="chakra-button rjsf-array-item-copy emotion-13"
                       disabled={false}
                       id="root_0__copy"
                       onClick={[Function]}
@@ -332,7 +332,7 @@ exports[`array fields array icons 1`] = `
                     </button>
                     <button
                       aria-label="Remove"
-                      className="chakra-button array-item-remove emotion-13"
+                      className="chakra-button rjsf-array-item-remove emotion-13"
                       disabled={false}
                       id="root_0__remove"
                       onClick={[Function]}
@@ -372,7 +372,7 @@ exports[`array fields array icons 1`] = `
                   className="emotion-6"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -422,7 +422,7 @@ exports[`array fields array icons 1`] = `
                   >
                     <button
                       aria-label="Move up"
-                      className="chakra-button array-item-move-up emotion-13"
+                      className="chakra-button rjsf-array-item-move-up emotion-13"
                       disabled={false}
                       id="root_1__moveUp"
                       onClick={[Function]}
@@ -451,7 +451,7 @@ exports[`array fields array icons 1`] = `
                     </button>
                     <button
                       aria-label="Move down"
-                      className="chakra-button array-item-move-down emotion-13"
+                      className="chakra-button rjsf-array-item-move-down emotion-13"
                       disabled={true}
                       id="root_1__moveDown"
                       onClick={[Function]}
@@ -480,7 +480,7 @@ exports[`array fields array icons 1`] = `
                     </button>
                     <button
                       aria-label="Copy"
-                      className="chakra-button array-item-copy emotion-13"
+                      className="chakra-button rjsf-array-item-copy emotion-13"
                       disabled={false}
                       id="root_1__copy"
                       onClick={[Function]}
@@ -514,7 +514,7 @@ exports[`array fields array icons 1`] = `
                     </button>
                     <button
                       aria-label="Remove"
-                      className="chakra-button array-item-remove emotion-13"
+                      className="chakra-button rjsf-array-item-remove emotion-13"
                       disabled={false}
                       id="root_1__remove"
                       onClick={[Function]}
@@ -555,7 +555,7 @@ exports[`array fields array icons 1`] = `
                 className="emotion-30"
               >
                 <button
-                  className="chakra-button array-item-add emotion-31"
+                  className="chakra-button rjsf-array-item-add emotion-31"
                   disabled={false}
                   id="root__add"
                   onClick={[Function]}
@@ -633,7 +633,7 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -954,7 +954,7 @@ exports[`array fields empty errors array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -972,7 +972,7 @@ exports[`array fields empty errors array 1`] = `
             className="emotion-3"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -1076,7 +1076,7 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1103,7 +1103,7 @@ exports[`array fields fixed array 1`] = `
                   className="emotion-6"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -1153,7 +1153,7 @@ exports[`array fields fixed array 1`] = `
                   className="emotion-6"
                 >
                   <div
-                    className="field-number"
+                    className="rjsf-field rjsf-field-number"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -1320,7 +1320,7 @@ exports[`array fields has errors 1`] = `
     </div>
   </div>
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-9"
@@ -1338,7 +1338,7 @@ exports[`array fields has errors 1`] = `
             className="emotion-12"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-9"
@@ -1455,7 +1455,7 @@ exports[`array fields no errors 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1473,7 +1473,7 @@ exports[`array fields no errors 1`] = `
             className="emotion-3"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -1573,7 +1573,7 @@ exports[`with title and description array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1621,7 +1621,7 @@ exports[`with title and description array 1`] = `
                 className="emotion-10"
               >
                 <button
-                  className="chakra-button array-item-add emotion-11"
+                  className="chakra-button rjsf-array-item-add emotion-11"
                   disabled={false}
                   id="root__add"
                   onClick={[Function]}
@@ -1747,7 +1747,7 @@ exports[`with title and description array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1795,7 +1795,7 @@ exports[`with title and description array icons 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -1872,7 +1872,7 @@ exports[`with title and description array icons 1`] = `
                   >
                     <button
                       aria-label="Move up"
-                      className="chakra-button array-item-move-up emotion-21"
+                      className="chakra-button rjsf-array-item-move-up emotion-21"
                       disabled={true}
                       id="root_0__moveUp"
                       onClick={[Function]}
@@ -1901,7 +1901,7 @@ exports[`with title and description array icons 1`] = `
                     </button>
                     <button
                       aria-label="Move down"
-                      className="chakra-button array-item-move-down emotion-21"
+                      className="chakra-button rjsf-array-item-move-down emotion-21"
                       disabled={false}
                       id="root_0__moveDown"
                       onClick={[Function]}
@@ -1930,7 +1930,7 @@ exports[`with title and description array icons 1`] = `
                     </button>
                     <button
                       aria-label="Copy"
-                      className="chakra-button array-item-copy emotion-21"
+                      className="chakra-button rjsf-array-item-copy emotion-21"
                       disabled={false}
                       id="root_0__copy"
                       onClick={[Function]}
@@ -1964,7 +1964,7 @@ exports[`with title and description array icons 1`] = `
                     </button>
                     <button
                       aria-label="Remove"
-                      className="chakra-button array-item-remove emotion-21"
+                      className="chakra-button rjsf-array-item-remove emotion-21"
                       disabled={false}
                       id="root_0__remove"
                       onClick={[Function]}
@@ -2004,7 +2004,7 @@ exports[`with title and description array icons 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -2081,7 +2081,7 @@ exports[`with title and description array icons 1`] = `
                   >
                     <button
                       aria-label="Move up"
-                      className="chakra-button array-item-move-up emotion-21"
+                      className="chakra-button rjsf-array-item-move-up emotion-21"
                       disabled={false}
                       id="root_1__moveUp"
                       onClick={[Function]}
@@ -2110,7 +2110,7 @@ exports[`with title and description array icons 1`] = `
                     </button>
                     <button
                       aria-label="Move down"
-                      className="chakra-button array-item-move-down emotion-21"
+                      className="chakra-button rjsf-array-item-move-down emotion-21"
                       disabled={true}
                       id="root_1__moveDown"
                       onClick={[Function]}
@@ -2139,7 +2139,7 @@ exports[`with title and description array icons 1`] = `
                     </button>
                     <button
                       aria-label="Copy"
-                      className="chakra-button array-item-copy emotion-21"
+                      className="chakra-button rjsf-array-item-copy emotion-21"
                       disabled={false}
                       id="root_1__copy"
                       onClick={[Function]}
@@ -2173,7 +2173,7 @@ exports[`with title and description array icons 1`] = `
                     </button>
                     <button
                       aria-label="Remove"
-                      className="chakra-button array-item-remove emotion-21"
+                      className="chakra-button rjsf-array-item-remove emotion-21"
                       disabled={false}
                       id="root_1__remove"
                       onClick={[Function]}
@@ -2214,7 +2214,7 @@ exports[`with title and description array icons 1`] = `
                 className="emotion-42"
               >
                 <button
-                  className="chakra-button array-item-add emotion-43"
+                  className="chakra-button rjsf-array-item-add emotion-43"
                   disabled={false}
                   id="root__add"
                   onClick={[Function]}
@@ -2300,7 +2300,7 @@ exports[`with title and description checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2670,7 +2670,7 @@ exports[`with title and description fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2718,7 +2718,7 @@ exports[`with title and description fixed array 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -2795,7 +2795,7 @@ exports[`with title and description fixed array 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="field-number"
+                    className="rjsf-field rjsf-field-number"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -2918,7 +2918,7 @@ exports[`with title and description from both array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2966,7 +2966,7 @@ exports[`with title and description from both array 1`] = `
                 className="emotion-10"
               >
                 <button
-                  className="chakra-button array-item-add emotion-11"
+                  className="chakra-button rjsf-array-item-add emotion-11"
                   disabled={false}
                   id="root__add"
                   onClick={[Function]}
@@ -3092,7 +3092,7 @@ exports[`with title and description from both array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -3140,7 +3140,7 @@ exports[`with title and description from both array icons 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -3217,7 +3217,7 @@ exports[`with title and description from both array icons 1`] = `
                   >
                     <button
                       aria-label="Move up"
-                      className="chakra-button array-item-move-up emotion-21"
+                      className="chakra-button rjsf-array-item-move-up emotion-21"
                       disabled={true}
                       id="root_0__moveUp"
                       onClick={[Function]}
@@ -3246,7 +3246,7 @@ exports[`with title and description from both array icons 1`] = `
                     </button>
                     <button
                       aria-label="Move down"
-                      className="chakra-button array-item-move-down emotion-21"
+                      className="chakra-button rjsf-array-item-move-down emotion-21"
                       disabled={false}
                       id="root_0__moveDown"
                       onClick={[Function]}
@@ -3275,7 +3275,7 @@ exports[`with title and description from both array icons 1`] = `
                     </button>
                     <button
                       aria-label="Copy"
-                      className="chakra-button array-item-copy emotion-21"
+                      className="chakra-button rjsf-array-item-copy emotion-21"
                       disabled={false}
                       id="root_0__copy"
                       onClick={[Function]}
@@ -3309,7 +3309,7 @@ exports[`with title and description from both array icons 1`] = `
                     </button>
                     <button
                       aria-label="Remove"
-                      className="chakra-button array-item-remove emotion-21"
+                      className="chakra-button rjsf-array-item-remove emotion-21"
                       disabled={false}
                       id="root_0__remove"
                       onClick={[Function]}
@@ -3349,7 +3349,7 @@ exports[`with title and description from both array icons 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -3426,7 +3426,7 @@ exports[`with title and description from both array icons 1`] = `
                   >
                     <button
                       aria-label="Move up"
-                      className="chakra-button array-item-move-up emotion-21"
+                      className="chakra-button rjsf-array-item-move-up emotion-21"
                       disabled={false}
                       id="root_1__moveUp"
                       onClick={[Function]}
@@ -3455,7 +3455,7 @@ exports[`with title and description from both array icons 1`] = `
                     </button>
                     <button
                       aria-label="Move down"
-                      className="chakra-button array-item-move-down emotion-21"
+                      className="chakra-button rjsf-array-item-move-down emotion-21"
                       disabled={true}
                       id="root_1__moveDown"
                       onClick={[Function]}
@@ -3484,7 +3484,7 @@ exports[`with title and description from both array icons 1`] = `
                     </button>
                     <button
                       aria-label="Copy"
-                      className="chakra-button array-item-copy emotion-21"
+                      className="chakra-button rjsf-array-item-copy emotion-21"
                       disabled={false}
                       id="root_1__copy"
                       onClick={[Function]}
@@ -3518,7 +3518,7 @@ exports[`with title and description from both array icons 1`] = `
                     </button>
                     <button
                       aria-label="Remove"
-                      className="chakra-button array-item-remove emotion-21"
+                      className="chakra-button rjsf-array-item-remove emotion-21"
                       disabled={false}
                       id="root_1__remove"
                       onClick={[Function]}
@@ -3559,7 +3559,7 @@ exports[`with title and description from both array icons 1`] = `
                 className="emotion-42"
               >
                 <button
-                  className="chakra-button array-item-add emotion-43"
+                  className="chakra-button rjsf-array-item-add emotion-43"
                   disabled={false}
                   id="root__add"
                   onClick={[Function]}
@@ -3645,7 +3645,7 @@ exports[`with title and description from both checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -4015,7 +4015,7 @@ exports[`with title and description from both fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -4063,7 +4063,7 @@ exports[`with title and description from both fixed array 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -4140,7 +4140,7 @@ exports[`with title and description from both fixed array 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="field-number"
+                    className="rjsf-field rjsf-field-number"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -4263,7 +4263,7 @@ exports[`with title and description from uiSchema array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -4311,7 +4311,7 @@ exports[`with title and description from uiSchema array 1`] = `
                 className="emotion-10"
               >
                 <button
-                  className="chakra-button array-item-add emotion-11"
+                  className="chakra-button rjsf-array-item-add emotion-11"
                   disabled={false}
                   id="root__add"
                   onClick={[Function]}
@@ -4437,7 +4437,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -4485,7 +4485,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -4562,7 +4562,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                   >
                     <button
                       aria-label="Move up"
-                      className="chakra-button array-item-move-up emotion-21"
+                      className="chakra-button rjsf-array-item-move-up emotion-21"
                       disabled={true}
                       id="root_0__moveUp"
                       onClick={[Function]}
@@ -4591,7 +4591,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     </button>
                     <button
                       aria-label="Move down"
-                      className="chakra-button array-item-move-down emotion-21"
+                      className="chakra-button rjsf-array-item-move-down emotion-21"
                       disabled={false}
                       id="root_0__moveDown"
                       onClick={[Function]}
@@ -4620,7 +4620,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     </button>
                     <button
                       aria-label="Copy"
-                      className="chakra-button array-item-copy emotion-21"
+                      className="chakra-button rjsf-array-item-copy emotion-21"
                       disabled={false}
                       id="root_0__copy"
                       onClick={[Function]}
@@ -4654,7 +4654,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     </button>
                     <button
                       aria-label="Remove"
-                      className="chakra-button array-item-remove emotion-21"
+                      className="chakra-button rjsf-array-item-remove emotion-21"
                       disabled={false}
                       id="root_0__remove"
                       onClick={[Function]}
@@ -4694,7 +4694,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -4771,7 +4771,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                   >
                     <button
                       aria-label="Move up"
-                      className="chakra-button array-item-move-up emotion-21"
+                      className="chakra-button rjsf-array-item-move-up emotion-21"
                       disabled={false}
                       id="root_1__moveUp"
                       onClick={[Function]}
@@ -4800,7 +4800,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     </button>
                     <button
                       aria-label="Move down"
-                      className="chakra-button array-item-move-down emotion-21"
+                      className="chakra-button rjsf-array-item-move-down emotion-21"
                       disabled={true}
                       id="root_1__moveDown"
                       onClick={[Function]}
@@ -4829,7 +4829,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     </button>
                     <button
                       aria-label="Copy"
-                      className="chakra-button array-item-copy emotion-21"
+                      className="chakra-button rjsf-array-item-copy emotion-21"
                       disabled={false}
                       id="root_1__copy"
                       onClick={[Function]}
@@ -4863,7 +4863,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     </button>
                     <button
                       aria-label="Remove"
-                      className="chakra-button array-item-remove emotion-21"
+                      className="chakra-button rjsf-array-item-remove emotion-21"
                       disabled={false}
                       id="root_1__remove"
                       onClick={[Function]}
@@ -4904,7 +4904,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                 className="emotion-42"
               >
                 <button
-                  className="chakra-button array-item-add emotion-43"
+                  className="chakra-button rjsf-array-item-add emotion-43"
                   disabled={false}
                   id="root__add"
                   onClick={[Function]}
@@ -4990,7 +4990,7 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5360,7 +5360,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5408,7 +5408,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -5485,7 +5485,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                   className="emotion-10"
                 >
                   <div
-                    className="field-number"
+                    className="rjsf-field rjsf-field-number"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -5599,7 +5599,7 @@ exports[`with title and description with global label off array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5626,7 +5626,7 @@ exports[`with title and description with global label off array 1`] = `
                 className="emotion-6"
               >
                 <button
-                  className="chakra-button array-item-add emotion-7"
+                  className="chakra-button rjsf-array-item-add emotion-7"
                   disabled={false}
                   id="root__add"
                   onClick={[Function]}
@@ -5739,7 +5739,7 @@ exports[`with title and description with global label off array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5766,7 +5766,7 @@ exports[`with title and description with global label off array icons 1`] = `
                   className="emotion-6"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -5816,7 +5816,7 @@ exports[`with title and description with global label off array icons 1`] = `
                   >
                     <button
                       aria-label="Move up"
-                      className="chakra-button array-item-move-up emotion-13"
+                      className="chakra-button rjsf-array-item-move-up emotion-13"
                       disabled={true}
                       id="root_0__moveUp"
                       onClick={[Function]}
@@ -5845,7 +5845,7 @@ exports[`with title and description with global label off array icons 1`] = `
                     </button>
                     <button
                       aria-label="Move down"
-                      className="chakra-button array-item-move-down emotion-13"
+                      className="chakra-button rjsf-array-item-move-down emotion-13"
                       disabled={false}
                       id="root_0__moveDown"
                       onClick={[Function]}
@@ -5874,7 +5874,7 @@ exports[`with title and description with global label off array icons 1`] = `
                     </button>
                     <button
                       aria-label="Copy"
-                      className="chakra-button array-item-copy emotion-13"
+                      className="chakra-button rjsf-array-item-copy emotion-13"
                       disabled={false}
                       id="root_0__copy"
                       onClick={[Function]}
@@ -5908,7 +5908,7 @@ exports[`with title and description with global label off array icons 1`] = `
                     </button>
                     <button
                       aria-label="Remove"
-                      className="chakra-button array-item-remove emotion-13"
+                      className="chakra-button rjsf-array-item-remove emotion-13"
                       disabled={false}
                       id="root_0__remove"
                       onClick={[Function]}
@@ -5948,7 +5948,7 @@ exports[`with title and description with global label off array icons 1`] = `
                   className="emotion-6"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -5998,7 +5998,7 @@ exports[`with title and description with global label off array icons 1`] = `
                   >
                     <button
                       aria-label="Move up"
-                      className="chakra-button array-item-move-up emotion-13"
+                      className="chakra-button rjsf-array-item-move-up emotion-13"
                       disabled={false}
                       id="root_1__moveUp"
                       onClick={[Function]}
@@ -6027,7 +6027,7 @@ exports[`with title and description with global label off array icons 1`] = `
                     </button>
                     <button
                       aria-label="Move down"
-                      className="chakra-button array-item-move-down emotion-13"
+                      className="chakra-button rjsf-array-item-move-down emotion-13"
                       disabled={true}
                       id="root_1__moveDown"
                       onClick={[Function]}
@@ -6056,7 +6056,7 @@ exports[`with title and description with global label off array icons 1`] = `
                     </button>
                     <button
                       aria-label="Copy"
-                      className="chakra-button array-item-copy emotion-13"
+                      className="chakra-button rjsf-array-item-copy emotion-13"
                       disabled={false}
                       id="root_1__copy"
                       onClick={[Function]}
@@ -6090,7 +6090,7 @@ exports[`with title and description with global label off array icons 1`] = `
                     </button>
                     <button
                       aria-label="Remove"
-                      className="chakra-button array-item-remove emotion-13"
+                      className="chakra-button rjsf-array-item-remove emotion-13"
                       disabled={false}
                       id="root_1__remove"
                       onClick={[Function]}
@@ -6131,7 +6131,7 @@ exports[`with title and description with global label off array icons 1`] = `
                 className="emotion-30"
               >
                 <button
-                  className="chakra-button array-item-add emotion-31"
+                  className="chakra-button rjsf-array-item-add emotion-31"
                   disabled={false}
                   id="root__add"
                   onClick={[Function]}
@@ -6217,7 +6217,7 @@ exports[`with title and description with global label off checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -6574,7 +6574,7 @@ exports[`with title and description with global label off fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -6601,7 +6601,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                   className="emotion-6"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -6651,7 +6651,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                   className="emotion-6"
                 >
                   <div
-                    className="field-number"
+                    className="rjsf-field rjsf-field-number"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"

--- a/packages/chakra-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Array.test.tsx.snap
@@ -1338,7 +1338,7 @@ exports[`array fields has errors 1`] = `
             className="emotion-12"
           >
             <div
-              className="rjsf-field rjsf-field-string"
+              className="rjsf-field rjsf-field-string rjsf-field-error"
             >
               <fieldset
                 className="fieldset__root emotion-9"

--- a/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
@@ -1237,7 +1237,7 @@ exports[`single fields help and error display 1`] = `
     </div>
   </div>
   <div
-    className="rjsf-field rjsf-field-string"
+    className="rjsf-field rjsf-field-string rjsf-field-error"
   >
     <fieldset
       className="fieldset__root emotion-9"

--- a/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -141,7 +141,7 @@ exports[`single fields checkbox field with label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -281,7 +281,7 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -639,7 +639,7 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -657,7 +657,7 @@ exports[`single fields field with description 1`] = `
             className="emotion-3"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -766,7 +766,7 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -784,7 +784,7 @@ exports[`single fields field with description in uiSchema 1`] = `
             className="emotion-3"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -879,7 +879,7 @@ exports[`single fields format color 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -948,7 +948,7 @@ exports[`single fields format date 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1017,7 +1017,7 @@ exports[`single fields format datetime 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1086,7 +1086,7 @@ exports[`single fields format time 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1237,7 +1237,7 @@ exports[`single fields help and error display 1`] = `
     </div>
   </div>
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-9"
@@ -1341,7 +1341,7 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1402,7 +1402,7 @@ exports[`single fields hidden label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1467,7 +1467,7 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-null"
+    className="rjsf-field rjsf-field-null"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1509,7 +1509,7 @@ exports[`single fields number field 0 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1579,7 +1579,7 @@ exports[`single fields number field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1649,7 +1649,7 @@ exports[`single fields password field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1726,7 +1726,7 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1938,7 +1938,7 @@ exports[`single fields schema examples 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2042,7 +2042,7 @@ exports[`single fields select field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2331,7 +2331,7 @@ exports[`single fields select field multiple choice 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2700,7 +2700,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -3072,7 +3072,7 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -3434,7 +3434,7 @@ exports[`single fields select field multiple choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -3806,7 +3806,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -4136,7 +4136,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -4420,7 +4420,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -4643,7 +4643,7 @@ exports[`single fields select field single choice form disabled using radio widg
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -4878,7 +4878,7 @@ exports[`single fields select field single choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5159,7 +5159,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5383,7 +5383,7 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-integer"
+    className="rjsf-field rjsf-field-integer"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5540,7 +5540,7 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5611,7 +5611,7 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5680,7 +5680,7 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5749,7 +5749,7 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5818,7 +5818,7 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5887,7 +5887,7 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5971,7 +5971,7 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -6004,7 +6004,7 @@ exports[`single fields title field 1`] = `
             className="emotion-6"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -6083,7 +6083,7 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-undefined"
+    className="rjsf-field rjsf-field-undefined"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -6154,7 +6154,7 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -6300,7 +6300,7 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"

--- a/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -141,7 +141,7 @@ exports[`single fields checkbox field with label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -281,7 +281,7 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -639,7 +639,7 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -657,7 +657,7 @@ exports[`single fields field with description 1`] = `
             className="emotion-3"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -766,7 +766,7 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -784,7 +784,7 @@ exports[`single fields field with description in uiSchema 1`] = `
             className="emotion-3"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -879,7 +879,7 @@ exports[`single fields format color 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -948,7 +948,7 @@ exports[`single fields format date 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1017,7 +1017,7 @@ exports[`single fields format datetime 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1086,7 +1086,7 @@ exports[`single fields format time 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1237,7 +1237,7 @@ exports[`single fields help and error display 1`] = `
     </div>
   </div>
   <div
-    className="form-group field field-string field-error has-error has-danger"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-9"
@@ -1341,7 +1341,7 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1402,7 +1402,7 @@ exports[`single fields hidden label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1467,7 +1467,7 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-null"
+    className="field-null"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1509,7 +1509,7 @@ exports[`single fields number field 0 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1579,7 +1579,7 @@ exports[`single fields number field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1649,7 +1649,7 @@ exports[`single fields password field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1726,7 +1726,7 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1938,7 +1938,7 @@ exports[`single fields schema examples 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2042,7 +2042,7 @@ exports[`single fields select field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2331,7 +2331,7 @@ exports[`single fields select field multiple choice 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2700,7 +2700,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -3072,7 +3072,7 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -3434,7 +3434,7 @@ exports[`single fields select field multiple choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -3806,7 +3806,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -4136,7 +4136,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -4420,7 +4420,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -4643,7 +4643,7 @@ exports[`single fields select field single choice form disabled using radio widg
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -4878,7 +4878,7 @@ exports[`single fields select field single choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5159,7 +5159,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5383,7 +5383,7 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-integer"
+    className="field-integer"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5540,7 +5540,7 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5611,7 +5611,7 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5680,7 +5680,7 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5749,7 +5749,7 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5818,7 +5818,7 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5887,7 +5887,7 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -5971,7 +5971,7 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -6004,7 +6004,7 @@ exports[`single fields title field 1`] = `
             className="emotion-6"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -6083,7 +6083,7 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-undefined"
+    className="field-undefined"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -6154,7 +6154,7 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -6300,7 +6300,7 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <fieldset
       className="fieldset__root emotion-0"

--- a/packages/chakra-ui/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/GridSnap.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -130,7 +130,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-object"
+                className="rjsf-field rjsf-field-object"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -170,7 +170,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -232,7 +232,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -287,7 +287,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -354,7 +354,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -416,7 +416,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-array"
+                className="rjsf-field rjsf-field-array"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -824,7 +824,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-object"
+                className="rjsf-field rjsf-field-object"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -844,7 +844,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -906,7 +906,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -961,7 +961,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -1024,7 +1024,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         size={6}
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -3397,7 +3397,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         size={6}
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -3746,7 +3746,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -3808,7 +3808,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -3863,7 +3863,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -3925,7 +3925,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -6419,7 +6419,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -6443,7 +6443,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-object"
+                className="rjsf-field rjsf-field-object"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -6483,7 +6483,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -6545,7 +6545,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -6600,7 +6600,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -6667,7 +6667,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -6729,7 +6729,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-array"
+                className="rjsf-field rjsf-field-array"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -7137,7 +7137,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-object"
+                className="rjsf-field rjsf-field-object"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -7157,7 +7157,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -7219,7 +7219,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -7274,7 +7274,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -7337,7 +7337,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         size={6}
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -9710,7 +9710,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         size={6}
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -10059,7 +10059,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -10114,7 +10114,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -10176,7 +10176,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -10231,7 +10231,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -10293,7 +10293,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -12787,7 +12787,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -12811,7 +12811,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-object"
+                className="rjsf-field rjsf-field-object"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -12851,7 +12851,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -12913,7 +12913,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -12968,7 +12968,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -13035,7 +13035,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -13097,7 +13097,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-array"
+                className="rjsf-field rjsf-field-array"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -13505,7 +13505,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-object"
+                className="rjsf-field rjsf-field-object"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -13525,7 +13525,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -13587,7 +13587,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -13642,7 +13642,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -13705,7 +13705,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         size={6}
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -16078,7 +16078,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         size={6}
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -16427,7 +16427,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -16616,7 +16616,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -16640,7 +16640,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-object"
+                className="rjsf-field rjsf-field-object"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -16680,7 +16680,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -16742,7 +16742,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -16797,7 +16797,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -16864,7 +16864,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -16926,7 +16926,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-array"
+                className="rjsf-field rjsf-field-array"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -17334,7 +17334,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-object"
+                className="rjsf-field rjsf-field-object"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -17354,7 +17354,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -17416,7 +17416,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -17471,7 +17471,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -17534,7 +17534,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         size={6}
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -19907,7 +19907,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         size={6}
                       >
                         <div
-                          className="field-string"
+                          className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -20256,7 +20256,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -20318,7 +20318,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -20373,7 +20373,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -20435,7 +20435,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -22895,7 +22895,7 @@ exports[`Three even column grid renders person and address in three columns, no 
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -22915,7 +22915,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -22950,7 +22950,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -23012,7 +23012,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -23067,7 +23067,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -23129,7 +23129,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -23191,7 +23191,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="field-array"
+              className="rjsf-field rjsf-field-array"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -23594,7 +23594,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -23656,7 +23656,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -23711,7 +23711,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -23773,7 +23773,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -26234,7 +26234,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -26254,7 +26254,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -26289,7 +26289,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -26351,7 +26351,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -26406,7 +26406,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -26468,7 +26468,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -26530,7 +26530,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="field-array"
+              className="rjsf-field rjsf-field-array"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -26933,7 +26933,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -26995,7 +26995,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -27050,7 +27050,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -27112,7 +27112,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"

--- a/packages/chakra-ui/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/GridSnap.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -130,7 +130,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-object"
+                className="field-object"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -170,7 +170,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -232,7 +232,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -287,7 +287,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -354,7 +354,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -416,7 +416,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-array"
+                className="field-array"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -824,7 +824,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-object"
+                className="field-object"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -844,7 +844,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -906,7 +906,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -961,7 +961,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -1024,7 +1024,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         size={6}
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -3397,7 +3397,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         size={6}
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -3746,7 +3746,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -3808,7 +3808,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -3863,7 +3863,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -3925,7 +3925,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -6419,7 +6419,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -6443,7 +6443,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-object"
+                className="field-object"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -6483,7 +6483,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -6545,7 +6545,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -6600,7 +6600,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -6667,7 +6667,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -6729,7 +6729,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-array"
+                className="field-array"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -7137,7 +7137,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-object"
+                className="field-object"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -7157,7 +7157,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -7219,7 +7219,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -7274,7 +7274,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -7337,7 +7337,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         size={6}
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -9710,7 +9710,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         size={6}
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -10059,7 +10059,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -10114,7 +10114,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -10176,7 +10176,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -10231,7 +10231,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -10293,7 +10293,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -12787,7 +12787,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -12811,7 +12811,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-object"
+                className="field-object"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -12851,7 +12851,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -12913,7 +12913,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -12968,7 +12968,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -13035,7 +13035,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -13097,7 +13097,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-array"
+                className="field-array"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -13505,7 +13505,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-object"
+                className="field-object"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -13525,7 +13525,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -13587,7 +13587,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -13642,7 +13642,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -13705,7 +13705,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         size={6}
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -16078,7 +16078,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         size={6}
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -16427,7 +16427,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -16616,7 +16616,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -16640,7 +16640,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-object"
+                className="field-object"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -16680,7 +16680,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -16742,7 +16742,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -16797,7 +16797,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -16864,7 +16864,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -16926,7 +16926,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-array"
+                className="field-array"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -17334,7 +17334,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-object"
+                className="field-object"
               >
                 <fieldset
                   className="fieldset__root emotion-0"
@@ -17354,7 +17354,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -17416,7 +17416,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -17471,7 +17471,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         data-testid="1"
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -17534,7 +17534,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         size={6}
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -19907,7 +19907,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         size={6}
                       >
                         <div
-                          className="form-group field field-string"
+                          className="field-string"
                         >
                           <fieldset
                             className="fieldset__root emotion-0"
@@ -20256,7 +20256,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -20318,7 +20318,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -20373,7 +20373,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -20435,7 +20435,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <fieldset
                       className="fieldset__root emotion-0"
@@ -22895,7 +22895,7 @@ exports[`Three even column grid renders person and address in three columns, no 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -22915,7 +22915,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -22950,7 +22950,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -23012,7 +23012,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -23067,7 +23067,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -23129,7 +23129,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -23191,7 +23191,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="form-group field field-array"
+              className="field-array"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -23594,7 +23594,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -23656,7 +23656,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -23711,7 +23711,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -23773,7 +23773,7 @@ exports[`Three even column grid renders person and address in three columns, no 
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -26234,7 +26234,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -26254,7 +26254,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -26289,7 +26289,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -26351,7 +26351,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -26406,7 +26406,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -26468,7 +26468,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -26530,7 +26530,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="form-group field field-array"
+              className="field-array"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -26933,7 +26933,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -26995,7 +26995,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -27050,7 +27050,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -27112,7 +27112,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"

--- a/packages/chakra-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Object.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -65,7 +65,7 @@ exports[`object fields additionalProperties 1`] = `
             className="emotion-3"
           >
             <div
-              className="form-group field field-string emotion-4"
+              className="field-string emotion-4"
             >
               <div
                 className="emotion-3"
@@ -260,7 +260,7 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -278,7 +278,7 @@ exports[`object fields object 1`] = `
             className="emotion-3"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -332,7 +332,7 @@ exports[`object fields object 1`] = `
             className="emotion-3"
           >
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -448,7 +448,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -466,7 +466,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
             className="emotion-3"
           >
             <div
-              className="form-group field field-string emotion-4"
+              className="field-string emotion-4"
             >
               <div
                 className="emotion-3"
@@ -696,7 +696,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -735,7 +735,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
             className="emotion-7"
           >
             <div
-              className="form-group field field-string emotion-8"
+              className="field-string emotion-8"
             >
               <div
                 className="emotion-7"
@@ -965,7 +965,7 @@ exports[`object fields with title and description from both additionalProperties
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1004,7 +1004,7 @@ exports[`object fields with title and description from both additionalProperties
             className="emotion-7"
           >
             <div
-              className="form-group field field-string emotion-8"
+              className="field-string emotion-8"
             >
               <div
                 className="emotion-7"
@@ -1212,7 +1212,7 @@ exports[`object fields with title and description from both object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1251,7 +1251,7 @@ exports[`object fields with title and description from both object 1`] = `
             className="emotion-7"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -1317,7 +1317,7 @@ exports[`object fields with title and description from both object 1`] = `
             className="emotion-7"
           >
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -1454,7 +1454,7 @@ exports[`object fields with title and description from uiSchema additionalProper
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1493,7 +1493,7 @@ exports[`object fields with title and description from uiSchema additionalProper
             className="emotion-7"
           >
             <div
-              className="form-group field field-string emotion-8"
+              className="field-string emotion-8"
             >
               <div
                 className="emotion-7"
@@ -1701,7 +1701,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1740,7 +1740,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
             className="emotion-7"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -1806,7 +1806,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
             className="emotion-7"
           >
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -1943,7 +1943,7 @@ exports[`object fields with title and description from uiSchema show add button 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1982,7 +1982,7 @@ exports[`object fields with title and description from uiSchema show add button 
             className="emotion-7"
           >
             <div
-              className="form-group field field-string emotion-8"
+              className="field-string emotion-8"
             >
               <div
                 className="emotion-7"
@@ -2190,7 +2190,7 @@ exports[`object fields with title and description object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2229,7 +2229,7 @@ exports[`object fields with title and description object 1`] = `
             className="emotion-7"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -2295,7 +2295,7 @@ exports[`object fields with title and description object 1`] = `
             className="emotion-7"
           >
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -2432,7 +2432,7 @@ exports[`object fields with title and description show add button and fields if 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2471,7 +2471,7 @@ exports[`object fields with title and description show add button and fields if 
             className="emotion-7"
           >
             <div
-              className="form-group field field-string emotion-8"
+              className="field-string emotion-8"
             >
               <div
                 className="emotion-7"
@@ -2692,7 +2692,7 @@ exports[`object fields with title and description with global label off addition
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2710,7 +2710,7 @@ exports[`object fields with title and description with global label off addition
             className="emotion-3"
           >
             <div
-              className="form-group field field-string emotion-4"
+              className="field-string emotion-4"
             >
               <div
                 className="emotion-3"
@@ -2896,7 +2896,7 @@ exports[`object fields with title and description with global label off object 1
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2914,7 +2914,7 @@ exports[`object fields with title and description with global label off object 1
             className="emotion-3"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -2959,7 +2959,7 @@ exports[`object fields with title and description with global label off object 1
             className="emotion-3"
           >
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -3066,7 +3066,7 @@ exports[`object fields with title and description with global label off show add
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -3084,7 +3084,7 @@ exports[`object fields with title and description with global label off show add
             className="emotion-3"
           >
             <div
-              className="form-group field field-string emotion-4"
+              className="field-string emotion-4"
             >
               <div
                 className="emotion-3"

--- a/packages/chakra-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Object.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -65,7 +65,7 @@ exports[`object fields additionalProperties 1`] = `
             className="emotion-3"
           >
             <div
-              className="field-string emotion-4"
+              className="rjsf-field rjsf-field-string emotion-4"
             >
               <div
                 className="emotion-3"
@@ -156,7 +156,7 @@ exports[`object fields additionalProperties 1`] = `
               >
                 <button
                   aria-label="Remove"
-                  className="chakra-button array-item-remove emotion-16"
+                  className="chakra-button rjsf-object-property-remove emotion-16"
                   disabled={false}
                   id="root_foo__remove"
                   onClick={[Function]}
@@ -193,7 +193,7 @@ exports[`object fields additionalProperties 1`] = `
             className="emotion-17"
           >
             <button
-              className="chakra-button object-property-expand emotion-18"
+              className="chakra-button rjsf-object-property-expand emotion-18"
               disabled={false}
               id="root__add"
               onClick={[Function]}
@@ -260,7 +260,7 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -278,7 +278,7 @@ exports[`object fields object 1`] = `
             className="emotion-3"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -332,7 +332,7 @@ exports[`object fields object 1`] = `
             className="emotion-3"
           >
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -448,7 +448,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -466,7 +466,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
             className="emotion-3"
           >
             <div
-              className="field-string emotion-4"
+              className="rjsf-field rjsf-field-string emotion-4"
             >
               <div
                 className="emotion-3"
@@ -557,7 +557,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
               >
                 <button
                   aria-label="Remove"
-                  className="chakra-button array-item-remove emotion-16"
+                  className="chakra-button rjsf-object-property-remove emotion-16"
                   disabled={false}
                   id="root_additionalProperty__remove"
                   onClick={[Function]}
@@ -594,7 +594,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
             className="emotion-17"
           >
             <button
-              className="chakra-button object-property-expand emotion-18"
+              className="chakra-button rjsf-object-property-expand emotion-18"
               disabled={false}
               id="root__add"
               onClick={[Function]}
@@ -696,7 +696,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -735,7 +735,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
             className="emotion-7"
           >
             <div
-              className="field-string emotion-8"
+              className="rjsf-field rjsf-field-string emotion-8"
             >
               <div
                 className="emotion-7"
@@ -826,7 +826,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
               >
                 <button
                   aria-label="Remove"
-                  className="chakra-button array-item-remove emotion-20"
+                  className="chakra-button rjsf-object-property-remove emotion-20"
                   disabled={false}
                   id="root_foo__remove"
                   onClick={[Function]}
@@ -863,7 +863,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
             className="emotion-21"
           >
             <button
-              className="chakra-button object-property-expand emotion-22"
+              className="chakra-button rjsf-object-property-expand emotion-22"
               disabled={false}
               id="root__add"
               onClick={[Function]}
@@ -965,7 +965,7 @@ exports[`object fields with title and description from both additionalProperties
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1004,7 +1004,7 @@ exports[`object fields with title and description from both additionalProperties
             className="emotion-7"
           >
             <div
-              className="field-string emotion-8"
+              className="rjsf-field rjsf-field-string emotion-8"
             >
               <div
                 className="emotion-7"
@@ -1095,7 +1095,7 @@ exports[`object fields with title and description from both additionalProperties
               >
                 <button
                   aria-label="Remove"
-                  className="chakra-button array-item-remove emotion-20"
+                  className="chakra-button rjsf-object-property-remove emotion-20"
                   disabled={false}
                   id="root_foo__remove"
                   onClick={[Function]}
@@ -1132,7 +1132,7 @@ exports[`object fields with title and description from both additionalProperties
             className="emotion-21"
           >
             <button
-              className="chakra-button object-property-expand emotion-22"
+              className="chakra-button rjsf-object-property-expand emotion-22"
               disabled={false}
               id="root__add"
               onClick={[Function]}
@@ -1212,7 +1212,7 @@ exports[`object fields with title and description from both object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1251,7 +1251,7 @@ exports[`object fields with title and description from both object 1`] = `
             className="emotion-7"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -1317,7 +1317,7 @@ exports[`object fields with title and description from both object 1`] = `
             className="emotion-7"
           >
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -1454,7 +1454,7 @@ exports[`object fields with title and description from uiSchema additionalProper
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1493,7 +1493,7 @@ exports[`object fields with title and description from uiSchema additionalProper
             className="emotion-7"
           >
             <div
-              className="field-string emotion-8"
+              className="rjsf-field rjsf-field-string emotion-8"
             >
               <div
                 className="emotion-7"
@@ -1584,7 +1584,7 @@ exports[`object fields with title and description from uiSchema additionalProper
               >
                 <button
                   aria-label="Remove"
-                  className="chakra-button array-item-remove emotion-20"
+                  className="chakra-button rjsf-object-property-remove emotion-20"
                   disabled={false}
                   id="root_foo__remove"
                   onClick={[Function]}
@@ -1621,7 +1621,7 @@ exports[`object fields with title and description from uiSchema additionalProper
             className="emotion-21"
           >
             <button
-              className="chakra-button object-property-expand emotion-22"
+              className="chakra-button rjsf-object-property-expand emotion-22"
               disabled={false}
               id="root__add"
               onClick={[Function]}
@@ -1701,7 +1701,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1740,7 +1740,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
             className="emotion-7"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -1806,7 +1806,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
             className="emotion-7"
           >
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -1943,7 +1943,7 @@ exports[`object fields with title and description from uiSchema show add button 
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -1982,7 +1982,7 @@ exports[`object fields with title and description from uiSchema show add button 
             className="emotion-7"
           >
             <div
-              className="field-string emotion-8"
+              className="rjsf-field rjsf-field-string emotion-8"
             >
               <div
                 className="emotion-7"
@@ -2073,7 +2073,7 @@ exports[`object fields with title and description from uiSchema show add button 
               >
                 <button
                   aria-label="Remove"
-                  className="chakra-button array-item-remove emotion-20"
+                  className="chakra-button rjsf-object-property-remove emotion-20"
                   disabled={false}
                   id="root_additionalProperty__remove"
                   onClick={[Function]}
@@ -2110,7 +2110,7 @@ exports[`object fields with title and description from uiSchema show add button 
             className="emotion-21"
           >
             <button
-              className="chakra-button object-property-expand emotion-22"
+              className="chakra-button rjsf-object-property-expand emotion-22"
               disabled={false}
               id="root__add"
               onClick={[Function]}
@@ -2190,7 +2190,7 @@ exports[`object fields with title and description object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2229,7 +2229,7 @@ exports[`object fields with title and description object 1`] = `
             className="emotion-7"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -2295,7 +2295,7 @@ exports[`object fields with title and description object 1`] = `
             className="emotion-7"
           >
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -2432,7 +2432,7 @@ exports[`object fields with title and description show add button and fields if 
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2471,7 +2471,7 @@ exports[`object fields with title and description show add button and fields if 
             className="emotion-7"
           >
             <div
-              className="field-string emotion-8"
+              className="rjsf-field rjsf-field-string emotion-8"
             >
               <div
                 className="emotion-7"
@@ -2562,7 +2562,7 @@ exports[`object fields with title and description show add button and fields if 
               >
                 <button
                   aria-label="Remove"
-                  className="chakra-button array-item-remove emotion-20"
+                  className="chakra-button rjsf-object-property-remove emotion-20"
                   disabled={false}
                   id="root_additionalProperty__remove"
                   onClick={[Function]}
@@ -2599,7 +2599,7 @@ exports[`object fields with title and description show add button and fields if 
             className="emotion-21"
           >
             <button
-              className="chakra-button object-property-expand emotion-22"
+              className="chakra-button rjsf-object-property-expand emotion-22"
               disabled={false}
               id="root__add"
               onClick={[Function]}
@@ -2692,7 +2692,7 @@ exports[`object fields with title and description with global label off addition
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2710,7 +2710,7 @@ exports[`object fields with title and description with global label off addition
             className="emotion-3"
           >
             <div
-              className="field-string emotion-4"
+              className="rjsf-field rjsf-field-string emotion-4"
             >
               <div
                 className="emotion-3"
@@ -2792,7 +2792,7 @@ exports[`object fields with title and description with global label off addition
               >
                 <button
                   aria-label="Remove"
-                  className="chakra-button array-item-remove emotion-15"
+                  className="chakra-button rjsf-object-property-remove emotion-15"
                   disabled={false}
                   id="root_foo__remove"
                   onClick={[Function]}
@@ -2829,7 +2829,7 @@ exports[`object fields with title and description with global label off addition
             className="emotion-16"
           >
             <button
-              className="chakra-button object-property-expand emotion-17"
+              className="chakra-button rjsf-object-property-expand emotion-17"
               disabled={false}
               id="root__add"
               onClick={[Function]}
@@ -2896,7 +2896,7 @@ exports[`object fields with title and description with global label off object 1
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -2914,7 +2914,7 @@ exports[`object fields with title and description with global label off object 1
             className="emotion-3"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -2959,7 +2959,7 @@ exports[`object fields with title and description with global label off object 1
             className="emotion-3"
           >
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <fieldset
                 className="fieldset__root emotion-0"
@@ -3066,7 +3066,7 @@ exports[`object fields with title and description with global label off show add
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <fieldset
       className="fieldset__root emotion-0"
@@ -3084,7 +3084,7 @@ exports[`object fields with title and description with global label off show add
             className="emotion-3"
           >
             <div
-              className="field-string emotion-4"
+              className="rjsf-field rjsf-field-string emotion-4"
             >
               <div
                 className="emotion-3"
@@ -3166,7 +3166,7 @@ exports[`object fields with title and description with global label off show add
               >
                 <button
                   aria-label="Remove"
-                  className="chakra-button array-item-remove emotion-15"
+                  className="chakra-button rjsf-object-property-remove emotion-15"
                   disabled={false}
                   id="root_additionalProperty__remove"
                   onClick={[Function]}
@@ -3203,7 +3203,7 @@ exports[`object fields with title and description with global label off show add
             className="emotion-16"
           >
             <button
-              className="chakra-button object-property-expand emotion-17"
+              className="chakra-button rjsf-object-property-expand emotion-17"
               disabled={false}
               id="root__add"
               onClick={[Function]}

--- a/packages/core/src/components/fields/ArrayField.tsx
+++ b/packages/core/src/components/fields/ArrayField.tsx
@@ -520,7 +520,7 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
           totalItems: keyedFormData.length,
         });
       }),
-      className: `field field-array field-array-of-${itemsSchema.type}`,
+      className: `rjsf-field rjsf-field-array rjsf-field-array-of-${itemsSchema.type}`,
       disabled,
       idSchema,
       uiSchema,
@@ -736,7 +736,7 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
     const canAdd = this.canAddItem(items) && !!additionalSchema;
     const arrayProps: ArrayFieldTemplateProps<T[], S, F> = {
       canAdd,
-      className: 'field field-array field-array-fixed-items',
+      className: 'rjsf-field rjsf-field-array rjsf-field-array-fixed-items',
       disabled,
       idSchema,
       formData,
@@ -901,7 +901,7 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
         schema: itemSchema,
         uiSchema: itemUiSchema,
       },
-      className: 'array-item',
+      className: 'rjsf-array-item',
       disabled,
       hasToolbar: has.toolbar,
       index,

--- a/packages/core/src/components/fields/ObjectField.tsx
+++ b/packages/core/src/components/fields/ObjectField.tsx
@@ -266,7 +266,7 @@ class ObjectField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
     } catch (err) {
       return (
         <div>
-          <p className='config-error' style={{ color: 'red' }}>
+          <p className='rjsf-config-error' style={{ color: 'red' }}>
             <Markdown options={{ disableParsingRawHTML: true }}>
               {translateString(TranslatableString.InvalidObjectField, [name || 'root', (err as Error).message])}
             </Markdown>

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -209,7 +209,10 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
   const help = uiOptions.help;
   const hidden = uiOptions.widget === 'hidden';
 
-  const classNames = [`field-${getSchemaType(schema)}`];
+  const classNames = ['rjsf-field', `rjsf-field-${getSchemaType(schema)}`];
+  if (!hideError && __errors && __errors.length > 0) {
+    classNames.push('rjsf-field-error');
+  }
   if (uiOptions.classNames) {
     classNames.push(uiOptions.classNames);
   }

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -209,10 +209,7 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
   const help = uiOptions.help;
   const hidden = uiOptions.widget === 'hidden';
 
-  const classNames = ['form-group', 'field', `field-${getSchemaType(schema)}`];
-  if (!hideError && __errors && __errors.length > 0) {
-    classNames.push('field-error has-error has-danger');
-  }
+  const classNames = [`field-${getSchemaType(schema)}`];
   if (uiOptions.classNames) {
     classNames.push(uiOptions.classNames);
   }

--- a/packages/core/src/components/templates/ArrayFieldItemButtonsTemplate.tsx
+++ b/packages/core/src/components/templates/ArrayFieldItemButtonsTemplate.tsx
@@ -43,7 +43,7 @@ export default function ArrayFieldItemButtonsTemplate<
       {(hasMoveUp || hasMoveDown) && (
         <MoveUpButton
           id={buttonId<T>(idSchema, 'moveUp')}
-          className='array-item-move-up'
+          className='rjsf-array-item-move-up'
           disabled={disabled || readonly || !hasMoveUp}
           onClick={onArrowUpClick}
           uiSchema={uiSchema}
@@ -53,7 +53,7 @@ export default function ArrayFieldItemButtonsTemplate<
       {(hasMoveUp || hasMoveDown) && (
         <MoveDownButton
           id={buttonId<T>(idSchema, 'moveDown')}
-          className='array-item-move-down'
+          className='rjsf-array-item-move-down'
           disabled={disabled || readonly || !hasMoveDown}
           onClick={onArrowDownClick}
           uiSchema={uiSchema}
@@ -63,7 +63,7 @@ export default function ArrayFieldItemButtonsTemplate<
       {hasCopy && (
         <CopyButton
           id={buttonId<T>(idSchema, 'copy')}
-          className='array-item-copy'
+          className='rjsf-array-item-copy'
           disabled={disabled || readonly}
           onClick={onCopyClick}
           uiSchema={uiSchema}
@@ -73,7 +73,7 @@ export default function ArrayFieldItemButtonsTemplate<
       {hasRemove && (
         <RemoveButton
           id={buttonId<T>(idSchema, 'remove')}
-          className='array-item-remove'
+          className='rjsf-array-item-remove'
           disabled={disabled || readonly}
           onClick={onRemoveClick}
           uiSchema={uiSchema}

--- a/packages/core/src/components/templates/ArrayFieldTemplate.tsx
+++ b/packages/core/src/components/templates/ArrayFieldTemplate.tsx
@@ -78,7 +78,7 @@ export default function ArrayFieldTemplate<
       {canAdd && (
         <AddButton
           id={buttonId<T>(idSchema, 'add')}
-          className='array-item-add'
+          className='rjsf-array-item-add'
           onClick={onAddClick}
           disabled={disabled || readonly}
           uiSchema={uiSchema}

--- a/packages/core/src/components/templates/ButtonTemplates/IconButton.tsx
+++ b/packages/core/src/components/templates/ButtonTemplates/IconButton.tsx
@@ -17,14 +17,7 @@ export function CopyButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
   const {
     registry: { translateString },
   } = props;
-  return (
-    <IconButton
-      title={translateString(TranslatableString.CopyButton)}
-      className='array-item-copy'
-      {...props}
-      icon='copy'
-    />
-  );
+  return <IconButton title={translateString(TranslatableString.CopyButton)} {...props} icon='copy' />;
 }
 
 export function MoveDownButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
@@ -33,14 +26,7 @@ export function MoveDownButton<T = any, S extends StrictRJSFSchema = RJSFSchema,
   const {
     registry: { translateString },
   } = props;
-  return (
-    <IconButton
-      title={translateString(TranslatableString.MoveDownButton)}
-      className='array-item-move-down'
-      {...props}
-      icon='arrow-down'
-    />
-  );
+  return <IconButton title={translateString(TranslatableString.MoveDownButton)} {...props} icon='arrow-down' />;
 }
 
 export function MoveUpButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
@@ -49,14 +35,7 @@ export function MoveUpButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F
   const {
     registry: { translateString },
   } = props;
-  return (
-    <IconButton
-      title={translateString(TranslatableString.MoveUpButton)}
-      className='array-item-move-up'
-      {...props}
-      icon='arrow-up'
-    />
-  );
+  return <IconButton title={translateString(TranslatableString.MoveUpButton)} {...props} icon='arrow-up' />;
 }
 
 export function RemoveButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
@@ -66,12 +45,6 @@ export function RemoveButton<T = any, S extends StrictRJSFSchema = RJSFSchema, F
     registry: { translateString },
   } = props;
   return (
-    <IconButton
-      title={translateString(TranslatableString.RemoveButton)}
-      className='array-item-remove'
-      {...props}
-      iconType='danger'
-      icon='remove'
-    />
+    <IconButton title={translateString(TranslatableString.RemoveButton)} {...props} iconType='danger' icon='remove' />
   );
 }

--- a/packages/core/src/components/templates/ObjectFieldTemplate.tsx
+++ b/packages/core/src/components/templates/ObjectFieldTemplate.tsx
@@ -73,7 +73,7 @@ export default function ObjectFieldTemplate<
       {canExpand<T, S, F>(schema, uiSchema, formData) && (
         <AddButton
           id={buttonId<T>(idSchema, 'add')}
-          className='object-property-expand'
+          className='rjsf-object-property-expand'
           onClick={onAddClick(schema)}
           disabled={disabled || readonly}
           uiSchema={uiSchema}

--- a/packages/core/src/components/templates/WrapIfAdditionalTemplate.tsx
+++ b/packages/core/src/components/templates/WrapIfAdditionalTemplate.tsx
@@ -43,9 +43,9 @@ export default function WrapIfAdditionalTemplate<
   const keyLabel = translateString(TranslatableString.KeyLabel, [label]);
   const additional = ADDITIONAL_PROPERTY_FLAG in schema;
 
-  const classNamesList = ['form-group', 'field', classNames];
+  const classNamesList = ['form-group', classNames];
   if (!hideError && rawErrors && rawErrors.length > 0) {
-    classNamesList.push('field-error has-error has-danger');
+    classNamesList.push('has-error has-danger');
   }
   const uiClassNames = classNamesList.join(' ').trim();
 
@@ -76,7 +76,7 @@ export default function WrapIfAdditionalTemplate<
         <div className='col-xs-2'>
           <RemoveButton
             id={buttonId<T>(id, 'remove')}
-            className='array-item-remove btn-block'
+            className='rjsf-object-property-remove btn-block'
             style={{ border: '0' }}
             disabled={disabled || readonly}
             onClick={onDropPropertyClick(label)}

--- a/packages/core/src/components/templates/WrapIfAdditionalTemplate.tsx
+++ b/packages/core/src/components/templates/WrapIfAdditionalTemplate.tsx
@@ -31,6 +31,8 @@ export default function WrapIfAdditionalTemplate<
     readonly,
     required,
     schema,
+    hideError,
+    rawErrors,
     children,
     uiSchema,
     registry,
@@ -41,16 +43,22 @@ export default function WrapIfAdditionalTemplate<
   const keyLabel = translateString(TranslatableString.KeyLabel, [label]);
   const additional = ADDITIONAL_PROPERTY_FLAG in schema;
 
+  const classNamesList = ['form-group', 'field', classNames];
+  if (!hideError && rawErrors && rawErrors.length > 0) {
+    classNamesList.push('field-error has-error has-danger');
+  }
+  const uiClassNames = classNamesList.join(' ').trim();
+
   if (!additional) {
     return (
-      <div className={classNames} style={style}>
+      <div className={uiClassNames} style={style}>
         {children}
       </div>
     );
   }
 
   return (
-    <div className={classNames} style={style}>
+    <div className={uiClassNames} style={style}>
       <div className='row'>
         <div className='col-xs-5 form-additional'>
           <div className='form-group'>

--- a/packages/core/src/components/widgets/RatingWidget.tsx
+++ b/packages/core/src/components/widgets/RatingWidget.tsx
@@ -79,7 +79,7 @@ export default function RatingWidget<
   };
 
   return (
-    <div className='field field-array'>
+    <>
       <div
         className='rating-widget'
         style={{
@@ -124,6 +124,6 @@ export default function RatingWidget<
           aria-hidden='true'
         />
       </div>
-    </div>
+    </>
   );
 }

--- a/packages/core/test/ArrayField.test.jsx
+++ b/packages/core/test/ArrayField.test.jsx
@@ -14,11 +14,11 @@ const ExposedArrayKeyTemplate = function (props) {
     <div className='array'>
       {props.items &&
         props.items.map((element) => (
-          <div key={element.key} className='array-item' data-rjsf-itemkey={element.key}>
+          <div key={element.key} className='rjsf-array-item' data-rjsf-itemkey={element.key}>
             <div>{element.children}</div>
             {(element.buttonsProps.hasMoveUp || element.buttonsProps.hasMoveDown) && (
               <button
-                className='array-item-move-down'
+                className='rjsf-array-item-move-down'
                 onClick={element.buttonsProps.onReorderClick(element.index, element.index + 1)}
               >
                 Down
@@ -26,19 +26,19 @@ const ExposedArrayKeyTemplate = function (props) {
             )}
             {(element.buttonsProps.hasMoveUp || element.buttonsProps.hasMoveDown) && (
               <button
-                className='array-item-move-up'
+                className='rjsf-array-item-move-up'
                 onClick={element.buttonsProps.onReorderClick(element.index, element.index - 1)}
               >
                 Up
               </button>
             )}
             {element.buttonsProps.hasCopy && (
-              <button className='array-item-copy' onClick={element.buttonsProps.onCopyIndexClick(element.index)}>
+              <button className='rjsf-array-item-copy' onClick={element.buttonsProps.onCopyIndexClick(element.index)}>
                 Copy
               </button>
             )}
             {element.buttonsProps.hasRemove && (
-              <button className='array-item-remove' onClick={element.buttonsProps.onDropIndexClick(element.index)}>
+              <button className='rjsf-array-item-remove' onClick={element.buttonsProps.onDropIndexClick(element.index)}>
                 Remove
               </button>
             )}
@@ -48,7 +48,7 @@ const ExposedArrayKeyTemplate = function (props) {
         ))}
 
       {props.canAdd && (
-        <div className='array-item-add'>
+        <div className='rjsf-array-item-add'>
           <button onClick={props.onAddClick} type='button'>
             Add New
           </button>
@@ -63,13 +63,13 @@ const CustomOnAddClickTemplate = function (props) {
     <div className='array'>
       {props.items &&
         props.items.map((element) => (
-          <div key={element.key} className='array-item'>
+          <div key={element.key} className='rjsf-array-item'>
             <div>{element.children}</div>
           </div>
         ))}
 
       {props.canAdd && (
-        <div className='array-item-add'>
+        <div className='rjsf-array-item-add'>
           <button onClick={() => props.onAddClick()} type='button'>
             Add New
           </button>
@@ -213,8 +213,8 @@ describe('ArrayField', () => {
     it('should warn on missing items descriptor', () => {
       const { node } = createFormComponent({ schema: { type: 'array' } });
 
-      expect(node.querySelector('.field-array > .unsupported-field').textContent).to.contain(
-        'Missing items definition'
+      expect(node.querySelector('.rjsf-field-array > .unsupported-field').textContent).to.contain(
+        'Missing items definition',
       );
     });
 
@@ -249,7 +249,7 @@ describe('ArrayField', () => {
         schema,
         formData: { foo: null },
       });
-      expect(node.querySelectorAll('.field-string')).to.have.length.of(0);
+      expect(node.querySelectorAll('.rjsf-field-string')).to.have.length.of(0);
     });
   });
 
@@ -269,14 +269,14 @@ describe('ArrayField', () => {
         schema,
         formData: { foo: null },
       });
-      expect(node.querySelectorAll('.field-string')).to.have.length.of(0);
+      expect(node.querySelectorAll('.rjsf-field-string')).to.have.length.of(0);
     });
     it('should contain a field in the list when nested array formData is a single item', () => {
       const { node } = createFormComponent({
         schema,
         formData: { foo: ['test'] },
       });
-      expect(node.querySelectorAll('.field-string')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field-string')).to.have.length.of(1);
     });
   });
 
@@ -408,13 +408,13 @@ describe('ArrayField', () => {
     it('should contain no field in the list by default', () => {
       const { node } = createFormComponent({ schema });
 
-      expect(node.querySelectorAll('.field-string')).to.have.length.of(0);
+      expect(node.querySelectorAll('.rjsf-field-string')).to.have.length.of(0);
     });
 
     it('should have an add button', () => {
       const { node } = createFormComponent({ schema });
 
-      expect(node.querySelector('.array-item-add button')).not.eql(null);
+      expect(node.querySelector('.rjsf-array-item-add button')).not.eql(null);
     });
 
     it('should not have an add button if addable is false', () => {
@@ -423,17 +423,17 @@ describe('ArrayField', () => {
         uiSchema: { 'ui:options': { addable: false } },
       });
 
-      expect(node.querySelector('.array-item-add button')).to.be.null;
+      expect(node.querySelector('.rjsf-array-item-add button')).to.be.null;
     });
 
     it('should add a new field when clicking the add button', () => {
       const { node } = createFormComponent({ schema });
 
       act(() => {
-        fireEvent.click(node.querySelector('.array-item-add button'));
+        fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
       });
 
-      expect(node.querySelectorAll('.field-string')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field-string')).to.have.length.of(1);
     });
 
     it('should assign new keys/ids when clicking the add button', () => {
@@ -443,10 +443,10 @@ describe('ArrayField', () => {
       });
 
       act(() => {
-        fireEvent.click(node.querySelector('.array-item-add button'));
+        fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
       });
 
-      expect(node.querySelector('.array-item').hasAttribute(ArrayKeyDataAttr)).to.be.true;
+      expect(node.querySelector('.rjsf-array-item').hasAttribute(ArrayKeyDataAttr)).to.be.true;
     });
 
     it('should add a field when clicking add button even if event is not passed to onAddClick', () => {
@@ -456,10 +456,10 @@ describe('ArrayField', () => {
       });
 
       act(() => {
-        fireEvent.click(node.querySelector('.array-item-add button'));
+        fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
       });
 
-      expect(node.querySelector('.array-item')).not.to.be.null;
+      expect(node.querySelector('.rjsf-array-item')).not.to.be.null;
     });
 
     it('should not provide an add button if length equals maxItems', () => {
@@ -468,7 +468,7 @@ describe('ArrayField', () => {
         formData: ['foo', 'bar'],
       });
 
-      expect(node.querySelector('.array-item-add button')).to.be.null;
+      expect(node.querySelector('.rjsf-array-item-add button')).to.be.null;
     });
 
     it('should provide an add button if length is lesser than maxItems', () => {
@@ -477,7 +477,7 @@ describe('ArrayField', () => {
         formData: ['foo'],
       });
 
-      expect(node.querySelector('.array-item-add button')).not.eql(null);
+      expect(node.querySelector('.rjsf-array-item-add button')).not.eql(null);
     });
 
     it('should retain existing row keys/ids when adding new row', () => {
@@ -487,15 +487,15 @@ describe('ArrayField', () => {
         templates: { ArrayFieldTemplate: ExposedArrayKeyTemplate },
       });
 
-      const startRows = node.querySelectorAll('.array-item');
+      const startRows = node.querySelectorAll('.rjsf-array-item');
       const startRow1_key = startRows[0].getAttribute(ArrayKeyDataAttr);
       const startRow2_key = startRows[1] ? startRows[1].getAttribute(ArrayKeyDataAttr) : undefined;
 
       act(() => {
-        fireEvent.click(node.querySelector('.array-item-add button'));
+        fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
       });
 
-      const endRows = node.querySelectorAll('.array-item');
+      const endRows = node.querySelectorAll('.rjsf-array-item');
       const endRow1_key = endRows[0].getAttribute(ArrayKeyDataAttr);
       const endRow2_key = endRows[1].getAttribute(ArrayKeyDataAttr);
 
@@ -513,7 +513,7 @@ describe('ArrayField', () => {
         const addBeforeButton = (
           <button
             key={`array-item-add-before-${item.key}`}
-            className={'array-item-move-before array-item-move-before-to-' + beforeIndex}
+            className={'rjsf-array-item-move-before array-item-move-before-to-' + beforeIndex}
             onClick={item.buttonsProps.onAddIndexClick(beforeIndex)}
           >
             {'Add Item Above'}
@@ -524,7 +524,7 @@ describe('ArrayField', () => {
         const addAfterButton = (
           <button
             key={`array-item-add-after-${item.key}`}
-            className={'array-item-move-after array-item-move-after-to-' + afterIndex}
+            className={'rjsf-array-item-move-after array-item-move-after-to-' + afterIndex}
             onClick={item.buttonsProps.onAddIndexClick(afterIndex)}
           >
             {'Add Item Below'}
@@ -532,7 +532,7 @@ describe('ArrayField', () => {
         );
 
         return (
-          <div key={item.key} data-rjsf-itemkey={item.key} className={`array-item item-${item.index}`}>
+          <div key={item.key} data-rjsf-itemkey={item.key} className={`rjsf-array-item item-${item.index}`}>
             <div>{addBeforeButton}</div>
             {item.children}
             <div>{addAfterButton}</div>
@@ -551,10 +551,10 @@ describe('ArrayField', () => {
         templates: { ArrayFieldTemplate: addAboveOrBelowArrayFieldTemplate },
       });
 
-      const addBeforeButtons = node.querySelectorAll('.array-item-move-before');
-      const addAfterButtons = node.querySelectorAll('.array-item-move-after');
+      const addBeforeButtons = node.querySelectorAll('.rjsf-array-item-move-before');
+      const addAfterButtons = node.querySelectorAll('.rjsf-array-item-move-after');
 
-      const startRows = node.querySelectorAll('.array-item');
+      const startRows = node.querySelectorAll('.rjsf-array-item');
       const startRow1_key = startRows[0].getAttribute(ArrayKeyDataAttr);
       const startRow2_key = startRows[1].getAttribute(ArrayKeyDataAttr);
       const startRow3_key = startRows[2].getAttribute(ArrayKeyDataAttr);
@@ -567,7 +567,7 @@ describe('ArrayField', () => {
         fireEvent.click(addAfterButtons[0]);
       });
 
-      const endRows = node.querySelectorAll('.array-item');
+      const endRows = node.querySelectorAll('.rjsf-array-item');
       const endRow2_key = endRows[1].getAttribute(ArrayKeyDataAttr);
       const endRow4_key = endRows[3].getAttribute(ArrayKeyDataAttr);
       const endRow5_key = endRows[4].getAttribute(ArrayKeyDataAttr);
@@ -594,7 +594,7 @@ describe('ArrayField', () => {
         },
       });
 
-      expect(node.querySelector('.array-item-add button')).to.be.null;
+      expect(node.querySelector('.rjsf-array-item-add button')).to.be.null;
     });
 
     it('should ignore addable value if maxItems constraint is not satisfied', () => {
@@ -608,17 +608,17 @@ describe('ArrayField', () => {
         },
       });
 
-      expect(node.querySelector('.array-item-add button')).to.be.null;
+      expect(node.querySelector('.rjsf-array-item-add button')).to.be.null;
     });
 
     it('should mark a non-null array item widget as required', () => {
       const { node } = createFormComponent({ schema });
 
       act(() => {
-        fireEvent.click(node.querySelector('.array-item-add button'));
+        fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
       });
 
-      expect(node.querySelector('.field-string input[type=text]').required).eql(true);
+      expect(node.querySelector('.rjsf-field-string input[type=text]').required).eql(true);
     });
 
     it('should fill an array field with data', () => {
@@ -626,7 +626,7 @@ describe('ArrayField', () => {
         schema,
         formData: ['foo', 'bar'],
       });
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
 
       expect(inputs).to.have.length.of(2);
       expect(inputs[0].value).eql('foo');
@@ -636,8 +636,8 @@ describe('ArrayField', () => {
     it("shouldn't have reorder buttons when list length <= 1", () => {
       const { node } = createFormComponent({ schema, formData: ['foo'] });
 
-      expect(node.querySelector('.array-item-move-up')).eql(null);
-      expect(node.querySelector('.array-item-move-down')).eql(null);
+      expect(node.querySelector('.rjsf-array-item-move-up')).eql(null);
+      expect(node.querySelector('.rjsf-array-item-move-down')).eql(null);
     });
 
     it('should have reorder buttons when list length >= 2', () => {
@@ -646,8 +646,8 @@ describe('ArrayField', () => {
         formData: ['foo', 'bar'],
       });
 
-      expect(node.querySelector('.array-item-move-up')).not.eql(null);
-      expect(node.querySelector('.array-item-move-down')).not.eql(null);
+      expect(node.querySelector('.rjsf-array-item-move-up')).not.eql(null);
+      expect(node.querySelector('.rjsf-array-item-move-down')).not.eql(null);
     });
 
     it('should move down a field from the list', () => {
@@ -655,13 +655,13 @@ describe('ArrayField', () => {
         schema,
         formData: ['foo', 'bar', 'baz'],
       });
-      const moveDownBtns = node.querySelectorAll('.array-item-move-down');
+      const moveDownBtns = node.querySelectorAll('.rjsf-array-item-move-down');
 
       act(() => {
         fireEvent.click(moveDownBtns[0]);
       });
 
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       expect(inputs).to.have.length.of(3);
       expect(inputs[0].value).eql('bar');
       expect(inputs[1].value).eql('foo');
@@ -673,13 +673,13 @@ describe('ArrayField', () => {
         schema,
         formData: ['foo', 'bar', 'baz'],
       });
-      const moveUpBtns = node.querySelectorAll('.array-item-move-up');
+      const moveUpBtns = node.querySelectorAll('.rjsf-array-item-move-up');
 
       act(() => {
         fireEvent.click(moveUpBtns[2]);
       });
 
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       expect(inputs).to.have.length.of(3);
       expect(inputs[0].value).eql('foo');
       expect(inputs[1].value).eql('baz');
@@ -692,8 +692,8 @@ describe('ArrayField', () => {
         formData: ['foo', 'bar', 'baz'],
         templates: { ArrayFieldTemplate: ExposedArrayKeyTemplate },
       });
-      const moveDownBtns = node.querySelectorAll('.array-item-move-down');
-      const startRows = node.querySelectorAll('.array-item');
+      const moveDownBtns = node.querySelectorAll('.rjsf-array-item-move-down');
+      const startRows = node.querySelectorAll('.rjsf-array-item');
       const startRow1_key = startRows[0].getAttribute(ArrayKeyDataAttr);
       const startRow2_key = startRows[1].getAttribute(ArrayKeyDataAttr);
       const startRow3_key = startRows[2].getAttribute(ArrayKeyDataAttr);
@@ -702,7 +702,7 @@ describe('ArrayField', () => {
         fireEvent.click(moveDownBtns[0]);
       });
 
-      const endRows = node.querySelectorAll('.array-item');
+      const endRows = node.querySelectorAll('.rjsf-array-item');
       const endRow1_key = endRows[0].getAttribute(ArrayKeyDataAttr);
       const endRow2_key = endRows[1].getAttribute(ArrayKeyDataAttr);
       const endRow3_key = endRows[2].getAttribute(ArrayKeyDataAttr);
@@ -722,8 +722,8 @@ describe('ArrayField', () => {
         formData: ['foo', 'bar', 'baz'],
         templates: { ArrayFieldTemplate: ExposedArrayKeyTemplate },
       });
-      const moveUpBtns = node.querySelectorAll('.array-item-move-up');
-      const startRows = node.querySelectorAll('.array-item');
+      const moveUpBtns = node.querySelectorAll('.rjsf-array-item-move-up');
+      const startRows = node.querySelectorAll('.rjsf-array-item');
       const startRow1_key = startRows[0].getAttribute(ArrayKeyDataAttr);
       const startRow2_key = startRows[1].getAttribute(ArrayKeyDataAttr);
       const startRow3_key = startRows[2].getAttribute(ArrayKeyDataAttr);
@@ -732,7 +732,7 @@ describe('ArrayField', () => {
         fireEvent.click(moveUpBtns[2]);
       });
 
-      const endRows = node.querySelectorAll('.array-item');
+      const endRows = node.querySelectorAll('.rjsf-array-item');
       const endRow1_key = endRows[0].getAttribute(ArrayKeyDataAttr);
       const endRow2_key = endRows[1].getAttribute(ArrayKeyDataAttr);
       const endRow3_key = endRows[2].getAttribute(ArrayKeyDataAttr);
@@ -757,11 +757,11 @@ describe('ArrayField', () => {
               onClick={props.buttonsProps.onReorderClick(props.index, i)}
             >
               {'Move item to index ' + i}
-            </button>
+            </button>,
           );
         }
         return (
-          <div key={props.key} data-rjsf-itemkey={props.key} className={`array-item item-${props.index}`}>
+          <div key={props.key} data-rjsf-itemkey={props.key} className={`rjsf-array-item item-${props.index}`}>
             {props.children}
             {buttons}
           </div>
@@ -778,7 +778,7 @@ describe('ArrayField', () => {
         templates: { ArrayFieldTemplate: moveAnywhereArrayFieldTemplate },
       });
 
-      const startRows = node.querySelectorAll('.array-item');
+      const startRows = node.querySelectorAll('.rjsf-array-item');
       const startRow1_key = startRows[0].getAttribute(ArrayKeyDataAttr);
       const startRow2_key = startRows[1].getAttribute(ArrayKeyDataAttr);
       const startRow3_key = startRows[2].getAttribute(ArrayKeyDataAttr);
@@ -788,12 +788,12 @@ describe('ArrayField', () => {
         fireEvent.click(button);
       });
 
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       expect(inputs[0].value).eql('bar');
       expect(inputs[1].value).eql('baz');
       expect(inputs[2].value).eql('foo');
 
-      const endRows = node.querySelectorAll('.array-item');
+      const endRows = node.querySelectorAll('.rjsf-array-item');
       const endRow1_key = endRows[0].getAttribute(ArrayKeyDataAttr);
       const endRow2_key = endRows[1].getAttribute(ArrayKeyDataAttr);
       const endRow3_key = endRows[2].getAttribute(ArrayKeyDataAttr);
@@ -812,8 +812,8 @@ describe('ArrayField', () => {
         schema,
         formData: ['foo', 'bar'],
       });
-      const moveUpBtns = node.querySelectorAll('.array-item-move-up');
-      const moveDownBtns = node.querySelectorAll('.array-item-move-down');
+      const moveUpBtns = node.querySelectorAll('.rjsf-array-item-move-up');
+      const moveDownBtns = node.querySelectorAll('.rjsf-array-item-move-down');
 
       expect(moveUpBtns[0].disabled).eql(true);
       expect(moveDownBtns[0].disabled).eql(false);
@@ -827,8 +827,8 @@ describe('ArrayField', () => {
         formData: ['foo', 'bar'],
         uiSchema: { 'ui:globalOptions': { orderable: false } },
       });
-      const moveUpBtns = node.querySelector('.array-item-move-up');
-      const moveDownBtns = node.querySelector('.array-item-move-down');
+      const moveUpBtns = node.querySelector('.rjsf-array-item-move-up');
+      const moveDownBtns = node.querySelector('.rjsf-array-item-move-down');
 
       expect(moveUpBtns).to.be.null;
       expect(moveDownBtns).to.be.null;
@@ -840,8 +840,8 @@ describe('ArrayField', () => {
         formData: ['foo', 'bar'],
         uiSchema: { 'ui:options': { orderable: false } },
       });
-      const moveUpBtns = node.querySelector('.array-item-move-up');
-      const moveDownBtns = node.querySelector('.array-item-move-down');
+      const moveUpBtns = node.querySelector('.rjsf-array-item-move-up');
+      const moveDownBtns = node.querySelector('.rjsf-array-item-move-down');
 
       expect(moveUpBtns).to.be.null;
       expect(moveDownBtns).to.be.null;
@@ -853,8 +853,8 @@ describe('ArrayField', () => {
         formData: ['foo', 'bar'],
         uiSchema: { 'ui:orderable': false },
       });
-      const moveUpBtns = node.querySelector('.array-item-move-up');
-      const moveDownBtns = node.querySelector('.array-item-move-down');
+      const moveUpBtns = node.querySelector('.rjsf-array-item-move-up');
+      const moveDownBtns = node.querySelector('.rjsf-array-item-move-down');
 
       expect(moveUpBtns).to.be.null;
       expect(moveDownBtns).to.be.null;
@@ -865,13 +865,13 @@ describe('ArrayField', () => {
         schema,
         formData: ['foo', 'bar'],
       });
-      const dropBtns = node.querySelectorAll('.array-item-remove');
+      const dropBtns = node.querySelectorAll('.rjsf-array-item-remove');
 
       act(() => {
         fireEvent.click(dropBtns[0]);
       });
 
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       expect(inputs).to.have.length.of(1);
       expect(inputs[0].value).eql('bar');
     });
@@ -881,13 +881,13 @@ describe('ArrayField', () => {
         schema,
         formData: ['foo', 'bar', 'baz'],
       });
-      const deleteBtns = node.querySelectorAll('.array-item-remove');
+      const deleteBtns = node.querySelectorAll('.rjsf-array-item-remove');
 
       act(() => {
         fireEvent.click(deleteBtns[0]);
       });
 
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
 
       act(() => {
         fireEvent.change(inputs[0], { target: { value: 'fuzz' } });
@@ -905,15 +905,15 @@ describe('ArrayField', () => {
         templates: { ArrayFieldTemplate: ExposedArrayKeyTemplate },
       });
 
-      const startRows = node.querySelectorAll('.array-item');
+      const startRows = node.querySelectorAll('.rjsf-array-item');
       const startRow2_key = startRows[1].getAttribute(ArrayKeyDataAttr);
 
-      const dropBtns = node.querySelectorAll('.array-item-remove');
+      const dropBtns = node.querySelectorAll('.rjsf-array-item-remove');
       act(() => {
         fireEvent.click(dropBtns[0]);
       });
 
-      const endRows = node.querySelectorAll('.array-item');
+      const endRows = node.querySelectorAll('.rjsf-array-item');
       const endRow1_key = endRows[0].getAttribute(ArrayKeyDataAttr);
 
       expect(startRow2_key).to.equal(endRow1_key);
@@ -926,7 +926,7 @@ describe('ArrayField', () => {
         formData: ['foo', 'bar'],
         uiSchema: { 'ui:globalOptions': { removable: false } },
       });
-      const dropBtn = node.querySelector('.array-item-remove');
+      const dropBtn = node.querySelector('.rjsf-array-item-remove');
 
       expect(dropBtn).to.be.null;
     });
@@ -937,7 +937,7 @@ describe('ArrayField', () => {
         formData: ['foo', 'bar'],
         uiSchema: { 'ui:options': { removable: false } },
       });
-      const dropBtn = node.querySelector('.array-item-remove');
+      const dropBtn = node.querySelector('.rjsf-array-item-remove');
 
       expect(dropBtn).to.be.null;
     });
@@ -948,7 +948,7 @@ describe('ArrayField', () => {
         formData: ['foo', 'bar'],
         uiSchema: { 'ui:removable': false },
       });
-      const dropBtn = node.querySelector('.array-item-remove');
+      const dropBtn = node.querySelector('.rjsf-array-item-remove');
 
       expect(dropBtn).to.be.null;
     });
@@ -967,13 +967,13 @@ describe('ArrayField', () => {
         act(() => {
           fireEvent.submit(node);
         });
-      } catch (e) {
+      } catch {
         // Silencing error thrown as failure is expected here
       }
 
       expect(node.querySelectorAll('.has-error .error-detail')).to.have.length.of(1);
 
-      const dropBtns = node.querySelectorAll('.array-item-remove');
+      const dropBtns = node.querySelectorAll('.rjsf-array-item-remove');
 
       act(() => {
         fireEvent.click(dropBtns[0]);
@@ -987,7 +987,7 @@ describe('ArrayField', () => {
         schema,
         formData: ['foo', 'bar'],
       });
-      const dropBtn = node.querySelector('.array-item-copy');
+      const dropBtn = node.querySelector('.rjsf-array-item-copy');
 
       expect(dropBtn).to.be.null;
     });
@@ -998,7 +998,7 @@ describe('ArrayField', () => {
         formData: ['foo', 'bar'],
         uiSchema: { 'ui:globalOptions': { copyable: true } },
       });
-      const dropBtn = node.querySelector('.array-item-copy');
+      const dropBtn = node.querySelector('.rjsf-array-item-copy');
 
       expect(dropBtn).not.to.be.null;
     });
@@ -1009,7 +1009,7 @@ describe('ArrayField', () => {
         formData: ['foo', 'bar'],
         uiSchema: { 'ui:options': { copyable: true } },
       });
-      const dropBtn = node.querySelector('.array-item-copy');
+      const dropBtn = node.querySelector('.rjsf-array-item-copy');
 
       expect(dropBtn).not.to.be.null;
     });
@@ -1020,7 +1020,7 @@ describe('ArrayField', () => {
         formData: ['foo', 'bar'],
         uiSchema: { 'ui:copyable': true },
       });
-      const dropBtn = node.querySelector('.array-item-copy');
+      const dropBtn = node.querySelector('.rjsf-array-item-copy');
 
       expect(dropBtn).not.to.be.null;
     });
@@ -1031,13 +1031,13 @@ describe('ArrayField', () => {
         formData: ['foo', 'bar'],
         uiSchema: { 'ui:copyable': true },
       });
-      const copyBtns = node.querySelectorAll('.array-item-copy');
+      const copyBtns = node.querySelectorAll('.rjsf-array-item-copy');
 
       act(() => {
         fireEvent.click(copyBtns[0]);
       });
 
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       expect(inputs).to.have.length.of(3);
       expect(inputs[0].value).eql('foo');
       expect(inputs[1].value).eql('foo');
@@ -1078,7 +1078,7 @@ describe('ArrayField', () => {
           ],
           formData: [1, null, 3],
         },
-        'root_1'
+        'root_1',
       );
 
       submitForm(node);
@@ -1349,13 +1349,13 @@ describe('ArrayField', () => {
       it('should render a select widget with a label', () => {
         const { node } = createFormComponent({ schema });
 
-        expect(node.querySelector('.field label').textContent).eql('My field');
+        expect(node.querySelector('.rjsf-field label').textContent).eql('My field');
       });
 
       it('should render a select widget with multiple attribute', () => {
         const { node } = createFormComponent({ schema });
 
-        expect(node.querySelector('.field select').getAttribute('multiple')).not.to.be.null;
+        expect(node.querySelector('.rjsf-field select').getAttribute('multiple')).not.to.be.null;
       });
 
       it('should render options', () => {
@@ -1368,7 +1368,7 @@ describe('ArrayField', () => {
         const { node, onChange } = createFormComponent({ schema });
 
         act(() => {
-          Simulate.change(node.querySelector('.field select'), {
+          Simulate.change(node.querySelector('.rjsf-field select'), {
             target: {
               options: [
                 { selected: true, value: 0 }, // use index
@@ -1384,7 +1384,7 @@ describe('ArrayField', () => {
           {
             formData: ['foo', 'bar'],
           },
-          'root'
+          'root',
         );
       });
 
@@ -1392,7 +1392,7 @@ describe('ArrayField', () => {
         const onBlur = sandbox.spy();
         const { node } = createFormComponent({ schema, onBlur });
 
-        const select = node.querySelector('.field select');
+        const select = node.querySelector('.rjsf-field select');
         Simulate.blur(select, {
           target: {
             options: [
@@ -1410,7 +1410,7 @@ describe('ArrayField', () => {
         const onFocus = sandbox.spy();
         const { node } = createFormComponent({ schema, onFocus });
 
-        const select = node.querySelector('.field select');
+        const select = node.querySelector('.rjsf-field select');
         Simulate.focus(select, {
           target: {
             options: [
@@ -1430,7 +1430,7 @@ describe('ArrayField', () => {
           formData: ['foo', 'bar'],
         });
 
-        const options = node.querySelectorAll('.field select option');
+        const options = node.querySelectorAll('.rjsf-field select option');
         expect(options).to.have.length.of(3);
         expect(options[0].selected).eql(true); // foo
         expect(options[1].selected).eql(true); // bar
@@ -1520,7 +1520,7 @@ describe('ArrayField', () => {
           {
             formData: ['foo', 'fuzz'],
           },
-          'root'
+          'root',
         );
       });
 
@@ -1543,7 +1543,7 @@ describe('ArrayField', () => {
           {
             formData: ['foo', 'fuzz'],
           },
-          'root'
+          'root',
         );
         labels = [].map.call(node.querySelectorAll('[type=checkbox]'), (node) => node.checked);
         expect(labels).eql([true, false, true]);
@@ -1649,13 +1649,13 @@ describe('ArrayField', () => {
     it('should render a select widget with a label', () => {
       const { node } = createFormComponent({ schema });
 
-      expect(node.querySelector('.field label').textContent).eql('My field');
+      expect(node.querySelector('.rjsf-field label').textContent).eql('My field');
     });
 
     it('should render a file widget with multiple attribute', () => {
       const { node } = createFormComponent({ schema });
 
-      expect(node.querySelector('.field [type=file]').getAttribute('multiple')).not.to.be.null;
+      expect(node.querySelector('.rjsf-field [type=file]').getAttribute('multiple')).not.to.be.null;
     });
 
     it('should handle a two change events that results in two items in the list', async () => {
@@ -1670,7 +1670,7 @@ describe('ArrayField', () => {
       const { node, onChange } = createFormComponent({ schema });
 
       act(() => {
-        fireEvent.change(node.querySelector('.field input[type=file]'), {
+        fireEvent.change(node.querySelector('.rjsf-field input[type=file]'), {
           target: {
             files: [{ name: 'file1.txt', size: 1, type: 'type' }],
           },
@@ -1686,11 +1686,11 @@ describe('ArrayField', () => {
         {
           formData: ['data:text/plain;name=file1.txt;base64,x='],
         },
-        'root'
+        'root',
       );
 
       act(() => {
-        fireEvent.change(node.querySelector('.field input[type=file]'), {
+        fireEvent.change(node.querySelector('.rjsf-field input[type=file]'), {
           target: {
             files: [{ name: 'file2.txt', size: 2, type: 'type' }],
           },
@@ -1706,7 +1706,7 @@ describe('ArrayField', () => {
         {
           formData: ['data:text/plain;name=file1.txt;base64,x=', 'data:text/plain;name=file2.txt;base64,x='],
         },
-        'root'
+        'root',
       );
     });
 
@@ -1722,7 +1722,7 @@ describe('ArrayField', () => {
       const { node, onChange } = createFormComponent({ schema });
 
       act(() => {
-        fireEvent.change(node.querySelector('.field input[type=file]'), {
+        fireEvent.change(node.querySelector('.rjsf-field input[type=file]'), {
           target: {
             files: [
               { name: 'file1.txt', size: 1, type: 'type' },
@@ -1741,7 +1741,7 @@ describe('ArrayField', () => {
         {
           formData: ['data:text/plain;name=file1.txt;base64,x=', 'data:text/plain;name=file2.txt;base64,x='],
         },
-        'root'
+        'root',
       );
     });
 
@@ -1845,7 +1845,7 @@ describe('ArrayField', () => {
       expect(node.querySelectorAll('fieldset fieldset')).to.be.empty;
 
       act(() => {
-        fireEvent.click(node.querySelector('.array-item-add button'));
+        fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
       });
 
       expect(node.querySelectorAll('fieldset fieldset')).to.have.length.of(1);
@@ -1940,16 +1940,16 @@ describe('ArrayField', () => {
 
     it('should render field widgets', () => {
       const { node } = createFormComponent({ schema });
-      const strInput = node.querySelector('fieldset .field-string input[type=text]');
-      const numInput = node.querySelector('fieldset .field-number input[type=number]');
+      const strInput = node.querySelector('fieldset .rjsf-field-string input[type=text]');
+      const numInput = node.querySelector('fieldset .rjsf-field-number input[type=number]');
       expect(strInput.id).eql('root_0');
       expect(numInput.id).eql('root_1');
     });
 
     it('should mark non-null item widgets as required', () => {
       const { node } = createFormComponent({ schema });
-      const strInput = node.querySelector('fieldset .field-string input[type=text]');
-      const numInput = node.querySelector('fieldset .field-number input[type=number]');
+      const strInput = node.querySelector('fieldset .rjsf-field-string input[type=text]');
+      const numInput = node.querySelector('fieldset .rjsf-field-number input[type=number]');
       expect(strInput.required).eql(true);
       expect(numInput.required).eql(true);
     });
@@ -1959,16 +1959,16 @@ describe('ArrayField', () => {
         schema,
         formData: ['foo', 42],
       });
-      const strInput = node.querySelector('fieldset .field-string input[type=text]');
-      const numInput = node.querySelector('fieldset .field-number input[type=number]');
+      const strInput = node.querySelector('fieldset .rjsf-field-string input[type=text]');
+      const numInput = node.querySelector('fieldset .rjsf-field-number input[type=number]');
       expect(strInput.value).eql('foo');
       expect(numInput.value).eql('42');
     });
 
     it('should handle change events', () => {
       const { node, onChange } = createFormComponent({ schema });
-      const strInput = node.querySelector('fieldset .field-string input[type=text]');
-      const numInput = node.querySelector('fieldset .field-number input[type=number]');
+      const strInput = node.querySelector('fieldset .rjsf-field-string input[type=text]');
+      const numInput = node.querySelector('fieldset .rjsf-field-number input[type=number]');
 
       act(() => {
         fireEvent.change(strInput, { target: { value: 'bar' } });
@@ -1983,7 +1983,7 @@ describe('ArrayField', () => {
         {
           formData: ['bar', 101],
         },
-        'root'
+        'root',
       );
     });
 
@@ -1992,7 +1992,7 @@ describe('ArrayField', () => {
         schema: schemaAdditional,
         formData: [1, 2, 'bar'],
       });
-      const addInput = node.querySelector('fieldset .field-string input[type=text]');
+      const addInput = node.querySelector('fieldset .rjsf-field-string input[type=text]');
       expect(addInput.id).eql('root_2');
       expect(addInput.value).eql('bar');
     });
@@ -2007,18 +2007,18 @@ describe('ArrayField', () => {
         },
         formData: [1, 2, 'bar'],
       });
-      const label = node.querySelector('fieldset .field-string label.control-label');
+      const label = node.querySelector('fieldset .rjsf-field-string label.control-label');
       expect(label.textContent).eql('Custom title*');
     });
 
     it('should have an add button if additionalItems is an object', () => {
       const { node } = createFormComponent({ schema: schemaAdditional });
-      expect(node.querySelector('.array-item-add button')).not.to.be.null;
+      expect(node.querySelector('.rjsf-array-item-add button')).not.to.be.null;
     });
 
     it('should not have an add button if additionalItems is not set', () => {
       const { node } = createFormComponent({ schema });
-      expect(node.querySelector('.array-item-add button')).to.be.null;
+      expect(node.querySelector('.rjsf-array-item-add button')).to.be.null;
     });
 
     it('should not have an add button if global addable is false', () => {
@@ -2026,7 +2026,7 @@ describe('ArrayField', () => {
         schema,
         uiSchema: { 'ui:globalOptions': { addable: false } },
       });
-      expect(node.querySelector('.array-item-add button')).to.be.null;
+      expect(node.querySelector('.rjsf-array-item-add button')).to.be.null;
     });
 
     it('should not have an add button if addable is false', () => {
@@ -2034,7 +2034,7 @@ describe('ArrayField', () => {
         schema,
         uiSchema: { 'ui:options': { addable: false } },
       });
-      expect(node.querySelector('.array-item-add button')).to.be.null;
+      expect(node.querySelector('.rjsf-array-item-add button')).to.be.null;
     });
 
     it('[fixed-noadditional] should not provide an add button regardless maxItems', () => {
@@ -2042,7 +2042,7 @@ describe('ArrayField', () => {
         schema: { maxItems: 3, ...schema },
       });
 
-      expect(node.querySelector('.array-item-add button')).to.be.null;
+      expect(node.querySelector('.rjsf-array-item-add button')).to.be.null;
     });
 
     it('[fixed] should not provide an add button if length equals maxItems', () => {
@@ -2050,7 +2050,7 @@ describe('ArrayField', () => {
         schema: { maxItems: 2, ...schemaAdditional },
       });
 
-      expect(node.querySelector('.array-item-add button')).to.be.null;
+      expect(node.querySelector('.rjsf-array-item-add button')).to.be.null;
     });
 
     it('[fixed] should provide an add button if length is lesser than maxItems', () => {
@@ -2058,7 +2058,7 @@ describe('ArrayField', () => {
         schema: { maxItems: 3, ...schemaAdditional },
       });
 
-      expect(node.querySelector('.array-item-add button')).not.to.be.null;
+      expect(node.querySelector('.rjsf-array-item-add button')).not.to.be.null;
     });
 
     it('[fixed] should not provide an add button if addable is expliclty false regardless maxItems value', () => {
@@ -2071,7 +2071,7 @@ describe('ArrayField', () => {
         },
       });
 
-      expect(node.querySelector('.array-item-add button')).to.be.null;
+      expect(node.querySelector('.rjsf-array-item-add button')).to.be.null;
     });
 
     it('[fixed] should ignore addable value if maxItems constraint is not satisfied', () => {
@@ -2084,7 +2084,7 @@ describe('ArrayField', () => {
         },
       });
 
-      expect(node.querySelector('.array-item-add button')).to.be.null;
+      expect(node.querySelector('.rjsf-array-item-add button')).to.be.null;
     });
 
     it('[fixed] should pass uiSchema to fixed array', () => {
@@ -2141,20 +2141,20 @@ describe('ArrayField', () => {
           templates: { ArrayFieldTemplate: ExposedArrayKeyTemplate },
         });
 
-        const addBtn = node.querySelector('.array-item-add button');
+        const addBtn = node.querySelector('.rjsf-array-item-add button');
 
         act(() => {
           fireEvent.click(addBtn);
         });
 
-        expect(node.querySelectorAll('.field-string')).to.have.length.of(2);
+        expect(node.querySelectorAll('.rjsf-field-string')).to.have.length.of(2);
 
         sinon.assert.calledWithMatch(
           onChange.lastCall,
           {
             formData: [1, 2, 'foo', undefined],
           },
-          'root'
+          'root',
         );
       });
 
@@ -2165,19 +2165,19 @@ describe('ArrayField', () => {
           templates: { ArrayFieldTemplate: ExposedArrayKeyTemplate },
         });
 
-        const startRows = node.querySelectorAll('.array-item');
+        const startRows = node.querySelectorAll('.rjsf-array-item');
         const startRow1_key = startRows[0].getAttribute(ArrayKeyDataAttr);
         const startRow2_key = startRows[1].getAttribute(ArrayKeyDataAttr);
         const startRow3_key = startRows[2].getAttribute(ArrayKeyDataAttr);
         const startRow4_key = startRows[3] ? startRows[3].getAttribute(ArrayKeyDataAttr) : undefined;
 
-        const addBtn = node.querySelector('.array-item-add button');
+        const addBtn = node.querySelector('.rjsf-array-item-add button');
 
         act(() => {
           fireEvent.click(addBtn);
         });
 
-        const endRows = node.querySelectorAll('.array-item');
+        const endRows = node.querySelectorAll('.rjsf-array-item');
         const endRow1_key = endRows[0].getAttribute(ArrayKeyDataAttr);
         const endRow2_key = endRows[1].getAttribute(ArrayKeyDataAttr);
         const endRow3_key = endRows[2].getAttribute(ArrayKeyDataAttr);
@@ -2202,13 +2202,13 @@ describe('ArrayField', () => {
           templates: { ArrayFieldTemplate: ExposedArrayKeyTemplate },
         });
 
-        const addBtn = node.querySelector('.array-item-add button');
+        const addBtn = node.querySelector('.rjsf-array-item-add button');
 
         act(() => {
           fireEvent.click(addBtn);
         });
 
-        const inputs = node.querySelectorAll('.field-string input[type=text]');
+        const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
 
         act(() => {
           fireEvent.change(inputs[0], { target: { value: 'bar' } });
@@ -2223,7 +2223,7 @@ describe('ArrayField', () => {
           {
             formData: [1, 2, 'bar', 'baz'],
           },
-          'root'
+          'root',
         );
       });
 
@@ -2234,20 +2234,20 @@ describe('ArrayField', () => {
           templates: { ArrayFieldTemplate: ExposedArrayKeyTemplate },
         });
 
-        const addBtn = node.querySelector('.array-item-add button');
+        const addBtn = node.querySelector('.rjsf-array-item-add button');
 
         act(() => {
           fireEvent.click(addBtn);
         });
 
-        let dropBtns = node.querySelectorAll('.array-item-remove');
+        let dropBtns = node.querySelectorAll('.rjsf-array-item-remove');
 
         act(() => {
           fireEvent.click(dropBtns[0]);
         });
 
-        expect(node.querySelectorAll('.field-string')).to.have.length.of(1);
-        const inputs = node.querySelectorAll('.field-string input[type=text]');
+        expect(node.querySelectorAll('.rjsf-field-string')).to.have.length.of(1);
+        const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
         act(() => {
           fireEvent.change(inputs[0], { target: { value: 'baz' } });
         });
@@ -2257,21 +2257,21 @@ describe('ArrayField', () => {
           {
             formData: [1, 2, 'baz'],
           },
-          'root'
+          'root',
         );
 
-        dropBtns = node.querySelectorAll('.array-item-remove');
+        dropBtns = node.querySelectorAll('.rjsf-array-item-remove');
         act(() => {
           fireEvent.click(dropBtns[0]);
         });
 
-        expect(node.querySelectorAll('.field-string')).to.be.empty;
+        expect(node.querySelectorAll('.rjsf-field-string')).to.be.empty;
         sinon.assert.calledWithMatch(
           onChange.lastCall,
           {
             formData: [1, 2],
           },
-          'root'
+          'root',
         );
       });
     });
@@ -2292,7 +2292,7 @@ describe('ArrayField', () => {
       const { node, onChange } = createFormComponent({ schema });
 
       act(() => {
-        Simulate.change(node.querySelector('.field select'), {
+        Simulate.change(node.querySelector('.rjsf-field select'), {
           target: {
             options: [
               { selected: true, value: '0' }, // use index
@@ -2308,7 +2308,7 @@ describe('ArrayField', () => {
         {
           formData: [1, 2],
         },
-        'root'
+        'root',
       );
     });
   });
@@ -2611,7 +2611,7 @@ describe('ArrayField', () => {
         });
 
         act(() => {
-          fireEvent.click(node.querySelector('.array-item-add button'));
+          fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
         });
 
         expect(node.querySelector('#title-Array-1')).to.not.be.null;
@@ -2637,7 +2637,7 @@ describe('ArrayField', () => {
         });
 
         act(() => {
-          fireEvent.click(node.querySelector('.array-item-add button'));
+          fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
         });
 
         expect(node.querySelector('#title-Boolean')).to.not.be.null;
@@ -2663,11 +2663,11 @@ describe('ArrayField', () => {
           });
 
           act(() => {
-            fireEvent.click(node.querySelector('.array-item-add button'));
+            fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
           });
 
           expect(node.querySelector('label[for="root_0"]').textContent).to.contain('Array-1');
-        }
+        },
       );
 
       it.each(widgetTestData)(
@@ -2692,14 +2692,14 @@ describe('ArrayField', () => {
           });
 
           act(() => {
-            fireEvent.click(node.querySelector('.array-item-add button'));
+            fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
           });
 
           const widgetLabelTextContent = node.querySelector('label[for="root_0"]').textContent;
 
           expect(widgetLabelTextContent).not.to.contain('Array-1');
           expect(widgetLabelTextContent).to.contain('Item Title');
-        }
+        },
       );
     });
 
@@ -2794,11 +2794,11 @@ describe('ArrayField', () => {
           });
 
           act(() => {
-            fireEvent.click(node.querySelector('.array-item-add button'));
+            fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
           });
 
           expect(node.querySelector('legend#root_0__title').textContent).to.contain('Array-1');
-        }
+        },
       );
 
       it.each(fieldTestDataWithLegend)(
@@ -2818,14 +2818,14 @@ describe('ArrayField', () => {
           });
 
           act(() => {
-            fireEvent.click(node.querySelector('.array-item-add button'));
+            fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
           });
 
           const legendTextContent = node.querySelector('legend#root_0__title').textContent;
 
           expect(legendTextContent).to.contain('Item Field Title');
           expect(legendTextContent).not.to.contain('Array-1');
-        }
+        },
       );
 
       it.each(fieldTestDataWithLabel)(
@@ -2842,11 +2842,11 @@ describe('ArrayField', () => {
           });
 
           act(() => {
-            fireEvent.click(node.querySelector('.array-item-add button'));
+            fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
           });
 
           expect(node.querySelector('label[for="root_0"]').textContent).to.contain('Array-1');
-        }
+        },
       );
 
       it.each(fieldTestDataWithLabel)(
@@ -2866,14 +2866,14 @@ describe('ArrayField', () => {
           });
 
           act(() => {
-            fireEvent.click(node.querySelector('.array-item-add button'));
+            fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
           });
 
           const labelTextContent = node.querySelector('label[for="root_0"]').textContent;
 
           expect(labelTextContent).to.contain('Item Field Title');
           expect(labelTextContent).to.not.contain('Array-1');
-        }
+        },
       );
     });
   });
@@ -2949,7 +2949,7 @@ describe('ArrayField', () => {
         fireEvent.submit(node);
       });
 
-      const inputs = node.querySelectorAll('.form-group.field-error input[type=text]');
+      const inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=text]');
       expect(inputs[0].id).eql('root_foo_0_bar');
       expect(inputs[1].id).eql('root_foo_1_bar');
     });
@@ -2967,7 +2967,7 @@ describe('ArrayField', () => {
       });
       fireEvent.submit(node);
 
-      const inputsNoError = node.querySelectorAll('.form-group.field-error input[type=text]');
+      const inputsNoError = node.querySelectorAll('.form-group.rjsf-field-error input[type=text]');
       expect(inputsNoError).to.have.length.of(0);
     });
   });
@@ -3300,7 +3300,7 @@ describe('ArrayField', () => {
         },
       });
 
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       act(() => {
         fireEvent.change(inputs[0], { target: { value: 'test' } });
       });
@@ -3325,7 +3325,7 @@ describe('ArrayField', () => {
         },
       });
 
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       act(() => {
         fireEvent.change(inputs[0], { target: { value: 'Appie' } });
       });
@@ -3348,7 +3348,7 @@ describe('ArrayField', () => {
         },
       });
 
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       act(() => {
         fireEvent.change(inputs[0], { target: { value: 'hello' } });
       });
@@ -3373,7 +3373,7 @@ describe('ArrayField', () => {
         },
       });
 
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       act(() => {
         fireEvent.change(inputs[0], { target: { value: 'test' } });
       });

--- a/packages/core/test/ArrayFieldTemplate.test.jsx
+++ b/packages/core/test/ArrayFieldTemplate.test.jsx
@@ -59,7 +59,7 @@ describe('ArrayFieldTemplate', () => {
             templates: { ArrayFieldTemplate },
           });
 
-          expect(node.querySelectorAll('.field-array .field-content div')).to.have.length.of(3);
+          expect(node.querySelectorAll('.rjsf-field-array .field-content div')).to.have.length.of(3);
         });
       });
       describe('with template configured in ui:ArrayFieldTemplate', () => {
@@ -72,7 +72,7 @@ describe('ArrayFieldTemplate', () => {
             },
           });
 
-          expect(node.querySelectorAll('.field-array .field-content div')).to.have.length.of(3);
+          expect(node.querySelectorAll('.rjsf-field-array .field-content div')).to.have.length.of(3);
         });
       });
       describe('with template configured globally being overriden in ui:ArrayFieldTemplate', () => {
@@ -87,7 +87,7 @@ describe('ArrayFieldTemplate', () => {
             templates: { ArrayFieldTemplate: () => <div /> },
           });
 
-          expect(node.querySelectorAll('.field-array .field-content div')).to.have.length.of(3);
+          expect(node.querySelectorAll('.rjsf-field-array .field-content div')).to.have.length.of(3);
         });
       });
     });
@@ -164,7 +164,7 @@ describe('ArrayFieldTemplate', () => {
         });
 
         it('should render text input for each array item', () => {
-          expect(node.querySelectorAll('.custom-array-item .field input[type=text]')).to.have.length.of(
+          expect(node.querySelectorAll('.custom-array-item .rjsf-field input[type=text]')).to.have.length.of(
             formData.length,
           );
         });
@@ -248,7 +248,7 @@ describe('ArrayFieldTemplate', () => {
         });
 
         it('should render text input for each array item', () => {
-          expect(node.querySelectorAll('.custom-array-item .field input[type=text]')).to.have.length.of(
+          expect(node.querySelectorAll('.custom-array-item .rjsf-field input[type=text]')).to.have.length.of(
             formData.length,
           );
         });
@@ -283,7 +283,7 @@ describe('ArrayFieldTemplate', () => {
         formData,
         templates: { ArrayFieldTemplate },
       });
-      expect(node.querySelectorAll('.field-array .field-content div')).to.have.length.of(3);
+      expect(node.querySelectorAll('.rjsf-field-array .field-content div')).to.have.length.of(3);
     });
   });
 
@@ -312,7 +312,7 @@ describe('ArrayFieldTemplate', () => {
             {items.map((item, i) => (
               <span key={i}>value: {formData[i]}</span>
             ))}
-            <button className='array-item-add' onClick={onAddClick} />
+            <button className='rjsf-array-item-add' onClick={onAddClick} />
           </div>
         );
       };
@@ -321,7 +321,7 @@ describe('ArrayFieldTemplate', () => {
         formData,
         templates: { ArrayFieldTemplate },
       });
-      Simulate.click(node.querySelector('.array-item-add'));
+      Simulate.click(node.querySelector('.rjsf-array-item-add'));
     });
   });
 });

--- a/packages/core/test/BooleanField.test.jsx
+++ b/packages/core/test/BooleanField.test.jsx
@@ -25,7 +25,7 @@ describe('BooleanField', () => {
       },
     });
 
-    expect(node.querySelectorAll('.field input[type=checkbox]')).to.have.length.of(1);
+    expect(node.querySelectorAll('.rjsf-field input[type=checkbox]')).to.have.length.of(1);
   });
 
   it('should render a boolean field with the expected id', () => {
@@ -35,7 +35,7 @@ describe('BooleanField', () => {
       },
     });
 
-    expect(node.querySelector('.field input[type=checkbox]').id).eql('root');
+    expect(node.querySelector('.rjsf-field input[type=checkbox]').id).eql('root');
   });
 
   it('should render a boolean field with a label', () => {
@@ -46,7 +46,7 @@ describe('BooleanField', () => {
       },
     });
 
-    expect(node.querySelector('.field label span').textContent).eql('foo');
+    expect(node.querySelector('.rjsf-field label span').textContent).eql('foo');
   });
 
   describe('HTML5 required attribute', () => {
@@ -167,7 +167,7 @@ describe('BooleanField', () => {
       },
     });
 
-    expect(node.querySelectorAll('.field label')).to.have.length.of(1);
+    expect(node.querySelectorAll('.rjsf-field label')).to.have.length.of(1);
   });
 
   it('should render a description', () => {
@@ -233,7 +233,7 @@ describe('BooleanField', () => {
       },
     });
 
-    expect(node.querySelector('.field input').checked).eql(true);
+    expect(node.querySelector('.rjsf-field input').checked).eql(true);
   });
 
   it('formData should default to undefined', () => {
@@ -264,7 +264,7 @@ describe('BooleanField', () => {
     const focusSpys = [sinon.spy(), sinon.spy()];
     const inputs = node.querySelectorAll('input[id^=root_bool]');
     expect(inputs.length).eql(2);
-    let errorInputs = node.querySelectorAll('.form-group.field-error input[id^=root_bool]');
+    let errorInputs = node.querySelectorAll('.form-group.rjsf-field-error input[id^=root_bool]');
     expect(errorInputs).to.have.length.of(0);
     // Since programmatically triggering focus does not call onFocus, change the focus method to a spy
     inputs[0].focus = focusSpys[0];
@@ -275,7 +275,7 @@ describe('BooleanField', () => {
     });
     sinon.assert.calledOnce(focusSpys[0]);
     sinon.assert.notCalled(focusSpys[1]);
-    errorInputs = node.querySelectorAll('.form-group.field-error input[id^=root_bool]');
+    errorInputs = node.querySelectorAll('.form-group.rjsf-field-error input[id^=root_bool]');
     expect(errorInputs).to.have.length.of(2);
   });
 
@@ -296,7 +296,7 @@ describe('BooleanField', () => {
     const focusSpys = [sinon.spy(), sinon.spy()];
     const inputs = node.querySelectorAll('input[id^=root_bool]');
     expect(inputs.length).eql(2);
-    let errorInputs = node.querySelectorAll('.form-group.field-error input[id^=root_bool]');
+    let errorInputs = node.querySelectorAll('.form-group.rjsf-field-error input[id^=root_bool]');
     expect(errorInputs).to.have.length.of(0);
     // Since programmatically triggering focus does not call onFocus, change the focus method to a spy
     inputs[0].focus = focusSpys[0];
@@ -307,7 +307,7 @@ describe('BooleanField', () => {
     });
     sinon.assert.calledOnce(focusSpys[0]);
     sinon.assert.notCalled(focusSpys[1]);
-    errorInputs = node.querySelectorAll('.form-group.field-error input[id^=root_bool]');
+    errorInputs = node.querySelectorAll('.form-group.rjsf-field-error input[id^=root_bool]');
     expect(errorInputs).to.have.length.of(0);
   });
 
@@ -334,7 +334,7 @@ describe('BooleanField', () => {
       formData: true,
     });
 
-    expect(node.querySelector('.field input').checked).eql(true);
+    expect(node.querySelector('.rjsf-field input').checked).eql(true);
   });
 
   it('should render radio widgets with the expected id', () => {
@@ -521,7 +521,7 @@ describe('BooleanField', () => {
       uiSchema: { 'ui:widget': 'select', 'ui:enumNames': ['Si!', 'No!'] },
     });
 
-    const labels = [].map.call(node.querySelectorAll('.field option'), (label) => label.textContent);
+    const labels = [].map.call(node.querySelectorAll('.rjsf-field option'), (label) => label.textContent);
     expect(labels).eql(['', 'Si!', 'No!']);
   });
 
@@ -694,7 +694,7 @@ describe('BooleanField', () => {
         },
       });
 
-      expect(node.querySelectorAll('.field select')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field select')).to.have.length.of(1);
     });
 
     it('should infer the value from an enum on change', () => {
@@ -706,8 +706,8 @@ describe('BooleanField', () => {
         onChange: spy,
       });
 
-      expect(node.querySelectorAll('.field select')).to.have.length.of(1);
-      const $select = node.querySelector('.field select');
+      expect(node.querySelectorAll('.rjsf-field select')).to.have.length.of(1);
+      const $select = node.querySelector('.rjsf-field select');
       expect($select.value).eql('');
 
       act(() => {
@@ -728,7 +728,7 @@ describe('BooleanField', () => {
         },
       });
 
-      expect(node.querySelector('.field label').textContent).eql('foo');
+      expect(node.querySelector('.rjsf-field label').textContent).eql('foo');
     });
 
     it('should assign a default value', () => {

--- a/packages/core/test/Form.test.jsx
+++ b/packages/core/test/Form.test.jsx
@@ -378,7 +378,7 @@ describeRepeated('Form common', (createFormComponent) => {
 
     it('should use the provided template for labels', () => {
       expect(node.querySelector('.my-template > label').textContent).eql('root object');
-      expect(node.querySelector('.my-template .field-string > label').textContent).eql('foo*');
+      expect(node.querySelector('.my-template .rjsf-field-string > label').textContent).eql('foo*');
     });
 
     it('should pass description as the provided React element', () => {
@@ -674,7 +674,7 @@ describeRepeated('Form common', (createFormComponent) => {
 
       const { node } = createFormComponent({ schema });
 
-      fireEvent.click(node.querySelector('.array-item-add button'));
+      fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
 
       expect(node.querySelector('input[type=text]').value).eql('hello');
     });
@@ -741,7 +741,7 @@ describeRepeated('Form common', (createFormComponent) => {
 
       expect(node.querySelector('#root_children_0_name')).to.not.exist;
 
-      fireEvent.click(node.querySelector('.array-item-add button'));
+      fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
 
       expect(node.querySelector('#root_children_0_name')).to.exist;
     });
@@ -897,7 +897,7 @@ describeRepeated('Form common', (createFormComponent) => {
     it('should propagate deeply nested defaults to submit handler', () => {
       const { node, onSubmit } = createFormComponent({ schema });
 
-      fireEvent.click(node.querySelector('.array-item-add button'));
+      fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
       fireEvent.submit(node);
 
       sinon.assert.calledWithMatch(onSubmit.lastCall, {
@@ -1772,7 +1772,7 @@ describeRepeated('Form common', (createFormComponent) => {
       };
       const { node, onChange } = createFormComponent({ ref: React.createRef(), schema });
 
-      fireEvent.click(node.querySelector('.array-item-add button'));
+      fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
 
       fireEvent.change(node.querySelector('input[type=text]'), {
         target: { value: 'yo' },
@@ -1797,7 +1797,7 @@ describeRepeated('Form common', (createFormComponent) => {
       };
       const { node, onChange } = createFormComponent({ ref: React.createRef(), schema });
 
-      fireEvent.click(node.querySelector('.array-item-add button'));
+      fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
 
       fireEvent.change(node.querySelector('input[type=text]'), {
         target: { value: 'yo' },
@@ -1850,7 +1850,7 @@ describeRepeated('Form common', (createFormComponent) => {
       const checkbox = node.querySelector('[type=checkbox]');
       fireEvent.click(checkbox);
 
-      fireEvent.click(node.querySelector('.array-item-add button'));
+      fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
 
       fireEvent.change(node.querySelector('input[type=text]'), {
         target: { value: 'yo' },
@@ -1899,7 +1899,7 @@ describeRepeated('Form common', (createFormComponent) => {
             target: { value: 'short' },
           });
 
-          expect(node.querySelectorAll('.field-error')).to.have.length.of(0);
+          expect(node.querySelectorAll('.rjsf-field-error')).to.have.length.of(0);
         });
 
         it("should clean contextualized errors up when they're fixed", () => {
@@ -1926,7 +1926,7 @@ describeRepeated('Form common', (createFormComponent) => {
           });
           fireEvent.submit(node);
 
-          expect(node.querySelectorAll('.field-error')).to.have.length.of(1);
+          expect(node.querySelectorAll('.rjsf-field-error')).to.have.length.of(1);
 
           // Fix the second field
           fireEvent.change(node.querySelectorAll('input[type=text]')[1], {
@@ -1937,7 +1937,7 @@ describeRepeated('Form common', (createFormComponent) => {
           // No error remaining, shouldn't throw.
           fireEvent.submit(node);
 
-          expect(node.querySelectorAll('.field-error')).to.have.length.of(0);
+          expect(node.querySelectorAll('.rjsf-field-error')).to.have.length.of(0);
         });
       });
 
@@ -1973,8 +1973,8 @@ describeRepeated('Form common', (createFormComponent) => {
             target: { value: 'short' },
           });
 
-          expect(node.querySelectorAll('.field-error')).to.have.length.of(1);
-          expect(node.querySelector('.field-string .error-detail').textContent).eql(
+          expect(node.querySelectorAll('.rjsf-field-error')).to.have.length.of(1);
+          expect(node.querySelector('.rjsf-field-string .error-detail').textContent).eql(
             'must NOT have fewer than 8 characters',
           );
         });
@@ -2217,8 +2217,8 @@ describeRepeated('Form common', (createFormComponent) => {
       it('should denote the error in the field', () => {
         const { node } = createFormComponent(formProps);
 
-        expect(node.querySelectorAll('.field-error')).to.have.length.of(1);
-        expect(node.querySelector('.field-string .error-detail').textContent).eql(
+        expect(node.querySelectorAll('.rjsf-field-error')).to.have.length.of(1);
+        expect(node.querySelector('.rjsf-field-string .error-detail').textContent).eql(
           'must NOT have fewer than 8 characters',
         );
       });
@@ -2261,7 +2261,7 @@ describeRepeated('Form common', (createFormComponent) => {
       it('should denote the error in the field', () => {
         const { node } = createFormComponent(formProps);
 
-        const liNodes = node.querySelectorAll('.field-string .error-detail li');
+        const liNodes = node.querySelectorAll('.rjsf-field-string .error-detail li');
         const errors = [].map.call(liNodes, (li) => li.textContent);
 
         expect(errors).eql(['must NOT have fewer than 8 characters', 'must match pattern "d+"']);
@@ -2312,9 +2312,9 @@ describeRepeated('Form common', (createFormComponent) => {
 
       it('should denote the error in the field', () => {
         const { node } = createFormComponent(formProps);
-        const errorDetail = node.querySelector('.field-object .field-string .error-detail');
+        const errorDetail = node.querySelector('.rjsf-field-object .rjsf-field-string .error-detail');
 
-        expect(node.querySelectorAll('.field-error')).to.have.length.of(1);
+        expect(node.querySelectorAll('.rjsf-field-error')).to.have.length.of(1);
         expect(errorDetail.textContent).eql('must NOT have fewer than 8 characters');
       });
     });
@@ -2352,21 +2352,21 @@ describeRepeated('Form common', (createFormComponent) => {
 
       it('should denote the error in the item field in error', () => {
         const { node } = createFormComponent(formProps);
-        const fieldNodes = node.querySelectorAll('.field-string');
+        const fieldNodes = node.querySelectorAll('.rjsf-field-string');
 
-        const liNodes = fieldNodes[1].querySelectorAll('.field-string .error-detail li');
+        const liNodes = fieldNodes[1].querySelectorAll('.rjsf-field-string .error-detail li');
         const errors = [].map.call(liNodes, (li) => li.textContent);
 
-        expect(fieldNodes[1].classList.contains('field-error')).eql(true);
+        expect(fieldNodes[1].classList.contains('rjsf-field-error')).eql(true);
         expect(errors).eql(['must NOT have fewer than 4 characters']);
       });
 
       it('should not denote errors on non impacted fields', () => {
         const { node } = createFormComponent(formProps);
-        const fieldNodes = node.querySelectorAll('.field-string');
+        const fieldNodes = node.querySelectorAll('.rjsf-field-string');
 
-        expect(fieldNodes[0].classList.contains('field-error')).eql(false);
-        expect(fieldNodes[2].classList.contains('field-error')).eql(false);
+        expect(fieldNodes[0].classList.contains('rjsf-field-error')).eql(false);
+        expect(fieldNodes[2].classList.contains('rjsf-field-error')).eql(false);
       });
     });
 
@@ -2422,7 +2422,7 @@ describeRepeated('Form common', (createFormComponent) => {
           },
         });
 
-        const liNodes = node.querySelectorAll('.field-string .error-detail li');
+        const liNodes = node.querySelectorAll('.rjsf-field-string .error-detail li');
         const errors = [].map.call(liNodes, (li) => li.textContent);
 
         expect(errors).eql(['must NOT have fewer than 4 characters']);
@@ -2490,7 +2490,7 @@ describeRepeated('Form common', (createFormComponent) => {
 
       it('should denote the error in the nested item field in error', () => {
         const { node } = createFormComponent(formProps);
-        const fields = node.querySelectorAll('.field-string');
+        const fields = node.querySelectorAll('.rjsf-field-string');
         const errors = [].map.call(fields, (field) => {
           const li = field.querySelector('.error-detail li');
           return li && li.textContent;
@@ -2543,12 +2543,12 @@ describeRepeated('Form common', (createFormComponent) => {
 
       it('should denote the error in the array nested item', () => {
         const { node } = createFormComponent(formProps);
-        const fieldNodes = node.querySelectorAll('.field-string');
+        const fieldNodes = node.querySelectorAll('.rjsf-field-string');
 
-        const liNodes = fieldNodes[1].querySelectorAll('.field-string .error-detail li');
+        const liNodes = fieldNodes[1].querySelectorAll('.rjsf-field-string .error-detail li');
         const errors = [].map.call(liNodes, (li) => li.textContent);
 
-        expect(fieldNodes[1].classList.contains('field-error')).eql(true);
+        expect(fieldNodes[1].classList.contains('rjsf-field-error')).eql(true);
         expect(errors).eql(['must NOT have fewer than 4 characters']);
       });
     });
@@ -4363,7 +4363,7 @@ describe('Form omitExtraData and liveOmit', () => {
     it("doesn't cause a race condition", () => {
       const { node } = createComponent(Container, { ...props });
 
-      fireEvent.click(node.querySelector('.array-item-add button'));
+      fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
 
       expect(node.querySelector('#root_0')).to.exist;
       expect(node.querySelector('#root_1').getAttribute('value')).to.eq('test');

--- a/packages/core/test/NullField.test.jsx
+++ b/packages/core/test/NullField.test.jsx
@@ -21,7 +21,7 @@ describe('NullField', () => {
         },
       });
 
-      expect(node.querySelectorAll('.field')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field')).to.have.length.of(1);
     });
 
     it('should render a null field with a label', () => {
@@ -32,7 +32,7 @@ describe('NullField', () => {
         },
       });
 
-      expect(node.querySelector('.field label').textContent).eql('foo');
+      expect(node.querySelector('.rjsf-field label').textContent).eql('foo');
     });
 
     it('should assign a default value', () => {

--- a/packages/core/test/NumberField.test.jsx
+++ b/packages/core/test/NumberField.test.jsx
@@ -102,7 +102,7 @@ describe('NumberField', () => {
           uiSchema,
         });
 
-        expect(node.querySelector('.field label').textContent).eql('foo');
+        expect(node.querySelector('.rjsf-field label').textContent).eql('foo');
       });
 
       it('should render a string field with a description', () => {
@@ -139,7 +139,7 @@ describe('NumberField', () => {
           uiSchema,
         });
 
-        expect(node.querySelector('.field input').value).eql('2');
+        expect(node.querySelector('.rjsf-field input').value).eql('2');
       });
 
       it('should handle a change event', () => {
@@ -161,7 +161,7 @@ describe('NumberField', () => {
           {
             formData: 2,
           },
-          'root'
+          'root',
         );
       });
 
@@ -210,7 +210,7 @@ describe('NumberField', () => {
           formData: 2,
         });
 
-        expect(node.querySelector('.field input').value).eql('2');
+        expect(node.querySelector('.rjsf-field input').value).eql('2');
       });
 
       describe('when inputting a number that ends with a dot and/or zero it should normalize it, without changing the input value', () => {
@@ -280,7 +280,7 @@ describe('NumberField', () => {
                 {
                   formData: test.output,
                 },
-                'root'
+                'root',
               );
               // "2." is not really a valid number in a input field of type number
               // so we need to use getAttribute("value") instead since .value outputs the empty string
@@ -311,7 +311,7 @@ describe('NumberField', () => {
           {
             formData: 0,
           },
-          'root'
+          'root',
         );
         expect($input.value).eql('.00');
       });
@@ -402,7 +402,7 @@ describe('NumberField', () => {
         // "2." is not really a valid number in a input field of type number
         // so we need to use getAttribute("value") instead since .value outputs the empty string
         setTimeout(() => {
-          expect(node.querySelector('.field input').getAttribute('value')).eql('2.');
+          expect(node.querySelector('.rjsf-field input').getAttribute('value')).eql('2.');
         });
 
         act(() => {
@@ -410,21 +410,21 @@ describe('NumberField', () => {
             target: { value: '2.0' },
           });
         });
-        expect(node.querySelector('.field input').value).eql('2.0');
+        expect(node.querySelector('.rjsf-field input').value).eql('2.0');
 
         act(() => {
           fireEvent.change(node.querySelector('input'), {
             target: { value: '2.00' },
           });
         });
-        expect(node.querySelector('.field input').value).eql('2.00');
+        expect(node.querySelector('.rjsf-field input').value).eql('2.00');
 
         act(() => {
           fireEvent.change(node.querySelector('input'), {
             target: { value: '2.000' },
           });
         });
-        expect(node.querySelector('.field input').value).eql('2.000');
+        expect(node.querySelector('.rjsf-field input').value).eql('2.000');
       });
 
       it('should allow a zero to be input', () => {
@@ -440,7 +440,7 @@ describe('NumberField', () => {
             target: { value: '0' },
           });
         });
-        expect(node.querySelector('.field input').value).eql('0');
+        expect(node.querySelector('.rjsf-field input').value).eql('0');
       });
 
       it('should render customized StringField', () => {
@@ -470,7 +470,7 @@ describe('NumberField', () => {
         },
       });
 
-      expect(node.querySelectorAll('.field select')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field select')).to.have.length.of(1);
     });
 
     it('should infer the value from an enum on change', () => {
@@ -482,12 +482,12 @@ describe('NumberField', () => {
         onChange: spy,
       });
 
-      expect(node.querySelectorAll('.field select')).to.have.length.of(1);
-      const $select = node.querySelector('.field select');
+      expect(node.querySelectorAll('.rjsf-field select')).to.have.length.of(1);
+      const $select = node.querySelector('.rjsf-field select');
       expect($select.value).eql('');
 
       act(() => {
-        fireEvent.change(node.querySelector('.field select'), {
+        fireEvent.change(node.querySelector('.rjsf-field select'), {
           target: { value: 0 }, // use index
         });
       });
@@ -505,7 +505,7 @@ describe('NumberField', () => {
         },
       });
 
-      expect(node.querySelector('.field label').textContent).eql('foo');
+      expect(node.querySelector('.rjsf-field label').textContent).eql('foo');
     });
 
     it('should assign a default value', () => {

--- a/packages/core/test/ObjectField.test.jsx
+++ b/packages/core/test/ObjectField.test.jsx
@@ -109,26 +109,26 @@ describe('ObjectField', () => {
     it('should render a default property label', () => {
       const { node } = createFormComponent({ schema });
 
-      expect(node.querySelector('.field-boolean label').textContent).eql('bar');
+      expect(node.querySelector('.rjsf-field-boolean label').textContent).eql('bar');
     });
 
     it('should render a string property', () => {
       const { node } = createFormComponent({ schema });
 
-      expect(node.querySelectorAll('.field input[type=text]')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field input[type=text]')).to.have.length.of(1);
     });
 
     it('should render a boolean property', () => {
       const { node } = createFormComponent({ schema });
 
-      expect(node.querySelectorAll('.field input[type=checkbox]')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field input[type=checkbox]')).to.have.length.of(1);
     });
 
     it('should handle a default object value', () => {
       const { node } = createFormComponent({ schema });
 
-      expect(node.querySelector('.field input[type=text]').value).eql('hey');
-      expect(node.querySelector('.field input[type=checkbox]').checked).eql(true);
+      expect(node.querySelector('.rjsf-field input[type=text]').value).eql('hey');
+      expect(node.querySelector('.rjsf-field input[type=checkbox]').checked).eql(true);
     });
 
     it('should handle required values', () => {
@@ -136,7 +136,7 @@ describe('ObjectField', () => {
 
       // Required field is <input type="text" required="">
       expect(node.querySelector('input[type=text]').getAttribute('required')).eql('');
-      expect(node.querySelector('.field-string label').textContent).eql('Foo*');
+      expect(node.querySelector('.rjsf-field-string label').textContent).eql('Foo*');
     });
 
     it('should fill fields with form data', () => {
@@ -148,8 +148,8 @@ describe('ObjectField', () => {
         },
       });
 
-      expect(node.querySelector('.field input[type=text]').value).eql('hey');
-      expect(node.querySelector('.field input[type=checkbox]').checked).eql(true);
+      expect(node.querySelector('.rjsf-field input[type=text]').value).eql('hey');
+      expect(node.querySelector('.rjsf-field input[type=checkbox]').checked).eql(true);
     });
 
     it('should handle object fields change events', () => {
@@ -164,7 +164,7 @@ describe('ObjectField', () => {
         {
           formData: { foo: 'changed' },
         },
-        'root_foo'
+        'root_foo',
       );
     });
 
@@ -273,7 +273,7 @@ describe('ObjectField', () => {
           errorSchema: {},
           errors: [],
         },
-        'root_checkbox'
+        'root_checkbox',
       );
     });
 
@@ -347,7 +347,7 @@ describe('ObjectField', () => {
         },
       });
 
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       act(() => {
         fireEvent.change(inputs[0], { target: { value: 'hello' } });
       });
@@ -366,7 +366,7 @@ describe('ObjectField', () => {
         },
       });
 
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       act(() => {
         fireEvent.change(inputs[0], { target: { value: 'test' } });
       });
@@ -383,7 +383,7 @@ describe('ObjectField', () => {
         },
       });
 
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       act(() => {
         fireEvent.change(inputs[0], { target: { value: 'hello' } });
       });
@@ -402,7 +402,7 @@ describe('ObjectField', () => {
         },
       });
 
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       act(() => {
         fireEvent.change(inputs[0], { target: { value: 'test' } });
       });
@@ -430,7 +430,7 @@ describe('ObjectField', () => {
           'ui:order': ['baz', 'qux', 'bar', 'foo'],
         },
       });
-      const labels = [].map.call(node.querySelectorAll('.field > label'), (l) => l.textContent);
+      const labels = [].map.call(node.querySelectorAll('.rjsf-field > label'), (l) => l.textContent);
 
       expect(labels).eql(['baz', 'qux', 'bar', 'foo']);
     });
@@ -442,7 +442,7 @@ describe('ObjectField', () => {
           'ui:order': ['baz', '*', 'foo'],
         },
       });
-      const labels = [].map.call(node.querySelectorAll('.field > label'), (l) => l.textContent);
+      const labels = [].map.call(node.querySelectorAll('.rjsf-field > label'), (l) => l.textContent);
 
       expect(labels).eql(['baz', 'bar', 'qux', 'foo']);
     });
@@ -455,7 +455,7 @@ describe('ObjectField', () => {
         },
       });
 
-      const labels = [].map.call(node.querySelectorAll('.field > label'), (l) => l.textContent);
+      const labels = [].map.call(node.querySelectorAll('.rjsf-field > label'), (l) => l.textContent);
 
       expect(labels).eql(['baz', 'qux', 'bar', 'foo']);
     });
@@ -468,7 +468,7 @@ describe('ObjectField', () => {
         },
       });
 
-      expect(node.querySelector('.config-error').textContent).to.match(/does not contain properties 'foo', 'qux'/);
+      expect(node.querySelector('.rjsf-config-error').textContent).to.match(/does not contain properties 'foo', 'qux'/);
     });
 
     it('should throw when more than one wildcard is present', () => {
@@ -479,7 +479,7 @@ describe('ObjectField', () => {
         },
       });
 
-      expect(node.querySelector('.config-error').textContent).to.match(/contains more than one wildcard/);
+      expect(node.querySelector('.rjsf-config-error').textContent).to.match(/contains more than one wildcard/);
     });
 
     it('should order referenced schema definitions', () => {
@@ -500,7 +500,7 @@ describe('ObjectField', () => {
           'ui:order': ['bar', 'foo'],
         },
       });
-      const labels = [].map.call(node.querySelectorAll('.field > label'), (l) => l.textContent);
+      const labels = [].map.call(node.querySelectorAll('.rjsf-field > label'), (l) => l.textContent);
 
       expect(labels).eql(['bar', 'foo']);
     });
@@ -530,7 +530,7 @@ describe('ObjectField', () => {
           },
         },
       });
-      const labels = [].map.call(node.querySelectorAll('.field > label'), (l) => l.textContent);
+      const labels = [].map.call(node.querySelectorAll('.rjsf-field > label'), (l) => l.textContent);
 
       expect(labels).eql(['bar', 'foo']);
     });
@@ -612,7 +612,7 @@ describe('ObjectField', () => {
         formData: { first: 1 },
       });
 
-      expect(node.querySelectorAll('.field-string')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field-string')).to.have.length.of(1);
     });
 
     it('uiSchema title should not affect additionalProperties', () => {
@@ -730,7 +730,7 @@ describe('ObjectField', () => {
         },
       });
 
-      expect(node.querySelectorAll('.field-string')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field-string')).to.have.length.of(1);
     });
 
     it('should render a label for the additional property key', () => {
@@ -803,7 +803,7 @@ describe('ObjectField', () => {
         {
           formData: { newFirst: 1, first: undefined },
         },
-        'root'
+        'root',
       );
     });
 
@@ -829,7 +829,7 @@ describe('ObjectField', () => {
         {
           formData: { 'Renamed custom title': 1 },
         },
-        'root'
+        'root',
       );
 
       const keyInput = node.querySelector('#root_Renamed\\ custom\\ title-key');
@@ -876,7 +876,7 @@ describe('ObjectField', () => {
         {
           formData: { first: 1, newSecond: 2, third: 3 },
         },
-        'root'
+        'root',
       );
 
       expect(Object.keys(onChange.lastCall.args[0].formData)).eql(['first', 'newSecond', 'third']);
@@ -902,7 +902,7 @@ describe('ObjectField', () => {
         {
           formData: { second: 2, 'second-1': 1 },
         },
-        'root'
+        'root',
       );
     });
 
@@ -929,7 +929,7 @@ describe('ObjectField', () => {
         {
           formData: { second: 2, second_1: 1 },
         },
-        'root'
+        'root',
       );
     });
 
@@ -958,7 +958,7 @@ describe('ObjectField', () => {
         {
           formData: { second: 2, second_1: 1 },
         },
-        'root'
+        'root',
       );
     });
 
@@ -1015,7 +1015,7 @@ describe('ObjectField', () => {
     it('should have an expand button', () => {
       const { node } = createFormComponent({ schema });
 
-      expect(node.querySelector('.object-property-expand button')).not.eql(null);
+      expect(node.querySelector('.rjsf-object-property-expand button')).not.eql(null);
     });
 
     it('should not have an expand button if expandable is false', () => {
@@ -1024,13 +1024,13 @@ describe('ObjectField', () => {
         uiSchema: { 'ui:options': { expandable: false } },
       });
 
-      expect(node.querySelector('.object-property-expand button')).to.be.null;
+      expect(node.querySelector('.rjsf-object-property-expand button')).to.be.null;
     });
 
     it('should add a new property when clicking the expand button', () => {
       const { node, onChange } = createFormComponent({ schema });
 
-      fireEvent.click(node.querySelector('.object-property-expand button'));
+      fireEvent.click(node.querySelector('.rjsf-object-property-expand button'));
 
       sinon.assert.calledWithMatch(onChange.lastCall, {
         formData: {
@@ -1045,7 +1045,7 @@ describe('ObjectField', () => {
         formData: { newKey: 1 },
       });
 
-      fireEvent.click(node.querySelector('.object-property-expand button'));
+      fireEvent.click(node.querySelector('.rjsf-object-property-expand button'));
       sinon.assert.calledWithMatch(onChange.lastCall, {
         formData: {
           'newKey-1': 'New Value',
@@ -1069,7 +1069,7 @@ describe('ObjectField', () => {
         formData: {},
       });
 
-      fireEvent.click(node.querySelector('.object-property-expand button'));
+      fireEvent.click(node.querySelector('.rjsf-object-property-expand button'));
 
       sinon.assert.calledWithMatch(onChange.lastCall, {
         formData: {
@@ -1089,7 +1089,7 @@ describe('ObjectField', () => {
         formData: {},
       });
 
-      fireEvent.click(node.querySelector('.object-property-expand button'));
+      fireEvent.click(node.querySelector('.rjsf-object-property-expand button'));
 
       sinon.assert.calledWithMatch(onChange.lastCall, {
         formData: {
@@ -1111,7 +1111,7 @@ describe('ObjectField', () => {
         formData: {},
       });
 
-      fireEvent.click(node.querySelector('.object-property-expand button'));
+      fireEvent.click(node.querySelector('.rjsf-object-property-expand button'));
 
       sinon.assert.calledWithMatch(onChange.lastCall, {
         formData: {
@@ -1133,7 +1133,7 @@ describe('ObjectField', () => {
         formData: {},
       });
 
-      fireEvent.click(node.querySelector('.object-property-expand button'));
+      fireEvent.click(node.querySelector('.rjsf-object-property-expand button'));
 
       sinon.assert.calledWithMatch(onChange.lastCall, {
         formData: {
@@ -1148,7 +1148,7 @@ describe('ObjectField', () => {
         formData: { first: 1 },
       });
 
-      expect(node.querySelector('.object-property-expand button')).to.be.null;
+      expect(node.querySelector('.rjsf-object-property-expand button')).to.be.null;
     });
 
     it('should provide an expand button if length is less than maxProperties', () => {
@@ -1157,7 +1157,7 @@ describe('ObjectField', () => {
         formData: { first: 1 },
       });
 
-      expect(node.querySelector('.object-property-expand button')).not.eql(null);
+      expect(node.querySelector('.rjsf-object-property-expand button')).not.eql(null);
     });
 
     it('should not provide an expand button if expandable is expliclty false regardless of maxProperties value', () => {
@@ -1171,7 +1171,7 @@ describe('ObjectField', () => {
         },
       });
 
-      expect(node.querySelector('.object-property-expand button')).to.be.null;
+      expect(node.querySelector('.rjsf-object-property-expand button')).to.be.null;
     });
 
     it('should ignore expandable value if maxProperties constraint is not satisfied', () => {
@@ -1185,7 +1185,7 @@ describe('ObjectField', () => {
         },
       });
 
-      expect(node.querySelector('.object-property-expand button')).to.be.null;
+      expect(node.querySelector('.rjsf-object-property-expand button')).to.be.null;
     });
 
     it('should not have delete button if expand button has not been clicked', () => {
@@ -1201,7 +1201,7 @@ describe('ObjectField', () => {
 
       expect(node.querySelector('.form-group > .form-additional > .form-additional + .col-xs-2 .btn-danger')).eql(null);
 
-      fireEvent.click(node.querySelector('.object-property-expand button'));
+      fireEvent.click(node.querySelector('.rjsf-object-property-expand button'));
 
       expect(node.querySelector('.form-group > .row > .form-additional + .col-xs-2 > .btn-danger')).to.not.be.null;
     });

--- a/packages/core/test/SchemaField.test.jsx
+++ b/packages/core/test/SchemaField.test.jsx
@@ -130,7 +130,7 @@ describe('SchemaField', () => {
         fields,
       });
 
-      expect(node.querySelectorAll('#custom > .field input[type=text]')).to.have.length.of(1);
+      expect(node.querySelectorAll('#custom > .rjsf-field input[type=text]')).to.have.length.of(1);
     });
   });
 

--- a/packages/core/test/StringField.test.jsx
+++ b/packages/core/test/StringField.test.jsx
@@ -59,7 +59,7 @@ describe('StringField', () => {
         },
       });
 
-      expect(node.querySelectorAll('.field input[type=text]')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field input[type=text]')).to.have.length.of(1);
     });
 
     it('should render a string field with a label', () => {
@@ -70,7 +70,7 @@ describe('StringField', () => {
         },
       });
 
-      expect(node.querySelector('.field label').textContent).eql('foo');
+      expect(node.querySelector('.rjsf-field label').textContent).eql('foo');
     });
 
     it('should render a string field with a description', () => {
@@ -92,8 +92,8 @@ describe('StringField', () => {
         },
       });
 
-      expect(node.querySelector('.field input').value).eql('plop');
-      expect(node.querySelectorAll('.field datalist > option')).to.have.length.of(0);
+      expect(node.querySelector('.rjsf-field input').value).eql('plop');
+      expect(node.querySelectorAll('.rjsf-field datalist > option')).to.have.length.of(0);
     });
 
     it('should render a string field with examples', () => {
@@ -104,9 +104,9 @@ describe('StringField', () => {
         },
       });
 
-      expect(node.querySelectorAll('.field datalist > option')).to.have.length.of(3);
-      const datalistId = node.querySelector('.field datalist').id;
-      expect(node.querySelector('.field input').getAttribute('list')).eql(datalistId);
+      expect(node.querySelectorAll('.rjsf-field datalist > option')).to.have.length.of(3);
+      const datalistId = node.querySelector('.rjsf-field datalist').id;
+      expect(node.querySelector('.rjsf-field input').getAttribute('list')).eql(datalistId);
     });
 
     it('should render a string with examples that includes the default value', () => {
@@ -117,9 +117,9 @@ describe('StringField', () => {
           examples: ['Chrome', 'Vivaldi'],
         },
       });
-      expect(node.querySelectorAll('.field datalist > option')).to.have.length.of(3);
-      const datalistId = node.querySelector('.field datalist').id;
-      expect(node.querySelector('.field input').getAttribute('list')).eql(datalistId);
+      expect(node.querySelectorAll('.rjsf-field datalist > option')).to.have.length.of(3);
+      const datalistId = node.querySelector('.rjsf-field datalist').id;
+      expect(node.querySelector('.rjsf-field input').getAttribute('list')).eql(datalistId);
     });
 
     it('should render a string with examples that overlaps with the default value', () => {
@@ -130,9 +130,9 @@ describe('StringField', () => {
           examples: ['Firefox', 'Chrome', 'Vivaldi'],
         },
       });
-      expect(node.querySelectorAll('.field datalist > option')).to.have.length.of(3);
-      const datalistId = node.querySelector('.field datalist').id;
-      expect(node.querySelector('.field input').getAttribute('list')).eql(datalistId);
+      expect(node.querySelectorAll('.rjsf-field datalist > option')).to.have.length.of(3);
+      const datalistId = node.querySelector('.rjsf-field datalist').id;
+      expect(node.querySelector('.rjsf-field input').getAttribute('list')).eql(datalistId);
     });
 
     it('should default submit value to undefined', () => {
@@ -165,7 +165,7 @@ describe('StringField', () => {
         {
           formData: 'yo',
         },
-        'root'
+        'root',
       );
     });
 
@@ -230,7 +230,7 @@ describe('StringField', () => {
         {
           formData: 'default',
         },
-        'root'
+        'root',
       );
     });
 
@@ -251,7 +251,7 @@ describe('StringField', () => {
         {
           formData: undefined,
         },
-        'root'
+        'root',
       );
     });
 
@@ -263,7 +263,7 @@ describe('StringField', () => {
         formData: 'plip',
       });
 
-      expect(node.querySelector('.field input').value).eql('plip');
+      expect(node.querySelector('.rjsf-field input').value).eql('plip');
     });
 
     it('should render the widget with the expected id', () => {
@@ -324,7 +324,7 @@ describe('StringField', () => {
         },
       });
 
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       act(() => {
         fireEvent.change(inputs[0], { target: { value: 'hello' } });
       });
@@ -343,7 +343,7 @@ describe('StringField', () => {
         },
       });
 
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       act(() => {
         fireEvent.change(inputs[0], { target: { value: 'test' } });
       });
@@ -360,7 +360,7 @@ describe('StringField', () => {
         },
       });
 
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       act(() => {
         fireEvent.change(inputs[0], { target: { value: 'hello' } });
       });
@@ -379,7 +379,7 @@ describe('StringField', () => {
         },
       });
 
-      const inputs = node.querySelectorAll('.field-string input[type=text]');
+      const inputs = node.querySelectorAll('.rjsf-field-string input[type=text]');
       act(() => {
         fireEvent.change(inputs[0], { target: { value: 'test' } });
       });
@@ -398,7 +398,7 @@ describe('StringField', () => {
         },
       });
 
-      expect(node.querySelectorAll('.field select')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field select')).to.have.length.of(1);
     });
 
     it('should render a string field for an enum without a type', () => {
@@ -408,7 +408,7 @@ describe('StringField', () => {
         },
       });
 
-      expect(node.querySelectorAll('.field select')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field select')).to.have.length.of(1);
     });
 
     it('should render a string field with a label', () => {
@@ -420,7 +420,7 @@ describe('StringField', () => {
         },
       });
 
-      expect(node.querySelector('.field label').textContent).eql('foo');
+      expect(node.querySelector('.rjsf-field label').textContent).eql('foo');
     });
 
     it('should render empty option', () => {
@@ -431,7 +431,7 @@ describe('StringField', () => {
         },
       });
 
-      expect(node.querySelectorAll('.field option')[0].value).eql('');
+      expect(node.querySelectorAll('.rjsf-field option')[0].value).eql('');
     });
 
     it('should render empty option with placeholder text', () => {
@@ -447,7 +447,7 @@ describe('StringField', () => {
         },
       });
 
-      expect(node.querySelectorAll('.field option')[0].textContent).eql('Test');
+      expect(node.querySelectorAll('.rjsf-field option')[0].textContent).eql('Test');
     });
 
     it('should assign a default value', () => {
@@ -483,7 +483,7 @@ describe('StringField', () => {
         {
           formData: 'foo',
         },
-        'root'
+        'root',
       );
     });
 
@@ -506,7 +506,7 @@ describe('StringField', () => {
         {
           formData: undefined,
         },
-        'root'
+        'root',
       );
     });
 
@@ -667,7 +667,7 @@ describe('StringField', () => {
         {
           formData: undefined,
         },
-        'root'
+        'root',
       );
     });
 
@@ -692,7 +692,7 @@ describe('StringField', () => {
         {
           formData: 'default',
         },
-        'root'
+        'root',
       );
     });
 
@@ -719,7 +719,7 @@ describe('StringField', () => {
         },
       });
 
-      expect(node.querySelectorAll('.field [type=datetime-local]')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field [type=datetime-local]')).to.have.length.of(1);
     });
 
     it('should assign a default value', () => {
@@ -790,7 +790,7 @@ describe('StringField', () => {
         },
         liveValidate: true,
       });
-      let inputs = node.querySelectorAll('.form-group.field-error input[type=datetime-local]');
+      let inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=datetime-local]');
       expect(inputs).to.have.length.of(0);
       act(() => {
         Simulate.change(node.querySelector('[type=datetime-local]'), {
@@ -810,7 +810,7 @@ describe('StringField', () => {
           },
         ],
       });
-      inputs = node.querySelectorAll('.form-group.field-error input[type=datetime-local]');
+      inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=datetime-local]');
       expect(inputs).to.have.length.of(1);
     });
     it('should reject an invalid entered datetime and hides error', () => {
@@ -824,7 +824,7 @@ describe('StringField', () => {
         },
         liveValidate: true,
       });
-      let inputs = node.querySelectorAll('.form-group.field-error input[type=datetime-local]');
+      let inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=datetime-local]');
 
       expect(inputs).to.have.length.of(0);
       act(() => {
@@ -845,7 +845,7 @@ describe('StringField', () => {
           },
         ],
       });
-      inputs = node.querySelectorAll('.form-group.field-error input[type=datetime-local]');
+      inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=datetime-local]');
       expect(inputs).to.have.length.of(0);
     });
 
@@ -890,7 +890,7 @@ describe('StringField', () => {
         uiSchema,
       });
 
-      expect(node.querySelectorAll('.field [type=date]')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field [type=date]')).to.have.length.of(1);
     });
 
     it('should assign a default value', () => {
@@ -1052,7 +1052,7 @@ describe('StringField', () => {
         },
       });
 
-      expect(node.querySelectorAll('.field [type=time]')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field [type=time]')).to.have.length.of(1);
     });
 
     it('should assign a default value', () => {
@@ -1186,7 +1186,7 @@ describe('StringField', () => {
         uiSchema,
       });
 
-      expect(node.querySelectorAll('.field select')).to.have.length.of(6);
+      expect(node.querySelectorAll('.rjsf-field select')).to.have.length.of(6);
     });
 
     it('should render a string field with a main label', () => {
@@ -1199,7 +1199,7 @@ describe('StringField', () => {
         uiSchema,
       });
 
-      expect(node.querySelector('.field label').textContent).eql('foo');
+      expect(node.querySelector('.rjsf-field label').textContent).eql('foo');
     });
 
     it('should assign a default value', () => {
@@ -1531,7 +1531,7 @@ describe('StringField', () => {
         uiSchema,
       });
 
-      expect(node.querySelectorAll('.field select')).to.have.length.of(3);
+      expect(node.querySelectorAll('.rjsf-field select')).to.have.length.of(3);
     });
 
     it('should render a string field with a main label', () => {
@@ -1544,7 +1544,7 @@ describe('StringField', () => {
         uiSchema,
       });
 
-      expect(node.querySelector('.field label').textContent).eql('foo');
+      expect(node.querySelector('.rjsf-field label').textContent).eql('foo');
     });
 
     it('should assign a default value', () => {
@@ -1836,7 +1836,7 @@ describe('StringField', () => {
         },
       });
 
-      expect(node.querySelectorAll('.field [type=email]')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field [type=email]')).to.have.length.of(1);
     });
 
     it('should render a string field with a label', () => {
@@ -1848,7 +1848,7 @@ describe('StringField', () => {
         },
       });
 
-      expect(node.querySelector('.field label').textContent).eql('foo');
+      expect(node.querySelector('.rjsf-field label').textContent).eql('foo');
     });
 
     it('should render a select field with a description', () => {
@@ -1976,7 +1976,7 @@ describe('StringField', () => {
         },
       });
 
-      expect(node.querySelectorAll('.field [type=url]')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field [type=url]')).to.have.length.of(1);
     });
 
     it('should render a string field with a label', () => {
@@ -1988,7 +1988,7 @@ describe('StringField', () => {
         },
       });
 
-      expect(node.querySelector('.field label').textContent).eql('foo');
+      expect(node.querySelector('.rjsf-field label').textContent).eql('foo');
     });
 
     it('should render a select field with a placeholder', () => {
@@ -2120,7 +2120,7 @@ describe('StringField', () => {
         uiSchema,
       });
 
-      expect(node.querySelectorAll('.field [type=color]')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field [type=color]')).to.have.length.of(1);
     });
 
     it('should assign a default value', () => {
@@ -2239,7 +2239,7 @@ describe('StringField', () => {
         },
       });
 
-      expect(node.querySelectorAll('.field [type=file]')).to.have.length.of(1);
+      expect(node.querySelectorAll('.rjsf-field [type=file]')).to.have.length.of(1);
     });
 
     it('should assign a default value', () => {

--- a/packages/core/test/__snapshots__/ArraySnap.test.tsx.snap
+++ b/packages/core/test/__snapshots__/ArraySnap.test.tsx.snap
@@ -7,10 +7,10 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <fieldset
-      className="field field-array field-array-of-string"
+      className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
       id="root"
     >
       <div
@@ -20,7 +20,7 @@ exports[`array fields array 1`] = `
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right array-item-add"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-array-item-add"
         >
           <button
             className="btn btn-info btn-add col-xs-12"
@@ -56,23 +56,23 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <fieldset
-      className="field field-array field-array-of-string"
+      className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
       id="root"
     >
       <div
         className="row array-item-list"
       >
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-9"
           >
             <div
-              className="form-group field field-string"
+              className="form-group rjsf-field rjsf-field-string"
             >
               <input
                 aria-describedby="root_0__error root_0__description root_0__help"
@@ -106,7 +106,7 @@ exports[`array fields array icons 1`] = `
               }
             >
               <button
-                className="btn btn-default array-item-move-up"
+                className="btn btn-default rjsf-array-item-move-up"
                 disabled={true}
                 id="root_0__moveUp"
                 onClick={[Function]}
@@ -118,7 +118,7 @@ exports[`array fields array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-move-down"
+                className="btn btn-default rjsf-array-item-move-down"
                 disabled={false}
                 id="root_0__moveDown"
                 onClick={[Function]}
@@ -130,7 +130,7 @@ exports[`array fields array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-copy"
+                className="btn btn-default rjsf-array-item-copy"
                 disabled={false}
                 id="root_0__copy"
                 onClick={[Function]}
@@ -142,7 +142,7 @@ exports[`array fields array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-danger array-item-remove"
+                className="btn btn-danger rjsf-array-item-remove"
                 disabled={false}
                 id="root_0__remove"
                 onClick={[Function]}
@@ -157,13 +157,13 @@ exports[`array fields array icons 1`] = `
           </div>
         </div>
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-9"
           >
             <div
-              className="form-group field field-string"
+              className="form-group rjsf-field rjsf-field-string"
             >
               <input
                 aria-describedby="root_1__error root_1__description root_1__help"
@@ -197,7 +197,7 @@ exports[`array fields array icons 1`] = `
               }
             >
               <button
-                className="btn btn-default array-item-move-up"
+                className="btn btn-default rjsf-array-item-move-up"
                 disabled={false}
                 id="root_1__moveUp"
                 onClick={[Function]}
@@ -209,7 +209,7 @@ exports[`array fields array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-move-down"
+                className="btn btn-default rjsf-array-item-move-down"
                 disabled={true}
                 id="root_1__moveDown"
                 onClick={[Function]}
@@ -221,7 +221,7 @@ exports[`array fields array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-copy"
+                className="btn btn-default rjsf-array-item-copy"
                 disabled={false}
                 id="root_1__copy"
                 onClick={[Function]}
@@ -233,7 +233,7 @@ exports[`array fields array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-danger array-item-remove"
+                className="btn btn-danger rjsf-array-item-remove"
                 disabled={false}
                 id="root_1__remove"
                 onClick={[Function]}
@@ -252,7 +252,7 @@ exports[`array fields array icons 1`] = `
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right array-item-add"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-array-item-add"
         >
           <button
             className="btn btn-info btn-add col-xs-12"
@@ -288,7 +288,7 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <select
       aria-describedby="root__error root__description root__help"
@@ -341,13 +341,13 @@ exports[`array fields empty errors array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
     >
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <label
           className="control-label"
@@ -394,23 +394,23 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <fieldset
-      className="field field-array field-array-fixed-items"
+      className="rjsf-field rjsf-field-array rjsf-field-array-fixed-items"
       id="root"
     >
       <div
         className="row array-item-list"
       >
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-12"
           >
             <div
-              className="form-group field field-string"
+              className="form-group rjsf-field rjsf-field-string"
             >
               <input
                 aria-describedby="root_0__error root_0__description root_0__help"
@@ -433,13 +433,13 @@ exports[`array fields fixed array 1`] = `
           </div>
         </div>
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-12"
           >
             <div
-              className="form-group field field-number"
+              className="form-group rjsf-field rjsf-field-number"
             >
               <input
                 aria-describedby="root_1__error root_1__description root_1__help"
@@ -506,13 +506,13 @@ exports[`array fields has errors 1`] = `
     </ul>
   </div>
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
     >
       <div
-        className="form-group field field-string field-error has-error has-danger"
+        className="form-group rjsf-field rjsf-field-string rjsf-field-error has-error has-danger"
       >
         <label
           className="control-label"
@@ -571,13 +571,13 @@ exports[`array fields no errors 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
     >
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <label
           className="control-label"
@@ -624,10 +624,10 @@ exports[`with title and description array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <fieldset
-      className="field field-array field-array-of-string"
+      className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
       id="root"
     >
       <legend
@@ -648,7 +648,7 @@ exports[`with title and description array 1`] = `
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right array-item-add"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-array-item-add"
         >
           <button
             className="btn btn-info btn-add col-xs-12"
@@ -684,10 +684,10 @@ exports[`with title and description array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <fieldset
-      className="field field-array field-array-of-string"
+      className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
       id="root"
     >
       <legend
@@ -705,13 +705,13 @@ exports[`with title and description array icons 1`] = `
         className="row array-item-list"
       >
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-9"
           >
             <div
-              className="form-group field field-string"
+              className="form-group rjsf-field rjsf-field-string"
             >
               <label
                 className="control-label"
@@ -762,7 +762,7 @@ exports[`with title and description array icons 1`] = `
               }
             >
               <button
-                className="btn btn-default array-item-move-up"
+                className="btn btn-default rjsf-array-item-move-up"
                 disabled={true}
                 id="root_0__moveUp"
                 onClick={[Function]}
@@ -774,7 +774,7 @@ exports[`with title and description array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-move-down"
+                className="btn btn-default rjsf-array-item-move-down"
                 disabled={false}
                 id="root_0__moveDown"
                 onClick={[Function]}
@@ -786,7 +786,7 @@ exports[`with title and description array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-copy"
+                className="btn btn-default rjsf-array-item-copy"
                 disabled={false}
                 id="root_0__copy"
                 onClick={[Function]}
@@ -798,7 +798,7 @@ exports[`with title and description array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-danger array-item-remove"
+                className="btn btn-danger rjsf-array-item-remove"
                 disabled={false}
                 id="root_0__remove"
                 onClick={[Function]}
@@ -813,13 +813,13 @@ exports[`with title and description array icons 1`] = `
           </div>
         </div>
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-9"
           >
             <div
-              className="form-group field field-string"
+              className="form-group rjsf-field rjsf-field-string"
             >
               <label
                 className="control-label"
@@ -870,7 +870,7 @@ exports[`with title and description array icons 1`] = `
               }
             >
               <button
-                className="btn btn-default array-item-move-up"
+                className="btn btn-default rjsf-array-item-move-up"
                 disabled={false}
                 id="root_1__moveUp"
                 onClick={[Function]}
@@ -882,7 +882,7 @@ exports[`with title and description array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-move-down"
+                className="btn btn-default rjsf-array-item-move-down"
                 disabled={true}
                 id="root_1__moveDown"
                 onClick={[Function]}
@@ -894,7 +894,7 @@ exports[`with title and description array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-copy"
+                className="btn btn-default rjsf-array-item-copy"
                 disabled={false}
                 id="root_1__copy"
                 onClick={[Function]}
@@ -906,7 +906,7 @@ exports[`with title and description array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-danger array-item-remove"
+                className="btn btn-danger rjsf-array-item-remove"
                 disabled={false}
                 id="root_1__remove"
                 onClick={[Function]}
@@ -925,7 +925,7 @@ exports[`with title and description array icons 1`] = `
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right array-item-add"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-array-item-add"
         >
           <button
             className="btn btn-info btn-add col-xs-12"
@@ -961,7 +961,7 @@ exports[`with title and description checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <label
       className="control-label"
@@ -1026,10 +1026,10 @@ exports[`with title and description fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <fieldset
-      className="field field-array field-array-fixed-items"
+      className="rjsf-field rjsf-field-array rjsf-field-array-fixed-items"
       id="root"
     >
       <legend
@@ -1047,13 +1047,13 @@ exports[`with title and description fixed array 1`] = `
         className="row array-item-list"
       >
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-12"
           >
             <div
-              className="form-group field field-string"
+              className="form-group rjsf-field rjsf-field-string"
             >
               <label
                 className="control-label"
@@ -1093,13 +1093,13 @@ exports[`with title and description fixed array 1`] = `
           </div>
         </div>
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-12"
           >
             <div
-              className="form-group field field-number"
+              className="form-group rjsf-field rjsf-field-number"
             >
               <label
                 className="control-label"
@@ -1161,10 +1161,10 @@ exports[`with title and description from both array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <fieldset
-      className="field field-array field-array-of-string"
+      className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
       id="root"
     >
       <legend
@@ -1185,7 +1185,7 @@ exports[`with title and description from both array 1`] = `
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right array-item-add"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-array-item-add"
         >
           <button
             className="btn btn-info btn-add col-xs-12"
@@ -1221,10 +1221,10 @@ exports[`with title and description from both array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <fieldset
-      className="field field-array field-array-of-string"
+      className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
       id="root"
     >
       <legend
@@ -1242,13 +1242,13 @@ exports[`with title and description from both array icons 1`] = `
         className="row array-item-list"
       >
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-9"
           >
             <div
-              className="form-group field field-string"
+              className="form-group rjsf-field rjsf-field-string"
             >
               <label
                 className="control-label"
@@ -1299,7 +1299,7 @@ exports[`with title and description from both array icons 1`] = `
               }
             >
               <button
-                className="btn btn-default array-item-move-up"
+                className="btn btn-default rjsf-array-item-move-up"
                 disabled={true}
                 id="root_0__moveUp"
                 onClick={[Function]}
@@ -1311,7 +1311,7 @@ exports[`with title and description from both array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-move-down"
+                className="btn btn-default rjsf-array-item-move-down"
                 disabled={false}
                 id="root_0__moveDown"
                 onClick={[Function]}
@@ -1323,7 +1323,7 @@ exports[`with title and description from both array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-copy"
+                className="btn btn-default rjsf-array-item-copy"
                 disabled={false}
                 id="root_0__copy"
                 onClick={[Function]}
@@ -1335,7 +1335,7 @@ exports[`with title and description from both array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-danger array-item-remove"
+                className="btn btn-danger rjsf-array-item-remove"
                 disabled={false}
                 id="root_0__remove"
                 onClick={[Function]}
@@ -1350,13 +1350,13 @@ exports[`with title and description from both array icons 1`] = `
           </div>
         </div>
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-9"
           >
             <div
-              className="form-group field field-string"
+              className="form-group rjsf-field rjsf-field-string"
             >
               <label
                 className="control-label"
@@ -1407,7 +1407,7 @@ exports[`with title and description from both array icons 1`] = `
               }
             >
               <button
-                className="btn btn-default array-item-move-up"
+                className="btn btn-default rjsf-array-item-move-up"
                 disabled={false}
                 id="root_1__moveUp"
                 onClick={[Function]}
@@ -1419,7 +1419,7 @@ exports[`with title and description from both array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-move-down"
+                className="btn btn-default rjsf-array-item-move-down"
                 disabled={true}
                 id="root_1__moveDown"
                 onClick={[Function]}
@@ -1431,7 +1431,7 @@ exports[`with title and description from both array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-copy"
+                className="btn btn-default rjsf-array-item-copy"
                 disabled={false}
                 id="root_1__copy"
                 onClick={[Function]}
@@ -1443,7 +1443,7 @@ exports[`with title and description from both array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-danger array-item-remove"
+                className="btn btn-danger rjsf-array-item-remove"
                 disabled={false}
                 id="root_1__remove"
                 onClick={[Function]}
@@ -1462,7 +1462,7 @@ exports[`with title and description from both array icons 1`] = `
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right array-item-add"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-array-item-add"
         >
           <button
             className="btn btn-info btn-add col-xs-12"
@@ -1498,7 +1498,7 @@ exports[`with title and description from both checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <label
       className="control-label"
@@ -1563,10 +1563,10 @@ exports[`with title and description from both fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <fieldset
-      className="field field-array field-array-fixed-items"
+      className="rjsf-field rjsf-field-array rjsf-field-array-fixed-items"
       id="root"
     >
       <legend
@@ -1584,13 +1584,13 @@ exports[`with title and description from both fixed array 1`] = `
         className="row array-item-list"
       >
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-12"
           >
             <div
-              className="form-group field field-string"
+              className="form-group rjsf-field rjsf-field-string"
             >
               <label
                 className="control-label"
@@ -1630,13 +1630,13 @@ exports[`with title and description from both fixed array 1`] = `
           </div>
         </div>
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-12"
           >
             <div
-              className="form-group field field-number"
+              className="form-group rjsf-field rjsf-field-number"
             >
               <label
                 className="control-label"
@@ -1698,10 +1698,10 @@ exports[`with title and description from uiSchema array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <fieldset
-      className="field field-array field-array-of-string"
+      className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
       id="root"
     >
       <legend
@@ -1722,7 +1722,7 @@ exports[`with title and description from uiSchema array 1`] = `
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right array-item-add"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-array-item-add"
         >
           <button
             className="btn btn-info btn-add col-xs-12"
@@ -1758,10 +1758,10 @@ exports[`with title and description from uiSchema array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <fieldset
-      className="field field-array field-array-of-string"
+      className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
       id="root"
     >
       <legend
@@ -1779,13 +1779,13 @@ exports[`with title and description from uiSchema array icons 1`] = `
         className="row array-item-list"
       >
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-9"
           >
             <div
-              className="form-group field field-string"
+              className="form-group rjsf-field rjsf-field-string"
             >
               <label
                 className="control-label"
@@ -1836,7 +1836,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
               }
             >
               <button
-                className="btn btn-default array-item-move-up"
+                className="btn btn-default rjsf-array-item-move-up"
                 disabled={true}
                 id="root_0__moveUp"
                 onClick={[Function]}
@@ -1848,7 +1848,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-move-down"
+                className="btn btn-default rjsf-array-item-move-down"
                 disabled={false}
                 id="root_0__moveDown"
                 onClick={[Function]}
@@ -1860,7 +1860,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-copy"
+                className="btn btn-default rjsf-array-item-copy"
                 disabled={false}
                 id="root_0__copy"
                 onClick={[Function]}
@@ -1872,7 +1872,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-danger array-item-remove"
+                className="btn btn-danger rjsf-array-item-remove"
                 disabled={false}
                 id="root_0__remove"
                 onClick={[Function]}
@@ -1887,13 +1887,13 @@ exports[`with title and description from uiSchema array icons 1`] = `
           </div>
         </div>
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-9"
           >
             <div
-              className="form-group field field-string"
+              className="form-group rjsf-field rjsf-field-string"
             >
               <label
                 className="control-label"
@@ -1944,7 +1944,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
               }
             >
               <button
-                className="btn btn-default array-item-move-up"
+                className="btn btn-default rjsf-array-item-move-up"
                 disabled={false}
                 id="root_1__moveUp"
                 onClick={[Function]}
@@ -1956,7 +1956,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-move-down"
+                className="btn btn-default rjsf-array-item-move-down"
                 disabled={true}
                 id="root_1__moveDown"
                 onClick={[Function]}
@@ -1968,7 +1968,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-copy"
+                className="btn btn-default rjsf-array-item-copy"
                 disabled={false}
                 id="root_1__copy"
                 onClick={[Function]}
@@ -1980,7 +1980,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-danger array-item-remove"
+                className="btn btn-danger rjsf-array-item-remove"
                 disabled={false}
                 id="root_1__remove"
                 onClick={[Function]}
@@ -1999,7 +1999,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right array-item-add"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-array-item-add"
         >
           <button
             className="btn btn-info btn-add col-xs-12"
@@ -2035,7 +2035,7 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <label
       className="control-label"
@@ -2100,10 +2100,10 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <fieldset
-      className="field field-array field-array-fixed-items"
+      className="rjsf-field rjsf-field-array rjsf-field-array-fixed-items"
       id="root"
     >
       <legend
@@ -2121,13 +2121,13 @@ exports[`with title and description from uiSchema fixed array 1`] = `
         className="row array-item-list"
       >
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-12"
           >
             <div
-              className="form-group field field-string"
+              className="form-group rjsf-field rjsf-field-string"
             >
               <label
                 className="control-label"
@@ -2167,13 +2167,13 @@ exports[`with title and description from uiSchema fixed array 1`] = `
           </div>
         </div>
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-12"
           >
             <div
-              className="form-group field field-number"
+              className="form-group rjsf-field rjsf-field-number"
             >
               <label
                 className="control-label"
@@ -2235,10 +2235,10 @@ exports[`with title and description with global label off array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <fieldset
-      className="field field-array field-array-of-string"
+      className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
       id="root"
     >
       <div
@@ -2248,7 +2248,7 @@ exports[`with title and description with global label off array 1`] = `
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right array-item-add"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-array-item-add"
         >
           <button
             className="btn btn-info btn-add col-xs-12"
@@ -2284,23 +2284,23 @@ exports[`with title and description with global label off array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <fieldset
-      className="field field-array field-array-of-string"
+      className="rjsf-field rjsf-field-array rjsf-field-array-of-string"
       id="root"
     >
       <div
         className="row array-item-list"
       >
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-9"
           >
             <div
-              className="form-group field field-string"
+              className="form-group rjsf-field rjsf-field-string"
             >
               <input
                 aria-describedby="root_0__error root_0__description root_0__help"
@@ -2334,7 +2334,7 @@ exports[`with title and description with global label off array icons 1`] = `
               }
             >
               <button
-                className="btn btn-default array-item-move-up"
+                className="btn btn-default rjsf-array-item-move-up"
                 disabled={true}
                 id="root_0__moveUp"
                 onClick={[Function]}
@@ -2346,7 +2346,7 @@ exports[`with title and description with global label off array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-move-down"
+                className="btn btn-default rjsf-array-item-move-down"
                 disabled={false}
                 id="root_0__moveDown"
                 onClick={[Function]}
@@ -2358,7 +2358,7 @@ exports[`with title and description with global label off array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-copy"
+                className="btn btn-default rjsf-array-item-copy"
                 disabled={false}
                 id="root_0__copy"
                 onClick={[Function]}
@@ -2370,7 +2370,7 @@ exports[`with title and description with global label off array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-danger array-item-remove"
+                className="btn btn-danger rjsf-array-item-remove"
                 disabled={false}
                 id="root_0__remove"
                 onClick={[Function]}
@@ -2385,13 +2385,13 @@ exports[`with title and description with global label off array icons 1`] = `
           </div>
         </div>
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-9"
           >
             <div
-              className="form-group field field-string"
+              className="form-group rjsf-field rjsf-field-string"
             >
               <input
                 aria-describedby="root_1__error root_1__description root_1__help"
@@ -2425,7 +2425,7 @@ exports[`with title and description with global label off array icons 1`] = `
               }
             >
               <button
-                className="btn btn-default array-item-move-up"
+                className="btn btn-default rjsf-array-item-move-up"
                 disabled={false}
                 id="root_1__moveUp"
                 onClick={[Function]}
@@ -2437,7 +2437,7 @@ exports[`with title and description with global label off array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-move-down"
+                className="btn btn-default rjsf-array-item-move-down"
                 disabled={true}
                 id="root_1__moveDown"
                 onClick={[Function]}
@@ -2449,7 +2449,7 @@ exports[`with title and description with global label off array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-default array-item-copy"
+                className="btn btn-default rjsf-array-item-copy"
                 disabled={false}
                 id="root_1__copy"
                 onClick={[Function]}
@@ -2461,7 +2461,7 @@ exports[`with title and description with global label off array icons 1`] = `
                 />
               </button>
               <button
-                className="btn btn-danger array-item-remove"
+                className="btn btn-danger rjsf-array-item-remove"
                 disabled={false}
                 id="root_1__remove"
                 onClick={[Function]}
@@ -2480,7 +2480,7 @@ exports[`with title and description with global label off array icons 1`] = `
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right array-item-add"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-array-item-add"
         >
           <button
             className="btn btn-info btn-add col-xs-12"
@@ -2516,7 +2516,7 @@ exports[`with title and description with global label off checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <label
       className="control-label"
@@ -2581,23 +2581,23 @@ exports[`with title and description with global label off fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <fieldset
-      className="field field-array field-array-fixed-items"
+      className="rjsf-field rjsf-field-array rjsf-field-array-fixed-items"
       id="root"
     >
       <div
         className="row array-item-list"
       >
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-12"
           >
             <div
-              className="form-group field field-string"
+              className="form-group rjsf-field rjsf-field-string"
             >
               <input
                 aria-describedby="root_0__error root_0__description root_0__help"
@@ -2620,13 +2620,13 @@ exports[`with title and description with global label off fixed array 1`] = `
           </div>
         </div>
         <div
-          className="array-item"
+          className="rjsf-array-item"
         >
           <div
             className="col-xs-12"
           >
             <div
-              className="form-group field field-number"
+              className="form-group rjsf-field rjsf-field-number"
             >
               <input
                 aria-describedby="root_1__error root_1__description root_1__help"

--- a/packages/core/test/__snapshots__/FormSnap.test.tsx.snap
+++ b/packages/core/test/__snapshots__/FormSnap.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="form-group rjsf-field rjsf-field-boolean"
   >
     <div
       className="checkbox "
@@ -49,7 +49,7 @@ exports[`single fields checkbox field with label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="form-group rjsf-field rjsf-field-boolean"
   >
     <div
       className="checkbox "
@@ -93,7 +93,7 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <label
       className="control-label"
@@ -222,13 +222,13 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
     >
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <label
           className="control-label"
@@ -281,13 +281,13 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
     >
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <label
           className="control-label"
@@ -340,7 +340,7 @@ exports[`single fields format color 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <input
       aria-describedby="root__error root__description root__help"
@@ -378,7 +378,7 @@ exports[`single fields format date 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <input
       aria-describedby="root__error root__description root__help"
@@ -416,7 +416,7 @@ exports[`single fields format datetime 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <input
       aria-describedby="root__error root__description root__help"
@@ -454,7 +454,7 @@ exports[`single fields format time 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <input
       aria-describedby="root__error root__description root__help"
@@ -514,7 +514,7 @@ exports[`single fields help and error display 1`] = `
     </ul>
   </div>
   <div
-    className="form-group field field-string field-error has-error has-danger"
+    className="form-group rjsf-field rjsf-field-string rjsf-field-error has-error has-danger"
   >
     <input
       aria-describedby="root__error root__description root__help"
@@ -570,7 +570,7 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
@@ -606,7 +606,7 @@ exports[`single fields hidden label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <input
       aria-describedby="root__error root__description root__help"
@@ -644,7 +644,7 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-null"
+    className="form-group rjsf-field rjsf-field-null"
   />
   <div>
     <button
@@ -665,7 +665,7 @@ exports[`single fields number field 0 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="form-group rjsf-field rjsf-field-number"
   >
     <input
       aria-describedby="root__error root__description root__help"
@@ -704,7 +704,7 @@ exports[`single fields number field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="form-group rjsf-field rjsf-field-number"
   >
     <input
       aria-describedby="root__error root__description root__help"
@@ -743,7 +743,7 @@ exports[`single fields password field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <input
       aria-describedby="root__error root__description root__help"
@@ -781,7 +781,7 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="form-group rjsf-field rjsf-field-boolean"
   >
     <div
       className="field-radio-group"
@@ -857,7 +857,7 @@ exports[`single fields schema examples 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <input
       aria-describedby="root__error root__description root__help root__examples"
@@ -915,7 +915,7 @@ exports[`single fields select field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <select
       aria-describedby="root__error root__description root__help"
@@ -965,7 +965,7 @@ exports[`single fields select field multiple choice 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <select
       aria-describedby="root__error root__description root__help"
@@ -1023,7 +1023,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <select
       aria-describedby="root__error root__description root__help"
@@ -1085,7 +1085,7 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <div
       className="checkboxes"
@@ -1208,7 +1208,7 @@ exports[`single fields select field multiple choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <select
       aria-describedby="root__error root__description root__help"
@@ -1271,7 +1271,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="form-group rjsf-field rjsf-field-array"
   >
     <select
       aria-describedby="root__error root__description root__help"
@@ -1324,7 +1324,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <select
       aria-describedby="root__error root__description root__help"
@@ -1376,7 +1376,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <div
       className="field-radio-group"
@@ -1452,7 +1452,7 @@ exports[`single fields select field single choice form disabled using radio widg
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <div
       className="field-radio-group"
@@ -1528,7 +1528,7 @@ exports[`single fields select field single choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <select
       aria-describedby="root__error root__description root__help"
@@ -1578,7 +1578,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <div
       className="field-radio-group"
@@ -1654,7 +1654,7 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-integer"
+    className="form-group rjsf-field rjsf-field-integer"
   >
     <div
       className="field-range-wrapper"
@@ -1703,7 +1703,7 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <div>
       <input
@@ -1743,7 +1743,7 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <input
       aria-describedby="root__error root__description root__help"
@@ -1781,7 +1781,7 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <input
       aria-describedby="root__error root__description root__help"
@@ -1819,7 +1819,7 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <input
       aria-describedby="root__error root__description root__help"
@@ -1857,7 +1857,7 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <input
       aria-describedby="root__error root__description root__help"
@@ -1895,7 +1895,7 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <textarea
       aria-describedby="root__error root__description root__help"
@@ -1931,7 +1931,7 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
@@ -1942,7 +1942,7 @@ exports[`single fields title field 1`] = `
         Titre 1
       </legend>
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <label
           className="control-label"
@@ -1989,7 +1989,7 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-undefined"
+    className="form-group rjsf-field rjsf-field-undefined"
   >
     <div
       className="unsupported-field"
@@ -2031,7 +2031,7 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="form-group rjsf-field rjsf-field-number"
   >
     <input
       aria-describedby="root__error root__description root__help"
@@ -2069,7 +2069,7 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="form-group rjsf-field rjsf-field-string"
   >
     <input
       aria-describedby="root__error root__description root__help"

--- a/packages/core/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/core/test/__snapshots__/GridSnap.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <div
       data-testid="0"
@@ -21,7 +21,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-object"
+            className="form-group rjsf-field rjsf-field-object"
           >
             <legend
               id="root_person__title"
@@ -40,7 +40,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -77,7 +77,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -109,7 +109,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -151,7 +151,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -188,7 +188,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-array"
+            className="form-group rjsf-field rjsf-field-array"
           >
             <label
               className="control-label"
@@ -344,7 +344,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-object"
+            className="form-group rjsf-field rjsf-field-object"
           >
             <div
               className="row"
@@ -355,7 +355,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="form-group rjsf-field rjsf-field-string"
                 >
                   <label
                     className="control-label"
@@ -392,7 +392,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="form-group rjsf-field rjsf-field-string"
                 >
                   <label
                     className="control-label"
@@ -424,7 +424,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="form-group rjsf-field rjsf-field-string"
                 >
                   <label
                     className="control-label"
@@ -464,7 +464,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="form-group rjsf-field rjsf-field-string"
                   >
                     <label
                       className="control-label"
@@ -783,7 +783,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="form-group rjsf-field rjsf-field-string"
                   >
                     <label
                       className="control-label"
@@ -829,7 +829,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field"
+            className="form-group"
           >
             <label
               className="control-label"
@@ -916,7 +916,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -953,7 +953,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -985,7 +985,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -1022,7 +1022,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -1358,7 +1358,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <div
       data-testid="0"
@@ -1372,7 +1372,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-object"
+            className="form-group rjsf-field rjsf-field-object"
           >
             <legend
               id="root_person__title"
@@ -1391,7 +1391,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -1428,7 +1428,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -1460,7 +1460,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -1502,7 +1502,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -1539,7 +1539,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-array"
+            className="form-group rjsf-field rjsf-field-array"
           >
             <label
               className="control-label"
@@ -1695,7 +1695,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-object"
+            className="form-group rjsf-field rjsf-field-object"
           >
             <div
               className="row"
@@ -1706,7 +1706,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="form-group rjsf-field rjsf-field-string"
                 >
                   <label
                     className="control-label"
@@ -1743,7 +1743,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="form-group rjsf-field rjsf-field-string"
                 >
                   <label
                     className="control-label"
@@ -1775,7 +1775,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="form-group rjsf-field rjsf-field-string"
                 >
                   <label
                     className="control-label"
@@ -1815,7 +1815,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="form-group rjsf-field rjsf-field-string"
                   >
                     <label
                       className="control-label"
@@ -2134,7 +2134,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="form-group rjsf-field rjsf-field-string"
                   >
                     <label
                       className="control-label"
@@ -2180,7 +2180,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field"
+            className="form-group"
           >
             <label
               className="control-label"
@@ -2267,7 +2267,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -2299,7 +2299,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -2336,7 +2336,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -2368,7 +2368,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -2405,7 +2405,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -2741,7 +2741,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <div
       data-testid="0"
@@ -2755,7 +2755,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-object"
+            className="form-group rjsf-field rjsf-field-object"
           >
             <legend
               id="root_person__title"
@@ -2774,7 +2774,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -2811,7 +2811,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -2843,7 +2843,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -2885,7 +2885,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -2922,7 +2922,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-array"
+            className="form-group rjsf-field rjsf-field-array"
           >
             <label
               className="control-label"
@@ -3078,7 +3078,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-object"
+            className="form-group rjsf-field rjsf-field-object"
           >
             <div
               className="row"
@@ -3089,7 +3089,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="form-group rjsf-field rjsf-field-string"
                 >
                   <label
                     className="control-label"
@@ -3126,7 +3126,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="form-group rjsf-field rjsf-field-string"
                 >
                   <label
                     className="control-label"
@@ -3158,7 +3158,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="form-group rjsf-field rjsf-field-string"
                 >
                   <label
                     className="control-label"
@@ -3198,7 +3198,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="form-group rjsf-field rjsf-field-string"
                   >
                     <label
                       className="control-label"
@@ -3517,7 +3517,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="form-group rjsf-field rjsf-field-string"
                   >
                     <label
                       className="control-label"
@@ -3563,7 +3563,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field"
+            className="form-group"
           >
             <label
               className="control-label"
@@ -3650,7 +3650,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -3703,7 +3703,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <div
       data-testid="0"
@@ -3717,7 +3717,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-object"
+            className="form-group rjsf-field rjsf-field-object"
           >
             <legend
               id="root_person__title"
@@ -3736,7 +3736,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -3773,7 +3773,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -3805,7 +3805,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -3847,7 +3847,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -3884,7 +3884,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-array"
+            className="form-group rjsf-field rjsf-field-array"
           >
             <label
               className="control-label"
@@ -4040,7 +4040,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-object"
+            className="form-group rjsf-field rjsf-field-object"
           >
             <div
               className="row"
@@ -4051,7 +4051,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="form-group rjsf-field rjsf-field-string"
                 >
                   <label
                     className="control-label"
@@ -4088,7 +4088,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="form-group rjsf-field rjsf-field-string"
                 >
                   <label
                     className="control-label"
@@ -4120,7 +4120,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="form-group rjsf-field rjsf-field-string"
                 >
                   <label
                     className="control-label"
@@ -4160,7 +4160,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="form-group rjsf-field rjsf-field-string"
                   >
                     <label
                       className="control-label"
@@ -4479,7 +4479,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="form-group rjsf-field rjsf-field-string"
                   >
                     <label
                       className="control-label"
@@ -4525,7 +4525,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field"
+            className="form-group"
           >
             <label
               className="control-label"
@@ -4612,7 +4612,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -4649,7 +4649,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -4681,7 +4681,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -4718,7 +4718,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="form-group rjsf-field rjsf-field-string"
           >
             <label
               className="control-label"
@@ -5054,7 +5054,7 @@ exports[`Three even column grid renders person and address in three columns, no 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <div
       className="row"
@@ -5065,7 +5065,7 @@ exports[`Three even column grid renders person and address in three columns, no 
         data-testid="1"
       >
         <div
-          className="form-group field field-object"
+          className="form-group rjsf-field rjsf-field-object"
         >
           <legend
             id="root_person__title"
@@ -5079,7 +5079,7 @@ exports[`Three even column grid renders person and address in three columns, no 
         data-testid="1"
       >
         <div
-          className="form-group field field-string"
+          className="form-group rjsf-field rjsf-field-string"
         >
           <label
             className="control-label"
@@ -5116,7 +5116,7 @@ exports[`Three even column grid renders person and address in three columns, no 
         data-testid="1"
       >
         <div
-          className="form-group field field-string"
+          className="form-group rjsf-field rjsf-field-string"
         >
           <label
             className="control-label"
@@ -5148,7 +5148,7 @@ exports[`Three even column grid renders person and address in three columns, no 
         data-testid="1"
       >
         <div
-          className="form-group field field-string"
+          className="form-group rjsf-field rjsf-field-string"
         >
           <label
             className="control-label"
@@ -5185,7 +5185,7 @@ exports[`Three even column grid renders person and address in three columns, no 
         data-testid="1"
       >
         <div
-          className="form-group field field-string"
+          className="form-group rjsf-field rjsf-field-string"
         >
           <label
             className="control-label"
@@ -5222,7 +5222,7 @@ exports[`Three even column grid renders person and address in three columns, no 
         data-testid="1"
       >
         <div
-          className="form-group field field-array"
+          className="form-group rjsf-field rjsf-field-array"
         >
           <label
             className="control-label"
@@ -5373,7 +5373,7 @@ exports[`Three even column grid renders person and address in three columns, no 
         data-testid="1"
       >
         <div
-          className="form-group field field-string"
+          className="form-group rjsf-field rjsf-field-string"
         >
           <label
             className="control-label"
@@ -5410,7 +5410,7 @@ exports[`Three even column grid renders person and address in three columns, no 
         data-testid="1"
       >
         <div
-          className="form-group field field-string"
+          className="form-group rjsf-field rjsf-field-string"
         >
           <label
             className="control-label"
@@ -5442,7 +5442,7 @@ exports[`Three even column grid renders person and address in three columns, no 
         data-testid="1"
       >
         <div
-          className="form-group field field-string"
+          className="form-group rjsf-field rjsf-field-string"
         >
           <label
             className="control-label"
@@ -5479,7 +5479,7 @@ exports[`Three even column grid renders person and address in three columns, no 
         data-testid="1"
       >
         <div
-          className="form-group field field-string"
+          className="form-group rjsf-field rjsf-field-string"
         >
           <label
             className="control-label"
@@ -5818,7 +5818,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <div
       className="row"
@@ -5829,7 +5829,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
         data-testid="1"
       >
         <div
-          className="form-group field field-object"
+          className="form-group rjsf-field rjsf-field-object"
         >
           <legend
             id="root_person__title"
@@ -5843,7 +5843,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
         data-testid="1"
       >
         <div
-          className="form-group field field-string"
+          className="form-group rjsf-field rjsf-field-string"
         >
           <label
             className="control-label"
@@ -5880,7 +5880,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
         data-testid="1"
       >
         <div
-          className="form-group field field-string"
+          className="form-group rjsf-field rjsf-field-string"
         >
           <label
             className="control-label"
@@ -5912,7 +5912,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
         data-testid="1"
       >
         <div
-          className="form-group field field-string"
+          className="form-group rjsf-field rjsf-field-string"
         >
           <label
             className="control-label"
@@ -5949,7 +5949,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
         data-testid="1"
       >
         <div
-          className="form-group field field-string"
+          className="form-group rjsf-field rjsf-field-string"
         >
           <label
             className="control-label"
@@ -5986,7 +5986,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
         data-testid="1"
       >
         <div
-          className="form-group field field-array"
+          className="form-group rjsf-field rjsf-field-array"
         >
           <label
             className="control-label"
@@ -6137,7 +6137,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
         data-testid="1"
       >
         <div
-          className="form-group field field-string"
+          className="form-group rjsf-field rjsf-field-string"
         >
           <label
             className="control-label"
@@ -6174,7 +6174,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
         data-testid="1"
       >
         <div
-          className="form-group field field-string"
+          className="form-group rjsf-field rjsf-field-string"
         >
           <label
             className="control-label"
@@ -6206,7 +6206,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
         data-testid="1"
       >
         <div
-          className="form-group field field-string"
+          className="form-group rjsf-field rjsf-field-string"
         >
           <label
             className="control-label"
@@ -6243,7 +6243,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
         data-testid="1"
       >
         <div
-          className="form-group field field-string"
+          className="form-group rjsf-field rjsf-field-string"
         >
           <label
             className="control-label"

--- a/packages/core/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/core/test/__snapshots__/GridSnap.test.tsx.snap
@@ -828,7 +828,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           }
         >
-          <div>
+          <div
+            className="form-group field"
+          >
             <label
               className="control-label"
               htmlFor="root_employment"
@@ -2177,7 +2179,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           }
         >
-          <div>
+          <div
+            className="form-group field"
+          >
             <label
               className="control-label"
               htmlFor="root_employment"
@@ -3558,7 +3562,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           }
         >
-          <div>
+          <div
+            className="form-group field"
+          >
             <label
               className="control-label"
               htmlFor="root_employment"
@@ -4518,7 +4524,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           }
         >
-          <div>
+          <div
+            className="form-group field"
+          >
             <label
               className="control-label"
               htmlFor="root_employment"

--- a/packages/core/test/__snapshots__/ObjectSnap.test.tsx.snap
+++ b/packages/core/test/__snapshots__/ObjectSnap.test.tsx.snap
@@ -7,13 +7,13 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
     >
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <div
           className="row"
@@ -70,7 +70,7 @@ exports[`object fields additionalProperties 1`] = `
             className="col-xs-2"
           >
             <button
-              className="btn btn-danger array-item-remove btn-block"
+              className="btn btn-danger rjsf-object-property-remove btn-block"
               disabled={false}
               id="root_foo__remove"
               onClick={[Function]}
@@ -93,7 +93,7 @@ exports[`object fields additionalProperties 1`] = `
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right object-property-expand"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-object-property-expand"
         >
           <button
             className="btn btn-info btn-add col-xs-12"
@@ -129,13 +129,13 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
     >
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <label
           className="control-label"
@@ -162,7 +162,7 @@ exports[`object fields object 1`] = `
         />
       </div>
       <div
-        className="form-group field field-number"
+        className="form-group rjsf-field rjsf-field-number"
       >
         <label
           className="control-label"
@@ -210,13 +210,13 @@ exports[`object fields show add button and fields if additionalProperties is tru
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
     >
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <div
           className="row"
@@ -273,7 +273,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
             className="col-xs-2"
           >
             <button
-              className="btn btn-danger array-item-remove btn-block"
+              className="btn btn-danger rjsf-object-property-remove btn-block"
               disabled={false}
               id="root_additionalProperty__remove"
               onClick={[Function]}
@@ -296,7 +296,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right object-property-expand"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-object-property-expand"
         >
           <button
             className="btn btn-info btn-add col-xs-12"
@@ -332,7 +332,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
@@ -349,7 +349,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
         a test description
       </p>
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <div
           className="row"
@@ -406,7 +406,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
             className="col-xs-2"
           >
             <button
-              className="btn btn-danger array-item-remove btn-block"
+              className="btn btn-danger rjsf-object-property-remove btn-block"
               disabled={false}
               id="root_foo__remove"
               onClick={[Function]}
@@ -429,7 +429,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right object-property-expand"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-object-property-expand"
         >
           <button
             className="btn btn-info btn-add col-xs-12"
@@ -465,7 +465,7 @@ exports[`object fields with title and description from both additionalProperties
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
@@ -482,7 +482,7 @@ exports[`object fields with title and description from both additionalProperties
         a fancier description
       </p>
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <div
           className="row"
@@ -539,7 +539,7 @@ exports[`object fields with title and description from both additionalProperties
             className="col-xs-2"
           >
             <button
-              className="btn btn-danger array-item-remove btn-block"
+              className="btn btn-danger rjsf-object-property-remove btn-block"
               disabled={false}
               id="root_foo__remove"
               onClick={[Function]}
@@ -562,7 +562,7 @@ exports[`object fields with title and description from both additionalProperties
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right object-property-expand"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-object-property-expand"
         >
           <button
             className="btn btn-info btn-add col-xs-12"
@@ -598,7 +598,7 @@ exports[`object fields with title and description from both object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
@@ -615,7 +615,7 @@ exports[`object fields with title and description from both object 1`] = `
         a fancier description
       </p>
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <label
           className="control-label"
@@ -648,7 +648,7 @@ exports[`object fields with title and description from both object 1`] = `
         />
       </div>
       <div
-        className="form-group field field-number"
+        className="form-group rjsf-field rjsf-field-number"
       >
         <label
           className="control-label"
@@ -702,7 +702,7 @@ exports[`object fields with title and description from uiSchema additionalProper
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
@@ -719,7 +719,7 @@ exports[`object fields with title and description from uiSchema additionalProper
         a fancier description
       </p>
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <div
           className="row"
@@ -776,7 +776,7 @@ exports[`object fields with title and description from uiSchema additionalProper
             className="col-xs-2"
           >
             <button
-              className="btn btn-danger array-item-remove btn-block"
+              className="btn btn-danger rjsf-object-property-remove btn-block"
               disabled={false}
               id="root_foo__remove"
               onClick={[Function]}
@@ -799,7 +799,7 @@ exports[`object fields with title and description from uiSchema additionalProper
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right object-property-expand"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-object-property-expand"
         >
           <button
             className="btn btn-info btn-add col-xs-12"
@@ -835,7 +835,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
@@ -852,7 +852,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
         a fancier description
       </p>
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <label
           className="control-label"
@@ -885,7 +885,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
         />
       </div>
       <div
-        className="form-group field field-number"
+        className="form-group rjsf-field rjsf-field-number"
       >
         <label
           className="control-label"
@@ -939,7 +939,7 @@ exports[`object fields with title and description from uiSchema show add button 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
@@ -956,7 +956,7 @@ exports[`object fields with title and description from uiSchema show add button 
         a fancier description
       </p>
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <div
           className="row"
@@ -1013,7 +1013,7 @@ exports[`object fields with title and description from uiSchema show add button 
             className="col-xs-2"
           >
             <button
-              className="btn btn-danger array-item-remove btn-block"
+              className="btn btn-danger rjsf-object-property-remove btn-block"
               disabled={false}
               id="root_additionalProperty__remove"
               onClick={[Function]}
@@ -1036,7 +1036,7 @@ exports[`object fields with title and description from uiSchema show add button 
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right object-property-expand"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-object-property-expand"
         >
           <button
             className="btn btn-info btn-add col-xs-12"
@@ -1072,7 +1072,7 @@ exports[`object fields with title and description object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
@@ -1089,7 +1089,7 @@ exports[`object fields with title and description object 1`] = `
         a test description
       </p>
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <label
           className="control-label"
@@ -1122,7 +1122,7 @@ exports[`object fields with title and description object 1`] = `
         />
       </div>
       <div
-        className="form-group field field-number"
+        className="form-group rjsf-field rjsf-field-number"
       >
         <label
           className="control-label"
@@ -1176,7 +1176,7 @@ exports[`object fields with title and description show add button and fields if 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
@@ -1193,7 +1193,7 @@ exports[`object fields with title and description show add button and fields if 
         a test description
       </p>
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <div
           className="row"
@@ -1250,7 +1250,7 @@ exports[`object fields with title and description show add button and fields if 
             className="col-xs-2"
           >
             <button
-              className="btn btn-danger array-item-remove btn-block"
+              className="btn btn-danger rjsf-object-property-remove btn-block"
               disabled={false}
               id="root_additionalProperty__remove"
               onClick={[Function]}
@@ -1273,7 +1273,7 @@ exports[`object fields with title and description show add button and fields if 
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right object-property-expand"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-object-property-expand"
         >
           <button
             className="btn btn-info btn-add col-xs-12"
@@ -1309,13 +1309,13 @@ exports[`object fields with title and description with global label off addition
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
     >
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <div
           className="row"
@@ -1366,7 +1366,7 @@ exports[`object fields with title and description with global label off addition
             className="col-xs-2"
           >
             <button
-              className="btn btn-danger array-item-remove btn-block"
+              className="btn btn-danger rjsf-object-property-remove btn-block"
               disabled={false}
               id="root_foo__remove"
               onClick={[Function]}
@@ -1389,7 +1389,7 @@ exports[`object fields with title and description with global label off addition
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right object-property-expand"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-object-property-expand"
         >
           <button
             className="btn btn-info btn-add col-xs-12"
@@ -1425,13 +1425,13 @@ exports[`object fields with title and description with global label off object 1
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
     >
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <input
           aria-describedby="root_a__error root_a__description root_a__help"
@@ -1452,7 +1452,7 @@ exports[`object fields with title and description with global label off object 1
         />
       </div>
       <div
-        className="form-group field field-number"
+        className="form-group rjsf-field rjsf-field-number"
       >
         <input
           aria-describedby="root_b__error root_b__description root_b__help"
@@ -1494,13 +1494,13 @@ exports[`object fields with title and description with global label off show add
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="form-group rjsf-field rjsf-field-object"
   >
     <fieldset
       id="root"
     >
       <div
-        className="form-group field field-string"
+        className="form-group rjsf-field rjsf-field-string"
       >
         <div
           className="row"
@@ -1551,7 +1551,7 @@ exports[`object fields with title and description with global label off show add
             className="col-xs-2"
           >
             <button
-              className="btn btn-danger array-item-remove btn-block"
+              className="btn btn-danger rjsf-object-property-remove btn-block"
               disabled={false}
               id="root_additionalProperty__remove"
               onClick={[Function]}
@@ -1574,7 +1574,7 @@ exports[`object fields with title and description with global label off show add
         className="row"
       >
         <p
-          className="col-xs-3 col-xs-offset-9 text-right object-property-expand"
+          className="col-xs-3 col-xs-offset-9 text-right rjsf-object-property-expand"
         >
           <button
             className="btn btn-info btn-add col-xs-12"

--- a/packages/core/test/anyOf.test.jsx
+++ b/packages/core/test/anyOf.test.jsx
@@ -161,7 +161,7 @@ describe('anyOf', () => {
       {
         formData: { foo: 'defaultbar' },
       },
-      'root__anyof_select'
+      'root__anyof_select',
     );
   });
 
@@ -237,7 +237,7 @@ describe('anyOf', () => {
       {
         formData: { foo: 'defaultbar' },
       },
-      'root__anyof_select'
+      'root__anyof_select',
     );
   });
 
@@ -277,7 +277,7 @@ describe('anyOf', () => {
       {
         formData: { foo: 'defaultbar' },
       },
-      'root__anyof_select'
+      'root__anyof_select',
     );
   });
 
@@ -379,7 +379,7 @@ describe('anyOf', () => {
       {
         formData: { foo: 'Lorem ipsum dolor sit amet' },
       },
-      'root_foo'
+      'root_foo',
     );
   });
 
@@ -420,7 +420,7 @@ describe('anyOf', () => {
           buzz: 'Lorem ipsum dolor sit amet',
         },
       },
-      'root_buzz'
+      'root_buzz',
     );
 
     act(() => {
@@ -437,7 +437,7 @@ describe('anyOf', () => {
           foo: 'Consectetur adipiscing elit',
         },
       },
-      'root_foo'
+      'root_foo',
     );
 
     const $select = node.querySelector('select');
@@ -488,7 +488,7 @@ describe('anyOf', () => {
       {
         formData: { userId: 12345 },
       },
-      'root_userId'
+      'root_userId',
     );
 
     const $select = node.querySelector('select');
@@ -504,7 +504,7 @@ describe('anyOf', () => {
       {
         formData: { userId: undefined },
       },
-      'root_userId'
+      'root_userId',
     );
 
     act(() => {
@@ -518,7 +518,7 @@ describe('anyOf', () => {
       {
         formData: { userId: 'Lorem ipsum dolor sit amet' },
       },
-      'root_userId'
+      'root_userId',
     );
   });
 
@@ -1103,10 +1103,10 @@ describe('anyOf', () => {
         schema,
       });
 
-      expect(node.querySelector('.array-item-add button')).not.eql(null);
+      expect(node.querySelector('.rjsf-array-item-add button')).not.eql(null);
 
       act(() => {
-        fireEvent.click(node.querySelector('.array-item-add button'));
+        fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
       });
 
       expect(node.querySelectorAll('select')).to.have.length.of(1);
@@ -1159,7 +1159,7 @@ describe('anyOf', () => {
       expect(selects[0].value).eql('0');
       expect(selects[1].value).eql('1');
 
-      const moveUpBtns = node.querySelectorAll('.array-item-move-up');
+      const moveUpBtns = node.querySelectorAll('.rjsf-array-item-move-up');
 
       act(() => {
         fireEvent.click(moveUpBtns[1]);
@@ -1206,12 +1206,12 @@ describe('anyOf', () => {
         },
       });
 
-      const moveDownBtns = node.querySelectorAll('.array-item-move-down');
+      const moveDownBtns = node.querySelectorAll('.rjsf-array-item-move-down');
       act(() => {
         fireEvent.click(moveDownBtns[0]);
       });
 
-      const strInputs = node.querySelectorAll('fieldset .field-string input[type=text]');
+      const strInputs = node.querySelectorAll('fieldset .rjsf-field-string input[type=text]');
 
       act(() => {
         fireEvent.change(strInputs[1], { target: { value: 'bar' } });
@@ -1250,10 +1250,10 @@ describe('anyOf', () => {
         schema,
       });
 
-      expect(node.querySelector('.array-item-add button')).not.eql(null);
+      expect(node.querySelector('.rjsf-array-item-add button')).not.eql(null);
 
       act(() => {
-        fireEvent.click(node.querySelector('.array-item-add button'));
+        fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
       });
 
       const $select = node.querySelector('select');
@@ -1630,7 +1630,7 @@ describe('anyOf', () => {
         fireEvent.submit(node);
       });
 
-      let inputs = node.querySelectorAll('.form-group.field-error input[type=number]');
+      let inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=number]');
       expect(inputs[0].id).eql('root_userId');
 
       const $select = node.querySelector('select');
@@ -1650,7 +1650,7 @@ describe('anyOf', () => {
         fireEvent.submit(node);
       });
 
-      inputs = node.querySelectorAll('.form-group.field-error input[type=text]');
+      inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=text]');
       expect(inputs[0].id).eql('root_userId');
     });
 
@@ -1673,7 +1673,7 @@ describe('anyOf', () => {
         fireEvent.submit(node);
       });
 
-      let inputs = node.querySelectorAll('.form-group.field-error input[type=number]');
+      let inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=number]');
       expect(inputs).to.have.length.of(0);
 
       const $select = node.querySelector('select');
@@ -1693,7 +1693,7 @@ describe('anyOf', () => {
         fireEvent.submit(node);
       });
 
-      inputs = node.querySelectorAll('.form-group.field-error input[type=text]');
+      inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=text]');
       expect(inputs).to.have.length.of(0);
     });
   });

--- a/packages/core/test/oneOf.test.jsx
+++ b/packages/core/test/oneOf.test.jsx
@@ -134,7 +134,7 @@ describe('oneOf', () => {
       {
         formData: { foo: 'defaultbar' },
       },
-      'root__oneof_select'
+      'root__oneof_select',
     );
   });
 
@@ -178,7 +178,7 @@ describe('oneOf', () => {
       {
         formData: { foo: 'defaultbar' },
       },
-      'root__oneof_select'
+      'root__oneof_select',
     );
   });
 
@@ -218,7 +218,7 @@ describe('oneOf', () => {
       {
         formData: { foo: 'defaultbar' },
       },
-      'root__oneof_select'
+      'root__oneof_select',
     );
   });
 
@@ -351,7 +351,7 @@ describe('oneOf', () => {
       {
         formData: { foo: 'Lorem ipsum dolor sit amet' },
       },
-      'root_foo'
+      'root_foo',
     );
   });
 
@@ -392,7 +392,7 @@ describe('oneOf', () => {
           buzz: 'Lorem ipsum dolor sit amet',
         },
       },
-      'root_buzz'
+      'root_buzz',
     );
 
     act(() => {
@@ -409,7 +409,7 @@ describe('oneOf', () => {
           foo: 'Consectetur adipiscing elit',
         },
       },
-      'root_foo'
+      'root_foo',
     );
 
     const $select = node.querySelector('select');
@@ -462,7 +462,7 @@ describe('oneOf', () => {
           userId: 12345,
         },
       },
-      'root_userId'
+      'root_userId',
     );
 
     const $select = node.querySelector('select');
@@ -480,7 +480,7 @@ describe('oneOf', () => {
           userId: undefined,
         },
       },
-      'root_userId'
+      'root_userId',
     );
 
     act(() => {
@@ -496,7 +496,7 @@ describe('oneOf', () => {
           userId: 'Lorem ipsum dolor sit amet',
         },
       },
-      'root_userId'
+      'root_userId',
     );
   });
 
@@ -822,7 +822,7 @@ describe('oneOf', () => {
       {
         formData: { ipsum: {}, lorem: undefined },
       },
-      'root__oneof_select'
+      'root__oneof_select',
     );
   });
 
@@ -998,9 +998,9 @@ describe('oneOf', () => {
         schema,
       });
 
-      expect(node.querySelector('.array-item-add button')).not.eql(null);
+      expect(node.querySelector('.rjsf-array-item-add button')).not.eql(null);
 
-      fireEvent.click(node.querySelector('.array-item-add button'));
+      fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
 
       const $select = node.querySelector('select');
       expect($select).not.eql(null);
@@ -1059,7 +1059,7 @@ describe('oneOf', () => {
       expect(selects[0].value).eql('0');
       expect(selects[1].value).eql('1');
 
-      const moveUpBtns = node.querySelectorAll('.array-item-move-up');
+      const moveUpBtns = node.querySelectorAll('.rjsf-array-item-move-up');
       fireEvent.click(moveUpBtns[1]);
 
       selects = node.querySelectorAll('select');
@@ -1103,10 +1103,10 @@ describe('oneOf', () => {
         },
       });
 
-      const moveDownBtns = node.querySelectorAll('.array-item-move-down');
+      const moveDownBtns = node.querySelectorAll('.rjsf-array-item-move-down');
       fireEvent.click(moveDownBtns[0]);
 
-      const strInputs = node.querySelectorAll('fieldset .field-string input[type=text]');
+      const strInputs = node.querySelectorAll('fieldset .rjsf-field-string input[type=text]');
 
       act(() => {
         fireEvent.change(strInputs[1], { target: { value: 'bar' } });
@@ -1218,9 +1218,9 @@ describe('oneOf', () => {
         schema,
       });
 
-      expect(node.querySelector('.array-item-add button')).not.eql(null);
+      expect(node.querySelector('.rjsf-array-item-add button')).not.eql(null);
 
-      fireEvent.click(node.querySelector('.array-item-add button'));
+      fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
 
       const $select = node.querySelector('select');
       expect($select).not.eql(null);
@@ -1233,7 +1233,7 @@ describe('oneOf', () => {
       // This works because the nested "add" button will now be the first to
       // appear in the dom
       act(() => {
-        fireEvent.click(node.querySelector('.array-item-add button'));
+        fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
       });
 
       expect($select.value).to.eql($select.options[1].value);
@@ -1499,9 +1499,9 @@ describe('oneOf', () => {
         schema,
       });
 
-      expect(node.querySelector('.array-item-add button')).not.eql(null);
+      expect(node.querySelector('.rjsf-array-item-add button')).not.eql(null);
 
-      fireEvent.click(node.querySelector('.array-item-add button'));
+      fireEvent.click(node.querySelector('.rjsf-array-item-add button'));
 
       const $select = node.querySelector('select');
       expect($select).not.eql(null);
@@ -1724,7 +1724,7 @@ describe('oneOf', () => {
       });
       fireEvent.submit(node);
 
-      let inputs = node.querySelectorAll('.form-group.field-error input[type=number]');
+      let inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=number]');
       expect(inputs[0].id).eql('root_userId');
 
       const $select = node.querySelector('select');
@@ -1742,7 +1742,7 @@ describe('oneOf', () => {
       });
       fireEvent.submit(node);
 
-      inputs = node.querySelectorAll('.form-group.field-error input[type=text]');
+      inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=text]');
       expect(inputs[0].id).eql('root_userId');
     });
     it('should NOT show error on options with different types when hideError: true', () => {
@@ -1761,7 +1761,7 @@ describe('oneOf', () => {
       });
       fireEvent.submit(node);
 
-      let inputs = node.querySelectorAll('.form-group.field-error input[type=number]');
+      let inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=number]');
       expect(inputs).to.have.length.of(0);
 
       const $select = node.querySelector('select');
@@ -1779,7 +1779,7 @@ describe('oneOf', () => {
       });
       fireEvent.submit(node);
 
-      inputs = node.querySelectorAll('.form-group.field-error input[type=text]');
+      inputs = node.querySelectorAll('.form-group.rjsf-field-error input[type=text]');
       expect(inputs).to.have.length.of(0);
     });
   });

--- a/packages/core/test/uiSchema.test.jsx
+++ b/packages/core/test/uiSchema.test.jsx
@@ -54,7 +54,7 @@ describe('uiSchema', () => {
       sandbox.stub(console, 'warn');
 
       const { node } = createFormComponent({ schema, uiSchema });
-      const [foo, bar, baz] = node.querySelectorAll('.field-string');
+      const [foo, bar, baz] = node.querySelectorAll('.rjsf-field-string');
 
       expect(foo.classList.contains('class-for-foo')).eql(true);
       expect(bar.classList.contains('class-for-bar')).eql(true);
@@ -92,7 +92,7 @@ describe('uiSchema', () => {
 
     it('should apply custom style to target widgets', () => {
       const { node } = createFormComponent({ schema, uiSchema });
-      const [foo, bar] = node.querySelectorAll('.field-string');
+      const [foo, bar] = node.querySelectorAll('.rjsf-field-string');
 
       expect(foo.style.paddingRight).eql('1em');
       expect(bar.style.paddingLeft).eql('1.5em');
@@ -1963,11 +1963,11 @@ describe('uiSchema', () => {
         });
 
         it('should disable the Add button', () => {
-          expect(node.querySelector('.array-item-add button').disabled).eql(true);
+          expect(node.querySelector('.rjsf-array-item-add button').disabled).eql(true);
         });
 
         it('should disable the Delete button', () => {
-          expect(node.querySelector('.array-item-remove').disabled).eql(true);
+          expect(node.querySelector('.rjsf-array-item-remove').disabled).eql(true);
         });
       });
 
@@ -2235,11 +2235,11 @@ describe('uiSchema', () => {
         });
 
         it('should disable the Add button', () => {
-          expect(node.querySelector('.array-item-add button').disabled).eql(true);
+          expect(node.querySelector('.rjsf-array-item-add button').disabled).eql(true);
         });
 
         it('should disable the Delete button', () => {
-          expect(node.querySelector('.array-item-remove').disabled).eql(true);
+          expect(node.querySelector('.rjsf-array-item-remove').disabled).eql(true);
         });
       });
 
@@ -2495,11 +2495,11 @@ describe('uiSchema', () => {
         });
 
         it('should disable the Add button', () => {
-          expect(node.querySelector('.array-item-add button').disabled).eql(true);
+          expect(node.querySelector('.rjsf-array-item-add button').disabled).eql(true);
         });
 
         it('should disable the Delete button', () => {
-          expect(node.querySelector('.array-item-remove').disabled).eql(true);
+          expect(node.querySelector('.rjsf-array-item-remove').disabled).eql(true);
         });
       });
 

--- a/packages/daisyui/src/templates/ArrayFieldItemButtonsTemplate/ArrayFieldItemButtonsTemplate.tsx
+++ b/packages/daisyui/src/templates/ArrayFieldItemButtonsTemplate/ArrayFieldItemButtonsTemplate.tsx
@@ -46,7 +46,7 @@ export default function ArrayFieldItemButtonsTemplate<
         <>
           <MoveUpButton
             id={buttonId<T>(idSchema, 'moveUp')}
-            className={`array-item-move-up ${btnClass}`}
+            className={`rjsf-array-item-move-up ${btnClass}`}
             disabled={disabled || readonly || !hasMoveUp}
             onClick={onArrowUpClick}
             uiSchema={uiSchema}
@@ -54,7 +54,7 @@ export default function ArrayFieldItemButtonsTemplate<
           />
           <MoveDownButton
             id={buttonId<T>(idSchema, 'moveDown')}
-            className={`array-item-move-down ${btnClass}`}
+            className={`rjsf-array-item-move-down ${btnClass}`}
             disabled={disabled || readonly || !hasMoveDown}
             onClick={onArrowDownClick}
             uiSchema={uiSchema}
@@ -65,7 +65,7 @@ export default function ArrayFieldItemButtonsTemplate<
       {hasCopy && (
         <CopyButton
           id={buttonId<T>(idSchema, 'copy')}
-          className={`array-item-copy ${btnClass}`}
+          className={`rjsf-array-item-copy ${btnClass}`}
           disabled={disabled || readonly}
           onClick={onCopyClick}
           uiSchema={uiSchema}
@@ -75,7 +75,7 @@ export default function ArrayFieldItemButtonsTemplate<
       {hasRemove && (
         <RemoveButton
           id={buttonId<T>(idSchema, 'remove')}
-          className={`array-item-remove ${removeBtnClass}`}
+          className={`rjsf-array-item-remove ${removeBtnClass}`}
           disabled={disabled || readonly}
           onClick={onRemoveClick}
           uiSchema={uiSchema}

--- a/packages/daisyui/src/templates/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/daisyui/src/templates/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -93,7 +93,7 @@ export default function ArrayFieldTemplate<T = any, S extends RJSFSchema = RJSFS
         registry={registry}
       />
       <div className='flex flex-col gap-4'>
-        <div className='array-item-list'>
+        <div className='rjsf-array-item-list'>
           {items &&
             items.map(({ key, ...itemProps }, index) => (
               <ArrayFieldItemTemplate key={key} {...itemProps} index={index} totalItems={items.length} />
@@ -106,7 +106,7 @@ export default function ArrayFieldTemplate<T = any, S extends RJSFSchema = RJSFS
           <div className='flex justify-end'>
             <AddButton
               id={buttonId<T>(idSchema, 'add')}
-              className='array-item-add btn btn-primary btn-sm'
+              className='rjsf-array-item-add btn btn-primary btn-sm'
               onClick={handleAddClick}
               disabled={disabled || readonly}
               uiSchema={uiSchema}

--- a/packages/daisyui/src/templates/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/daisyui/src/templates/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -15,7 +15,7 @@ export default function FieldErrorTemplate<
 >(props: FieldErrorProps<T, S, F>) {
   const { errors } = props;
   return (
-    <div className='field-error-template text-red-600'>
+    <div className='rjsf-field-error-template text-red-600'>
       <ul className='list-disc list-inside'>{errors?.map((error, index) => <li key={index}>{error}</li>) ?? []}</ul>
     </div>
   );

--- a/packages/daisyui/src/templates/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/daisyui/src/templates/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -16,7 +16,7 @@ export default function FieldHelpTemplate<
 >(props: FieldHelpProps<T, S, F>) {
   const { help } = props;
   return (
-    <div className='field-help-template text-gray-500 text-sm'>
+    <div className='rjsf-field-help-template text-gray-500 text-sm'>
       <div>{help}</div>
     </div>
   );

--- a/packages/daisyui/src/templates/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/daisyui/src/templates/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -94,7 +94,7 @@ export default function ObjectFieldTemplate<
           <div className='flex justify-end'>
             <AddButton
               id={buttonId<T>(idSchema, 'add')}
-              className='object-property-expand btn btn-primary btn-sm'
+              className='rjsf-object-property-expand btn btn-primary btn-sm'
               onClick={onAddClick(schema)}
               disabled={disabled || readonly}
               uiSchema={uiSchema}

--- a/packages/daisyui/src/templates/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/daisyui/src/templates/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -60,7 +60,7 @@ export default function WrapIfAdditionalTemplate<
         {schema.additionalProperties && (
           <button
             id={buttonId<T>(id, 'remove')}
-            className='array-item-remove btn btn-danger ml-2'
+            className='rjsf-array-item-remove btn btn-danger ml-2'
             onClick={handleRemove}
             disabled={disabled || readonly}
           >

--- a/packages/docs/docs/migration-guides/v6.x upgrade guide.md
+++ b/packages/docs/docs/migration-guides/v6.x upgrade guide.md
@@ -273,15 +273,39 @@ Use the `ui:enumNames` in the `UiSchema` instead.
 
 ### Other BREAKING CHANGES
 
-#### SchemaField removed Bootstrap 3 marker classes
+#### SchemaField removed Bootstrap 3 classes
 
-In fixing [#2280](https://github.com/rjsf-team/react-jsonschema-form/issues/2280), the following `Bootstrap 3` marker
-classes (`form-group`, `field` and `field-error`, `has-error` and `has-danger` error classes) were removed from the
-`classNames` prop passed down to the `FieldTemplate`. They were instead moved into the `WrapIfAdditionalTemplate` for
-the `core` theme to unsure that theme was unchanged. As a result, the themes (other than `core`) will no longer render
-those marker classes. If you use a non-`core` theme and were relying on them for in your application's styling or
-behavior (via css overrides perhaps), then you can still use the non-`Bootstrap 3` `field-<type>` marker class or your
-specific theme's error classes.
+In fixing [#2280](https://github.com/rjsf-team/react-jsonschema-form/issues/2280), the following `Bootstrap 3` classes
+(`form-group`, `has-error` and `has-danger` error classes) were removed from the `classNames` prop passed down to the
+`FieldTemplate`. They were instead moved into the `core` theme's `WrapIfAdditionalTemplate` to ensure that theme was
+unchanged. As a result, the themes (other than `core`) will no longer render those classes.
+
+If you use a non-`core` theme and were relying on them for in your application's styling or behavior (via css overrides
+perhaps), then you can still use the non-`Bootstrap 3` RJSF marker class (see below) or your specific theme's error classes.
+
+#### prefixed RJSF template and field marker classes
+
+Many of the `core` RJSF templates and field implementations that are shared across all themes were updated to add the
+`rjsf-` prefix to the marker classes that are being added to the rendered HTML. The following table highlights the old
+and new marker classes. If you were relying on any of these classes, simply do a rename:
+
+| old marker class               | new marker class                    |
+| ------------------------------ | ----------------------------------- |
+| `field`                        | `rjsf-field`                        |
+| `field-<schema.type>`          | `rjsf-field-<schema.type>`          |
+| `field-error`                  | `rjsf-field-error`                  |
+| `field-array`                  | `rjsf-field-array`                  |
+| `field-array-of-<schema.type>` | `rjsf-field-array-of-<schema.type>` |
+| `field-array-fixed-items`      | `rjsf-field-array-fixed-items`      |
+| `array-item`                   | `rjsf-array-item`                   |
+| `config-error`                 | `rjsf-config-error`                 |
+| `array-item-add`               | `rjsf-array-item-add`               |
+| `array-item-copy`              | `rjsf-array-item-copy`              |
+| `array-item-move-down`         | `rjsf-array-item-move-down`         |
+| `array-item-move-up`           | `rjsf-array-item-move-up`           |
+| `array-item-remove`            | `rjsf-array-item-remove`            |
+| `object-property-expand`       | `rjsf-object-property-expand`       |
+| `object-property-remove`       | `rjsf-object-property-remove`       |
 
 #### optionsList
 

--- a/packages/docs/docs/migration-guides/v6.x upgrade guide.md
+++ b/packages/docs/docs/migration-guides/v6.x upgrade guide.md
@@ -293,10 +293,11 @@ and new marker classes. If you were relying on any of these classes, simply do a
 | ------------------------------ | ----------------------------------- |
 | `field`                        | `rjsf-field`                        |
 | `field-<schema.type>`          | `rjsf-field-<schema.type>`          |
-| `field-error`                  | `rjsf-field-error`                  |
 | `field-array`                  | `rjsf-field-array`                  |
 | `field-array-of-<schema.type>` | `rjsf-field-array-of-<schema.type>` |
 | `field-array-fixed-items`      | `rjsf-field-array-fixed-items`      |
+| `field-error`                  | `rjsf-field-error`                  |
+| `field-hidden`                 | `rjsf-field-hidden`                 |
 | `array-item`                   | `rjsf-array-item`                   |
 | `config-error`                 | `rjsf-config-error`                 |
 | `array-item-add`               | `rjsf-array-item-add`               |

--- a/packages/docs/docs/migration-guides/v6.x upgrade guide.md
+++ b/packages/docs/docs/migration-guides/v6.x upgrade guide.md
@@ -273,6 +273,16 @@ Use the `ui:enumNames` in the `UiSchema` instead.
 
 ### Other BREAKING CHANGES
 
+#### SchemaField removed Bootstrap 3 marker classes
+
+In fixing [#2280](https://github.com/rjsf-team/react-jsonschema-form/issues/2280), the following `Bootstrap 3` marker
+classes (`form-group`, `field` and `field-error`, `has-error` and `has-danger` error classes) were removed from the
+`classNames` prop passed down to the `FieldTemplate`. They were instead moved into the `WrapIfAdditionalTemplate` for
+the `core` theme to unsure that theme was unchanged. As a result, the themes (other than `core`) will no longer render
+those marker classes. If you use a non-`core` theme and were relying on them for in your application's styling or
+behavior (via css overrides perhaps), then you can still use the non-`Bootstrap 3` `field-<type>` marker class or your
+specific theme's error classes.
+
 #### optionsList
 
 The generics ordering on the `optionsList()` function was changed from `<S, T, F>` to `<T, S, F>` to be consistent with the rest of the APIs.

--- a/packages/fluentui-rc/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/fluentui-rc/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -75,7 +75,7 @@ export default function ArrayFieldTemplate<
           <Flex hAlign='end'>
             <AddButton
               id={buttonId<T>(idSchema, 'add')}
-              className='array-item-add'
+              className='rjsf-array-item-add'
               onClick={onAddClick}
               disabled={disabled || readonly}
               uiSchema={uiSchema}

--- a/packages/fluentui-rc/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/fluentui-rc/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -85,7 +85,7 @@ export default function ObjectFieldTemplate<
           <Flex hAlign='end'>
             <AddButton
               id={buttonId<T>(idSchema, 'add')}
-              className='object-property-expand'
+              className='rjsf-object-property-expand'
               onClick={onAddClick(schema)}
               disabled={disabled || readonly}
               uiSchema={uiSchema}

--- a/packages/fluentui-rc/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/fluentui-rc/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -90,7 +90,7 @@ export default function WrapIfAdditionalTemplate<
         <RemoveButton
           id={buttonId<T>(id, 'remove')}
           iconType='default'
-          className='array-item-remove'
+          className='rjsf-object-property-remove'
           style={btnStyle}
           disabled={disabled || readonly}
           onClick={onDropPropertyClick(label)}

--- a/packages/fluentui-rc/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/fluentui-rc/test/__snapshots__/Array.test.tsx.snap
@@ -774,7 +774,7 @@ exports[`array fields has errors 1`] = `
           }
         >
           <div
-            className="rjsf-field rjsf-field-string"
+            className="rjsf-field rjsf-field-string rjsf-field-error"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"

--- a/packages/fluentui-rc/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/fluentui-rc/test/__snapshots__/Array.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -71,7 +71,7 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -86,7 +86,7 @@ exports[`array fields array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -249,7 +249,7 @@ exports[`array fields array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -461,7 +461,7 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -541,7 +541,7 @@ exports[`array fields empty errors array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -558,7 +558,7 @@ exports[`array fields empty errors array 1`] = `
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -616,7 +616,7 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -631,7 +631,7 @@ exports[`array fields fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -677,7 +677,7 @@ exports[`array fields fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -757,7 +757,7 @@ exports[`array fields has errors 1`] = `
     </ul>
   </div>
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -774,7 +774,7 @@ exports[`array fields has errors 1`] = `
           }
         >
           <div
-            className="form-group field field-string field-error has-error has-danger"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -847,7 +847,7 @@ exports[`array fields no errors 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -864,7 +864,7 @@ exports[`array fields no errors 1`] = `
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -922,7 +922,7 @@ exports[`with title and description array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1007,7 +1007,7 @@ exports[`with title and description array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1043,7 +1043,7 @@ exports[`with title and description array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1223,7 +1223,7 @@ exports[`with title and description array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1452,7 +1452,7 @@ exports[`with title and description checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1550,7 +1550,7 @@ exports[`with title and description fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1586,7 +1586,7 @@ exports[`with title and description fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1649,7 +1649,7 @@ exports[`with title and description fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1731,7 +1731,7 @@ exports[`with title and description from both array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1816,7 +1816,7 @@ exports[`with title and description from both array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1852,7 +1852,7 @@ exports[`with title and description from both array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2032,7 +2032,7 @@ exports[`with title and description from both array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2261,7 +2261,7 @@ exports[`with title and description from both checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2359,7 +2359,7 @@ exports[`with title and description from both fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2395,7 +2395,7 @@ exports[`with title and description from both fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2458,7 +2458,7 @@ exports[`with title and description from both fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2540,7 +2540,7 @@ exports[`with title and description from uiSchema array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2625,7 +2625,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2661,7 +2661,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2841,7 +2841,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3070,7 +3070,7 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3168,7 +3168,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3204,7 +3204,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3267,7 +3267,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3349,7 +3349,7 @@ exports[`with title and description with global label off array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3413,7 +3413,7 @@ exports[`with title and description with global label off array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3428,7 +3428,7 @@ exports[`with title and description with global label off array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3580,7 +3580,7 @@ exports[`with title and description with global label off array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3781,7 +3781,7 @@ exports[`with title and description with global label off checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3879,7 +3879,7 @@ exports[`with title and description with global label off fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3894,7 +3894,7 @@ exports[`with title and description with global label off fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3929,7 +3929,7 @@ exports[`with title and description with global label off fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"

--- a/packages/fluentui-rc/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/fluentui-rc/test/__snapshots__/Array.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -19,7 +19,7 @@ exports[`array fields array 1`] = `
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}
@@ -71,7 +71,7 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -86,7 +86,7 @@ exports[`array fields array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -133,7 +133,7 @@ exports[`array fields array icons 1`] = `
             }
           >
             <button
-              className="fui-Button r1alrhcs array-item-move-up ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-up ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={true}
               id="root_0__moveUp"
               onClick={[Function]}
@@ -160,7 +160,7 @@ exports[`array fields array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-move-down ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-down ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_0__moveDown"
               onClick={[Function]}
@@ -187,7 +187,7 @@ exports[`array fields array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_0__copy"
               onClick={[Function]}
@@ -214,7 +214,7 @@ exports[`array fields array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_0__remove"
               onClick={[Function]}
@@ -249,7 +249,7 @@ exports[`array fields array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -296,7 +296,7 @@ exports[`array fields array icons 1`] = `
             }
           >
             <button
-              className="fui-Button r1alrhcs array-item-move-up ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-up ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_1__moveUp"
               onClick={[Function]}
@@ -323,7 +323,7 @@ exports[`array fields array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-move-down ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-down ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={true}
               id="root_1__moveDown"
               onClick={[Function]}
@@ -350,7 +350,7 @@ exports[`array fields array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_1__copy"
               onClick={[Function]}
@@ -377,7 +377,7 @@ exports[`array fields array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_1__remove"
               onClick={[Function]}
@@ -409,7 +409,7 @@ exports[`array fields array icons 1`] = `
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}
@@ -461,7 +461,7 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -541,7 +541,7 @@ exports[`array fields empty errors array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -558,7 +558,7 @@ exports[`array fields empty errors array 1`] = `
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -616,7 +616,7 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -631,7 +631,7 @@ exports[`array fields fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -677,7 +677,7 @@ exports[`array fields fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -757,7 +757,7 @@ exports[`array fields has errors 1`] = `
     </ul>
   </div>
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -774,7 +774,7 @@ exports[`array fields has errors 1`] = `
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -847,7 +847,7 @@ exports[`array fields no errors 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -864,7 +864,7 @@ exports[`array fields no errors 1`] = `
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -922,7 +922,7 @@ exports[`with title and description array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -955,7 +955,7 @@ exports[`with title and description array 1`] = `
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}
@@ -1007,7 +1007,7 @@ exports[`with title and description array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1043,7 +1043,7 @@ exports[`with title and description array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1107,7 +1107,7 @@ exports[`with title and description array icons 1`] = `
             }
           >
             <button
-              className="fui-Button r1alrhcs array-item-move-up ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-up ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={true}
               id="root_0__moveUp"
               onClick={[Function]}
@@ -1134,7 +1134,7 @@ exports[`with title and description array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-move-down ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-down ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_0__moveDown"
               onClick={[Function]}
@@ -1161,7 +1161,7 @@ exports[`with title and description array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_0__copy"
               onClick={[Function]}
@@ -1188,7 +1188,7 @@ exports[`with title and description array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_0__remove"
               onClick={[Function]}
@@ -1223,7 +1223,7 @@ exports[`with title and description array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1287,7 +1287,7 @@ exports[`with title and description array icons 1`] = `
             }
           >
             <button
-              className="fui-Button r1alrhcs array-item-move-up ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-up ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_1__moveUp"
               onClick={[Function]}
@@ -1314,7 +1314,7 @@ exports[`with title and description array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-move-down ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-down ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={true}
               id="root_1__moveDown"
               onClick={[Function]}
@@ -1341,7 +1341,7 @@ exports[`with title and description array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_1__copy"
               onClick={[Function]}
@@ -1368,7 +1368,7 @@ exports[`with title and description array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_1__remove"
               onClick={[Function]}
@@ -1400,7 +1400,7 @@ exports[`with title and description array icons 1`] = `
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}
@@ -1452,7 +1452,7 @@ exports[`with title and description checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1550,7 +1550,7 @@ exports[`with title and description fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1586,7 +1586,7 @@ exports[`with title and description fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1649,7 +1649,7 @@ exports[`with title and description fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1731,7 +1731,7 @@ exports[`with title and description from both array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1764,7 +1764,7 @@ exports[`with title and description from both array 1`] = `
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}
@@ -1816,7 +1816,7 @@ exports[`with title and description from both array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1852,7 +1852,7 @@ exports[`with title and description from both array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1916,7 +1916,7 @@ exports[`with title and description from both array icons 1`] = `
             }
           >
             <button
-              className="fui-Button r1alrhcs array-item-move-up ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-up ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={true}
               id="root_0__moveUp"
               onClick={[Function]}
@@ -1943,7 +1943,7 @@ exports[`with title and description from both array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-move-down ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-down ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_0__moveDown"
               onClick={[Function]}
@@ -1970,7 +1970,7 @@ exports[`with title and description from both array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_0__copy"
               onClick={[Function]}
@@ -1997,7 +1997,7 @@ exports[`with title and description from both array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_0__remove"
               onClick={[Function]}
@@ -2032,7 +2032,7 @@ exports[`with title and description from both array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2096,7 +2096,7 @@ exports[`with title and description from both array icons 1`] = `
             }
           >
             <button
-              className="fui-Button r1alrhcs array-item-move-up ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-up ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_1__moveUp"
               onClick={[Function]}
@@ -2123,7 +2123,7 @@ exports[`with title and description from both array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-move-down ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-down ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={true}
               id="root_1__moveDown"
               onClick={[Function]}
@@ -2150,7 +2150,7 @@ exports[`with title and description from both array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_1__copy"
               onClick={[Function]}
@@ -2177,7 +2177,7 @@ exports[`with title and description from both array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_1__remove"
               onClick={[Function]}
@@ -2209,7 +2209,7 @@ exports[`with title and description from both array icons 1`] = `
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}
@@ -2261,7 +2261,7 @@ exports[`with title and description from both checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2359,7 +2359,7 @@ exports[`with title and description from both fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2395,7 +2395,7 @@ exports[`with title and description from both fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2458,7 +2458,7 @@ exports[`with title and description from both fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2540,7 +2540,7 @@ exports[`with title and description from uiSchema array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2573,7 +2573,7 @@ exports[`with title and description from uiSchema array 1`] = `
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}
@@ -2625,7 +2625,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2661,7 +2661,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2725,7 +2725,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
             }
           >
             <button
-              className="fui-Button r1alrhcs array-item-move-up ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-up ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={true}
               id="root_0__moveUp"
               onClick={[Function]}
@@ -2752,7 +2752,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-move-down ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-down ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_0__moveDown"
               onClick={[Function]}
@@ -2779,7 +2779,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_0__copy"
               onClick={[Function]}
@@ -2806,7 +2806,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_0__remove"
               onClick={[Function]}
@@ -2841,7 +2841,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2905,7 +2905,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
             }
           >
             <button
-              className="fui-Button r1alrhcs array-item-move-up ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-up ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_1__moveUp"
               onClick={[Function]}
@@ -2932,7 +2932,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-move-down ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-down ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={true}
               id="root_1__moveDown"
               onClick={[Function]}
@@ -2959,7 +2959,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_1__copy"
               onClick={[Function]}
@@ -2986,7 +2986,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_1__remove"
               onClick={[Function]}
@@ -3018,7 +3018,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}
@@ -3070,7 +3070,7 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3168,7 +3168,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3204,7 +3204,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3267,7 +3267,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3349,7 +3349,7 @@ exports[`with title and description with global label off array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3361,7 +3361,7 @@ exports[`with title and description with global label off array 1`] = `
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}
@@ -3413,7 +3413,7 @@ exports[`with title and description with global label off array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3428,7 +3428,7 @@ exports[`with title and description with global label off array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3464,7 +3464,7 @@ exports[`with title and description with global label off array icons 1`] = `
             }
           >
             <button
-              className="fui-Button r1alrhcs array-item-move-up ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-up ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={true}
               id="root_0__moveUp"
               onClick={[Function]}
@@ -3491,7 +3491,7 @@ exports[`with title and description with global label off array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-move-down ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-down ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_0__moveDown"
               onClick={[Function]}
@@ -3518,7 +3518,7 @@ exports[`with title and description with global label off array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_0__copy"
               onClick={[Function]}
@@ -3545,7 +3545,7 @@ exports[`with title and description with global label off array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_0__remove"
               onClick={[Function]}
@@ -3580,7 +3580,7 @@ exports[`with title and description with global label off array icons 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3616,7 +3616,7 @@ exports[`with title and description with global label off array icons 1`] = `
             }
           >
             <button
-              className="fui-Button r1alrhcs array-item-move-up ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-up ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_1__moveUp"
               onClick={[Function]}
@@ -3643,7 +3643,7 @@ exports[`with title and description with global label off array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-move-down ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-move-down ___vbvxfv0_jgl51i0 f1bg9a2p f1jj8ep1 f15xbau f4ikngz fy0fskl f1s2aq7o fdrzuqr f15x8b5r f1falr9n f12mpcsy f1gwvigk f1jnshp0 f18rmfxp fvgxktp fphbwmw f19vpps7 fv5swzo f1al02dq f1t6o4dc f10ztigi f1ft5sdu f12zbtn2 f1gzf82w fcvwxyo f8w4c43 f1ol4fw6 f1q1lw4e f1dwjv2g f4lkoma fg455y9 f1rvyvqg f1cwzwz f14g86mu f1dcs8yz fjwq6ea f1lr3nhc fn5gmvv f1mbxvi6 f1vmkb5g f53ppgq f1663y11 f18v5270 f80fkiy f1kc2mi9 f1y0svfh fihuait fnxhupq fx507ft fyd6l6x fb3rf2x f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={true}
               id="root_1__moveDown"
               onClick={[Function]}
@@ -3670,7 +3670,7 @@ exports[`with title and description with global label off array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-copy ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_1__copy"
               onClick={[Function]}
@@ -3697,7 +3697,7 @@ exports[`with title and description with global label off array icons 1`] = `
               </span>
             </button>
             <button
-              className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+              className="fui-Button r1alrhcs rjsf-array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
               disabled={false}
               id="root_1__remove"
               onClick={[Function]}
@@ -3729,7 +3729,7 @@ exports[`with title and description with global label off array icons 1`] = `
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-array-item-add ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}
@@ -3781,7 +3781,7 @@ exports[`with title and description with global label off checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3879,7 +3879,7 @@ exports[`with title and description with global label off fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3894,7 +3894,7 @@ exports[`with title and description with global label off fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3929,7 +3929,7 @@ exports[`with title and description with global label off fixed array 1`] = `
             className="fui-Flex ___9stze40_16wdn2w f22iagw fly5x3f f1l02sjl fzy362"
           >
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"

--- a/packages/fluentui-rc/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluentui-rc/test/__snapshots__/Form.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -62,7 +62,7 @@ exports[`single fields checkbox field with label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -119,7 +119,7 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -266,7 +266,7 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -283,7 +283,7 @@ exports[`single fields field with description 1`] = `
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -357,7 +357,7 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -374,7 +374,7 @@ exports[`single fields field with description in uiSchema 1`] = `
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -448,7 +448,7 @@ exports[`single fields format color 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -499,7 +499,7 @@ exports[`single fields format date 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -550,7 +550,7 @@ exports[`single fields format datetime 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -601,7 +601,7 @@ exports[`single fields format time 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -667,7 +667,7 @@ exports[`single fields help and error display 1`] = `
     </ul>
   </div>
   <div
-    className="form-group field field-string field-error has-error has-danger"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -739,7 +739,7 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -786,7 +786,7 @@ exports[`single fields hidden label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -833,7 +833,7 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-null"
+    className="field-null"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -861,7 +861,7 @@ exports[`single fields number field 0 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -913,7 +913,7 @@ exports[`single fields number field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -965,7 +965,7 @@ exports[`single fields password field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1016,7 +1016,7 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1107,7 +1107,7 @@ exports[`single fields schema examples 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1178,7 +1178,7 @@ exports[`single fields select field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1280,7 +1280,7 @@ exports[`single fields select field multiple choice 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1360,7 +1360,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1440,7 +1440,7 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1585,7 +1585,7 @@ exports[`single fields select field multiple choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1666,7 +1666,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1746,7 +1746,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1848,7 +1848,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1939,7 +1939,7 @@ exports[`single fields select field single choice form disabled using radio widg
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2030,7 +2030,7 @@ exports[`single fields select field single choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2133,7 +2133,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2224,7 +2224,7 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-integer"
+    className="field-integer"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2288,7 +2288,7 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2341,7 +2341,7 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2392,7 +2392,7 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2443,7 +2443,7 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2494,7 +2494,7 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2545,7 +2545,7 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2596,7 +2596,7 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2628,7 +2628,7 @@ exports[`single fields title field 1`] = `
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2686,7 +2686,7 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-undefined"
+    className="field-undefined"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2735,7 +2735,7 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2786,7 +2786,7 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"

--- a/packages/fluentui-rc/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluentui-rc/test/__snapshots__/Form.test.tsx.snap
@@ -667,7 +667,7 @@ exports[`single fields help and error display 1`] = `
     </ul>
   </div>
   <div
-    className="rjsf-field rjsf-field-string"
+    className="rjsf-field rjsf-field-string rjsf-field-error"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"

--- a/packages/fluentui-rc/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluentui-rc/test/__snapshots__/Form.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -62,7 +62,7 @@ exports[`single fields checkbox field with label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -119,7 +119,7 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -266,7 +266,7 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -283,7 +283,7 @@ exports[`single fields field with description 1`] = `
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -357,7 +357,7 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -374,7 +374,7 @@ exports[`single fields field with description in uiSchema 1`] = `
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -448,7 +448,7 @@ exports[`single fields format color 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -499,7 +499,7 @@ exports[`single fields format date 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -550,7 +550,7 @@ exports[`single fields format datetime 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -601,7 +601,7 @@ exports[`single fields format time 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -667,7 +667,7 @@ exports[`single fields help and error display 1`] = `
     </ul>
   </div>
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -739,7 +739,7 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -786,7 +786,7 @@ exports[`single fields hidden label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -833,7 +833,7 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-null"
+    className="rjsf-field rjsf-field-null"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -861,7 +861,7 @@ exports[`single fields number field 0 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -913,7 +913,7 @@ exports[`single fields number field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -965,7 +965,7 @@ exports[`single fields password field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1016,7 +1016,7 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1107,7 +1107,7 @@ exports[`single fields schema examples 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1178,7 +1178,7 @@ exports[`single fields select field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1280,7 +1280,7 @@ exports[`single fields select field multiple choice 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1360,7 +1360,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1440,7 +1440,7 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1585,7 +1585,7 @@ exports[`single fields select field multiple choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1666,7 +1666,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1746,7 +1746,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1848,7 +1848,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1939,7 +1939,7 @@ exports[`single fields select field single choice form disabled using radio widg
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2030,7 +2030,7 @@ exports[`single fields select field single choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2133,7 +2133,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2224,7 +2224,7 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-integer"
+    className="rjsf-field rjsf-field-integer"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2288,7 +2288,7 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2341,7 +2341,7 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2392,7 +2392,7 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2443,7 +2443,7 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2494,7 +2494,7 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2545,7 +2545,7 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2596,7 +2596,7 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2628,7 +2628,7 @@ exports[`single fields title field 1`] = `
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2686,7 +2686,7 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-undefined"
+    className="rjsf-field rjsf-field-undefined"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2735,7 +2735,7 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2786,7 +2786,7 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"

--- a/packages/fluentui-rc/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/fluentui-rc/test/__snapshots__/GridSnap.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -34,7 +34,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-object"
+            className="field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -67,7 +67,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -116,7 +116,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -159,7 +159,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -208,7 +208,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -258,7 +258,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-array"
+            className="field-array"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -505,7 +505,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-object"
+            className="field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -518,7 +518,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -561,7 +561,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -598,7 +598,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -644,7 +644,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -738,7 +738,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -898,7 +898,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -941,7 +941,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -981,7 +981,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <div
                   className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1024,7 +1024,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <div
                   className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1141,7 +1141,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1168,7 +1168,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-object"
+            className="field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1201,7 +1201,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1250,7 +1250,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1293,7 +1293,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1342,7 +1342,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1392,7 +1392,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-array"
+            className="field-array"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1639,7 +1639,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-object"
+            className="field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1652,7 +1652,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1695,7 +1695,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1732,7 +1732,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1778,7 +1778,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1872,7 +1872,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2032,7 +2032,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2069,7 +2069,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2112,7 +2112,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2152,7 +2152,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <div
                   className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2195,7 +2195,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <div
                   className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2312,7 +2312,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2339,7 +2339,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-object"
+            className="field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2372,7 +2372,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2421,7 +2421,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2464,7 +2464,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2513,7 +2513,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2563,7 +2563,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-array"
+            className="field-array"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2810,7 +2810,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-object"
+            className="field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2823,7 +2823,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2866,7 +2866,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2903,7 +2903,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2949,7 +2949,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3043,7 +3043,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3203,7 +3203,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3268,7 +3268,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3295,7 +3295,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-object"
+            className="field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3328,7 +3328,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3377,7 +3377,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3420,7 +3420,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3469,7 +3469,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3519,7 +3519,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-array"
+            className="field-array"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3766,7 +3766,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="form-group field field-object"
+            className="field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3779,7 +3779,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3822,7 +3822,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3859,7 +3859,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3905,7 +3905,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3999,7 +3999,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4159,7 +4159,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4202,7 +4202,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4242,7 +4242,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <div
                   className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4285,7 +4285,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="form-group field field-string"
+                className="field-string"
               >
                 <div
                   className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4402,7 +4402,7 @@ exports[`Three even column grid renders person and address in three columns, no 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4429,7 +4429,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-object"
+            className="field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4462,7 +4462,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4511,7 +4511,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4554,7 +4554,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4603,7 +4603,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4652,7 +4652,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-array"
+            className="field-array"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4872,7 +4872,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4921,7 +4921,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4964,7 +4964,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5013,7 +5013,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5137,7 +5137,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5164,7 +5164,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-object"
+            className="field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5197,7 +5197,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5246,7 +5246,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5289,7 +5289,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5338,7 +5338,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5387,7 +5387,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-array"
+            className="field-array"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5607,7 +5607,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5656,7 +5656,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5699,7 +5699,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5748,7 +5748,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"

--- a/packages/fluentui-rc/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/fluentui-rc/test/__snapshots__/GridSnap.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -34,7 +34,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-object"
+            className="rjsf-field rjsf-field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -67,7 +67,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -116,7 +116,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -159,7 +159,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -208,7 +208,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -258,7 +258,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-array"
+            className="rjsf-field rjsf-field-array"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -505,7 +505,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-object"
+            className="rjsf-field rjsf-field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -518,7 +518,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -561,7 +561,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -598,7 +598,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -644,7 +644,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -738,7 +738,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -898,7 +898,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -941,7 +941,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -981,7 +981,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <div
                   className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1024,7 +1024,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <div
                   className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1141,7 +1141,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1168,7 +1168,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-object"
+            className="rjsf-field rjsf-field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1201,7 +1201,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1250,7 +1250,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1293,7 +1293,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1342,7 +1342,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1392,7 +1392,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-array"
+            className="rjsf-field rjsf-field-array"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1639,7 +1639,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-object"
+            className="rjsf-field rjsf-field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1652,7 +1652,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1695,7 +1695,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1732,7 +1732,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1778,7 +1778,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1872,7 +1872,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2032,7 +2032,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2069,7 +2069,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2112,7 +2112,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2152,7 +2152,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <div
                   className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2195,7 +2195,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <div
                   className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2312,7 +2312,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2339,7 +2339,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-object"
+            className="rjsf-field rjsf-field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2372,7 +2372,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2421,7 +2421,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2464,7 +2464,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2513,7 +2513,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2563,7 +2563,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-array"
+            className="rjsf-field rjsf-field-array"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2810,7 +2810,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-object"
+            className="rjsf-field rjsf-field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2823,7 +2823,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2866,7 +2866,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2903,7 +2903,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2949,7 +2949,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3043,7 +3043,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3203,7 +3203,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3268,7 +3268,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3295,7 +3295,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-object"
+            className="rjsf-field rjsf-field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3328,7 +3328,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3377,7 +3377,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3420,7 +3420,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3469,7 +3469,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3519,7 +3519,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-array"
+            className="rjsf-field rjsf-field-array"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3766,7 +3766,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            className="field-object"
+            className="rjsf-field rjsf-field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3779,7 +3779,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3822,7 +3822,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3859,7 +3859,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   data-testid="1"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3905,7 +3905,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -3999,7 +3999,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4159,7 +4159,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4202,7 +4202,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4242,7 +4242,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <div
                   className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4285,7 +4285,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               data-testid="1"
             >
               <div
-                className="field-string"
+                className="rjsf-field rjsf-field-string"
               >
                 <div
                   className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4402,7 +4402,7 @@ exports[`Three even column grid renders person and address in three columns, no 
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4429,7 +4429,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-object"
+            className="rjsf-field rjsf-field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4462,7 +4462,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4511,7 +4511,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4554,7 +4554,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4603,7 +4603,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4652,7 +4652,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-array"
+            className="rjsf-field rjsf-field-array"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4872,7 +4872,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4921,7 +4921,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -4964,7 +4964,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5013,7 +5013,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5137,7 +5137,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5164,7 +5164,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-object"
+            className="rjsf-field rjsf-field-object"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5197,7 +5197,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5246,7 +5246,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5289,7 +5289,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5338,7 +5338,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5387,7 +5387,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-array"
+            className="rjsf-field rjsf-field-array"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5607,7 +5607,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5656,7 +5656,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5699,7 +5699,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -5748,7 +5748,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"

--- a/packages/fluentui-rc/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/fluentui-rc/test/__snapshots__/Object.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -24,7 +24,7 @@ exports[`object fields additionalProperties 1`] = `
           }
         >
           <div
-            className="fui-Flex field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
+            className="fui-Flex rjsf-field rjsf-field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
           >
             <div>
               <div
@@ -88,7 +88,7 @@ exports[`object fields additionalProperties 1`] = `
             </div>
             <div>
               <button
-                className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+                className="fui-Button r1alrhcs rjsf-object-property-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
                 disabled={false}
                 id="root_foo__remove"
                 onClick={[Function]}
@@ -129,7 +129,7 @@ exports[`object fields additionalProperties 1`] = `
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs object-property-expand ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-object-property-expand ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}
@@ -181,7 +181,7 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -198,7 +198,7 @@ exports[`object fields object 1`] = `
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -240,7 +240,7 @@ exports[`object fields object 1`] = `
           }
         >
           <div
-            className="field-number"
+            className="rjsf-field rjsf-field-number"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -299,7 +299,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -316,7 +316,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
           }
         >
           <div
-            className="fui-Flex field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
+            className="fui-Flex rjsf-field rjsf-field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
           >
             <div>
               <div
@@ -380,7 +380,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
             </div>
             <div>
               <button
-                className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+                className="fui-Button r1alrhcs rjsf-object-property-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
                 disabled={false}
                 id="root_additionalProperty__remove"
                 onClick={[Function]}
@@ -421,7 +421,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs object-property-expand ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-object-property-expand ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}
@@ -473,7 +473,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -511,7 +511,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
           }
         >
           <div
-            className="fui-Flex field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
+            className="fui-Flex rjsf-field rjsf-field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
           >
             <div>
               <div
@@ -575,7 +575,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
             </div>
             <div>
               <button
-                className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+                className="fui-Button r1alrhcs rjsf-object-property-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
                 disabled={false}
                 id="root_foo__remove"
                 onClick={[Function]}
@@ -616,7 +616,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs object-property-expand ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-object-property-expand ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}
@@ -668,7 +668,7 @@ exports[`object fields with title and description from both additionalProperties
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -706,7 +706,7 @@ exports[`object fields with title and description from both additionalProperties
           }
         >
           <div
-            className="fui-Flex field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
+            className="fui-Flex rjsf-field rjsf-field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
           >
             <div>
               <div
@@ -770,7 +770,7 @@ exports[`object fields with title and description from both additionalProperties
             </div>
             <div>
               <button
-                className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+                className="fui-Button r1alrhcs rjsf-object-property-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
                 disabled={false}
                 id="root_foo__remove"
                 onClick={[Function]}
@@ -811,7 +811,7 @@ exports[`object fields with title and description from both additionalProperties
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs object-property-expand ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-object-property-expand ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}
@@ -863,7 +863,7 @@ exports[`object fields with title and description from both object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -901,7 +901,7 @@ exports[`object fields with title and description from both object 1`] = `
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -959,7 +959,7 @@ exports[`object fields with title and description from both object 1`] = `
           }
         >
           <div
-            className="field-number"
+            className="rjsf-field rjsf-field-number"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1034,7 +1034,7 @@ exports[`object fields with title and description from uiSchema additionalProper
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1072,7 +1072,7 @@ exports[`object fields with title and description from uiSchema additionalProper
           }
         >
           <div
-            className="fui-Flex field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
+            className="fui-Flex rjsf-field rjsf-field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
           >
             <div>
               <div
@@ -1136,7 +1136,7 @@ exports[`object fields with title and description from uiSchema additionalProper
             </div>
             <div>
               <button
-                className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+                className="fui-Button r1alrhcs rjsf-object-property-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
                 disabled={false}
                 id="root_foo__remove"
                 onClick={[Function]}
@@ -1177,7 +1177,7 @@ exports[`object fields with title and description from uiSchema additionalProper
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs object-property-expand ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-object-property-expand ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}
@@ -1229,7 +1229,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1267,7 +1267,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1325,7 +1325,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
           }
         >
           <div
-            className="field-number"
+            className="rjsf-field rjsf-field-number"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1400,7 +1400,7 @@ exports[`object fields with title and description from uiSchema show add button 
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1438,7 +1438,7 @@ exports[`object fields with title and description from uiSchema show add button 
           }
         >
           <div
-            className="fui-Flex field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
+            className="fui-Flex rjsf-field rjsf-field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
           >
             <div>
               <div
@@ -1502,7 +1502,7 @@ exports[`object fields with title and description from uiSchema show add button 
             </div>
             <div>
               <button
-                className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+                className="fui-Button r1alrhcs rjsf-object-property-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
                 disabled={false}
                 id="root_additionalProperty__remove"
                 onClick={[Function]}
@@ -1543,7 +1543,7 @@ exports[`object fields with title and description from uiSchema show add button 
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs object-property-expand ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-object-property-expand ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}
@@ -1595,7 +1595,7 @@ exports[`object fields with title and description object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1633,7 +1633,7 @@ exports[`object fields with title and description object 1`] = `
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1691,7 +1691,7 @@ exports[`object fields with title and description object 1`] = `
           }
         >
           <div
-            className="field-number"
+            className="rjsf-field rjsf-field-number"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1766,7 +1766,7 @@ exports[`object fields with title and description show add button and fields if 
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1804,7 +1804,7 @@ exports[`object fields with title and description show add button and fields if 
           }
         >
           <div
-            className="fui-Flex field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
+            className="fui-Flex rjsf-field rjsf-field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
           >
             <div>
               <div
@@ -1868,7 +1868,7 @@ exports[`object fields with title and description show add button and fields if 
             </div>
             <div>
               <button
-                className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+                className="fui-Button r1alrhcs rjsf-object-property-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
                 disabled={false}
                 id="root_additionalProperty__remove"
                 onClick={[Function]}
@@ -1909,7 +1909,7 @@ exports[`object fields with title and description show add button and fields if 
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs object-property-expand ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-object-property-expand ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}
@@ -1961,7 +1961,7 @@ exports[`object fields with title and description with global label off addition
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1978,7 +1978,7 @@ exports[`object fields with title and description with global label off addition
           }
         >
           <div
-            className="fui-Flex field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
+            className="fui-Flex rjsf-field rjsf-field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
           >
             <div>
               <div
@@ -2036,7 +2036,7 @@ exports[`object fields with title and description with global label off addition
             </div>
             <div>
               <button
-                className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+                className="fui-Button r1alrhcs rjsf-object-property-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
                 disabled={false}
                 id="root_foo__remove"
                 onClick={[Function]}
@@ -2077,7 +2077,7 @@ exports[`object fields with title and description with global label off addition
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs object-property-expand ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-object-property-expand ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}
@@ -2129,7 +2129,7 @@ exports[`object fields with title and description with global label off object 1
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2146,7 +2146,7 @@ exports[`object fields with title and description with global label off object 1
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2182,7 +2182,7 @@ exports[`object fields with title and description with global label off object 1
           }
         >
           <div
-            className="field-number"
+            className="rjsf-field rjsf-field-number"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2235,7 +2235,7 @@ exports[`object fields with title and description with global label off show add
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2252,7 +2252,7 @@ exports[`object fields with title and description with global label off show add
           }
         >
           <div
-            className="fui-Flex field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
+            className="fui-Flex rjsf-field rjsf-field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
           >
             <div>
               <div
@@ -2310,7 +2310,7 @@ exports[`object fields with title and description with global label off show add
             </div>
             <div>
               <button
-                className="fui-Button r1alrhcs array-item-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+                className="fui-Button r1alrhcs rjsf-object-property-remove ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
                 disabled={false}
                 id="root_additionalProperty__remove"
                 onClick={[Function]}
@@ -2351,7 +2351,7 @@ exports[`object fields with title and description with global label off show add
           className="fui-Flex ___1ncave0_cx496c0 f22iagw f9c4gz4"
         >
           <button
-            className="fui-Button r1alrhcs object-property-expand ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
+            className="fui-Button r1alrhcs rjsf-object-property-expand ___mzo0df0_1ut924j f1sbtcvk fwiuce9 fdghr9 f15vdbe4 fwbmr0d f44c6la"
             disabled={false}
             id="root__add"
             onClick={[Function]}

--- a/packages/fluentui-rc/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/fluentui-rc/test/__snapshots__/Object.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -24,7 +24,7 @@ exports[`object fields additionalProperties 1`] = `
           }
         >
           <div
-            className="fui-Flex form-group field field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
+            className="fui-Flex field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
           >
             <div>
               <div
@@ -181,7 +181,7 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -198,7 +198,7 @@ exports[`object fields object 1`] = `
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -240,7 +240,7 @@ exports[`object fields object 1`] = `
           }
         >
           <div
-            className="form-group field field-number"
+            className="field-number"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -299,7 +299,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -316,7 +316,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
           }
         >
           <div
-            className="fui-Flex form-group field field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
+            className="fui-Flex field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
           >
             <div>
               <div
@@ -473,7 +473,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -511,7 +511,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
           }
         >
           <div
-            className="fui-Flex form-group field field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
+            className="fui-Flex field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
           >
             <div>
               <div
@@ -668,7 +668,7 @@ exports[`object fields with title and description from both additionalProperties
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -706,7 +706,7 @@ exports[`object fields with title and description from both additionalProperties
           }
         >
           <div
-            className="fui-Flex form-group field field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
+            className="fui-Flex field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
           >
             <div>
               <div
@@ -863,7 +863,7 @@ exports[`object fields with title and description from both object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -901,7 +901,7 @@ exports[`object fields with title and description from both object 1`] = `
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -959,7 +959,7 @@ exports[`object fields with title and description from both object 1`] = `
           }
         >
           <div
-            className="form-group field field-number"
+            className="field-number"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1034,7 +1034,7 @@ exports[`object fields with title and description from uiSchema additionalProper
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1072,7 +1072,7 @@ exports[`object fields with title and description from uiSchema additionalProper
           }
         >
           <div
-            className="fui-Flex form-group field field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
+            className="fui-Flex field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
           >
             <div>
               <div
@@ -1229,7 +1229,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1267,7 +1267,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1325,7 +1325,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
           }
         >
           <div
-            className="form-group field field-number"
+            className="field-number"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1400,7 +1400,7 @@ exports[`object fields with title and description from uiSchema show add button 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1438,7 +1438,7 @@ exports[`object fields with title and description from uiSchema show add button 
           }
         >
           <div
-            className="fui-Flex form-group field field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
+            className="fui-Flex field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
           >
             <div>
               <div
@@ -1595,7 +1595,7 @@ exports[`object fields with title and description object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1633,7 +1633,7 @@ exports[`object fields with title and description object 1`] = `
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1691,7 +1691,7 @@ exports[`object fields with title and description object 1`] = `
           }
         >
           <div
-            className="form-group field field-number"
+            className="field-number"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1766,7 +1766,7 @@ exports[`object fields with title and description show add button and fields if 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1804,7 +1804,7 @@ exports[`object fields with title and description show add button and fields if 
           }
         >
           <div
-            className="fui-Flex form-group field field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
+            className="fui-Flex field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
           >
             <div>
               <div
@@ -1961,7 +1961,7 @@ exports[`object fields with title and description with global label off addition
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -1978,7 +1978,7 @@ exports[`object fields with title and description with global label off addition
           }
         >
           <div
-            className="fui-Flex form-group field field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
+            className="fui-Flex field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
           >
             <div>
               <div
@@ -2129,7 +2129,7 @@ exports[`object fields with title and description with global label off object 1
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2146,7 +2146,7 @@ exports[`object fields with title and description with global label off object 1
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2182,7 +2182,7 @@ exports[`object fields with title and description with global label off object 1
           }
         >
           <div
-            className="form-group field field-number"
+            className="field-number"
           >
             <div
               className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2235,7 +2235,7 @@ exports[`object fields with title and description with global label off show add
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
@@ -2252,7 +2252,7 @@ exports[`object fields with title and description with global label off show add
           }
         >
           <div
-            className="fui-Flex form-group field field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
+            className="fui-Flex field-string ___8gv6eg0_pb6o3x0 f22iagw f122n59 f1lv1r8n"
           >
             <div>
               <div

--- a/packages/mui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/mui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -71,7 +71,7 @@ export default function ArrayFieldTemplate<
               <Box mt={2}>
                 <AddButton
                   id={buttonId<T>(idSchema, 'add')}
-                  className='array-item-add'
+                  className='rjsf-array-item-add'
                   onClick={onAddClick}
                   disabled={disabled || readonly}
                   uiSchema={uiSchema}

--- a/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/mui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -86,7 +86,7 @@ export default function ObjectFieldTemplate<
             <Grid2>
               <AddButton
                 id={buttonId<T>(idSchema, 'add')}
-                className='object-property-expand'
+                className='rjsf-object-property-expand'
                 onClick={onAddClick(schema)}
                 disabled={disabled || readonly}
                 uiSchema={uiSchema}

--- a/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/mui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -77,7 +77,7 @@ export default function WrapIfAdditionalTemplate<
       <Grid2>
         <RemoveButton
           id={buttonId<T>(id, 'remove')}
-          className='array-item-remove'
+          className='rjsf-object-property-remove'
           iconType='default'
           style={btnStyle}
           disabled={disabled || readonly}

--- a/packages/mui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Array.test.tsx.snap
@@ -3834,7 +3834,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-16:focus::-ms-input-
           }
         >
           <div
-            className="rjsf-field rjsf-field-string"
+            className="rjsf-field rjsf-field-string rjsf-field-error"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-9"

--- a/packages/mui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Array.test.tsx.snap
@@ -282,7 +282,7 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1061,7 +1061,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1103,7 +1103,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1318,7 +1318,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1978,7 +1978,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2493,7 +2493,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2515,7 +2515,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2985,7 +2985,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3027,7 +3027,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3106,7 +3106,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3812,7 +3812,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-16:focus::-ms-input-
     </div>
   </div>
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-9"
@@ -3834,7 +3834,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-16:focus::-ms-input-
           }
         >
           <div
-            className="form-group field field-string field-error has-error has-danger"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-9"
@@ -4345,7 +4345,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4367,7 +4367,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4768,7 +4768,7 @@ exports[`with title and description array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5676,7 +5676,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5743,7 +5743,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5988,7 +5988,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6749,7 +6749,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-4:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7359,7 +7359,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7426,7 +7426,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7535,7 +7535,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7967,7 +7967,7 @@ exports[`with title and description from both array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -8875,7 +8875,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -8942,7 +8942,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9187,7 +9187,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9948,7 +9948,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-4:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10558,7 +10558,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10625,7 +10625,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10734,7 +10734,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11166,7 +11166,7 @@ exports[`with title and description from uiSchema array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -12074,7 +12074,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -12141,7 +12141,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -12386,7 +12386,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13147,7 +13147,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-4:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13757,7 +13757,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13824,7 +13824,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13933,7 +13933,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -14331,7 +14331,7 @@ exports[`with title and description with global label off array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -15110,7 +15110,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -15152,7 +15152,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -15367,7 +15367,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -16098,7 +16098,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-4:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -16608,7 +16608,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -16650,7 +16650,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -16729,7 +16729,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"

--- a/packages/mui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Array.test.tsx.snap
@@ -282,7 +282,7 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -308,7 +308,7 @@ exports[`array fields array 1`] = `
                 className="MuiBox-root emotion-5"
               >
                 <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-6"
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-array-item-add emotion-6"
                   disabled={null}
                   id="root__add"
                   onBlur={[Function]}
@@ -1061,7 +1061,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1103,7 +1103,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1159,7 +1159,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-14"
             >
               <button
-                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall array-item-move-up emotion-15"
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall rjsf-array-item-move-up emotion-15"
                 disabled={true}
                 id="root_0__moveUp"
                 onBlur={[Function]}
@@ -1192,7 +1192,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-move-down emotion-15"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-move-down emotion-15"
                 disabled={null}
                 id="root_0__moveDown"
                 onBlur={[Function]}
@@ -1225,7 +1225,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-copy emotion-15"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-copy emotion-15"
                 disabled={null}
                 id="root_0__copy"
                 onBlur={[Function]}
@@ -1258,7 +1258,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-21"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-array-item-remove emotion-21"
                 disabled={null}
                 id="root_0__remove"
                 onBlur={[Function]}
@@ -1318,7 +1318,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1374,7 +1374,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-14"
             >
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-move-up emotion-15"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-move-up emotion-15"
                 disabled={null}
                 id="root_1__moveUp"
                 onBlur={[Function]}
@@ -1407,7 +1407,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall array-item-move-down emotion-15"
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall rjsf-array-item-move-down emotion-15"
                 disabled={true}
                 id="root_1__moveDown"
                 onBlur={[Function]}
@@ -1440,7 +1440,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-copy emotion-15"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-copy emotion-15"
                 disabled={null}
                 id="root_1__copy"
                 onBlur={[Function]}
@@ -1473,7 +1473,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-21"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-array-item-remove emotion-21"
                 disabled={null}
                 id="root_1__remove"
                 onBlur={[Function]}
@@ -1517,7 +1517,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                 className="MuiBox-root emotion-45"
               >
                 <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-46"
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-array-item-add emotion-46"
                   disabled={null}
                   id="root__add"
                   onBlur={[Function]}
@@ -1978,7 +1978,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2493,7 +2493,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2515,7 +2515,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2985,7 +2985,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3027,7 +3027,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3106,7 +3106,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3812,7 +3812,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-16:focus::-ms-input-
     </div>
   </div>
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-9"
@@ -3834,7 +3834,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-16:focus::-ms-input-
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-9"
@@ -4345,7 +4345,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4367,7 +4367,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4768,7 +4768,7 @@ exports[`with title and description array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4819,7 +4819,7 @@ exports[`with title and description array 1`] = `
                 className="MuiBox-root emotion-9"
               >
                 <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-10"
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-array-item-add emotion-10"
                   disabled={null}
                   id="root__add"
                   onBlur={[Function]}
@@ -5676,7 +5676,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5743,7 +5743,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5829,7 +5829,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-22"
             >
               <button
-                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall array-item-move-up emotion-23"
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall rjsf-array-item-move-up emotion-23"
                 disabled={true}
                 id="root_0__moveUp"
                 onBlur={[Function]}
@@ -5862,7 +5862,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-move-down emotion-23"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-move-down emotion-23"
                 disabled={null}
                 id="root_0__moveDown"
                 onBlur={[Function]}
@@ -5895,7 +5895,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-copy emotion-23"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-copy emotion-23"
                 disabled={null}
                 id="root_0__copy"
                 onBlur={[Function]}
@@ -5928,7 +5928,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-29"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-array-item-remove emotion-29"
                 disabled={null}
                 id="root_0__remove"
                 onBlur={[Function]}
@@ -5988,7 +5988,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6074,7 +6074,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-22"
             >
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-move-up emotion-23"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-move-up emotion-23"
                 disabled={null}
                 id="root_1__moveUp"
                 onBlur={[Function]}
@@ -6107,7 +6107,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall array-item-move-down emotion-23"
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall rjsf-array-item-move-down emotion-23"
                 disabled={true}
                 id="root_1__moveDown"
                 onBlur={[Function]}
@@ -6140,7 +6140,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-copy emotion-23"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-copy emotion-23"
                 disabled={null}
                 id="root_1__copy"
                 onBlur={[Function]}
@@ -6173,7 +6173,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-29"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-array-item-remove emotion-29"
                 disabled={null}
                 id="root_1__remove"
                 onBlur={[Function]}
@@ -6217,7 +6217,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 className="MuiBox-root emotion-57"
               >
                 <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-58"
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-array-item-add emotion-58"
                   disabled={null}
                   id="root__add"
                   onBlur={[Function]}
@@ -6749,7 +6749,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-4:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7359,7 +7359,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7426,7 +7426,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7535,7 +7535,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7967,7 +7967,7 @@ exports[`with title and description from both array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -8018,7 +8018,7 @@ exports[`with title and description from both array 1`] = `
                 className="MuiBox-root emotion-9"
               >
                 <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-10"
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-array-item-add emotion-10"
                   disabled={null}
                   id="root__add"
                   onBlur={[Function]}
@@ -8875,7 +8875,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -8942,7 +8942,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9028,7 +9028,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-22"
             >
               <button
-                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall array-item-move-up emotion-23"
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall rjsf-array-item-move-up emotion-23"
                 disabled={true}
                 id="root_0__moveUp"
                 onBlur={[Function]}
@@ -9061,7 +9061,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-move-down emotion-23"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-move-down emotion-23"
                 disabled={null}
                 id="root_0__moveDown"
                 onBlur={[Function]}
@@ -9094,7 +9094,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-copy emotion-23"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-copy emotion-23"
                 disabled={null}
                 id="root_0__copy"
                 onBlur={[Function]}
@@ -9127,7 +9127,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-29"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-array-item-remove emotion-29"
                 disabled={null}
                 id="root_0__remove"
                 onBlur={[Function]}
@@ -9187,7 +9187,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9273,7 +9273,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-22"
             >
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-move-up emotion-23"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-move-up emotion-23"
                 disabled={null}
                 id="root_1__moveUp"
                 onBlur={[Function]}
@@ -9306,7 +9306,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall array-item-move-down emotion-23"
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall rjsf-array-item-move-down emotion-23"
                 disabled={true}
                 id="root_1__moveDown"
                 onBlur={[Function]}
@@ -9339,7 +9339,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-copy emotion-23"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-copy emotion-23"
                 disabled={null}
                 id="root_1__copy"
                 onBlur={[Function]}
@@ -9372,7 +9372,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-29"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-array-item-remove emotion-29"
                 disabled={null}
                 id="root_1__remove"
                 onBlur={[Function]}
@@ -9416,7 +9416,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 className="MuiBox-root emotion-57"
               >
                 <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-58"
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-array-item-add emotion-58"
                   disabled={null}
                   id="root__add"
                   onBlur={[Function]}
@@ -9948,7 +9948,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-4:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10558,7 +10558,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10625,7 +10625,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10734,7 +10734,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11166,7 +11166,7 @@ exports[`with title and description from uiSchema array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11217,7 +11217,7 @@ exports[`with title and description from uiSchema array 1`] = `
                 className="MuiBox-root emotion-9"
               >
                 <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-10"
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-array-item-add emotion-10"
                   disabled={null}
                   id="root__add"
                   onBlur={[Function]}
@@ -12074,7 +12074,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -12141,7 +12141,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -12227,7 +12227,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-22"
             >
               <button
-                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall array-item-move-up emotion-23"
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall rjsf-array-item-move-up emotion-23"
                 disabled={true}
                 id="root_0__moveUp"
                 onBlur={[Function]}
@@ -12260,7 +12260,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-move-down emotion-23"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-move-down emotion-23"
                 disabled={null}
                 id="root_0__moveDown"
                 onBlur={[Function]}
@@ -12293,7 +12293,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-copy emotion-23"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-copy emotion-23"
                 disabled={null}
                 id="root_0__copy"
                 onBlur={[Function]}
@@ -12326,7 +12326,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-29"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-array-item-remove emotion-29"
                 disabled={null}
                 id="root_0__remove"
                 onBlur={[Function]}
@@ -12386,7 +12386,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -12472,7 +12472,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-22"
             >
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-move-up emotion-23"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-move-up emotion-23"
                 disabled={null}
                 id="root_1__moveUp"
                 onBlur={[Function]}
@@ -12505,7 +12505,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall array-item-move-down emotion-23"
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall rjsf-array-item-move-down emotion-23"
                 disabled={true}
                 id="root_1__moveDown"
                 onBlur={[Function]}
@@ -12538,7 +12538,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-copy emotion-23"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-copy emotion-23"
                 disabled={null}
                 id="root_1__copy"
                 onBlur={[Function]}
@@ -12571,7 +12571,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-29"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-array-item-remove emotion-29"
                 disabled={null}
                 id="root_1__remove"
                 onBlur={[Function]}
@@ -12615,7 +12615,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                 className="MuiBox-root emotion-57"
               >
                 <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-58"
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-array-item-add emotion-58"
                   disabled={null}
                   id="root__add"
                   onBlur={[Function]}
@@ -13147,7 +13147,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-4:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13757,7 +13757,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13824,7 +13824,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13933,7 +13933,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -14331,7 +14331,7 @@ exports[`with title and description with global label off array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -14357,7 +14357,7 @@ exports[`with title and description with global label off array 1`] = `
                 className="MuiBox-root emotion-5"
               >
                 <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-6"
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-array-item-add emotion-6"
                   disabled={null}
                   id="root__add"
                   onBlur={[Function]}
@@ -15110,7 +15110,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -15152,7 +15152,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -15208,7 +15208,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-14"
             >
               <button
-                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall array-item-move-up emotion-15"
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall rjsf-array-item-move-up emotion-15"
                 disabled={true}
                 id="root_0__moveUp"
                 onBlur={[Function]}
@@ -15241,7 +15241,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-move-down emotion-15"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-move-down emotion-15"
                 disabled={null}
                 id="root_0__moveDown"
                 onBlur={[Function]}
@@ -15274,7 +15274,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-copy emotion-15"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-copy emotion-15"
                 disabled={null}
                 id="root_0__copy"
                 onBlur={[Function]}
@@ -15307,7 +15307,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-21"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-array-item-remove emotion-21"
                 disabled={null}
                 id="root_0__remove"
                 onBlur={[Function]}
@@ -15367,7 +15367,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -15423,7 +15423,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-14"
             >
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-move-up emotion-15"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-move-up emotion-15"
                 disabled={null}
                 id="root_1__moveUp"
                 onBlur={[Function]}
@@ -15456,7 +15456,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall array-item-move-down emotion-15"
+                className="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeSmall rjsf-array-item-move-down emotion-15"
                 disabled={true}
                 id="root_1__moveDown"
                 onBlur={[Function]}
@@ -15489,7 +15489,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall array-item-copy emotion-15"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall rjsf-array-item-copy emotion-15"
                 disabled={null}
                 id="root_1__copy"
                 onBlur={[Function]}
@@ -15522,7 +15522,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                 </svg>
               </button>
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-21"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-array-item-remove emotion-21"
                 disabled={null}
                 id="root_1__remove"
                 onBlur={[Function]}
@@ -15566,7 +15566,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                 className="MuiBox-root emotion-45"
               >
                 <button
-                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium array-item-add emotion-46"
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-array-item-add emotion-46"
                   disabled={null}
                   id="root__add"
                   onBlur={[Function]}
@@ -16098,7 +16098,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-4:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -16608,7 +16608,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -16650,7 +16650,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -16729,7 +16729,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
                     className="MuiBox-root emotion-2"
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -4441,7 +4441,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
     </div>
   </div>
   <div
-    className="rjsf-field rjsf-field-string"
+    className="rjsf-field rjsf-field-string rjsf-field-error"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-9"

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -261,7 +261,7 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -606,7 +606,7 @@ exports[`single fields checkbox field with label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -987,7 +987,7 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1667,7 +1667,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1689,7 +1689,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2220,7 +2220,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2242,7 +2242,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2660,7 +2660,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3053,7 +3053,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3446,7 +3446,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3839,7 +3839,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4441,7 +4441,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
     </div>
   </div>
   <div
-    className="form-group field field-string field-error has-error has-danger"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-9"
@@ -4701,7 +4701,7 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5076,7 +5076,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5286,7 +5286,7 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-null"
+    className="field-null"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5637,7 +5637,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6031,7 +6031,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6425,7 +6425,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6827,7 +6827,7 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7320,7 +7320,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7810,7 +7810,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -8309,7 +8309,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -8807,7 +8807,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9206,7 +9206,7 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9849,7 +9849,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10344,7 +10344,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10842,7 +10842,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11331,7 +11331,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11826,7 +11826,7 @@ exports[`single fields select field single choice form disabled using radio widg
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -12398,7 +12398,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -12816,7 +12816,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13343,7 +13343,7 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-integer"
+    className="field-integer"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13781,7 +13781,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -14176,7 +14176,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -14569,7 +14569,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -14962,7 +14962,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -15355,7 +15355,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -15751,7 +15751,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -16282,7 +16282,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-10:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -16318,7 +16318,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-10:focus::-ms-input-
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -16537,7 +16537,7 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-undefined"
+    className="field-undefined"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -16909,7 +16909,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -17302,7 +17302,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -261,7 +261,7 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -606,7 +606,7 @@ exports[`single fields checkbox field with label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -987,7 +987,7 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1667,7 +1667,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1689,7 +1689,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2220,7 +2220,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2242,7 +2242,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2660,7 +2660,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3053,7 +3053,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3446,7 +3446,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3839,7 +3839,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4441,7 +4441,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
     </div>
   </div>
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-9"
@@ -4701,7 +4701,7 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5076,7 +5076,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5286,7 +5286,7 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-null"
+    className="rjsf-field rjsf-field-null"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5637,7 +5637,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6031,7 +6031,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6425,7 +6425,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6827,7 +6827,7 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7320,7 +7320,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7810,7 +7810,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -8309,7 +8309,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -8807,7 +8807,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9206,7 +9206,7 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9849,7 +9849,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10344,7 +10344,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10842,7 +10842,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11331,7 +11331,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11826,7 +11826,7 @@ exports[`single fields select field single choice form disabled using radio widg
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -12398,7 +12398,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -12816,7 +12816,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13343,7 +13343,7 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-integer"
+    className="rjsf-field rjsf-field-integer"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13781,7 +13781,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -14176,7 +14176,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -14569,7 +14569,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -14962,7 +14962,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -15355,7 +15355,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -15751,7 +15751,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -16282,7 +16282,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-10:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -16318,7 +16318,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-10:focus::-ms-input-
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -16537,7 +16537,7 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-undefined"
+    className="rjsf-field rjsf-field-undefined"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -16909,7 +16909,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -17302,7 +17302,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"

--- a/packages/mui/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/GridSnap.test.tsx.snap
@@ -1137,7 +1137,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1155,7 +1155,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1187,7 +1187,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1255,7 +1255,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1314,7 +1314,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1387,7 +1387,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1455,7 +1455,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-array"
+              className="field-array"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1762,7 +1762,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1776,7 +1776,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1844,7 +1844,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1903,7 +1903,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1975,7 +1975,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2073,7 +2073,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2366,7 +2366,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2434,7 +2434,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2493,7 +2493,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2561,7 +2561,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3825,7 +3825,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3843,7 +3843,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3875,7 +3875,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3943,7 +3943,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4002,7 +4002,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4075,7 +4075,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4143,7 +4143,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-array"
+              className="field-array"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4450,7 +4450,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4464,7 +4464,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4532,7 +4532,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4591,7 +4591,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4663,7 +4663,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4761,7 +4761,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5054,7 +5054,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5113,7 +5113,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5181,7 +5181,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5240,7 +5240,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5308,7 +5308,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6717,7 +6717,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6735,7 +6735,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6767,7 +6767,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6835,7 +6835,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6894,7 +6894,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6967,7 +6967,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7035,7 +7035,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-array"
+              className="field-array"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7342,7 +7342,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7356,7 +7356,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7424,7 +7424,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7483,7 +7483,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7555,7 +7555,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7653,7 +7653,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7946,7 +7946,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9199,7 +9199,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9217,7 +9217,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9249,7 +9249,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9317,7 +9317,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9376,7 +9376,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9449,7 +9449,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9517,7 +9517,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-array"
+              className="field-array"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9824,7 +9824,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9838,7 +9838,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9906,7 +9906,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9965,7 +9965,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10037,7 +10037,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10135,7 +10135,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10428,7 +10428,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10496,7 +10496,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10555,7 +10555,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10623,7 +10623,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11645,7 +11645,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11659,7 +11659,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-object"
+            className="field-object"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11686,7 +11686,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11754,7 +11754,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11813,7 +11813,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11881,7 +11881,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11949,7 +11949,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-array"
+            className="field-array"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -12251,7 +12251,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -12319,7 +12319,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -12378,7 +12378,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -12446,7 +12446,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13443,7 +13443,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13457,7 +13457,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-object"
+            className="field-object"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13484,7 +13484,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13552,7 +13552,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13611,7 +13611,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13679,7 +13679,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13747,7 +13747,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-array"
+            className="field-array"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -14049,7 +14049,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -14117,7 +14117,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -14176,7 +14176,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -14244,7 +14244,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"

--- a/packages/mui/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/GridSnap.test.tsx.snap
@@ -1137,7 +1137,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1155,7 +1155,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1187,7 +1187,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1255,7 +1255,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1314,7 +1314,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1387,7 +1387,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1455,7 +1455,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-array"
+              className="rjsf-field rjsf-field-array"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1762,7 +1762,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1776,7 +1776,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1844,7 +1844,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1903,7 +1903,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1975,7 +1975,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2073,7 +2073,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2366,7 +2366,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2434,7 +2434,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2493,7 +2493,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2561,7 +2561,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3825,7 +3825,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3843,7 +3843,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3875,7 +3875,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3943,7 +3943,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4002,7 +4002,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4075,7 +4075,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4143,7 +4143,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-array"
+              className="rjsf-field rjsf-field-array"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4450,7 +4450,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4464,7 +4464,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4532,7 +4532,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4591,7 +4591,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4663,7 +4663,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4761,7 +4761,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5054,7 +5054,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5113,7 +5113,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5181,7 +5181,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5240,7 +5240,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5308,7 +5308,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6717,7 +6717,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6735,7 +6735,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6767,7 +6767,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6835,7 +6835,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6894,7 +6894,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6967,7 +6967,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7035,7 +7035,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-array"
+              className="rjsf-field rjsf-field-array"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7342,7 +7342,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7356,7 +7356,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7424,7 +7424,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7483,7 +7483,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7555,7 +7555,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7653,7 +7653,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7946,7 +7946,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9199,7 +9199,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9217,7 +9217,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9249,7 +9249,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9317,7 +9317,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9376,7 +9376,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9449,7 +9449,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9517,7 +9517,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-array"
+              className="rjsf-field rjsf-field-array"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9824,7 +9824,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9838,7 +9838,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9906,7 +9906,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9965,7 +9965,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10037,7 +10037,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10135,7 +10135,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10428,7 +10428,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10496,7 +10496,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10555,7 +10555,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10623,7 +10623,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11645,7 +11645,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11659,7 +11659,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-object"
+            className="rjsf-field rjsf-field-object"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11686,7 +11686,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11754,7 +11754,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11813,7 +11813,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11881,7 +11881,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11949,7 +11949,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-array"
+            className="rjsf-field rjsf-field-array"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -12251,7 +12251,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -12319,7 +12319,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -12378,7 +12378,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -12446,7 +12446,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13443,7 +13443,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13457,7 +13457,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-object"
+            className="rjsf-field rjsf-field-object"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13484,7 +13484,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13552,7 +13552,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13611,7 +13611,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13679,7 +13679,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -13747,7 +13747,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-array"
+            className="rjsf-field rjsf-field-array"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -14049,7 +14049,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -14117,7 +14117,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -14176,7 +14176,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -14244,7 +14244,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"

--- a/packages/mui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Object.test.tsx.snap
@@ -720,7 +720,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -742,7 +742,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
           }
         >
           <div
-            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 field-string emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 rjsf-field rjsf-field-string emotion-3"
           >
             <div
               className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
@@ -850,7 +850,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-19"
             >
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-20"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-object-property-remove emotion-20"
                 disabled={null}
                 id="root_foo__remove"
                 onBlur={[Function]}
@@ -900,7 +900,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
             className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-19"
           >
             <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium object-property-expand emotion-24"
+              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-object-property-expand emotion-24"
               disabled={null}
               id="root__add"
               onBlur={[Function]}
@@ -1376,7 +1376,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1398,7 +1398,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1461,7 +1461,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
           }
         >
           <div
-            className="field-number"
+            className="rjsf-field rjsf-field-number"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2263,7 +2263,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2285,7 +2285,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
           }
         >
           <div
-            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 field-string emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 rjsf-field rjsf-field-string emotion-3"
           >
             <div
               className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
@@ -2393,7 +2393,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-19"
             >
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-20"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-object-property-remove emotion-20"
                 disabled={null}
                 id="root_additionalProperty__remove"
                 onBlur={[Function]}
@@ -2443,7 +2443,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
             className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-19"
           >
             <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium object-property-expand emotion-24"
+              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-object-property-expand emotion-24"
               disabled={null}
               id="root__add"
               onBlur={[Function]}
@@ -3262,7 +3262,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3309,7 +3309,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           }
         >
           <div
-            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 field-string emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 rjsf-field rjsf-field-string emotion-7"
           >
             <div
               className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
@@ -3417,7 +3417,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
             >
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-24"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-object-property-remove emotion-24"
                 disabled={null}
                 id="root_foo__remove"
                 onBlur={[Function]}
@@ -3467,7 +3467,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
             className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
           >
             <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium object-property-expand emotion-28"
+              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-object-property-expand emotion-28"
               disabled={null}
               id="root__add"
               onBlur={[Function]}
@@ -4286,7 +4286,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4333,7 +4333,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           }
         >
           <div
-            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 field-string emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 rjsf-field rjsf-field-string emotion-7"
           >
             <div
               className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
@@ -4441,7 +4441,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
             >
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-24"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-object-property-remove emotion-24"
                 disabled={null}
                 id="root_foo__remove"
                 onBlur={[Function]}
@@ -4491,7 +4491,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
             className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
           >
             <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium object-property-expand emotion-28"
+              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-object-property-expand emotion-28"
               disabled={null}
               id="root__add"
               onBlur={[Function]}
@@ -5011,7 +5011,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5058,7 +5058,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5137,7 +5137,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           }
         >
           <div
-            className="field-number"
+            className="rjsf-field rjsf-field-number"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5993,7 +5993,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6040,7 +6040,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           }
         >
           <div
-            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 field-string emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 rjsf-field rjsf-field-string emotion-7"
           >
             <div
               className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
@@ -6148,7 +6148,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
             >
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-24"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-object-property-remove emotion-24"
                 disabled={null}
                 id="root_foo__remove"
                 onBlur={[Function]}
@@ -6198,7 +6198,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
             className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
           >
             <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium object-property-expand emotion-28"
+              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-object-property-expand emotion-28"
               disabled={null}
               id="root__add"
               onBlur={[Function]}
@@ -6718,7 +6718,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6765,7 +6765,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6844,7 +6844,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           }
         >
           <div
-            className="field-number"
+            className="rjsf-field rjsf-field-number"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7696,7 +7696,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7743,7 +7743,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           }
         >
           <div
-            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 field-string emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 rjsf-field rjsf-field-string emotion-7"
           >
             <div
               className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
@@ -7851,7 +7851,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
             >
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-24"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-object-property-remove emotion-24"
                 disabled={null}
                 id="root_additionalProperty__remove"
                 onBlur={[Function]}
@@ -7901,7 +7901,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
             className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
           >
             <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium object-property-expand emotion-28"
+              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-object-property-expand emotion-28"
               disabled={null}
               id="root__add"
               onBlur={[Function]}
@@ -8421,7 +8421,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -8468,7 +8468,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -8547,7 +8547,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           }
         >
           <div
-            className="field-number"
+            className="rjsf-field rjsf-field-number"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9399,7 +9399,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9446,7 +9446,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           }
         >
           <div
-            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 field-string emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 rjsf-field rjsf-field-string emotion-7"
           >
             <div
               className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
@@ -9554,7 +9554,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
             >
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-24"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-object-property-remove emotion-24"
                 disabled={null}
                 id="root_additionalProperty__remove"
                 onBlur={[Function]}
@@ -9604,7 +9604,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
             className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-23"
           >
             <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium object-property-expand emotion-28"
+              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-object-property-expand emotion-28"
               disabled={null}
               id="root__add"
               onBlur={[Function]}
@@ -10395,7 +10395,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10417,7 +10417,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
           }
         >
           <div
-            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 field-string emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 rjsf-field rjsf-field-string emotion-3"
           >
             <div
               className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
@@ -10520,7 +10520,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-18"
             >
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-19"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-object-property-remove emotion-19"
                 disabled={null}
                 id="root_foo__remove"
                 onBlur={[Function]}
@@ -10570,7 +10570,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
             className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-18"
           >
             <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium object-property-expand emotion-23"
+              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-object-property-expand emotion-23"
               disabled={null}
               id="root__add"
               onBlur={[Function]}
@@ -10994,7 +10994,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11016,7 +11016,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11074,7 +11074,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
           }
         >
           <div
-            className="field-number"
+            className="rjsf-field rjsf-field-number"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11881,7 +11881,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11903,7 +11903,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
           }
         >
           <div
-            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 field-string emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 rjsf-field rjsf-field-string emotion-3"
           >
             <div
               className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
@@ -12006,7 +12006,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
               className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-18"
             >
               <button
-                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall array-item-remove emotion-19"
+                className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorError MuiIconButton-sizeSmall rjsf-object-property-remove emotion-19"
                 disabled={null}
                 id="root_additionalProperty__remove"
                 onBlur={[Function]}
@@ -12056,7 +12056,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
             className="MuiGrid2-root MuiGrid2-direction-xs-row emotion-18"
           >
             <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium object-property-expand emotion-23"
+              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorPrimary MuiIconButton-sizeMedium rjsf-object-property-expand emotion-23"
               disabled={null}
               id="root__add"
               onBlur={[Function]}

--- a/packages/mui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Object.test.tsx.snap
@@ -720,7 +720,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -742,7 +742,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
           }
         >
           <div
-            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 field-string emotion-3"
           >
             <div
               className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
@@ -1376,7 +1376,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1398,7 +1398,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -1461,7 +1461,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
           }
         >
           <div
-            className="form-group field field-number"
+            className="field-number"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2263,7 +2263,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -2285,7 +2285,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
           }
         >
           <div
-            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 field-string emotion-3"
           >
             <div
               className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
@@ -3262,7 +3262,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -3309,7 +3309,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           }
         >
           <div
-            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 field-string emotion-7"
           >
             <div
               className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
@@ -4286,7 +4286,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -4333,7 +4333,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           }
         >
           <div
-            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 field-string emotion-7"
           >
             <div
               className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
@@ -5011,7 +5011,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5058,7 +5058,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5137,7 +5137,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           }
         >
           <div
-            className="form-group field field-number"
+            className="field-number"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -5993,7 +5993,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6040,7 +6040,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           }
         >
           <div
-            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 field-string emotion-7"
           >
             <div
               className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
@@ -6718,7 +6718,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6765,7 +6765,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -6844,7 +6844,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           }
         >
           <div
-            className="form-group field field-number"
+            className="field-number"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7696,7 +7696,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -7743,7 +7743,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           }
         >
           <div
-            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 field-string emotion-7"
           >
             <div
               className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
@@ -8421,7 +8421,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -8468,7 +8468,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -8547,7 +8547,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-11:focus::-ms-input-
           }
         >
           <div
-            className="form-group field field-number"
+            className="field-number"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9399,7 +9399,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -9446,7 +9446,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-12:focus::-ms-input-
           }
         >
           <div
-            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-7"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 field-string emotion-7"
           >
             <div
               className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-8"
@@ -10395,7 +10395,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -10417,7 +10417,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
           }
         >
           <div
-            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 field-string emotion-3"
           >
             <div
               className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"
@@ -10994,7 +10994,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11016,7 +11016,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11074,7 +11074,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-6:focus::-ms-input-p
           }
         >
           <div
-            className="form-group field field-number"
+            className="field-number"
           >
             <div
               className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11881,7 +11881,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
@@ -11903,7 +11903,7 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-8:focus::-ms-input-p
           }
         >
           <div
-            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 form-group field field-string emotion-3"
+            className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 field-string emotion-3"
           >
             <div
               className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-auto emotion-4"

--- a/packages/react-bootstrap/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/react-bootstrap/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -70,7 +70,7 @@ export default function ArrayFieldTemplate<
                   <Col xs={3} className='py-4 col-lg-3 col-3'>
                     <AddButton
                       id={buttonId<T>(idSchema, 'add')}
-                      className='array-item-add'
+                      className='rjsf-array-item-add'
                       onClick={onAddClick}
                       disabled={disabled || readonly}
                       uiSchema={uiSchema}

--- a/packages/react-bootstrap/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/react-bootstrap/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -78,7 +78,7 @@ export default function ObjectFieldTemplate<
                 id={buttonId<T>(idSchema, 'add')}
                 onClick={onAddClick(schema)}
                 disabled={disabled || readonly}
-                className='object-property-expand'
+                className='rjsf-object-property-expand'
                 uiSchema={uiSchema}
                 registry={registry}
               />

--- a/packages/react-bootstrap/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/react-bootstrap/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -69,7 +69,7 @@ export default function WrapIfAdditionalTemplate<
       <Col xs={2} className='py-4 d-grid gap-2'>
         <RemoveButton
           id={buttonId<T>(id, 'remove')}
-          className='array-item-remove w-100'
+          className='rjsf-object-property-remove w-100'
           disabled={disabled || readonly}
           onClick={onDropPropertyClick(label)}
           uiSchema={uiSchema}

--- a/packages/react-bootstrap/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/react-bootstrap/test/__snapshots__/Array.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <div>
@@ -33,7 +33,7 @@ exports[`array fields array 1`] = `
                     className="py-4 col-lg-3 col-3 col-3"
                   >
                     <button
-                      className="ml-1 array-item-add btn btn-primary"
+                      className="ml-1 rjsf-array-item-add btn btn-primary"
                       disabled={false}
                       id="root__add"
                       onClick={[Function]}
@@ -99,7 +99,7 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <div>
@@ -120,7 +120,7 @@ exports[`array fields array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -280,7 +280,7 @@ exports[`array fields array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -445,7 +445,7 @@ exports[`array fields array icons 1`] = `
                     className="py-4 col-lg-3 col-3 col-3"
                   >
                     <button
-                      className="ml-1 array-item-add btn btn-primary"
+                      className="ml-1 rjsf-array-item-add btn btn-primary"
                       disabled={false}
                       id="root__add"
                       onClick={[Function]}
@@ -511,7 +511,7 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <label
@@ -575,7 +575,7 @@ exports[`array fields empty errors array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -594,7 +594,7 @@ exports[`array fields empty errors array 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -645,7 +645,7 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <div>
@@ -666,7 +666,7 @@ exports[`array fields fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -707,7 +707,7 @@ exports[`array fields fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div>
                         <label
@@ -793,7 +793,7 @@ exports[`array fields has errors 1`] = `
     </div>
   </div>
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -812,7 +812,7 @@ exports[`array fields has errors 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -880,7 +880,7 @@ exports[`array fields no errors 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -899,7 +899,7 @@ exports[`array fields no errors 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -950,7 +950,7 @@ exports[`with title and description array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <div>
@@ -1000,7 +1000,7 @@ exports[`with title and description array 1`] = `
                     className="py-4 col-lg-3 col-3 col-3"
                   >
                     <button
-                      className="ml-1 array-item-add btn btn-primary"
+                      className="ml-1 rjsf-array-item-add btn btn-primary"
                       disabled={false}
                       id="root__add"
                       onClick={[Function]}
@@ -1066,7 +1066,7 @@ exports[`with title and description array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <div>
@@ -1111,7 +1111,7 @@ exports[`with title and description array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -1284,7 +1284,7 @@ exports[`with title and description array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -1462,7 +1462,7 @@ exports[`with title and description array icons 1`] = `
                     className="py-4 col-lg-3 col-3 col-3"
                   >
                     <button
-                      className="ml-1 array-item-add btn btn-primary"
+                      className="ml-1 rjsf-array-item-add btn btn-primary"
                       disabled={false}
                       id="root__add"
                       onClick={[Function]}
@@ -1528,7 +1528,7 @@ exports[`with title and description checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <label
@@ -1606,7 +1606,7 @@ exports[`with title and description fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <div>
@@ -1651,7 +1651,7 @@ exports[`with title and description fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -1705,7 +1705,7 @@ exports[`with title and description fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div>
                         <label
@@ -1777,7 +1777,7 @@ exports[`with title and description from both array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <div>
@@ -1827,7 +1827,7 @@ exports[`with title and description from both array 1`] = `
                     className="py-4 col-lg-3 col-3 col-3"
                   >
                     <button
-                      className="ml-1 array-item-add btn btn-primary"
+                      className="ml-1 rjsf-array-item-add btn btn-primary"
                       disabled={false}
                       id="root__add"
                       onClick={[Function]}
@@ -1893,7 +1893,7 @@ exports[`with title and description from both array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <div>
@@ -1938,7 +1938,7 @@ exports[`with title and description from both array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -2111,7 +2111,7 @@ exports[`with title and description from both array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -2289,7 +2289,7 @@ exports[`with title and description from both array icons 1`] = `
                     className="py-4 col-lg-3 col-3 col-3"
                   >
                     <button
-                      className="ml-1 array-item-add btn btn-primary"
+                      className="ml-1 rjsf-array-item-add btn btn-primary"
                       disabled={false}
                       id="root__add"
                       onClick={[Function]}
@@ -2355,7 +2355,7 @@ exports[`with title and description from both checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <label
@@ -2433,7 +2433,7 @@ exports[`with title and description from both fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <div>
@@ -2478,7 +2478,7 @@ exports[`with title and description from both fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -2532,7 +2532,7 @@ exports[`with title and description from both fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div>
                         <label
@@ -2604,7 +2604,7 @@ exports[`with title and description from uiSchema array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <div>
@@ -2654,7 +2654,7 @@ exports[`with title and description from uiSchema array 1`] = `
                     className="py-4 col-lg-3 col-3 col-3"
                   >
                     <button
-                      className="ml-1 array-item-add btn btn-primary"
+                      className="ml-1 rjsf-array-item-add btn btn-primary"
                       disabled={false}
                       id="root__add"
                       onClick={[Function]}
@@ -2720,7 +2720,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <div>
@@ -2765,7 +2765,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -2938,7 +2938,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -3116,7 +3116,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     className="py-4 col-lg-3 col-3 col-3"
                   >
                     <button
-                      className="ml-1 array-item-add btn btn-primary"
+                      className="ml-1 rjsf-array-item-add btn btn-primary"
                       disabled={false}
                       id="root__add"
                       onClick={[Function]}
@@ -3182,7 +3182,7 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <label
@@ -3260,7 +3260,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <div>
@@ -3305,7 +3305,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -3359,7 +3359,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div>
                         <label
@@ -3431,7 +3431,7 @@ exports[`with title and description with global label off array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <div>
@@ -3457,7 +3457,7 @@ exports[`with title and description with global label off array 1`] = `
                     className="py-4 col-lg-3 col-3 col-3"
                   >
                     <button
-                      className="ml-1 array-item-add btn btn-primary"
+                      className="ml-1 rjsf-array-item-add btn btn-primary"
                       disabled={false}
                       id="root__add"
                       onClick={[Function]}
@@ -3523,7 +3523,7 @@ exports[`with title and description with global label off array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <div>
@@ -3544,7 +3544,7 @@ exports[`with title and description with global label off array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <input
@@ -3698,7 +3698,7 @@ exports[`with title and description with global label off array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <input
@@ -3857,7 +3857,7 @@ exports[`with title and description with global label off array icons 1`] = `
                     className="py-4 col-lg-3 col-3 col-3"
                   >
                     <button
-                      className="ml-1 array-item-add btn btn-primary"
+                      className="ml-1 rjsf-array-item-add btn btn-primary"
                       disabled={false}
                       id="root__add"
                       onClick={[Function]}
@@ -3923,7 +3923,7 @@ exports[`with title and description with global label off checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <label
@@ -4001,7 +4001,7 @@ exports[`with title and description with global label off fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <div>
@@ -4022,7 +4022,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <input
@@ -4057,7 +4057,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div>
                         <input

--- a/packages/react-bootstrap/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/react-bootstrap/test/__snapshots__/Array.test.tsx.snap
@@ -812,7 +812,7 @@ exports[`array fields has errors 1`] = `
           >
              
             <div
-              className="rjsf-field rjsf-field-string"
+              className="rjsf-field rjsf-field-string rjsf-field-error"
             >
               <div>
                 <label

--- a/packages/react-bootstrap/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/react-bootstrap/test/__snapshots__/Array.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <div>
@@ -99,7 +99,7 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <div>
@@ -120,7 +120,7 @@ exports[`array fields array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -280,7 +280,7 @@ exports[`array fields array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -511,7 +511,7 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <label
@@ -575,7 +575,7 @@ exports[`array fields empty errors array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -594,7 +594,7 @@ exports[`array fields empty errors array 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -645,7 +645,7 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <div>
@@ -666,7 +666,7 @@ exports[`array fields fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -707,7 +707,7 @@ exports[`array fields fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div>
                         <label
@@ -793,7 +793,7 @@ exports[`array fields has errors 1`] = `
     </div>
   </div>
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -812,7 +812,7 @@ exports[`array fields has errors 1`] = `
           >
              
             <div
-              className="form-group field field-string field-error has-error has-danger"
+              className="field-string"
             >
               <div>
                 <label
@@ -880,7 +880,7 @@ exports[`array fields no errors 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -899,7 +899,7 @@ exports[`array fields no errors 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -950,7 +950,7 @@ exports[`with title and description array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <div>
@@ -1066,7 +1066,7 @@ exports[`with title and description array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <div>
@@ -1111,7 +1111,7 @@ exports[`with title and description array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -1284,7 +1284,7 @@ exports[`with title and description array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -1528,7 +1528,7 @@ exports[`with title and description checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <label
@@ -1606,7 +1606,7 @@ exports[`with title and description fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <div>
@@ -1651,7 +1651,7 @@ exports[`with title and description fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -1705,7 +1705,7 @@ exports[`with title and description fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div>
                         <label
@@ -1777,7 +1777,7 @@ exports[`with title and description from both array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <div>
@@ -1893,7 +1893,7 @@ exports[`with title and description from both array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <div>
@@ -1938,7 +1938,7 @@ exports[`with title and description from both array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -2111,7 +2111,7 @@ exports[`with title and description from both array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -2355,7 +2355,7 @@ exports[`with title and description from both checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <label
@@ -2433,7 +2433,7 @@ exports[`with title and description from both fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <div>
@@ -2478,7 +2478,7 @@ exports[`with title and description from both fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -2532,7 +2532,7 @@ exports[`with title and description from both fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div>
                         <label
@@ -2604,7 +2604,7 @@ exports[`with title and description from uiSchema array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <div>
@@ -2720,7 +2720,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <div>
@@ -2765,7 +2765,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -2938,7 +2938,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -3182,7 +3182,7 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <label
@@ -3260,7 +3260,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <div>
@@ -3305,7 +3305,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -3359,7 +3359,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div>
                         <label
@@ -3431,7 +3431,7 @@ exports[`with title and description with global label off array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <div>
@@ -3523,7 +3523,7 @@ exports[`with title and description with global label off array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <div>
@@ -3544,7 +3544,7 @@ exports[`with title and description with global label off array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <input
@@ -3698,7 +3698,7 @@ exports[`with title and description with global label off array icons 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <input
@@ -3923,7 +3923,7 @@ exports[`with title and description with global label off checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <label
@@ -4001,7 +4001,7 @@ exports[`with title and description with global label off fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <div>
@@ -4022,7 +4022,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <input
@@ -4057,7 +4057,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                     className="col-lg-9 col-9"
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div>
                         <input

--- a/packages/react-bootstrap/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/react-bootstrap/test/__snapshots__/Form.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <div>
       <div
@@ -53,7 +53,7 @@ exports[`single fields checkbox field with label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <div>
       <div
@@ -106,7 +106,7 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <label
@@ -238,7 +238,7 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -257,7 +257,7 @@ exports[`single fields field with description 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -320,7 +320,7 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -339,7 +339,7 @@ exports[`single fields field with description in uiSchema 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -402,7 +402,7 @@ exports[`single fields format color 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label
@@ -445,7 +445,7 @@ exports[`single fields format date 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label
@@ -488,7 +488,7 @@ exports[`single fields format datetime 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label
@@ -531,7 +531,7 @@ exports[`single fields format time 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label
@@ -601,7 +601,7 @@ exports[`single fields help and error display 1`] = `
     </div>
   </div>
   <div
-    className="form-group field field-string field-error has-error has-danger"
+    className="field-string"
   >
     <div>
       <label
@@ -667,7 +667,7 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -719,7 +719,7 @@ exports[`single fields hidden label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <input
@@ -758,7 +758,7 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-null"
+    className="field-null"
   >
     <div>
       <label
@@ -786,7 +786,7 @@ exports[`single fields number field 0 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <div>
       <label
@@ -830,7 +830,7 @@ exports[`single fields number field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <div>
       <label
@@ -874,7 +874,7 @@ exports[`single fields password field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label
@@ -917,7 +917,7 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <div>
       <label
@@ -997,7 +997,7 @@ exports[`single fields schema examples 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label
@@ -1060,7 +1060,7 @@ exports[`single fields select field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label
@@ -1118,7 +1118,7 @@ exports[`single fields select field multiple choice 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <label
@@ -1189,7 +1189,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <label
@@ -1260,7 +1260,7 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <label
@@ -1390,7 +1390,7 @@ exports[`single fields select field multiple choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <label
@@ -1466,7 +1466,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div>
       <label
@@ -1530,7 +1530,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label
@@ -1588,7 +1588,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label
@@ -1668,7 +1668,7 @@ exports[`single fields select field single choice form disabled using radio widg
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label
@@ -1748,7 +1748,7 @@ exports[`single fields select field single choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label
@@ -1806,7 +1806,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label
@@ -1886,7 +1886,7 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-integer"
+    className="field-integer"
   >
     <div>
       <label
@@ -1932,7 +1932,7 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label
@@ -1977,7 +1977,7 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label
@@ -2020,7 +2020,7 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label
@@ -2063,7 +2063,7 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label
@@ -2106,7 +2106,7 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label
@@ -2149,7 +2149,7 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label
@@ -2195,7 +2195,7 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -2230,7 +2230,7 @@ exports[`single fields title field 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -2281,7 +2281,7 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-undefined"
+    className="field-undefined"
   >
     <div>
       <label
@@ -2329,7 +2329,7 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <div>
       <label
@@ -2372,7 +2372,7 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div>
       <label

--- a/packages/react-bootstrap/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/react-bootstrap/test/__snapshots__/Form.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <div>
       <div
@@ -53,7 +53,7 @@ exports[`single fields checkbox field with label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <div>
       <div
@@ -106,7 +106,7 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <label
@@ -238,7 +238,7 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -257,7 +257,7 @@ exports[`single fields field with description 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -320,7 +320,7 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -339,7 +339,7 @@ exports[`single fields field with description in uiSchema 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -402,7 +402,7 @@ exports[`single fields format color 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -445,7 +445,7 @@ exports[`single fields format date 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -488,7 +488,7 @@ exports[`single fields format datetime 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -531,7 +531,7 @@ exports[`single fields format time 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -601,7 +601,7 @@ exports[`single fields help and error display 1`] = `
     </div>
   </div>
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -667,7 +667,7 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -719,7 +719,7 @@ exports[`single fields hidden label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <input
@@ -758,7 +758,7 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-null"
+    className="rjsf-field rjsf-field-null"
   >
     <div>
       <label
@@ -786,7 +786,7 @@ exports[`single fields number field 0 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <div>
       <label
@@ -830,7 +830,7 @@ exports[`single fields number field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <div>
       <label
@@ -874,7 +874,7 @@ exports[`single fields password field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -917,7 +917,7 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <div>
       <label
@@ -997,7 +997,7 @@ exports[`single fields schema examples 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -1060,7 +1060,7 @@ exports[`single fields select field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -1118,7 +1118,7 @@ exports[`single fields select field multiple choice 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <label
@@ -1189,7 +1189,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <label
@@ -1260,7 +1260,7 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <label
@@ -1390,7 +1390,7 @@ exports[`single fields select field multiple choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <label
@@ -1466,7 +1466,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div>
       <label
@@ -1530,7 +1530,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -1588,7 +1588,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -1668,7 +1668,7 @@ exports[`single fields select field single choice form disabled using radio widg
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -1748,7 +1748,7 @@ exports[`single fields select field single choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -1806,7 +1806,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -1886,7 +1886,7 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-integer"
+    className="rjsf-field rjsf-field-integer"
   >
     <div>
       <label
@@ -1932,7 +1932,7 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -1977,7 +1977,7 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -2020,7 +2020,7 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -2063,7 +2063,7 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -2106,7 +2106,7 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -2149,7 +2149,7 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label
@@ -2195,7 +2195,7 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -2230,7 +2230,7 @@ exports[`single fields title field 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -2281,7 +2281,7 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-undefined"
+    className="rjsf-field rjsf-field-undefined"
   >
     <div>
       <label
@@ -2329,7 +2329,7 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <div>
       <label
@@ -2372,7 +2372,7 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div>
       <label

--- a/packages/react-bootstrap/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/react-bootstrap/test/__snapshots__/Form.test.tsx.snap
@@ -601,7 +601,7 @@ exports[`single fields help and error display 1`] = `
     </div>
   </div>
   <div
-    className="rjsf-field rjsf-field-string"
+    className="rjsf-field rjsf-field-string rjsf-field-error"
   >
     <div>
       <label

--- a/packages/react-bootstrap/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/react-bootstrap/test/__snapshots__/GridSnap.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -23,7 +23,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div>
                 <div
@@ -55,7 +55,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -89,7 +89,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -122,7 +122,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -161,7 +161,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -195,7 +195,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-array"
+              className="rjsf-field rjsf-field-array"
             >
               <div>
                 <label
@@ -357,7 +357,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div>
                 <div
@@ -369,7 +369,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -403,7 +403,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -436,7 +436,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -475,7 +475,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div>
                           <label
@@ -902,7 +902,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div>
                           <label
@@ -1048,7 +1048,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div>
                     <label
@@ -1082,7 +1082,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div>
                     <label
@@ -1115,7 +1115,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div>
                     <label
@@ -1149,7 +1149,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div>
                     <label
@@ -1596,7 +1596,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -1612,7 +1612,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div>
                 <div
@@ -1644,7 +1644,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -1678,7 +1678,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -1711,7 +1711,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -1750,7 +1750,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -1784,7 +1784,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-array"
+              className="rjsf-field rjsf-field-array"
             >
               <div>
                 <label
@@ -1946,7 +1946,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div>
                 <div
@@ -1958,7 +1958,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -1992,7 +1992,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -2025,7 +2025,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -2064,7 +2064,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div>
                           <label
@@ -2491,7 +2491,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div>
                           <label
@@ -2637,7 +2637,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div>
                     <label
@@ -2670,7 +2670,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div>
                     <label
@@ -2704,7 +2704,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div>
                     <label
@@ -2737,7 +2737,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div>
                     <label
@@ -2771,7 +2771,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div>
                     <label
@@ -3218,7 +3218,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -3234,7 +3234,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div>
                 <div
@@ -3266,7 +3266,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -3300,7 +3300,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -3333,7 +3333,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -3372,7 +3372,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -3406,7 +3406,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-array"
+              className="rjsf-field rjsf-field-array"
             >
               <div>
                 <label
@@ -3568,7 +3568,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div>
                 <div
@@ -3580,7 +3580,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -3614,7 +3614,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -3647,7 +3647,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -3686,7 +3686,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div>
                           <label
@@ -4113,7 +4113,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div>
                           <label
@@ -4259,7 +4259,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div>
                     <label
@@ -4316,7 +4316,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -4332,7 +4332,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div>
                 <div
@@ -4364,7 +4364,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -4398,7 +4398,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -4431,7 +4431,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -4470,7 +4470,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -4504,7 +4504,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-array"
+              className="rjsf-field rjsf-field-array"
             >
               <div>
                 <label
@@ -4666,7 +4666,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div>
                 <div
@@ -4678,7 +4678,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -4712,7 +4712,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -4745,7 +4745,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div>
                         <label
@@ -4784,7 +4784,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div>
                           <label
@@ -5211,7 +5211,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div>
                           <label
@@ -5357,7 +5357,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div>
                     <label
@@ -5391,7 +5391,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div>
                     <label
@@ -5424,7 +5424,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div>
                     <label
@@ -5458,7 +5458,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div>
                     <label
@@ -5905,7 +5905,7 @@ exports[`Three even column grid renders person and address in three columns, no 
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -5917,7 +5917,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-object"
+            className="rjsf-field rjsf-field-object"
           >
             <div>
               <div
@@ -5944,7 +5944,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div>
               <label
@@ -5978,7 +5978,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div>
               <label
@@ -6011,7 +6011,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div>
               <label
@@ -6045,7 +6045,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div>
               <label
@@ -6079,7 +6079,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-array"
+            className="rjsf-field rjsf-field-array"
           >
             <div>
               <label
@@ -6236,7 +6236,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div>
               <label
@@ -6270,7 +6270,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div>
               <label
@@ -6303,7 +6303,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div>
               <label
@@ -6337,7 +6337,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div>
               <label
@@ -6785,7 +6785,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -6797,7 +6797,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-object"
+            className="rjsf-field rjsf-field-object"
           >
             <div>
               <div
@@ -6824,7 +6824,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div>
               <label
@@ -6858,7 +6858,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div>
               <label
@@ -6891,7 +6891,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div>
               <label
@@ -6925,7 +6925,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div>
               <label
@@ -6959,7 +6959,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-array"
+            className="rjsf-field rjsf-field-array"
           >
             <div>
               <label
@@ -7116,7 +7116,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div>
               <label
@@ -7150,7 +7150,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div>
               <label
@@ -7183,7 +7183,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div>
               <label
@@ -7217,7 +7217,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div>
               <label

--- a/packages/react-bootstrap/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/react-bootstrap/test/__snapshots__/GridSnap.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -23,7 +23,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div>
                 <div
@@ -55,7 +55,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -89,7 +89,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -122,7 +122,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -161,7 +161,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -195,7 +195,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-array"
+              className="field-array"
             >
               <div>
                 <label
@@ -357,7 +357,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div>
                 <div
@@ -369,7 +369,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -403,7 +403,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -436,7 +436,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -475,7 +475,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div>
                           <label
@@ -902,7 +902,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div>
                           <label
@@ -1048,7 +1048,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div>
                     <label
@@ -1082,7 +1082,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div>
                     <label
@@ -1115,7 +1115,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div>
                     <label
@@ -1149,7 +1149,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div>
                     <label
@@ -1596,7 +1596,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -1612,7 +1612,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div>
                 <div
@@ -1644,7 +1644,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -1678,7 +1678,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -1711,7 +1711,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -1750,7 +1750,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -1784,7 +1784,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-array"
+              className="field-array"
             >
               <div>
                 <label
@@ -1946,7 +1946,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div>
                 <div
@@ -1958,7 +1958,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -1992,7 +1992,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -2025,7 +2025,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -2064,7 +2064,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div>
                           <label
@@ -2491,7 +2491,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div>
                           <label
@@ -2637,7 +2637,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div>
                     <label
@@ -2670,7 +2670,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div>
                     <label
@@ -2704,7 +2704,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div>
                     <label
@@ -2737,7 +2737,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div>
                     <label
@@ -2771,7 +2771,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div>
                     <label
@@ -3218,7 +3218,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -3234,7 +3234,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div>
                 <div
@@ -3266,7 +3266,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -3300,7 +3300,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -3333,7 +3333,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -3372,7 +3372,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -3406,7 +3406,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-array"
+              className="field-array"
             >
               <div>
                 <label
@@ -3568,7 +3568,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div>
                 <div
@@ -3580,7 +3580,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -3614,7 +3614,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -3647,7 +3647,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -3686,7 +3686,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div>
                           <label
@@ -4113,7 +4113,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div>
                           <label
@@ -4259,7 +4259,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div>
                     <label
@@ -4316,7 +4316,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -4332,7 +4332,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div>
                 <div
@@ -4364,7 +4364,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -4398,7 +4398,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -4431,7 +4431,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -4470,7 +4470,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -4504,7 +4504,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-array"
+              className="field-array"
             >
               <div>
                 <label
@@ -4666,7 +4666,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div>
                 <div
@@ -4678,7 +4678,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -4712,7 +4712,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -4745,7 +4745,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div>
                         <label
@@ -4784,7 +4784,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div>
                           <label
@@ -5211,7 +5211,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div>
                           <label
@@ -5357,7 +5357,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div>
                     <label
@@ -5391,7 +5391,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div>
                     <label
@@ -5424,7 +5424,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div>
                     <label
@@ -5458,7 +5458,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 data-testid="1"
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div>
                     <label
@@ -5905,7 +5905,7 @@ exports[`Three even column grid renders person and address in three columns, no 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -5917,7 +5917,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-object"
+            className="field-object"
           >
             <div>
               <div
@@ -5944,7 +5944,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div>
               <label
@@ -5978,7 +5978,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div>
               <label
@@ -6011,7 +6011,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div>
               <label
@@ -6045,7 +6045,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div>
               <label
@@ -6079,7 +6079,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-array"
+            className="field-array"
           >
             <div>
               <label
@@ -6236,7 +6236,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div>
               <label
@@ -6270,7 +6270,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div>
               <label
@@ -6303,7 +6303,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div>
               <label
@@ -6337,7 +6337,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div>
               <label
@@ -6785,7 +6785,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -6797,7 +6797,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-object"
+            className="field-object"
           >
             <div>
               <div
@@ -6824,7 +6824,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div>
               <label
@@ -6858,7 +6858,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div>
               <label
@@ -6891,7 +6891,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div>
               <label
@@ -6925,7 +6925,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div>
               <label
@@ -6959,7 +6959,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-array"
+            className="field-array"
           >
             <div>
               <label
@@ -7116,7 +7116,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div>
               <label
@@ -7150,7 +7150,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div>
               <label
@@ -7183,7 +7183,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div>
               <label
@@ -7217,7 +7217,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div>
               <label

--- a/packages/react-bootstrap/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/react-bootstrap/test/__snapshots__/Object.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -26,7 +26,7 @@ exports[`object fields additionalProperties 1`] = `
           >
              
             <div
-              className="field-string row"
+              className="rjsf-field rjsf-field-string row"
             >
               <div
                 className="col-5"
@@ -119,7 +119,7 @@ exports[`object fields additionalProperties 1`] = `
             className="py-4 col-3 offset-9"
           >
             <button
-              className="ml-1 object-property-expand btn btn-primary"
+              className="ml-1 rjsf-object-property-expand btn btn-primary"
               disabled={false}
               id="root__add"
               onClick={[Function]}
@@ -181,7 +181,7 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -200,7 +200,7 @@ exports[`object fields object 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -242,7 +242,7 @@ exports[`object fields object 1`] = `
           >
              
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <div>
                 <label
@@ -294,7 +294,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -313,7 +313,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
           >
              
             <div
-              className="field-string row"
+              className="rjsf-field rjsf-field-string row"
             >
               <div
                 className="col-5"
@@ -406,7 +406,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
             className="py-4 col-3 offset-9"
           >
             <button
-              className="ml-1 object-property-expand btn btn-primary"
+              className="ml-1 rjsf-object-property-expand btn btn-primary"
               disabled={false}
               id="root__add"
               onClick={[Function]}
@@ -468,7 +468,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -511,7 +511,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
           >
              
             <div
-              className="field-string row"
+              className="rjsf-field rjsf-field-string row"
             >
               <div
                 className="col-5"
@@ -604,7 +604,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
             className="py-4 col-3 offset-9"
           >
             <button
-              className="ml-1 object-property-expand btn btn-primary"
+              className="ml-1 rjsf-object-property-expand btn btn-primary"
               disabled={false}
               id="root__add"
               onClick={[Function]}
@@ -666,7 +666,7 @@ exports[`object fields with title and description from both additionalProperties
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -709,7 +709,7 @@ exports[`object fields with title and description from both additionalProperties
           >
              
             <div
-              className="field-string row"
+              className="rjsf-field rjsf-field-string row"
             >
               <div
                 className="col-5"
@@ -802,7 +802,7 @@ exports[`object fields with title and description from both additionalProperties
             className="py-4 col-3 offset-9"
           >
             <button
-              className="ml-1 object-property-expand btn btn-primary"
+              className="ml-1 rjsf-object-property-expand btn btn-primary"
               disabled={false}
               id="root__add"
               onClick={[Function]}
@@ -864,7 +864,7 @@ exports[`object fields with title and description from both object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -907,7 +907,7 @@ exports[`object fields with title and description from both object 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -961,7 +961,7 @@ exports[`object fields with title and description from both object 1`] = `
           >
              
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <div>
                 <label
@@ -1025,7 +1025,7 @@ exports[`object fields with title and description from uiSchema additionalProper
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -1068,7 +1068,7 @@ exports[`object fields with title and description from uiSchema additionalProper
           >
              
             <div
-              className="field-string row"
+              className="rjsf-field rjsf-field-string row"
             >
               <div
                 className="col-5"
@@ -1161,7 +1161,7 @@ exports[`object fields with title and description from uiSchema additionalProper
             className="py-4 col-3 offset-9"
           >
             <button
-              className="ml-1 object-property-expand btn btn-primary"
+              className="ml-1 rjsf-object-property-expand btn btn-primary"
               disabled={false}
               id="root__add"
               onClick={[Function]}
@@ -1223,7 +1223,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -1266,7 +1266,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -1320,7 +1320,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
           >
              
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <div>
                 <label
@@ -1384,7 +1384,7 @@ exports[`object fields with title and description from uiSchema show add button 
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -1427,7 +1427,7 @@ exports[`object fields with title and description from uiSchema show add button 
           >
              
             <div
-              className="field-string row"
+              className="rjsf-field rjsf-field-string row"
             >
               <div
                 className="col-5"
@@ -1520,7 +1520,7 @@ exports[`object fields with title and description from uiSchema show add button 
             className="py-4 col-3 offset-9"
           >
             <button
-              className="ml-1 object-property-expand btn btn-primary"
+              className="ml-1 rjsf-object-property-expand btn btn-primary"
               disabled={false}
               id="root__add"
               onClick={[Function]}
@@ -1582,7 +1582,7 @@ exports[`object fields with title and description object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -1625,7 +1625,7 @@ exports[`object fields with title and description object 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <label
@@ -1679,7 +1679,7 @@ exports[`object fields with title and description object 1`] = `
           >
              
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <div>
                 <label
@@ -1743,7 +1743,7 @@ exports[`object fields with title and description show add button and fields if 
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -1786,7 +1786,7 @@ exports[`object fields with title and description show add button and fields if 
           >
              
             <div
-              className="field-string row"
+              className="rjsf-field rjsf-field-string row"
             >
               <div
                 className="col-5"
@@ -1879,7 +1879,7 @@ exports[`object fields with title and description show add button and fields if 
             className="py-4 col-3 offset-9"
           >
             <button
-              className="ml-1 object-property-expand btn btn-primary"
+              className="ml-1 rjsf-object-property-expand btn btn-primary"
               disabled={false}
               id="root__add"
               onClick={[Function]}
@@ -1941,7 +1941,7 @@ exports[`object fields with title and description with global label off addition
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -1960,7 +1960,7 @@ exports[`object fields with title and description with global label off addition
           >
              
             <div
-              className="field-string row"
+              className="rjsf-field rjsf-field-string row"
             >
               <div
                 className="col-5"
@@ -2047,7 +2047,7 @@ exports[`object fields with title and description with global label off addition
             className="py-4 col-3 offset-9"
           >
             <button
-              className="ml-1 object-property-expand btn btn-primary"
+              className="ml-1 rjsf-object-property-expand btn btn-primary"
               disabled={false}
               id="root__add"
               onClick={[Function]}
@@ -2109,7 +2109,7 @@ exports[`object fields with title and description with global label off object 1
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -2128,7 +2128,7 @@ exports[`object fields with title and description with global label off object 1
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div>
                 <input
@@ -2164,7 +2164,7 @@ exports[`object fields with title and description with global label off object 1
           >
              
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <div>
                 <input
@@ -2210,7 +2210,7 @@ exports[`object fields with title and description with global label off show add
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div>
       <div
@@ -2229,7 +2229,7 @@ exports[`object fields with title and description with global label off show add
           >
              
             <div
-              className="field-string row"
+              className="rjsf-field rjsf-field-string row"
             >
               <div
                 className="col-5"
@@ -2316,7 +2316,7 @@ exports[`object fields with title and description with global label off show add
             className="py-4 col-3 offset-9"
           >
             <button
-              className="ml-1 object-property-expand btn btn-primary"
+              className="ml-1 rjsf-object-property-expand btn btn-primary"
               disabled={false}
               id="root__add"
               onClick={[Function]}

--- a/packages/react-bootstrap/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/react-bootstrap/test/__snapshots__/Object.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -26,7 +26,7 @@ exports[`object fields additionalProperties 1`] = `
           >
              
             <div
-              className="form-group field field-string row"
+              className="field-string row"
             >
               <div
                 className="col-5"
@@ -181,7 +181,7 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -200,7 +200,7 @@ exports[`object fields object 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -242,7 +242,7 @@ exports[`object fields object 1`] = `
           >
              
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <div>
                 <label
@@ -294,7 +294,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -313,7 +313,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
           >
              
             <div
-              className="form-group field field-string row"
+              className="field-string row"
             >
               <div
                 className="col-5"
@@ -468,7 +468,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -511,7 +511,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
           >
              
             <div
-              className="form-group field field-string row"
+              className="field-string row"
             >
               <div
                 className="col-5"
@@ -666,7 +666,7 @@ exports[`object fields with title and description from both additionalProperties
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -709,7 +709,7 @@ exports[`object fields with title and description from both additionalProperties
           >
              
             <div
-              className="form-group field field-string row"
+              className="field-string row"
             >
               <div
                 className="col-5"
@@ -864,7 +864,7 @@ exports[`object fields with title and description from both object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -907,7 +907,7 @@ exports[`object fields with title and description from both object 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -961,7 +961,7 @@ exports[`object fields with title and description from both object 1`] = `
           >
              
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <div>
                 <label
@@ -1025,7 +1025,7 @@ exports[`object fields with title and description from uiSchema additionalProper
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -1068,7 +1068,7 @@ exports[`object fields with title and description from uiSchema additionalProper
           >
              
             <div
-              className="form-group field field-string row"
+              className="field-string row"
             >
               <div
                 className="col-5"
@@ -1223,7 +1223,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -1266,7 +1266,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -1320,7 +1320,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
           >
              
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <div>
                 <label
@@ -1384,7 +1384,7 @@ exports[`object fields with title and description from uiSchema show add button 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -1427,7 +1427,7 @@ exports[`object fields with title and description from uiSchema show add button 
           >
              
             <div
-              className="form-group field field-string row"
+              className="field-string row"
             >
               <div
                 className="col-5"
@@ -1582,7 +1582,7 @@ exports[`object fields with title and description object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -1625,7 +1625,7 @@ exports[`object fields with title and description object 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <label
@@ -1679,7 +1679,7 @@ exports[`object fields with title and description object 1`] = `
           >
              
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <div>
                 <label
@@ -1743,7 +1743,7 @@ exports[`object fields with title and description show add button and fields if 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -1786,7 +1786,7 @@ exports[`object fields with title and description show add button and fields if 
           >
              
             <div
-              className="form-group field field-string row"
+              className="field-string row"
             >
               <div
                 className="col-5"
@@ -1941,7 +1941,7 @@ exports[`object fields with title and description with global label off addition
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -1960,7 +1960,7 @@ exports[`object fields with title and description with global label off addition
           >
              
             <div
-              className="form-group field field-string row"
+              className="field-string row"
             >
               <div
                 className="col-5"
@@ -2109,7 +2109,7 @@ exports[`object fields with title and description with global label off object 1
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -2128,7 +2128,7 @@ exports[`object fields with title and description with global label off object 1
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div>
                 <input
@@ -2164,7 +2164,7 @@ exports[`object fields with title and description with global label off object 1
           >
              
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <div>
                 <input
@@ -2210,7 +2210,7 @@ exports[`object fields with title and description with global label off show add
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div>
       <div
@@ -2229,7 +2229,7 @@ exports[`object fields with title and description with global label off show add
           >
              
             <div
-              className="form-group field field-string row"
+              className="field-string row"
             >
               <div
                 className="col-5"

--- a/packages/semantic-ui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
+++ b/packages/semantic-ui/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
@@ -35,7 +35,7 @@ export default function ArrayFieldItemTemplate<
   // Pull the semantic props out of the uiOptions that were put in via the ArrayFieldTemplate
   const { horizontalButtons = true, wrapItem = false } = uiOptions.semantic as GenericObjectType;
   return (
-    <div className='array-item'>
+    <div className='rjsf-array-item'>
       <MaybeWrap wrap={wrapItem} component={Segment}>
         <Grid style={{ ...gridStyle(!horizontalButtons), alignItems: 'center' }}>
           <Grid.Column width={16} verticalAlign='middle'>

--- a/packages/semantic-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/semantic-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -108,7 +108,7 @@ export default function ArrayFieldTemplate<
           >
             <AddButton
               id={buttonId<T>(idSchema, 'add')}
-              className='array-item-add'
+              className='rjsf-array-item-add'
               onClick={onAddClick}
               disabled={disabled || readonly}
               uiSchema={uiSchema}

--- a/packages/semantic-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/semantic-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -82,7 +82,7 @@ export default function ObjectFieldTemplate<
             >
               <AddButton
                 id={buttonId<T>(idSchema, 'add')}
-                className='object-property-expand'
+                className='rjsf-object-property-expand'
                 onClick={onAddClick(schema)}
                 disabled={disabled || readonly}
                 uiSchema={uiSchema}

--- a/packages/semantic-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/semantic-ui/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -83,7 +83,7 @@ export default function WrapIfAdditionalTemplate<
             <RemoveButton
               id={buttonId<T>(id, 'remove')}
               iconType='mini'
-              className='array-item-remove'
+              className='rjsf-object-property-remove'
               disabled={disabled || readonly}
               onClick={onDropPropertyClick(label)}
               uiSchema={uiSchema}

--- a/packages/semantic-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Array.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -62,7 +62,7 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -91,7 +91,7 @@ exports[`array fields array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -198,7 +198,7 @@ exports[`array fields array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -332,7 +332,7 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -448,13 +448,13 @@ exports[`array fields empty errors array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="grouped equal width fields"
@@ -507,7 +507,7 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -536,7 +536,7 @@ exports[`array fields fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -585,7 +585,7 @@ exports[`array fields fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-number"
+                    className="field-number"
                   >
                     <div
                       className="grouped equal width fields"
@@ -658,13 +658,13 @@ exports[`array fields has errors 1`] = `
     </ul>
   </div>
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="form-group field field-string field-error has-error has-danger"
+        className="field-string"
       >
         <div
           className="grouped equal width fields"
@@ -736,13 +736,13 @@ exports[`array fields no errors 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="grouped equal width fields"
@@ -795,7 +795,7 @@ exports[`with title and description array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -862,7 +862,7 @@ exports[`with title and description array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -903,7 +903,7 @@ exports[`with title and description array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -1021,7 +1021,7 @@ exports[`with title and description array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -1166,7 +1166,7 @@ exports[`with title and description checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -1293,7 +1293,7 @@ exports[`with title and description fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -1334,7 +1334,7 @@ exports[`with title and description fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -1394,7 +1394,7 @@ exports[`with title and description fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-number"
+                    className="field-number"
                   >
                     <div
                       className="grouped equal width fields"
@@ -1460,7 +1460,7 @@ exports[`with title and description from both array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -1527,7 +1527,7 @@ exports[`with title and description from both array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -1568,7 +1568,7 @@ exports[`with title and description from both array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -1686,7 +1686,7 @@ exports[`with title and description from both array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -1831,7 +1831,7 @@ exports[`with title and description from both checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -1958,7 +1958,7 @@ exports[`with title and description from both fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -1999,7 +1999,7 @@ exports[`with title and description from both fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -2059,7 +2059,7 @@ exports[`with title and description from both fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-number"
+                    className="field-number"
                   >
                     <div
                       className="grouped equal width fields"
@@ -2125,7 +2125,7 @@ exports[`with title and description from uiSchema array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -2192,7 +2192,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -2233,7 +2233,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -2351,7 +2351,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -2496,7 +2496,7 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -2623,7 +2623,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -2664,7 +2664,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -2724,7 +2724,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-number"
+                    className="field-number"
                   >
                     <div
                       className="grouped equal width fields"
@@ -2790,7 +2790,7 @@ exports[`with title and description with global label off array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -2845,7 +2845,7 @@ exports[`with title and description with global label off array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -2874,7 +2874,7 @@ exports[`with title and description with global label off array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -2981,7 +2981,7 @@ exports[`with title and description with global label off array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -3115,7 +3115,7 @@ exports[`with title and description with global label off checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -3242,7 +3242,7 @@ exports[`with title and description with global label off fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -3271,7 +3271,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-string"
+                    className="field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -3320,7 +3320,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="form-group field field-number"
+                    className="field-number"
                   >
                     <div
                       className="grouped equal width fields"

--- a/packages/semantic-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Array.test.tsx.snap
@@ -664,7 +664,7 @@ exports[`array fields has errors 1`] = `
       className="grouped equal width fields"
     >
       <div
-        className="rjsf-field rjsf-field-string"
+        className="rjsf-field rjsf-field-string rjsf-field-error"
       >
         <div
           className="grouped equal width fields"

--- a/packages/semantic-ui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Array.test.tsx.snap
@@ -7,13 +7,13 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field field-array field-array-of-string sortable-form-fields"
+        className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields"
       >
         <div>
           <div
@@ -29,7 +29,7 @@ exports[`array fields array 1`] = `
             }
           >
             <button
-              className="ui tiny icon button array-item-add"
+              className="ui tiny icon button rjsf-array-item-add"
               id="root__add"
               onClick={[Function]}
               title="Add Item"
@@ -62,20 +62,20 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field field-array field-array-of-string sortable-form-fields"
+        className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields"
       >
         <div>
           <div
             className="row array-item-list"
           >
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -91,7 +91,7 @@ exports[`array fields array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -128,7 +128,7 @@ exports[`array fields array icons 1`] = `
                     className="ui mini buttons"
                   >
                     <button
-                      className="ui icon disabled button array-item-move-up"
+                      className="ui icon disabled button rjsf-array-item-move-up"
                       disabled={true}
                       id="root_0__moveUp"
                       onClick={[Function]}
@@ -142,7 +142,7 @@ exports[`array fields array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-move-down"
+                      className="ui icon button rjsf-array-item-move-down"
                       id="root_0__moveDown"
                       onClick={[Function]}
                       title="Move down"
@@ -154,7 +154,7 @@ exports[`array fields array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-copy"
+                      className="ui icon button rjsf-array-item-copy"
                       id="root_0__copy"
                       onClick={[Function]}
                       title="Copy"
@@ -166,7 +166,7 @@ exports[`array fields array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-remove"
+                      className="ui icon button rjsf-array-item-remove"
                       id="root_0__remove"
                       onClick={[Function]}
                       title="Remove"
@@ -182,7 +182,7 @@ exports[`array fields array icons 1`] = `
               </div>
             </div>
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -198,7 +198,7 @@ exports[`array fields array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -235,7 +235,7 @@ exports[`array fields array icons 1`] = `
                     className="ui mini buttons"
                   >
                     <button
-                      className="ui icon button array-item-move-up"
+                      className="ui icon button rjsf-array-item-move-up"
                       id="root_1__moveUp"
                       onClick={[Function]}
                       title="Move up"
@@ -247,7 +247,7 @@ exports[`array fields array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon disabled button array-item-move-down"
+                      className="ui icon disabled button rjsf-array-item-move-down"
                       disabled={true}
                       id="root_1__moveDown"
                       onClick={[Function]}
@@ -261,7 +261,7 @@ exports[`array fields array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-copy"
+                      className="ui icon button rjsf-array-item-copy"
                       id="root_1__copy"
                       onClick={[Function]}
                       title="Copy"
@@ -273,7 +273,7 @@ exports[`array fields array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-remove"
+                      className="ui icon button rjsf-array-item-remove"
                       id="root_1__remove"
                       onClick={[Function]}
                       title="Remove"
@@ -299,7 +299,7 @@ exports[`array fields array icons 1`] = `
             }
           >
             <button
-              className="ui tiny icon button array-item-add"
+              className="ui tiny icon button rjsf-array-item-add"
               id="root__add"
               onClick={[Function]}
               title="Add Item"
@@ -332,7 +332,7 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
@@ -448,13 +448,13 @@ exports[`array fields empty errors array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="grouped equal width fields"
@@ -507,20 +507,20 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field field-array field-array-fixed-items"
+        className="rjsf-field rjsf-field-array rjsf-field-array-fixed-items"
       >
         <div>
           <div
             className="row array-item-list"
           >
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -536,7 +536,7 @@ exports[`array fields fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -569,7 +569,7 @@ exports[`array fields fixed array 1`] = `
               </div>
             </div>
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -585,7 +585,7 @@ exports[`array fields fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-number"
+                    className="rjsf-field rjsf-field-number"
                   >
                     <div
                       className="grouped equal width fields"
@@ -658,13 +658,13 @@ exports[`array fields has errors 1`] = `
     </ul>
   </div>
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="grouped equal width fields"
@@ -736,13 +736,13 @@ exports[`array fields no errors 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="grouped equal width fields"
@@ -795,13 +795,13 @@ exports[`with title and description array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field field-array field-array-of-string sortable-form-fields"
+        className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields"
       >
         <h5
           className="ui dividing header"
@@ -829,7 +829,7 @@ exports[`with title and description array 1`] = `
             }
           >
             <button
-              className="ui tiny icon button array-item-add"
+              className="ui tiny icon button rjsf-array-item-add"
               id="root__add"
               onClick={[Function]}
               title="Add Item"
@@ -862,13 +862,13 @@ exports[`with title and description array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field field-array field-array-of-string sortable-form-fields"
+        className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields"
       >
         <h5
           className="ui dividing header"
@@ -887,7 +887,7 @@ exports[`with title and description array icons 1`] = `
             className="row array-item-list"
           >
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -903,7 +903,7 @@ exports[`with title and description array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -951,7 +951,7 @@ exports[`with title and description array icons 1`] = `
                     className="ui mini buttons"
                   >
                     <button
-                      className="ui icon disabled button array-item-move-up"
+                      className="ui icon disabled button rjsf-array-item-move-up"
                       disabled={true}
                       id="root_0__moveUp"
                       onClick={[Function]}
@@ -965,7 +965,7 @@ exports[`with title and description array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-move-down"
+                      className="ui icon button rjsf-array-item-move-down"
                       id="root_0__moveDown"
                       onClick={[Function]}
                       title="Move down"
@@ -977,7 +977,7 @@ exports[`with title and description array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-copy"
+                      className="ui icon button rjsf-array-item-copy"
                       id="root_0__copy"
                       onClick={[Function]}
                       title="Copy"
@@ -989,7 +989,7 @@ exports[`with title and description array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-remove"
+                      className="ui icon button rjsf-array-item-remove"
                       id="root_0__remove"
                       onClick={[Function]}
                       title="Remove"
@@ -1005,7 +1005,7 @@ exports[`with title and description array icons 1`] = `
               </div>
             </div>
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -1021,7 +1021,7 @@ exports[`with title and description array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -1069,7 +1069,7 @@ exports[`with title and description array icons 1`] = `
                     className="ui mini buttons"
                   >
                     <button
-                      className="ui icon button array-item-move-up"
+                      className="ui icon button rjsf-array-item-move-up"
                       id="root_1__moveUp"
                       onClick={[Function]}
                       title="Move up"
@@ -1081,7 +1081,7 @@ exports[`with title and description array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon disabled button array-item-move-down"
+                      className="ui icon disabled button rjsf-array-item-move-down"
                       disabled={true}
                       id="root_1__moveDown"
                       onClick={[Function]}
@@ -1095,7 +1095,7 @@ exports[`with title and description array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-copy"
+                      className="ui icon button rjsf-array-item-copy"
                       id="root_1__copy"
                       onClick={[Function]}
                       title="Copy"
@@ -1107,7 +1107,7 @@ exports[`with title and description array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-remove"
+                      className="ui icon button rjsf-array-item-remove"
                       id="root_1__remove"
                       onClick={[Function]}
                       title="Remove"
@@ -1133,7 +1133,7 @@ exports[`with title and description array icons 1`] = `
             }
           >
             <button
-              className="ui tiny icon button array-item-add"
+              className="ui tiny icon button rjsf-array-item-add"
               id="root__add"
               onClick={[Function]}
               title="Add Item"
@@ -1166,7 +1166,7 @@ exports[`with title and description checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
@@ -1293,13 +1293,13 @@ exports[`with title and description fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field field-array field-array-fixed-items"
+        className="rjsf-field rjsf-field-array rjsf-field-array-fixed-items"
       >
         <h5
           className="ui dividing header"
@@ -1318,7 +1318,7 @@ exports[`with title and description fixed array 1`] = `
             className="row array-item-list"
           >
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -1334,7 +1334,7 @@ exports[`with title and description fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -1378,7 +1378,7 @@ exports[`with title and description fixed array 1`] = `
               </div>
             </div>
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -1394,7 +1394,7 @@ exports[`with title and description fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-number"
+                    className="rjsf-field rjsf-field-number"
                   >
                     <div
                       className="grouped equal width fields"
@@ -1460,13 +1460,13 @@ exports[`with title and description from both array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field field-array field-array-of-string sortable-form-fields"
+        className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields"
       >
         <h5
           className="ui dividing header"
@@ -1494,7 +1494,7 @@ exports[`with title and description from both array 1`] = `
             }
           >
             <button
-              className="ui tiny icon button array-item-add"
+              className="ui tiny icon button rjsf-array-item-add"
               id="root__add"
               onClick={[Function]}
               title="Add Item"
@@ -1527,13 +1527,13 @@ exports[`with title and description from both array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field field-array field-array-of-string sortable-form-fields"
+        className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields"
       >
         <h5
           className="ui dividing header"
@@ -1552,7 +1552,7 @@ exports[`with title and description from both array icons 1`] = `
             className="row array-item-list"
           >
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -1568,7 +1568,7 @@ exports[`with title and description from both array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -1616,7 +1616,7 @@ exports[`with title and description from both array icons 1`] = `
                     className="ui mini buttons"
                   >
                     <button
-                      className="ui icon disabled button array-item-move-up"
+                      className="ui icon disabled button rjsf-array-item-move-up"
                       disabled={true}
                       id="root_0__moveUp"
                       onClick={[Function]}
@@ -1630,7 +1630,7 @@ exports[`with title and description from both array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-move-down"
+                      className="ui icon button rjsf-array-item-move-down"
                       id="root_0__moveDown"
                       onClick={[Function]}
                       title="Move down"
@@ -1642,7 +1642,7 @@ exports[`with title and description from both array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-copy"
+                      className="ui icon button rjsf-array-item-copy"
                       id="root_0__copy"
                       onClick={[Function]}
                       title="Copy"
@@ -1654,7 +1654,7 @@ exports[`with title and description from both array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-remove"
+                      className="ui icon button rjsf-array-item-remove"
                       id="root_0__remove"
                       onClick={[Function]}
                       title="Remove"
@@ -1670,7 +1670,7 @@ exports[`with title and description from both array icons 1`] = `
               </div>
             </div>
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -1686,7 +1686,7 @@ exports[`with title and description from both array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -1734,7 +1734,7 @@ exports[`with title and description from both array icons 1`] = `
                     className="ui mini buttons"
                   >
                     <button
-                      className="ui icon button array-item-move-up"
+                      className="ui icon button rjsf-array-item-move-up"
                       id="root_1__moveUp"
                       onClick={[Function]}
                       title="Move up"
@@ -1746,7 +1746,7 @@ exports[`with title and description from both array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon disabled button array-item-move-down"
+                      className="ui icon disabled button rjsf-array-item-move-down"
                       disabled={true}
                       id="root_1__moveDown"
                       onClick={[Function]}
@@ -1760,7 +1760,7 @@ exports[`with title and description from both array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-copy"
+                      className="ui icon button rjsf-array-item-copy"
                       id="root_1__copy"
                       onClick={[Function]}
                       title="Copy"
@@ -1772,7 +1772,7 @@ exports[`with title and description from both array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-remove"
+                      className="ui icon button rjsf-array-item-remove"
                       id="root_1__remove"
                       onClick={[Function]}
                       title="Remove"
@@ -1798,7 +1798,7 @@ exports[`with title and description from both array icons 1`] = `
             }
           >
             <button
-              className="ui tiny icon button array-item-add"
+              className="ui tiny icon button rjsf-array-item-add"
               id="root__add"
               onClick={[Function]}
               title="Add Item"
@@ -1831,7 +1831,7 @@ exports[`with title and description from both checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
@@ -1958,13 +1958,13 @@ exports[`with title and description from both fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field field-array field-array-fixed-items"
+        className="rjsf-field rjsf-field-array rjsf-field-array-fixed-items"
       >
         <h5
           className="ui dividing header"
@@ -1983,7 +1983,7 @@ exports[`with title and description from both fixed array 1`] = `
             className="row array-item-list"
           >
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -1999,7 +1999,7 @@ exports[`with title and description from both fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -2043,7 +2043,7 @@ exports[`with title and description from both fixed array 1`] = `
               </div>
             </div>
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -2059,7 +2059,7 @@ exports[`with title and description from both fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-number"
+                    className="rjsf-field rjsf-field-number"
                   >
                     <div
                       className="grouped equal width fields"
@@ -2125,13 +2125,13 @@ exports[`with title and description from uiSchema array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field field-array field-array-of-string sortable-form-fields"
+        className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields"
       >
         <h5
           className="ui dividing header"
@@ -2159,7 +2159,7 @@ exports[`with title and description from uiSchema array 1`] = `
             }
           >
             <button
-              className="ui tiny icon button array-item-add"
+              className="ui tiny icon button rjsf-array-item-add"
               id="root__add"
               onClick={[Function]}
               title="Add Item"
@@ -2192,13 +2192,13 @@ exports[`with title and description from uiSchema array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field field-array field-array-of-string sortable-form-fields"
+        className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields"
       >
         <h5
           className="ui dividing header"
@@ -2217,7 +2217,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
             className="row array-item-list"
           >
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -2233,7 +2233,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -2281,7 +2281,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     className="ui mini buttons"
                   >
                     <button
-                      className="ui icon disabled button array-item-move-up"
+                      className="ui icon disabled button rjsf-array-item-move-up"
                       disabled={true}
                       id="root_0__moveUp"
                       onClick={[Function]}
@@ -2295,7 +2295,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-move-down"
+                      className="ui icon button rjsf-array-item-move-down"
                       id="root_0__moveDown"
                       onClick={[Function]}
                       title="Move down"
@@ -2307,7 +2307,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-copy"
+                      className="ui icon button rjsf-array-item-copy"
                       id="root_0__copy"
                       onClick={[Function]}
                       title="Copy"
@@ -2319,7 +2319,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-remove"
+                      className="ui icon button rjsf-array-item-remove"
                       id="root_0__remove"
                       onClick={[Function]}
                       title="Remove"
@@ -2335,7 +2335,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
               </div>
             </div>
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -2351,7 +2351,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -2399,7 +2399,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     className="ui mini buttons"
                   >
                     <button
-                      className="ui icon button array-item-move-up"
+                      className="ui icon button rjsf-array-item-move-up"
                       id="root_1__moveUp"
                       onClick={[Function]}
                       title="Move up"
@@ -2411,7 +2411,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon disabled button array-item-move-down"
+                      className="ui icon disabled button rjsf-array-item-move-down"
                       disabled={true}
                       id="root_1__moveDown"
                       onClick={[Function]}
@@ -2425,7 +2425,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-copy"
+                      className="ui icon button rjsf-array-item-copy"
                       id="root_1__copy"
                       onClick={[Function]}
                       title="Copy"
@@ -2437,7 +2437,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-remove"
+                      className="ui icon button rjsf-array-item-remove"
                       id="root_1__remove"
                       onClick={[Function]}
                       title="Remove"
@@ -2463,7 +2463,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
             }
           >
             <button
-              className="ui tiny icon button array-item-add"
+              className="ui tiny icon button rjsf-array-item-add"
               id="root__add"
               onClick={[Function]}
               title="Add Item"
@@ -2496,7 +2496,7 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
@@ -2623,13 +2623,13 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field field-array field-array-fixed-items"
+        className="rjsf-field rjsf-field-array rjsf-field-array-fixed-items"
       >
         <h5
           className="ui dividing header"
@@ -2648,7 +2648,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
             className="row array-item-list"
           >
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -2664,7 +2664,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -2708,7 +2708,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
               </div>
             </div>
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -2724,7 +2724,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-number"
+                    className="rjsf-field rjsf-field-number"
                   >
                     <div
                       className="grouped equal width fields"
@@ -2790,13 +2790,13 @@ exports[`with title and description with global label off array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field field-array field-array-of-string sortable-form-fields"
+        className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields"
       >
         <div>
           <div
@@ -2812,7 +2812,7 @@ exports[`with title and description with global label off array 1`] = `
             }
           >
             <button
-              className="ui tiny icon button array-item-add"
+              className="ui tiny icon button rjsf-array-item-add"
               id="root__add"
               onClick={[Function]}
               title="Add Item"
@@ -2845,20 +2845,20 @@ exports[`with title and description with global label off array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field field-array field-array-of-string sortable-form-fields"
+        className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields"
       >
         <div>
           <div
             className="row array-item-list"
           >
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -2874,7 +2874,7 @@ exports[`with title and description with global label off array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -2911,7 +2911,7 @@ exports[`with title and description with global label off array icons 1`] = `
                     className="ui mini buttons"
                   >
                     <button
-                      className="ui icon disabled button array-item-move-up"
+                      className="ui icon disabled button rjsf-array-item-move-up"
                       disabled={true}
                       id="root_0__moveUp"
                       onClick={[Function]}
@@ -2925,7 +2925,7 @@ exports[`with title and description with global label off array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-move-down"
+                      className="ui icon button rjsf-array-item-move-down"
                       id="root_0__moveDown"
                       onClick={[Function]}
                       title="Move down"
@@ -2937,7 +2937,7 @@ exports[`with title and description with global label off array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-copy"
+                      className="ui icon button rjsf-array-item-copy"
                       id="root_0__copy"
                       onClick={[Function]}
                       title="Copy"
@@ -2949,7 +2949,7 @@ exports[`with title and description with global label off array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-remove"
+                      className="ui icon button rjsf-array-item-remove"
                       id="root_0__remove"
                       onClick={[Function]}
                       title="Remove"
@@ -2965,7 +2965,7 @@ exports[`with title and description with global label off array icons 1`] = `
               </div>
             </div>
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -2981,7 +2981,7 @@ exports[`with title and description with global label off array icons 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -3018,7 +3018,7 @@ exports[`with title and description with global label off array icons 1`] = `
                     className="ui mini buttons"
                   >
                     <button
-                      className="ui icon button array-item-move-up"
+                      className="ui icon button rjsf-array-item-move-up"
                       id="root_1__moveUp"
                       onClick={[Function]}
                       title="Move up"
@@ -3030,7 +3030,7 @@ exports[`with title and description with global label off array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon disabled button array-item-move-down"
+                      className="ui icon disabled button rjsf-array-item-move-down"
                       disabled={true}
                       id="root_1__moveDown"
                       onClick={[Function]}
@@ -3044,7 +3044,7 @@ exports[`with title and description with global label off array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-copy"
+                      className="ui icon button rjsf-array-item-copy"
                       id="root_1__copy"
                       onClick={[Function]}
                       title="Copy"
@@ -3056,7 +3056,7 @@ exports[`with title and description with global label off array icons 1`] = `
                       />
                     </button>
                     <button
-                      className="ui icon button array-item-remove"
+                      className="ui icon button rjsf-array-item-remove"
                       id="root_1__remove"
                       onClick={[Function]}
                       title="Remove"
@@ -3082,7 +3082,7 @@ exports[`with title and description with global label off array icons 1`] = `
             }
           >
             <button
-              className="ui tiny icon button array-item-add"
+              className="ui tiny icon button rjsf-array-item-add"
               id="root__add"
               onClick={[Function]}
               title="Add Item"
@@ -3115,7 +3115,7 @@ exports[`with title and description with global label off checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
@@ -3242,20 +3242,20 @@ exports[`with title and description with global label off fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field field-array field-array-fixed-items"
+        className="rjsf-field rjsf-field-array rjsf-field-array-fixed-items"
       >
         <div>
           <div
             className="row array-item-list"
           >
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -3271,7 +3271,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-string"
+                    className="rjsf-field rjsf-field-string"
                   >
                     <div
                       className="grouped equal width fields"
@@ -3304,7 +3304,7 @@ exports[`with title and description with global label off fixed array 1`] = `
               </div>
             </div>
             <div
-              className="array-item"
+              className="rjsf-array-item"
             >
               <div
                 className="ui grid"
@@ -3320,7 +3320,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                   className="middle aligned sixteen wide column"
                 >
                   <div
-                    className="field-number"
+                    className="rjsf-field rjsf-field-number"
                   >
                     <div
                       className="grouped equal width fields"

--- a/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`semantic-ui specific tests field with special semantic options 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
@@ -25,7 +25,7 @@ exports[`semantic-ui specific tests field with special semantic options 1`] = `
         A simple test theme form example.
       </p>
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="grouped equal width fields"
@@ -170,7 +170,7 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <div
       className="grouped equal width fields"
@@ -225,7 +225,7 @@ exports[`single fields checkbox field with label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <div
       className="grouped equal width fields"
@@ -282,7 +282,7 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
@@ -446,13 +446,13 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="grouped equal width fields"
@@ -511,13 +511,13 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="grouped equal width fields"
@@ -576,7 +576,7 @@ exports[`single fields format color 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -621,7 +621,7 @@ exports[`single fields format date 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -666,7 +666,7 @@ exports[`single fields format datetime 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -711,7 +711,7 @@ exports[`single fields format time 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -774,7 +774,7 @@ exports[`single fields help and error display 1`] = `
     </ul>
   </div>
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -850,7 +850,7 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
@@ -888,7 +888,7 @@ exports[`single fields hidden label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -933,7 +933,7 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-null"
+    className="rjsf-field rjsf-field-null"
   >
     <div
       className="grouped equal width fields"
@@ -956,7 +956,7 @@ exports[`single fields number field 0 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <div
       className="grouped equal width fields"
@@ -1002,7 +1002,7 @@ exports[`single fields number field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <div
       className="grouped equal width fields"
@@ -1048,7 +1048,7 @@ exports[`single fields password field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -1093,7 +1093,7 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <div
       className="grouped equal width fields"
@@ -1187,7 +1187,7 @@ exports[`single fields schema examples 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -1252,7 +1252,7 @@ exports[`single fields select field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -1370,7 +1370,7 @@ exports[`single fields select field multiple choice 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
@@ -1505,7 +1505,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
@@ -1640,7 +1640,7 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
@@ -1798,7 +1798,7 @@ exports[`single fields select field multiple choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
@@ -1919,7 +1919,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="grouped equal width fields"
@@ -2035,7 +2035,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2153,7 +2153,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2247,7 +2247,7 @@ exports[`single fields select field single choice form disabled using radio widg
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2343,7 +2343,7 @@ exports[`single fields select field single choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2463,7 +2463,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2557,7 +2557,7 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-integer"
+    className="rjsf-field rjsf-field-integer"
   >
     <div
       className="grouped equal width fields"
@@ -2601,7 +2601,7 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2648,7 +2648,7 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2693,7 +2693,7 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2738,7 +2738,7 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2783,7 +2783,7 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2828,7 +2828,7 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2871,7 +2871,7 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
@@ -2883,7 +2883,7 @@ exports[`single fields title field 1`] = `
         Titre 1
       </h5>
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="grouped equal width fields"
@@ -2936,7 +2936,7 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-undefined"
+    className="rjsf-field rjsf-field-undefined"
   >
     <div
       className="grouped equal width fields"
@@ -2980,7 +2980,7 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <div
       className="grouped equal width fields"
@@ -3025,7 +3025,7 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="grouped equal width fields"

--- a/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
@@ -774,7 +774,7 @@ exports[`single fields help and error display 1`] = `
     </ul>
   </div>
   <div
-    className="rjsf-field rjsf-field-string"
+    className="rjsf-field rjsf-field-string rjsf-field-error"
   >
     <div
       className="grouped equal width fields"

--- a/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`semantic-ui specific tests field with special semantic options 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
@@ -25,7 +25,7 @@ exports[`semantic-ui specific tests field with special semantic options 1`] = `
         A simple test theme form example.
       </p>
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="grouped equal width fields"
@@ -170,7 +170,7 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <div
       className="grouped equal width fields"
@@ -225,7 +225,7 @@ exports[`single fields checkbox field with label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <div
       className="grouped equal width fields"
@@ -282,7 +282,7 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -446,13 +446,13 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="grouped equal width fields"
@@ -511,13 +511,13 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="grouped equal width fields"
@@ -576,7 +576,7 @@ exports[`single fields format color 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -621,7 +621,7 @@ exports[`single fields format date 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -666,7 +666,7 @@ exports[`single fields format datetime 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -711,7 +711,7 @@ exports[`single fields format time 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -774,7 +774,7 @@ exports[`single fields help and error display 1`] = `
     </ul>
   </div>
   <div
-    className="form-group field field-string field-error has-error has-danger"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -850,7 +850,7 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
@@ -888,7 +888,7 @@ exports[`single fields hidden label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -933,7 +933,7 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-null"
+    className="field-null"
   >
     <div
       className="grouped equal width fields"
@@ -956,7 +956,7 @@ exports[`single fields number field 0 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <div
       className="grouped equal width fields"
@@ -1002,7 +1002,7 @@ exports[`single fields number field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <div
       className="grouped equal width fields"
@@ -1048,7 +1048,7 @@ exports[`single fields password field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -1093,7 +1093,7 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <div
       className="grouped equal width fields"
@@ -1187,7 +1187,7 @@ exports[`single fields schema examples 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -1252,7 +1252,7 @@ exports[`single fields select field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -1370,7 +1370,7 @@ exports[`single fields select field multiple choice 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -1505,7 +1505,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -1640,7 +1640,7 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -1798,7 +1798,7 @@ exports[`single fields select field multiple choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -1919,7 +1919,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="grouped equal width fields"
@@ -2035,7 +2035,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2153,7 +2153,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2247,7 +2247,7 @@ exports[`single fields select field single choice form disabled using radio widg
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2343,7 +2343,7 @@ exports[`single fields select field single choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2463,7 +2463,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2557,7 +2557,7 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-integer"
+    className="field-integer"
   >
     <div
       className="grouped equal width fields"
@@ -2601,7 +2601,7 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2648,7 +2648,7 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2693,7 +2693,7 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2738,7 +2738,7 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2783,7 +2783,7 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2828,7 +2828,7 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"
@@ -2871,7 +2871,7 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
@@ -2883,7 +2883,7 @@ exports[`single fields title field 1`] = `
         Titre 1
       </h5>
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="grouped equal width fields"
@@ -2936,7 +2936,7 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-undefined"
+    className="field-undefined"
   >
     <div
       className="grouped equal width fields"
@@ -2980,7 +2980,7 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <div
       className="grouped equal width fields"
@@ -3025,7 +3025,7 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="grouped equal width fields"

--- a/packages/semantic-ui/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/GridSnap.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
@@ -35,7 +35,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="grouped equal width fields"
@@ -69,7 +69,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -114,7 +114,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -159,7 +159,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -216,7 +216,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -261,7 +261,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-array"
+              className="rjsf-field rjsf-field-array"
             >
               <div
                 className="grouped equal width fields"
@@ -463,7 +463,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="grouped equal width fields"
@@ -489,7 +489,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -535,7 +535,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -581,7 +581,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -635,7 +635,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       }
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="grouped equal width fields"
@@ -1779,7 +1779,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       }
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="grouped equal width fields"
@@ -1957,7 +1957,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -2003,7 +2003,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -2049,7 +2049,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -2095,7 +2095,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -3252,7 +3252,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
@@ -3280,7 +3280,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="grouped equal width fields"
@@ -3314,7 +3314,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -3359,7 +3359,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -3404,7 +3404,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -3461,7 +3461,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -3506,7 +3506,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-array"
+              className="rjsf-field rjsf-field-array"
             >
               <div
                 className="grouped equal width fields"
@@ -3708,7 +3708,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="grouped equal width fields"
@@ -3734,7 +3734,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -3780,7 +3780,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -3826,7 +3826,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -3880,7 +3880,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       }
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="grouped equal width fields"
@@ -5024,7 +5024,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       }
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="grouped equal width fields"
@@ -5202,7 +5202,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -5248,7 +5248,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -5294,7 +5294,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -5340,7 +5340,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -5386,7 +5386,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -6543,7 +6543,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
@@ -6571,7 +6571,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="grouped equal width fields"
@@ -6605,7 +6605,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -6650,7 +6650,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -6695,7 +6695,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -6752,7 +6752,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -6797,7 +6797,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-array"
+              className="rjsf-field rjsf-field-array"
             >
               <div
                 className="grouped equal width fields"
@@ -6999,7 +6999,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="grouped equal width fields"
@@ -7025,7 +7025,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -7071,7 +7071,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -7117,7 +7117,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -7171,7 +7171,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       }
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="grouped equal width fields"
@@ -8315,7 +8315,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       }
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="grouped equal width fields"
@@ -8493,7 +8493,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -8549,7 +8549,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
@@ -8577,7 +8577,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="grouped equal width fields"
@@ -8611,7 +8611,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -8656,7 +8656,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -8701,7 +8701,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -8758,7 +8758,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -8803,7 +8803,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="field-array"
+              className="rjsf-field rjsf-field-array"
             >
               <div
                 className="grouped equal width fields"
@@ -9005,7 +9005,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="grouped equal width fields"
@@ -9031,7 +9031,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -9077,7 +9077,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -9123,7 +9123,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -9177,7 +9177,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       }
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="grouped equal width fields"
@@ -10321,7 +10321,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       }
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="grouped equal width fields"
@@ -10499,7 +10499,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -10545,7 +10545,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -10591,7 +10591,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -10637,7 +10637,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="field-string"
+                  className="rjsf-field rjsf-field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -11794,7 +11794,7 @@ exports[`Three even column grid renders person and address in three columns, no 
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
@@ -11818,7 +11818,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-object"
+            className="rjsf-field rjsf-field-object"
           >
             <div
               className="grouped equal width fields"
@@ -11842,7 +11842,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="grouped equal width fields"
@@ -11887,7 +11887,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="grouped equal width fields"
@@ -11932,7 +11932,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="grouped equal width fields"
@@ -11977,7 +11977,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="grouped equal width fields"
@@ -12022,7 +12022,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-array"
+            className="rjsf-field rjsf-field-array"
           >
             <div
               className="grouped equal width fields"
@@ -12218,7 +12218,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="grouped equal width fields"
@@ -12263,7 +12263,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="grouped equal width fields"
@@ -12308,7 +12308,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="grouped equal width fields"
@@ -12353,7 +12353,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="grouped equal width fields"
@@ -13516,7 +13516,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
@@ -13540,7 +13540,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-object"
+            className="rjsf-field rjsf-field-object"
           >
             <div
               className="grouped equal width fields"
@@ -13564,7 +13564,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="grouped equal width fields"
@@ -13609,7 +13609,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="grouped equal width fields"
@@ -13654,7 +13654,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="grouped equal width fields"
@@ -13699,7 +13699,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="grouped equal width fields"
@@ -13744,7 +13744,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-array"
+            className="rjsf-field rjsf-field-array"
           >
             <div
               className="grouped equal width fields"
@@ -13940,7 +13940,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="grouped equal width fields"
@@ -13985,7 +13985,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="grouped equal width fields"
@@ -14030,7 +14030,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="grouped equal width fields"
@@ -14075,7 +14075,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="grouped equal width fields"

--- a/packages/semantic-ui/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/GridSnap.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
@@ -35,7 +35,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="grouped equal width fields"
@@ -69,7 +69,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -114,7 +114,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -159,7 +159,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -216,7 +216,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -261,7 +261,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-array"
+              className="field-array"
             >
               <div
                 className="grouped equal width fields"
@@ -463,7 +463,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="grouped equal width fields"
@@ -489,7 +489,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -535,7 +535,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -581,7 +581,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -635,7 +635,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       }
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="grouped equal width fields"
@@ -1779,7 +1779,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       }
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="grouped equal width fields"
@@ -1957,7 +1957,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -2003,7 +2003,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -2049,7 +2049,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -2095,7 +2095,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -3252,7 +3252,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
@@ -3280,7 +3280,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="grouped equal width fields"
@@ -3314,7 +3314,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -3359,7 +3359,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -3404,7 +3404,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -3461,7 +3461,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -3506,7 +3506,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-array"
+              className="field-array"
             >
               <div
                 className="grouped equal width fields"
@@ -3708,7 +3708,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="grouped equal width fields"
@@ -3734,7 +3734,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -3780,7 +3780,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -3826,7 +3826,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -3880,7 +3880,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       }
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="grouped equal width fields"
@@ -5024,7 +5024,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       }
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="grouped equal width fields"
@@ -5202,7 +5202,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -5248,7 +5248,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -5294,7 +5294,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -5340,7 +5340,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -5386,7 +5386,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -6543,7 +6543,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
@@ -6571,7 +6571,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="grouped equal width fields"
@@ -6605,7 +6605,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -6650,7 +6650,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -6695,7 +6695,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -6752,7 +6752,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -6797,7 +6797,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-array"
+              className="field-array"
             >
               <div
                 className="grouped equal width fields"
@@ -6999,7 +6999,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="grouped equal width fields"
@@ -7025,7 +7025,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -7071,7 +7071,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -7117,7 +7117,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -7171,7 +7171,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       }
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="grouped equal width fields"
@@ -8315,7 +8315,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       }
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="grouped equal width fields"
@@ -8493,7 +8493,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -8549,7 +8549,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
@@ -8577,7 +8577,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="grouped equal width fields"
@@ -8611,7 +8611,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -8656,7 +8656,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -8701,7 +8701,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -8758,7 +8758,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="grouped equal width fields"
@@ -8803,7 +8803,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             }
           >
             <div
-              className="form-group field field-array"
+              className="field-array"
             >
               <div
                 className="grouped equal width fields"
@@ -9005,7 +9005,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="grouped equal width fields"
@@ -9031,7 +9031,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -9077,7 +9077,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -9123,7 +9123,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     }
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="grouped equal width fields"
@@ -9177,7 +9177,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       }
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="grouped equal width fields"
@@ -10321,7 +10321,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       }
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="grouped equal width fields"
@@ -10499,7 +10499,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -10545,7 +10545,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -10591,7 +10591,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -10637,7 +10637,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 }
               >
                 <div
-                  className="form-group field field-string"
+                  className="field-string"
                 >
                   <div
                     className="grouped equal width fields"
@@ -11794,7 +11794,7 @@ exports[`Three even column grid renders person and address in three columns, no 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
@@ -11818,7 +11818,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-object"
+            className="field-object"
           >
             <div
               className="grouped equal width fields"
@@ -11842,7 +11842,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="grouped equal width fields"
@@ -11887,7 +11887,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="grouped equal width fields"
@@ -11932,7 +11932,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="grouped equal width fields"
@@ -11977,7 +11977,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="grouped equal width fields"
@@ -12022,7 +12022,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-array"
+            className="field-array"
           >
             <div
               className="grouped equal width fields"
@@ -12218,7 +12218,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="grouped equal width fields"
@@ -12263,7 +12263,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="grouped equal width fields"
@@ -12308,7 +12308,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="grouped equal width fields"
@@ -12353,7 +12353,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="grouped equal width fields"
@@ -13516,7 +13516,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
@@ -13540,7 +13540,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-object"
+            className="field-object"
           >
             <div
               className="grouped equal width fields"
@@ -13564,7 +13564,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="grouped equal width fields"
@@ -13609,7 +13609,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="grouped equal width fields"
@@ -13654,7 +13654,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="grouped equal width fields"
@@ -13699,7 +13699,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="grouped equal width fields"
@@ -13744,7 +13744,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-array"
+            className="field-array"
           >
             <div
               className="grouped equal width fields"
@@ -13940,7 +13940,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="grouped equal width fields"
@@ -13985,7 +13985,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="grouped equal width fields"
@@ -14030,7 +14030,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="grouped equal width fields"
@@ -14075,7 +14075,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           }
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="grouped equal width fields"

--- a/packages/semantic-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Object.test.tsx.snap
@@ -7,13 +7,13 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="ui equal width grid"
@@ -158,13 +158,13 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="grouped equal width fields"
@@ -199,7 +199,7 @@ exports[`object fields object 1`] = `
         </div>
       </div>
       <div
-        className="form-group field field-number"
+        className="field-number"
       >
         <div
           className="grouped equal width fields"
@@ -253,13 +253,13 @@ exports[`object fields show add button and fields if additionalProperties is tru
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="ui equal width grid"
@@ -404,7 +404,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
@@ -422,7 +422,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
         a test description
       </p>
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="ui equal width grid"
@@ -567,7 +567,7 @@ exports[`object fields with title and description from both additionalProperties
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
@@ -585,7 +585,7 @@ exports[`object fields with title and description from both additionalProperties
         a fancier description
       </p>
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="ui equal width grid"
@@ -730,7 +730,7 @@ exports[`object fields with title and description from both object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
@@ -748,7 +748,7 @@ exports[`object fields with title and description from both object 1`] = `
         a fancier description
       </p>
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="grouped equal width fields"
@@ -789,7 +789,7 @@ exports[`object fields with title and description from both object 1`] = `
         </div>
       </div>
       <div
-        className="form-group field field-number"
+        className="field-number"
       >
         <div
           className="grouped equal width fields"
@@ -849,7 +849,7 @@ exports[`object fields with title and description from uiSchema additionalProper
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
@@ -867,7 +867,7 @@ exports[`object fields with title and description from uiSchema additionalProper
         a fancier description
       </p>
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="ui equal width grid"
@@ -1012,7 +1012,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
@@ -1030,7 +1030,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
         a fancier description
       </p>
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="grouped equal width fields"
@@ -1071,7 +1071,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
         </div>
       </div>
       <div
-        className="form-group field field-number"
+        className="field-number"
       >
         <div
           className="grouped equal width fields"
@@ -1131,7 +1131,7 @@ exports[`object fields with title and description from uiSchema show add button 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
@@ -1149,7 +1149,7 @@ exports[`object fields with title and description from uiSchema show add button 
         a fancier description
       </p>
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="ui equal width grid"
@@ -1294,7 +1294,7 @@ exports[`object fields with title and description object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
@@ -1312,7 +1312,7 @@ exports[`object fields with title and description object 1`] = `
         a test description
       </p>
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="grouped equal width fields"
@@ -1353,7 +1353,7 @@ exports[`object fields with title and description object 1`] = `
         </div>
       </div>
       <div
-        className="form-group field field-number"
+        className="field-number"
       >
         <div
           className="grouped equal width fields"
@@ -1413,7 +1413,7 @@ exports[`object fields with title and description show add button and fields if 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
@@ -1431,7 +1431,7 @@ exports[`object fields with title and description show add button and fields if 
         a test description
       </p>
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="ui equal width grid"
@@ -1576,13 +1576,13 @@ exports[`object fields with title and description with global label off addition
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="ui equal width grid"
@@ -1722,13 +1722,13 @@ exports[`object fields with title and description with global label off object 1
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="grouped equal width fields"
@@ -1758,7 +1758,7 @@ exports[`object fields with title and description with global label off object 1
         </div>
       </div>
       <div
-        className="form-group field field-number"
+        className="field-number"
       >
         <div
           className="grouped equal width fields"
@@ -1807,13 +1807,13 @@ exports[`object fields with title and description with global label off show add
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="form-group field field-string"
+        className="field-string"
       >
         <div
           className="ui equal width grid"

--- a/packages/semantic-ui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Object.test.tsx.snap
@@ -7,13 +7,13 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="ui equal width grid"
@@ -94,7 +94,7 @@ exports[`object fields additionalProperties 1`] = `
               className="column"
             >
               <button
-                className="ui mini icon button array-item-remove"
+                className="ui mini icon button rjsf-object-property-remove"
                 id="root_foo__remove"
                 onClick={[Function]}
                 title="Remove"
@@ -125,7 +125,7 @@ exports[`object fields additionalProperties 1`] = `
             }
           >
             <button
-              className="ui tiny icon button object-property-expand"
+              className="ui tiny icon button rjsf-object-property-expand"
               id="root__add"
               onClick={[Function]}
               title="Add Item"
@@ -158,13 +158,13 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="grouped equal width fields"
@@ -199,7 +199,7 @@ exports[`object fields object 1`] = `
         </div>
       </div>
       <div
-        className="field-number"
+        className="rjsf-field rjsf-field-number"
       >
         <div
           className="grouped equal width fields"
@@ -253,13 +253,13 @@ exports[`object fields show add button and fields if additionalProperties is tru
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="ui equal width grid"
@@ -340,7 +340,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
               className="column"
             >
               <button
-                className="ui mini icon button array-item-remove"
+                className="ui mini icon button rjsf-object-property-remove"
                 id="root_additionalProperty__remove"
                 onClick={[Function]}
                 title="Remove"
@@ -371,7 +371,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
             }
           >
             <button
-              className="ui tiny icon button object-property-expand"
+              className="ui tiny icon button rjsf-object-property-expand"
               id="root__add"
               onClick={[Function]}
               title="Add Item"
@@ -404,7 +404,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
@@ -422,7 +422,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
         a test description
       </p>
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="ui equal width grid"
@@ -503,7 +503,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
               className="column"
             >
               <button
-                className="ui mini icon button array-item-remove"
+                className="ui mini icon button rjsf-object-property-remove"
                 id="root_foo__remove"
                 onClick={[Function]}
                 title="Remove"
@@ -534,7 +534,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
             }
           >
             <button
-              className="ui tiny icon button object-property-expand"
+              className="ui tiny icon button rjsf-object-property-expand"
               id="root__add"
               onClick={[Function]}
               title="Add Item"
@@ -567,7 +567,7 @@ exports[`object fields with title and description from both additionalProperties
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
@@ -585,7 +585,7 @@ exports[`object fields with title and description from both additionalProperties
         a fancier description
       </p>
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="ui equal width grid"
@@ -666,7 +666,7 @@ exports[`object fields with title and description from both additionalProperties
               className="column"
             >
               <button
-                className="ui mini icon button array-item-remove"
+                className="ui mini icon button rjsf-object-property-remove"
                 id="root_foo__remove"
                 onClick={[Function]}
                 title="Remove"
@@ -697,7 +697,7 @@ exports[`object fields with title and description from both additionalProperties
             }
           >
             <button
-              className="ui tiny icon button object-property-expand"
+              className="ui tiny icon button rjsf-object-property-expand"
               id="root__add"
               onClick={[Function]}
               title="Add Item"
@@ -730,7 +730,7 @@ exports[`object fields with title and description from both object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
@@ -748,7 +748,7 @@ exports[`object fields with title and description from both object 1`] = `
         a fancier description
       </p>
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="grouped equal width fields"
@@ -789,7 +789,7 @@ exports[`object fields with title and description from both object 1`] = `
         </div>
       </div>
       <div
-        className="field-number"
+        className="rjsf-field rjsf-field-number"
       >
         <div
           className="grouped equal width fields"
@@ -849,7 +849,7 @@ exports[`object fields with title and description from uiSchema additionalProper
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
@@ -867,7 +867,7 @@ exports[`object fields with title and description from uiSchema additionalProper
         a fancier description
       </p>
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="ui equal width grid"
@@ -948,7 +948,7 @@ exports[`object fields with title and description from uiSchema additionalProper
               className="column"
             >
               <button
-                className="ui mini icon button array-item-remove"
+                className="ui mini icon button rjsf-object-property-remove"
                 id="root_foo__remove"
                 onClick={[Function]}
                 title="Remove"
@@ -979,7 +979,7 @@ exports[`object fields with title and description from uiSchema additionalProper
             }
           >
             <button
-              className="ui tiny icon button object-property-expand"
+              className="ui tiny icon button rjsf-object-property-expand"
               id="root__add"
               onClick={[Function]}
               title="Add Item"
@@ -1012,7 +1012,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
@@ -1030,7 +1030,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
         a fancier description
       </p>
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="grouped equal width fields"
@@ -1071,7 +1071,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
         </div>
       </div>
       <div
-        className="field-number"
+        className="rjsf-field rjsf-field-number"
       >
         <div
           className="grouped equal width fields"
@@ -1131,7 +1131,7 @@ exports[`object fields with title and description from uiSchema show add button 
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
@@ -1149,7 +1149,7 @@ exports[`object fields with title and description from uiSchema show add button 
         a fancier description
       </p>
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="ui equal width grid"
@@ -1230,7 +1230,7 @@ exports[`object fields with title and description from uiSchema show add button 
               className="column"
             >
               <button
-                className="ui mini icon button array-item-remove"
+                className="ui mini icon button rjsf-object-property-remove"
                 id="root_additionalProperty__remove"
                 onClick={[Function]}
                 title="Remove"
@@ -1261,7 +1261,7 @@ exports[`object fields with title and description from uiSchema show add button 
             }
           >
             <button
-              className="ui tiny icon button object-property-expand"
+              className="ui tiny icon button rjsf-object-property-expand"
               id="root__add"
               onClick={[Function]}
               title="Add Item"
@@ -1294,7 +1294,7 @@ exports[`object fields with title and description object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
@@ -1312,7 +1312,7 @@ exports[`object fields with title and description object 1`] = `
         a test description
       </p>
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="grouped equal width fields"
@@ -1353,7 +1353,7 @@ exports[`object fields with title and description object 1`] = `
         </div>
       </div>
       <div
-        className="field-number"
+        className="rjsf-field rjsf-field-number"
       >
         <div
           className="grouped equal width fields"
@@ -1413,7 +1413,7 @@ exports[`object fields with title and description show add button and fields if 
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
@@ -1431,7 +1431,7 @@ exports[`object fields with title and description show add button and fields if 
         a test description
       </p>
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="ui equal width grid"
@@ -1512,7 +1512,7 @@ exports[`object fields with title and description show add button and fields if 
               className="column"
             >
               <button
-                className="ui mini icon button array-item-remove"
+                className="ui mini icon button rjsf-object-property-remove"
                 id="root_additionalProperty__remove"
                 onClick={[Function]}
                 title="Remove"
@@ -1543,7 +1543,7 @@ exports[`object fields with title and description show add button and fields if 
             }
           >
             <button
-              className="ui tiny icon button object-property-expand"
+              className="ui tiny icon button rjsf-object-property-expand"
               id="root__add"
               onClick={[Function]}
               title="Add Item"
@@ -1576,13 +1576,13 @@ exports[`object fields with title and description with global label off addition
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="ui equal width grid"
@@ -1658,7 +1658,7 @@ exports[`object fields with title and description with global label off addition
               className="column"
             >
               <button
-                className="ui mini icon button array-item-remove"
+                className="ui mini icon button rjsf-object-property-remove"
                 id="root_foo__remove"
                 onClick={[Function]}
                 title="Remove"
@@ -1689,7 +1689,7 @@ exports[`object fields with title and description with global label off addition
             }
           >
             <button
-              className="ui tiny icon button object-property-expand"
+              className="ui tiny icon button rjsf-object-property-expand"
               id="root__add"
               onClick={[Function]}
               title="Add Item"
@@ -1722,13 +1722,13 @@ exports[`object fields with title and description with global label off object 1
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="grouped equal width fields"
@@ -1758,7 +1758,7 @@ exports[`object fields with title and description with global label off object 1
         </div>
       </div>
       <div
-        className="field-number"
+        className="rjsf-field rjsf-field-number"
       >
         <div
           className="grouped equal width fields"
@@ -1807,13 +1807,13 @@ exports[`object fields with title and description with global label off show add
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="grouped equal width fields"
     >
       <div
-        className="field-string"
+        className="rjsf-field rjsf-field-string"
       >
         <div
           className="ui equal width grid"
@@ -1889,7 +1889,7 @@ exports[`object fields with title and description with global label off show add
               className="column"
             >
               <button
-                className="ui mini icon button array-item-remove"
+                className="ui mini icon button rjsf-object-property-remove"
                 id="root_additionalProperty__remove"
                 onClick={[Function]}
                 title="Remove"
@@ -1920,7 +1920,7 @@ exports[`object fields with title and description with global label off show add
             }
           >
             <button
-              className="ui tiny icon button object-property-expand"
+              className="ui tiny icon button rjsf-object-property-expand"
               id="root__add"
               onClick={[Function]}
               title="Add Item"

--- a/packages/shadcn/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/shadcn/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -68,7 +68,7 @@ export default function ArrayFieldTemplate<
               <div className='mt-2 flex'>
                 <AddButton
                   id={buttonId<T>(idSchema, 'add')}
-                  className='array-item-add'
+                  className='rjsf-array-item-add'
                   onClick={onAddClick}
                   disabled={disabled || readonly}
                   uiSchema={uiSchema}

--- a/packages/shadcn/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/shadcn/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -78,7 +78,7 @@ export default function ObjectFieldTemplate<
             id={buttonId<T>(idSchema, 'add')}
             onClick={onAddClick(schema)}
             disabled={disabled || readonly}
-            className='object-property-expand'
+            className='rjsf-object-property-expand'
             uiSchema={uiSchema}
             registry={registry}
           />

--- a/packages/shadcn/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
+++ b/packages/shadcn/src/WrapIfAdditionalTemplate/WrapIfAdditionalTemplate.tsx
@@ -80,7 +80,7 @@ export default function WrapIfAdditionalTemplate<
         <RemoveButton
           id={buttonId<T>(id, 'remove')}
           iconType='block'
-          className='w-full'
+          className='rjsf-object-property-remove w-full'
           disabled={disabled || readonly}
           onClick={onDropPropertyClick(label)}
           uiSchema={uiSchema}

--- a/packages/shadcn/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/shadcn/test/__snapshots__/Array.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -89,7 +89,7 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -112,7 +112,7 @@ exports[`array fields array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -153,7 +153,7 @@ exports[`array fields array icons 1`] = `
                       className="flex gap-2"
                     >
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-up"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-up"
                         disabled={true}
                         id="root_0__moveUp"
                         onClick={[Function]}
@@ -178,7 +178,7 @@ exports[`array fields array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-down"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-down"
                         disabled={false}
                         id="root_0__moveDown"
                         onClick={[Function]}
@@ -203,7 +203,7 @@ exports[`array fields array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-copy"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-copy"
                         disabled={false}
                         id="root_0__copy"
                         onClick={[Function]}
@@ -290,7 +290,7 @@ exports[`array fields array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -331,7 +331,7 @@ exports[`array fields array icons 1`] = `
                       className="flex gap-2"
                     >
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-up"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-up"
                         disabled={false}
                         id="root_1__moveUp"
                         onClick={[Function]}
@@ -356,7 +356,7 @@ exports[`array fields array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-down"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-down"
                         disabled={true}
                         id="root_1__moveDown"
                         onClick={[Function]}
@@ -381,7 +381,7 @@ exports[`array fields array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-copy"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-copy"
                         disabled={false}
                         id="root_1__copy"
                         onClick={[Function]}
@@ -527,7 +527,7 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -618,7 +618,7 @@ exports[`array fields empty errors array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -634,7 +634,7 @@ exports[`array fields empty errors array 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -691,7 +691,7 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -714,7 +714,7 @@ exports[`array fields fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -761,7 +761,7 @@ exports[`array fields fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -874,7 +874,7 @@ exports[`array fields has errors 1`] = `
     </div>
   </div>
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -890,7 +890,7 @@ exports[`array fields has errors 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -957,7 +957,7 @@ exports[`array fields no errors 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -973,7 +973,7 @@ exports[`array fields no errors 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1030,7 +1030,7 @@ exports[`with title and description array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -1139,7 +1139,7 @@ exports[`with title and description array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -1189,7 +1189,7 @@ exports[`with title and description array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -1243,7 +1243,7 @@ exports[`with title and description array icons 1`] = `
                       className="flex gap-2"
                     >
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-up"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-up"
                         disabled={true}
                         id="root_0__moveUp"
                         onClick={[Function]}
@@ -1268,7 +1268,7 @@ exports[`with title and description array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-down"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-down"
                         disabled={false}
                         id="root_0__moveDown"
                         onClick={[Function]}
@@ -1293,7 +1293,7 @@ exports[`with title and description array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-copy"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-copy"
                         disabled={false}
                         id="root_0__copy"
                         onClick={[Function]}
@@ -1380,7 +1380,7 @@ exports[`with title and description array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -1434,7 +1434,7 @@ exports[`with title and description array icons 1`] = `
                       className="flex gap-2"
                     >
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-up"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-up"
                         disabled={false}
                         id="root_1__moveUp"
                         onClick={[Function]}
@@ -1459,7 +1459,7 @@ exports[`with title and description array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-down"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-down"
                         disabled={true}
                         id="root_1__moveDown"
                         onClick={[Function]}
@@ -1484,7 +1484,7 @@ exports[`with title and description array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-copy"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-copy"
                         disabled={false}
                         id="root_1__copy"
                         onClick={[Function]}
@@ -1630,7 +1630,7 @@ exports[`with title and description checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -1735,7 +1735,7 @@ exports[`with title and description fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -1785,7 +1785,7 @@ exports[`with title and description fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -1845,7 +1845,7 @@ exports[`with title and description fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -1923,7 +1923,7 @@ exports[`with title and description from both array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -2032,7 +2032,7 @@ exports[`with title and description from both array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -2082,7 +2082,7 @@ exports[`with title and description from both array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -2136,7 +2136,7 @@ exports[`with title and description from both array icons 1`] = `
                       className="flex gap-2"
                     >
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-up"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-up"
                         disabled={true}
                         id="root_0__moveUp"
                         onClick={[Function]}
@@ -2161,7 +2161,7 @@ exports[`with title and description from both array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-down"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-down"
                         disabled={false}
                         id="root_0__moveDown"
                         onClick={[Function]}
@@ -2186,7 +2186,7 @@ exports[`with title and description from both array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-copy"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-copy"
                         disabled={false}
                         id="root_0__copy"
                         onClick={[Function]}
@@ -2273,7 +2273,7 @@ exports[`with title and description from both array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -2327,7 +2327,7 @@ exports[`with title and description from both array icons 1`] = `
                       className="flex gap-2"
                     >
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-up"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-up"
                         disabled={false}
                         id="root_1__moveUp"
                         onClick={[Function]}
@@ -2352,7 +2352,7 @@ exports[`with title and description from both array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-down"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-down"
                         disabled={true}
                         id="root_1__moveDown"
                         onClick={[Function]}
@@ -2377,7 +2377,7 @@ exports[`with title and description from both array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-copy"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-copy"
                         disabled={false}
                         id="root_1__copy"
                         onClick={[Function]}
@@ -2523,7 +2523,7 @@ exports[`with title and description from both checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -2628,7 +2628,7 @@ exports[`with title and description from both fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -2678,7 +2678,7 @@ exports[`with title and description from both fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -2738,7 +2738,7 @@ exports[`with title and description from both fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -2816,7 +2816,7 @@ exports[`with title and description from uiSchema array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -2925,7 +2925,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -2975,7 +2975,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -3029,7 +3029,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                       className="flex gap-2"
                     >
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-up"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-up"
                         disabled={true}
                         id="root_0__moveUp"
                         onClick={[Function]}
@@ -3054,7 +3054,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-down"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-down"
                         disabled={false}
                         id="root_0__moveDown"
                         onClick={[Function]}
@@ -3079,7 +3079,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-copy"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-copy"
                         disabled={false}
                         id="root_0__copy"
                         onClick={[Function]}
@@ -3166,7 +3166,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -3220,7 +3220,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                       className="flex gap-2"
                     >
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-up"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-up"
                         disabled={false}
                         id="root_1__moveUp"
                         onClick={[Function]}
@@ -3245,7 +3245,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-down"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-down"
                         disabled={true}
                         id="root_1__moveDown"
                         onClick={[Function]}
@@ -3270,7 +3270,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-copy"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-copy"
                         disabled={false}
                         id="root_1__copy"
                         onClick={[Function]}
@@ -3416,7 +3416,7 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -3521,7 +3521,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -3571,7 +3571,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -3631,7 +3631,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -3709,7 +3709,7 @@ exports[`with title and description with global label off array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -3791,7 +3791,7 @@ exports[`with title and description with global label off array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -3814,7 +3814,7 @@ exports[`with title and description with global label off array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -3849,7 +3849,7 @@ exports[`with title and description with global label off array icons 1`] = `
                       className="flex gap-2"
                     >
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-up"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-up"
                         disabled={true}
                         id="root_0__moveUp"
                         onClick={[Function]}
@@ -3874,7 +3874,7 @@ exports[`with title and description with global label off array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-down"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-down"
                         disabled={false}
                         id="root_0__moveDown"
                         onClick={[Function]}
@@ -3899,7 +3899,7 @@ exports[`with title and description with global label off array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-copy"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-copy"
                         disabled={false}
                         id="root_0__copy"
                         onClick={[Function]}
@@ -3986,7 +3986,7 @@ exports[`with title and description with global label off array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -4021,7 +4021,7 @@ exports[`with title and description with global label off array icons 1`] = `
                       className="flex gap-2"
                     >
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-up"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-up"
                         disabled={false}
                         id="root_1__moveUp"
                         onClick={[Function]}
@@ -4046,7 +4046,7 @@ exports[`with title and description with global label off array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-move-down"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-move-down"
                         disabled={true}
                         id="root_1__moveDown"
                         onClick={[Function]}
@@ -4071,7 +4071,7 @@ exports[`with title and description with global label off array icons 1`] = `
                         </svg>
                       </button>
                       <button
-                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 array-item-copy"
+                        className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground h-9 w-9 rjsf-array-item-copy"
                         disabled={false}
                         id="root_1__copy"
                         onClick={[Function]}
@@ -4217,7 +4217,7 @@ exports[`with title and description with global label off checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -4322,7 +4322,7 @@ exports[`with title and description with global label off fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -4345,7 +4345,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -4386,7 +4386,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="field-number"
+                      className="rjsf-field rjsf-field-number"
                     >
                       <div
                         className="flex flex-col gap-2"

--- a/packages/shadcn/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/shadcn/test/__snapshots__/Array.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`array fields array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -89,7 +89,7 @@ exports[`array fields array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -112,7 +112,7 @@ exports[`array fields array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -290,7 +290,7 @@ exports[`array fields array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -527,7 +527,7 @@ exports[`array fields checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -618,7 +618,7 @@ exports[`array fields empty errors array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -634,7 +634,7 @@ exports[`array fields empty errors array 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -691,7 +691,7 @@ exports[`array fields fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -714,7 +714,7 @@ exports[`array fields fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -761,7 +761,7 @@ exports[`array fields fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -874,7 +874,7 @@ exports[`array fields has errors 1`] = `
     </div>
   </div>
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -890,7 +890,7 @@ exports[`array fields has errors 1`] = `
           >
              
             <div
-              className="form-group field field-string field-error has-error has-danger"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -957,7 +957,7 @@ exports[`array fields no errors 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -973,7 +973,7 @@ exports[`array fields no errors 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1030,7 +1030,7 @@ exports[`with title and description array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -1139,7 +1139,7 @@ exports[`with title and description array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -1189,7 +1189,7 @@ exports[`with title and description array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -1380,7 +1380,7 @@ exports[`with title and description array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -1630,7 +1630,7 @@ exports[`with title and description checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -1735,7 +1735,7 @@ exports[`with title and description fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -1785,7 +1785,7 @@ exports[`with title and description fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -1845,7 +1845,7 @@ exports[`with title and description fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -1923,7 +1923,7 @@ exports[`with title and description from both array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -2032,7 +2032,7 @@ exports[`with title and description from both array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -2082,7 +2082,7 @@ exports[`with title and description from both array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -2273,7 +2273,7 @@ exports[`with title and description from both array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -2523,7 +2523,7 @@ exports[`with title and description from both checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -2628,7 +2628,7 @@ exports[`with title and description from both fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -2678,7 +2678,7 @@ exports[`with title and description from both fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -2738,7 +2738,7 @@ exports[`with title and description from both fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -2816,7 +2816,7 @@ exports[`with title and description from uiSchema array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -2925,7 +2925,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -2975,7 +2975,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -3166,7 +3166,7 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -3416,7 +3416,7 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -3521,7 +3521,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -3571,7 +3571,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -3631,7 +3631,7 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -3709,7 +3709,7 @@ exports[`with title and description with global label off array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -3791,7 +3791,7 @@ exports[`with title and description with global label off array icons 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -3814,7 +3814,7 @@ exports[`with title and description with global label off array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -3986,7 +3986,7 @@ exports[`with title and description with global label off array icons 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -4217,7 +4217,7 @@ exports[`with title and description with global label off checkboxes 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -4322,7 +4322,7 @@ exports[`with title and description with global label off fixed array 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -4345,7 +4345,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -4386,7 +4386,7 @@ exports[`with title and description with global label off fixed array 1`] = `
                     className="grow shrink"
                   >
                     <div
-                      className="form-group field field-number"
+                      className="field-number"
                     >
                       <div
                         className="flex flex-col gap-2"

--- a/packages/shadcn/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/shadcn/test/__snapshots__/Array.test.tsx.snap
@@ -890,7 +890,7 @@ exports[`array fields has errors 1`] = `
           >
              
             <div
-              className="rjsf-field rjsf-field-string"
+              className="rjsf-field rjsf-field-string rjsf-field-error"
             >
               <div
                 className="flex flex-col gap-2"

--- a/packages/shadcn/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/shadcn/test/__snapshots__/Form.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <div
       className="flex flex-col gap-2"
@@ -82,7 +82,7 @@ exports[`single fields checkbox field with label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <div
       className="flex flex-col gap-2"
@@ -159,7 +159,7 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -383,7 +383,7 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -399,7 +399,7 @@ exports[`single fields field with description 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -468,7 +468,7 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -484,7 +484,7 @@ exports[`single fields field with description in uiSchema 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -553,7 +553,7 @@ exports[`single fields format color 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -602,7 +602,7 @@ exports[`single fields format date 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -651,7 +651,7 @@ exports[`single fields format datetime 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -700,7 +700,7 @@ exports[`single fields format time 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -797,7 +797,7 @@ exports[`single fields help and error display 1`] = `
     </div>
   </div>
   <div
-    className="form-group field field-string field-error has-error has-danger"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -862,7 +862,7 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -911,7 +911,7 @@ exports[`single fields hidden label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -956,7 +956,7 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-null"
+    className="field-null"
   >
     <div
       className="flex flex-col gap-2"
@@ -986,7 +986,7 @@ exports[`single fields number field 0 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <div
       className="flex flex-col gap-2"
@@ -1036,7 +1036,7 @@ exports[`single fields number field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <div
       className="flex flex-col gap-2"
@@ -1086,7 +1086,7 @@ exports[`single fields password field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -1135,7 +1135,7 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-boolean"
+    className="field-boolean"
   >
     <div
       className="flex flex-col gap-2"
@@ -1278,7 +1278,7 @@ exports[`single fields schema examples 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -1347,7 +1347,7 @@ exports[`single fields select field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -1438,7 +1438,7 @@ exports[`single fields select field multiple choice 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -1529,7 +1529,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -1620,7 +1620,7 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -1843,7 +1843,7 @@ exports[`single fields select field multiple choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -2000,7 +2000,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-array"
+    className="field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -2091,7 +2091,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -2182,7 +2182,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -2326,7 +2326,7 @@ exports[`single fields select field single choice form disabled using radio widg
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -2472,7 +2472,7 @@ exports[`single fields select field single choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -2565,7 +2565,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -2711,7 +2711,7 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-integer"
+    className="field-integer"
   >
     <div
       className="flex flex-col gap-2"
@@ -2808,7 +2808,7 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -2859,7 +2859,7 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -2908,7 +2908,7 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -2957,7 +2957,7 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -3006,7 +3006,7 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -3055,7 +3055,7 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -3104,7 +3104,7 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -3139,7 +3139,7 @@ exports[`single fields title field 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -3196,7 +3196,7 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-undefined"
+    className="field-undefined"
   >
     <div
       className="flex flex-col gap-2"
@@ -3246,7 +3246,7 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-number"
+    className="field-number"
   >
     <div
       className="flex flex-col gap-2"
@@ -3295,7 +3295,7 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-string"
+    className="field-string"
   >
     <div
       className="flex flex-col gap-2"

--- a/packages/shadcn/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/shadcn/test/__snapshots__/Form.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`single fields checkbox field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <div
       className="flex flex-col gap-2"
@@ -82,7 +82,7 @@ exports[`single fields checkbox field with label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <div
       className="flex flex-col gap-2"
@@ -159,7 +159,7 @@ exports[`single fields checkboxes field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -383,7 +383,7 @@ exports[`single fields field with description 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -399,7 +399,7 @@ exports[`single fields field with description 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -468,7 +468,7 @@ exports[`single fields field with description in uiSchema 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -484,7 +484,7 @@ exports[`single fields field with description in uiSchema 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -553,7 +553,7 @@ exports[`single fields format color 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -602,7 +602,7 @@ exports[`single fields format date 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -651,7 +651,7 @@ exports[`single fields format datetime 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -700,7 +700,7 @@ exports[`single fields format time 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -797,7 +797,7 @@ exports[`single fields help and error display 1`] = `
     </div>
   </div>
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -862,7 +862,7 @@ exports[`single fields hidden field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -911,7 +911,7 @@ exports[`single fields hidden label 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -956,7 +956,7 @@ exports[`single fields null field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-null"
+    className="rjsf-field rjsf-field-null"
   >
     <div
       className="flex flex-col gap-2"
@@ -986,7 +986,7 @@ exports[`single fields number field 0 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <div
       className="flex flex-col gap-2"
@@ -1036,7 +1036,7 @@ exports[`single fields number field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <div
       className="flex flex-col gap-2"
@@ -1086,7 +1086,7 @@ exports[`single fields password field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -1135,7 +1135,7 @@ exports[`single fields radio field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-boolean"
+    className="rjsf-field rjsf-field-boolean"
   >
     <div
       className="flex flex-col gap-2"
@@ -1278,7 +1278,7 @@ exports[`single fields schema examples 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -1347,7 +1347,7 @@ exports[`single fields select field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -1438,7 +1438,7 @@ exports[`single fields select field multiple choice 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -1529,7 +1529,7 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -1620,7 +1620,7 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -1843,7 +1843,7 @@ exports[`single fields select field multiple choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -2000,7 +2000,7 @@ exports[`single fields select field multiple choice with labels 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-array"
+    className="rjsf-field rjsf-field-array"
   >
     <div
       className="flex flex-col gap-2"
@@ -2091,7 +2091,7 @@ exports[`single fields select field single choice enumDisabled 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -2182,7 +2182,7 @@ exports[`single fields select field single choice enumDisabled using radio widge
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -2326,7 +2326,7 @@ exports[`single fields select field single choice form disabled using radio widg
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -2472,7 +2472,7 @@ exports[`single fields select field single choice formData 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -2565,7 +2565,7 @@ exports[`single fields select field single choice uiSchema disabled using radio 
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -2711,7 +2711,7 @@ exports[`single fields slider field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-integer"
+    className="rjsf-field rjsf-field-integer"
   >
     <div
       className="flex flex-col gap-2"
@@ -2808,7 +2808,7 @@ exports[`single fields string field format data-url 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -2859,7 +2859,7 @@ exports[`single fields string field format email 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -2908,7 +2908,7 @@ exports[`single fields string field format uri 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -2957,7 +2957,7 @@ exports[`single fields string field regular 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -3006,7 +3006,7 @@ exports[`single fields string field with placeholder 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -3055,7 +3055,7 @@ exports[`single fields textarea field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"
@@ -3104,7 +3104,7 @@ exports[`single fields title field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -3139,7 +3139,7 @@ exports[`single fields title field 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -3196,7 +3196,7 @@ exports[`single fields unsupported field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-undefined"
+    className="rjsf-field rjsf-field-undefined"
   >
     <div
       className="flex flex-col gap-2"
@@ -3246,7 +3246,7 @@ exports[`single fields up/down field 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-number"
+    className="rjsf-field rjsf-field-number"
   >
     <div
       className="flex flex-col gap-2"
@@ -3295,7 +3295,7 @@ exports[`single fields using custom tagName 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-string"
+    className="rjsf-field rjsf-field-string"
   >
     <div
       className="flex flex-col gap-2"

--- a/packages/shadcn/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/shadcn/test/__snapshots__/Form.test.tsx.snap
@@ -797,7 +797,7 @@ exports[`single fields help and error display 1`] = `
     </div>
   </div>
   <div
-    className="rjsf-field rjsf-field-string"
+    className="rjsf-field rjsf-field-string rjsf-field-error"
   >
     <div
       className="flex flex-col gap-2"

--- a/packages/shadcn/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/shadcn/test/__snapshots__/GridSnap.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -25,7 +25,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="flex flex-col gap-2"
@@ -62,7 +62,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -102,7 +102,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -141,7 +141,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -186,7 +186,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -226,7 +226,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-array"
+              className="rjsf-field rjsf-field-array"
             >
               <div
                 className="flex flex-col gap-2"
@@ -502,7 +502,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="flex flex-col gap-2"
@@ -516,7 +516,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -556,7 +556,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -595,7 +595,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -639,7 +639,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="flex flex-col gap-2"
@@ -720,7 +720,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="flex flex-col gap-2"
@@ -961,7 +961,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1001,7 +1001,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1040,7 +1040,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1080,7 +1080,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1179,7 +1179,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -1197,7 +1197,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1234,7 +1234,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1274,7 +1274,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1313,7 +1313,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1358,7 +1358,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1398,7 +1398,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-array"
+              className="rjsf-field rjsf-field-array"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1674,7 +1674,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1688,7 +1688,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -1728,7 +1728,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -1767,7 +1767,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -1811,7 +1811,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="flex flex-col gap-2"
@@ -1892,7 +1892,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="flex flex-col gap-2"
@@ -2133,7 +2133,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2172,7 +2172,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2212,7 +2212,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2251,7 +2251,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2291,7 +2291,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2390,7 +2390,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -2408,7 +2408,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2445,7 +2445,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2485,7 +2485,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2524,7 +2524,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2569,7 +2569,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2609,7 +2609,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-array"
+              className="rjsf-field rjsf-field-array"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2885,7 +2885,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2899,7 +2899,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -2939,7 +2939,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -2978,7 +2978,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -3022,7 +3022,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="flex flex-col gap-2"
@@ -3103,7 +3103,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="flex flex-col gap-2"
@@ -3344,7 +3344,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -3402,7 +3402,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -3420,7 +3420,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="flex flex-col gap-2"
@@ -3457,7 +3457,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -3497,7 +3497,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -3536,7 +3536,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -3581,7 +3581,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -3621,7 +3621,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-array"
+              className="rjsf-field rjsf-field-array"
             >
               <div
                 className="flex flex-col gap-2"
@@ -3897,7 +3897,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-object"
+              className="rjsf-field rjsf-field-object"
             >
               <div
                 className="flex flex-col gap-2"
@@ -3911,7 +3911,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -3951,7 +3951,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -3990,7 +3990,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="field-string"
+                      className="rjsf-field rjsf-field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -4034,7 +4034,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="flex flex-col gap-2"
@@ -4115,7 +4115,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="field-string"
+                        className="rjsf-field rjsf-field-string"
                       >
                         <div
                           className="flex flex-col gap-2"
@@ -4356,7 +4356,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -4396,7 +4396,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -4435,7 +4435,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -4475,7 +4475,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -4574,7 +4574,7 @@ exports[`Three even column grid renders person and address in three columns, no 
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -4588,7 +4588,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-object"
+            className="rjsf-field rjsf-field-object"
           >
             <div
               className="flex flex-col gap-2"
@@ -4620,7 +4620,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -4660,7 +4660,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -4699,7 +4699,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -4739,7 +4739,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -4779,7 +4779,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-array"
+            className="rjsf-field rjsf-field-array"
           >
             <div
               className="flex flex-col gap-2"
@@ -5050,7 +5050,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5090,7 +5090,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5129,7 +5129,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5169,7 +5169,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5271,7 +5271,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -5285,7 +5285,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-object"
+            className="rjsf-field rjsf-field-object"
           >
             <div
               className="flex flex-col gap-2"
@@ -5317,7 +5317,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5357,7 +5357,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5396,7 +5396,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5436,7 +5436,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5476,7 +5476,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-array"
+            className="rjsf-field rjsf-field-array"
           >
             <div
               className="flex flex-col gap-2"
@@ -5747,7 +5747,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5787,7 +5787,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5826,7 +5826,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5866,7 +5866,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="field-string"
+            className="rjsf-field rjsf-field-string"
           >
             <div
               className="flex flex-col gap-2"

--- a/packages/shadcn/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/shadcn/test/__snapshots__/GridSnap.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -25,7 +25,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="flex flex-col gap-2"
@@ -62,7 +62,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -102,7 +102,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -141,7 +141,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -186,7 +186,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -226,7 +226,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-array"
+              className="field-array"
             >
               <div
                 className="flex flex-col gap-2"
@@ -502,7 +502,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="flex flex-col gap-2"
@@ -516,7 +516,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -556,7 +556,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -595,7 +595,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -639,7 +639,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="flex flex-col gap-2"
@@ -720,7 +720,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="flex flex-col gap-2"
@@ -961,7 +961,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1001,7 +1001,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1040,7 +1040,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1080,7 +1080,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1179,7 +1179,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -1197,7 +1197,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1234,7 +1234,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1274,7 +1274,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1313,7 +1313,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1358,7 +1358,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1398,7 +1398,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-array"
+              className="field-array"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1674,7 +1674,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1688,7 +1688,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -1728,7 +1728,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -1767,7 +1767,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -1811,7 +1811,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="flex flex-col gap-2"
@@ -1892,7 +1892,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="flex flex-col gap-2"
@@ -2133,7 +2133,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2172,7 +2172,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2212,7 +2212,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2251,7 +2251,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2291,7 +2291,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2390,7 +2390,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -2408,7 +2408,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2445,7 +2445,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2485,7 +2485,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2524,7 +2524,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2569,7 +2569,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2609,7 +2609,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-array"
+              className="field-array"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2885,7 +2885,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2899,7 +2899,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -2939,7 +2939,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -2978,7 +2978,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -3022,7 +3022,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="flex flex-col gap-2"
@@ -3103,7 +3103,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="flex flex-col gap-2"
@@ -3344,7 +3344,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -3402,7 +3402,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -3420,7 +3420,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="flex flex-col gap-2"
@@ -3457,7 +3457,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -3497,7 +3497,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -3536,7 +3536,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -3581,7 +3581,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -3621,7 +3621,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-array"
+              className="field-array"
             >
               <div
                 className="flex flex-col gap-2"
@@ -3897,7 +3897,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-object"
+              className="field-object"
             >
               <div
                 className="flex flex-col gap-2"
@@ -3911,7 +3911,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -3951,7 +3951,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -3990,7 +3990,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     data-testid="1"
                   >
                     <div
-                      className="form-group field field-string"
+                      className="field-string"
                     >
                       <div
                         className="flex flex-col gap-2"
@@ -4034,7 +4034,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="flex flex-col gap-2"
@@ -4115,7 +4115,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       data-testid="1"
                     >
                       <div
-                        className="form-group field field-string"
+                        className="field-string"
                       >
                         <div
                           className="flex flex-col gap-2"
@@ -4356,7 +4356,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -4396,7 +4396,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -4435,7 +4435,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -4475,7 +4475,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
             data-testid="1"
           >
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -4574,7 +4574,7 @@ exports[`Three even column grid renders person and address in three columns, no 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -4588,7 +4588,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-object"
+            className="field-object"
           >
             <div
               className="flex flex-col gap-2"
@@ -4620,7 +4620,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -4660,7 +4660,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -4699,7 +4699,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -4739,7 +4739,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -4779,7 +4779,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-array"
+            className="field-array"
           >
             <div
               className="flex flex-col gap-2"
@@ -5050,7 +5050,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5090,7 +5090,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5129,7 +5129,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5169,7 +5169,7 @@ exports[`Three even column grid renders person and address in three columns, no 
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5271,7 +5271,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -5285,7 +5285,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-object"
+            className="field-object"
           >
             <div
               className="flex flex-col gap-2"
@@ -5317,7 +5317,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5357,7 +5357,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5396,7 +5396,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5436,7 +5436,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5476,7 +5476,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-array"
+            className="field-array"
           >
             <div
               className="flex flex-col gap-2"
@@ -5747,7 +5747,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5787,7 +5787,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5826,7 +5826,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="flex flex-col gap-2"
@@ -5866,7 +5866,7 @@ exports[`Two even column grid renders person and address in two columns, no empl
           data-testid="1"
         >
           <div
-            className="form-group field field-string"
+            className="field-string"
           >
             <div
               className="flex flex-col gap-2"

--- a/packages/shadcn/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/shadcn/test/__snapshots__/Object.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -23,7 +23,7 @@ exports[`object fields additionalProperties 1`] = `
           >
              
             <div
-              className="flex flex-row items-center gap-2 relative w-full field-string"
+              className="flex flex-row items-center gap-2 relative w-full rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col w-full gap-2 line-clamp-1"
@@ -199,7 +199,7 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -215,7 +215,7 @@ exports[`object fields object 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -258,7 +258,7 @@ exports[`object fields object 1`] = `
           >
              
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <div
                 className="flex flex-col gap-2"
@@ -316,7 +316,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -332,7 +332,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
           >
              
             <div
-              className="flex flex-row items-center gap-2 relative w-full field-string"
+              className="flex flex-row items-center gap-2 relative w-full rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col w-full gap-2 line-clamp-1"
@@ -508,7 +508,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -551,7 +551,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
           >
              
             <div
-              className="flex flex-row items-center gap-2 relative w-full field-string"
+              className="flex flex-row items-center gap-2 relative w-full rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col w-full gap-2 line-clamp-1"
@@ -727,7 +727,7 @@ exports[`object fields with title and description from both additionalProperties
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -770,7 +770,7 @@ exports[`object fields with title and description from both additionalProperties
           >
              
             <div
-              className="flex flex-row items-center gap-2 relative w-full field-string"
+              className="flex flex-row items-center gap-2 relative w-full rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col w-full gap-2 line-clamp-1"
@@ -946,7 +946,7 @@ exports[`object fields with title and description from both object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -989,7 +989,7 @@ exports[`object fields with title and description from both object 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1044,7 +1044,7 @@ exports[`object fields with title and description from both object 1`] = `
           >
              
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1114,7 +1114,7 @@ exports[`object fields with title and description from uiSchema additionalProper
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -1157,7 +1157,7 @@ exports[`object fields with title and description from uiSchema additionalProper
           >
              
             <div
-              className="flex flex-row items-center gap-2 relative w-full field-string"
+              className="flex flex-row items-center gap-2 relative w-full rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col w-full gap-2 line-clamp-1"
@@ -1333,7 +1333,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -1376,7 +1376,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1431,7 +1431,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
           >
              
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1501,7 +1501,7 @@ exports[`object fields with title and description from uiSchema show add button 
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -1544,7 +1544,7 @@ exports[`object fields with title and description from uiSchema show add button 
           >
              
             <div
-              className="flex flex-row items-center gap-2 relative w-full field-string"
+              className="flex flex-row items-center gap-2 relative w-full rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col w-full gap-2 line-clamp-1"
@@ -1720,7 +1720,7 @@ exports[`object fields with title and description object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -1763,7 +1763,7 @@ exports[`object fields with title and description object 1`] = `
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1818,7 +1818,7 @@ exports[`object fields with title and description object 1`] = `
           >
              
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1888,7 +1888,7 @@ exports[`object fields with title and description show add button and fields if 
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -1931,7 +1931,7 @@ exports[`object fields with title and description show add button and fields if 
           >
              
             <div
-              className="flex flex-row items-center gap-2 relative w-full field-string"
+              className="flex flex-row items-center gap-2 relative w-full rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col w-full gap-2 line-clamp-1"
@@ -2107,7 +2107,7 @@ exports[`object fields with title and description with global label off addition
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -2123,7 +2123,7 @@ exports[`object fields with title and description with global label off addition
           >
              
             <div
-              className="flex flex-row items-center gap-2 relative w-full field-string"
+              className="flex flex-row items-center gap-2 relative w-full rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col w-full gap-2 line-clamp-1"
@@ -2293,7 +2293,7 @@ exports[`object fields with title and description with global label off object 1
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -2309,7 +2309,7 @@ exports[`object fields with title and description with global label off object 1
           >
              
             <div
-              className="field-string"
+              className="rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2346,7 +2346,7 @@ exports[`object fields with title and description with global label off object 1
           >
              
             <div
-              className="field-number"
+              className="rjsf-field rjsf-field-number"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2398,7 +2398,7 @@ exports[`object fields with title and description with global label off show add
   onSubmit={[Function]}
 >
   <div
-    className="field-object"
+    className="rjsf-field rjsf-field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -2414,7 +2414,7 @@ exports[`object fields with title and description with global label off show add
           >
              
             <div
-              className="flex flex-row items-center gap-2 relative w-full field-string"
+              className="flex flex-row items-center gap-2 relative w-full rjsf-field rjsf-field-string"
             >
               <div
                 className="flex flex-col w-full gap-2 line-clamp-1"

--- a/packages/shadcn/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/shadcn/test/__snapshots__/Object.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`object fields additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -23,7 +23,7 @@ exports[`object fields additionalProperties 1`] = `
           >
              
             <div
-              className="flex flex-row items-center gap-2 relative w-full form-group field field-string"
+              className="flex flex-row items-center gap-2 relative w-full field-string"
             >
               <div
                 className="flex flex-col w-full gap-2 line-clamp-1"
@@ -199,7 +199,7 @@ exports[`object fields object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -215,7 +215,7 @@ exports[`object fields object 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -258,7 +258,7 @@ exports[`object fields object 1`] = `
           >
              
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <div
                 className="flex flex-col gap-2"
@@ -316,7 +316,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -332,7 +332,7 @@ exports[`object fields show add button and fields if additionalProperties is tru
           >
              
             <div
-              className="flex flex-row items-center gap-2 relative w-full form-group field field-string"
+              className="flex flex-row items-center gap-2 relative w-full field-string"
             >
               <div
                 className="flex flex-col w-full gap-2 line-clamp-1"
@@ -508,7 +508,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -551,7 +551,7 @@ exports[`object fields with title and description additionalProperties 1`] = `
           >
              
             <div
-              className="flex flex-row items-center gap-2 relative w-full form-group field field-string"
+              className="flex flex-row items-center gap-2 relative w-full field-string"
             >
               <div
                 className="flex flex-col w-full gap-2 line-clamp-1"
@@ -727,7 +727,7 @@ exports[`object fields with title and description from both additionalProperties
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -770,7 +770,7 @@ exports[`object fields with title and description from both additionalProperties
           >
              
             <div
-              className="flex flex-row items-center gap-2 relative w-full form-group field field-string"
+              className="flex flex-row items-center gap-2 relative w-full field-string"
             >
               <div
                 className="flex flex-col w-full gap-2 line-clamp-1"
@@ -946,7 +946,7 @@ exports[`object fields with title and description from both object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -989,7 +989,7 @@ exports[`object fields with title and description from both object 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1044,7 +1044,7 @@ exports[`object fields with title and description from both object 1`] = `
           >
              
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1114,7 +1114,7 @@ exports[`object fields with title and description from uiSchema additionalProper
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -1157,7 +1157,7 @@ exports[`object fields with title and description from uiSchema additionalProper
           >
              
             <div
-              className="flex flex-row items-center gap-2 relative w-full form-group field field-string"
+              className="flex flex-row items-center gap-2 relative w-full field-string"
             >
               <div
                 className="flex flex-col w-full gap-2 line-clamp-1"
@@ -1333,7 +1333,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -1376,7 +1376,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1431,7 +1431,7 @@ exports[`object fields with title and description from uiSchema object 1`] = `
           >
              
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1501,7 +1501,7 @@ exports[`object fields with title and description from uiSchema show add button 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -1544,7 +1544,7 @@ exports[`object fields with title and description from uiSchema show add button 
           >
              
             <div
-              className="flex flex-row items-center gap-2 relative w-full form-group field field-string"
+              className="flex flex-row items-center gap-2 relative w-full field-string"
             >
               <div
                 className="flex flex-col w-full gap-2 line-clamp-1"
@@ -1720,7 +1720,7 @@ exports[`object fields with title and description object 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -1763,7 +1763,7 @@ exports[`object fields with title and description object 1`] = `
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1818,7 +1818,7 @@ exports[`object fields with title and description object 1`] = `
           >
              
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <div
                 className="flex flex-col gap-2"
@@ -1888,7 +1888,7 @@ exports[`object fields with title and description show add button and fields if 
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -1931,7 +1931,7 @@ exports[`object fields with title and description show add button and fields if 
           >
              
             <div
-              className="flex flex-row items-center gap-2 relative w-full form-group field field-string"
+              className="flex flex-row items-center gap-2 relative w-full field-string"
             >
               <div
                 className="flex flex-col w-full gap-2 line-clamp-1"
@@ -2107,7 +2107,7 @@ exports[`object fields with title and description with global label off addition
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -2123,7 +2123,7 @@ exports[`object fields with title and description with global label off addition
           >
              
             <div
-              className="flex flex-row items-center gap-2 relative w-full form-group field field-string"
+              className="flex flex-row items-center gap-2 relative w-full field-string"
             >
               <div
                 className="flex flex-col w-full gap-2 line-clamp-1"
@@ -2293,7 +2293,7 @@ exports[`object fields with title and description with global label off object 1
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -2309,7 +2309,7 @@ exports[`object fields with title and description with global label off object 1
           >
              
             <div
-              className="form-group field field-string"
+              className="field-string"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2346,7 +2346,7 @@ exports[`object fields with title and description with global label off object 1
           >
              
             <div
-              className="form-group field field-number"
+              className="field-number"
             >
               <div
                 className="flex flex-col gap-2"
@@ -2398,7 +2398,7 @@ exports[`object fields with title and description with global label off show add
   onSubmit={[Function]}
 >
   <div
-    className="form-group field field-object"
+    className="field-object"
   >
     <div
       className="flex flex-col gap-2"
@@ -2414,7 +2414,7 @@ exports[`object fields with title and description with global label off show add
           >
              
             <div
-              className="flex flex-row items-center gap-2 relative w-full form-group field field-string"
+              className="flex flex-row items-center gap-2 relative w-full field-string"
             >
               <div
                 className="flex flex-col w-full gap-2 line-clamp-1"

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -784,6 +784,8 @@ export type WrapIfAdditionalTemplateProps<
   FieldTemplateProps<T, S, F>,
   | 'id'
   | 'classNames'
+  | 'hideError'
+  | 'rawErrors'
   | 'style'
   | 'label'
   | 'required'

--- a/packages/validator-ajv8/test/createPrecompiledValidator.test.ts
+++ b/packages/validator-ajv8/test/createPrecompiledValidator.test.ts
@@ -15,7 +15,7 @@ type TestType = {
   bar: boolean;
 };
 
-const validateFns = superSchemaFns as ValidatorFunctions;
+const validateFns = superSchemaFns as unknown as ValidatorFunctions;
 const rootSchema = superSchema as unknown as RJSFSchema;
 const mockedValidator = jest.mocked(AJV8PrecompiledValidator);
 

--- a/packages/validator-ajv8/test/precompiledValidator.test.ts
+++ b/packages/validator-ajv8/test/precompiledValidator.test.ts
@@ -20,8 +20,8 @@ import * as superSchemaFns from './harness/superSchema.cjs';
 import * as superSchemaOptionsFns from './harness/superSchemaOptions.cjs';
 import superSchema from './harness/superSchema.json';
 
-const validateFns = superSchemaFns as ValidatorFunctions;
-const validateOptionsFns = superSchemaOptionsFns as ValidatorFunctions;
+const validateFns = superSchemaFns as unknown as ValidatorFunctions;
+const validateOptionsFns = superSchemaOptionsFns as unknown as ValidatorFunctions;
 const rootSchema = superSchema as unknown as RJSFSchema;
 
 describe('AJV8PrecompiledValidator', () => {


### PR DESCRIPTION
### Reasons for making this change

Fixed #2280 by moving marker classes from `SchemaField` to `WrapIfAdditionalTemplate`
- In `@rjsf/utils`, updated `WrapIfAdditionalTemplateProps` to pick up the `hideError` and `rawErrors` props from `FieldTemplateProps`
- In `@rjsf/core`, updated `SchemaField` to move the `form-group` class to the `WrapIfAdditionalTemplate`
  - Also moved the `has-error` and `has-danger` error classes
  - Updated the grid snapshot due to the change
  - Prefixed all rjsf marker classes with `rjsf-`
- Updated the snapshots in other themes due to the removed marker classes
- Updated the `CHANGELOG_v6.md` and `v6x upgrade guide.md` to reflect these changes

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
