### PR TITLE
Fix 4537 by removing exports from package.json files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.24.10
+
+## Dev / docs / playground
+
+- Updated all `package.json` files in the `packages` directories to remove the `exports` blocks, fixing [#4537](https://github.com/rjsf-team/react-jsonschema-form/issues/4537)
 
 # 5.24.9
 

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -5,33 +5,6 @@
   "main": "dist/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
-  "exports": {
-    ".": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    },
-    "./dist": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./dist/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    }
-  },
   "scripts": {
     "compileReplacer": "tsc -p tsconfig.replacer.json",
     "build:ts": "npm run compileReplacer && rimraf ./lib && tsc -b tsconfig.build.json && tsc-alias -p tsconfig.build.json",

--- a/packages/bootstrap-4/package.json
+++ b/packages/bootstrap-4/package.json
@@ -4,33 +4,6 @@
   "main": "dist/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
-  "exports": {
-    ".": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    },
-    "./dist": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./dist/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    }
-  },
   "description": "Bootstrap 4 theme, fields and widgets for react-jsonschema-form",
   "files": [
     "dist",

--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -5,33 +5,6 @@
   "main": "dist/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
-  "exports": {
-    ".": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    },
-    "./dist": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./dist/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    }
-  },
   "files": [
     "dist",
     "lib",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,33 +28,6 @@
   "main": "dist/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
-  "exports": {
-    ".": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    },
-    "./dist": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./dist/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    }
-  },
   "files": [
     "dist",
     "lib",

--- a/packages/fluent-ui/package.json
+++ b/packages/fluent-ui/package.json
@@ -4,33 +4,6 @@
   "main": "dist/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
-  "exports": {
-    ".": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    },
-    "./dist": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./dist/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    }
-  },
   "description": "Fluent UI theme, fields and widgets for react-jsonschema-form",
   "files": [
     "dist",

--- a/packages/fluentui-rc/package.json
+++ b/packages/fluentui-rc/package.json
@@ -27,33 +27,6 @@
   "main": "dist/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
-  "exports": {
-    ".": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    },
-    "./dist": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./dist/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    }
-  },
   "files": [
     "dist",
     "lib",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -5,33 +5,6 @@
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "description": "Material UI 4 theme, fields and widgets for react-jsonschema-form",
-  "exports": {
-    ".": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    },
-    "./dist": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./dist/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    }
-  },
   "files": [
     "dist",
     "lib",

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -5,33 +5,6 @@
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "description": "Material UI 5 theme, fields and widgets for react-jsonschema-form",
-  "exports": {
-    ".": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    },
-    "./dist": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./dist/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    }
-  },
   "files": [
     "dist",
     "lib",

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -5,33 +5,6 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "description": "Semantic UI theme, fields and widgets for react-jsonschema-form",
-  "exports": {
-    ".": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    },
-    "./dist": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./dist/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    }
-  },
   "files": [
     "dist",
     "lib",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,33 +5,6 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "description": "Utility functions for @rjsf/core",
-  "exports": {
-    ".": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    },
-    "./dist": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./dist/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    }
-  },
   "files": [
     "dist",
     "lib",

--- a/packages/validator-ajv8/package.json
+++ b/packages/validator-ajv8/package.json
@@ -5,48 +5,6 @@
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
   "description": "The ajv-8 based validator for @rjsf/core",
-  "exports": {
-    ".": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./compileSchemaValidators": {
-      "require": "./dist/compileSchemaValidators.js",
-      "import": "./lib/compileSchemaValidators.js",
-      "types": "./lib/compileSchemaValidators.d.ts"
-    },
-    "./lib/compileSchemaValidators": {
-      "require": "./dist/compileSchemaValidators.js",
-      "import": "./lib/compileSchemaValidators.js",
-      "types": "./lib/compileSchemaValidators.d.ts"
-    },
-    "./dist/compileSchemaValidators": {
-      "require": "./dist/compileSchemaValidators.js",
-      "import": "./lib/compileSchemaValidators.js",
-      "types": "./lib/compileSchemaValidators.d.ts"
-    },
-    "./lib": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./lib/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    },
-    "./dist": {
-      "require": "./dist/index.js",
-      "import": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "./dist/*.js": {
-      "require": "./dist/*.js",
-      "import": "./lib/*.js",
-      "types": "./lib/*.d.ts"
-    }
-  },
   "files": [
     "dist",
     "lib",


### PR DESCRIPTION
### Reasons for making this change

Fixes #4537 by removing `exports` block from the `package.json` files for each `packages` directory
- Updated all `package.json` files to remove the `exports` block from them
- Updated the `CHANGELOG.md` file accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
