### PR TITLE
Fix markdown in descriptions rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated `DescriptionField` to render the `description` using the `RichDescription` field
 - Updated `FieldTemplate` to move the checkbox implementation into the `CheckboxWidget` adding the `description` for checkboxes
 - Updated `package.json` to make the package publishable
+- Updated `DaisyUIFrameProvider` to extract the bulk of the code into `DaisyUIFrameComponent` to add a `useEffect()` with a cleanup to remove the tailwind styles
 
 ## @rjsf/fluentui-rc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/daisyui
 
 - Updated `DescriptionField` to render the `description` using the `RichDescription` field
-- Updated `FieldTemplate` to render the `description` for checkboxes 
+- Updated `FieldTemplate` to move the checkbox implementation into the `CheckboxWidget` adding the `description` for checkboxes
+- Updated `package.json` to make the package publishable
 
 ## @rjsf/fluentui-rc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,57 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 6.0.0-beta.2
+
+## @rjsf/antd
+
+- Updated `DescriptionField` to render the `description` using the `RichDescription` field
+
+## @rjsf/chakra-ui
+
+- Updated `DescriptionField` to render the `description` using the `RichDescription` field
+
+## @rjsf/core
+
+- Added new `RichDescription` component, refactored from `SchemaField` to support Rich Text descriptions in Markdown format
+- Updated `DescriptionField` to render the `description` using the `RichDescription` field
+
+## @rjsf/daisyui
+
+- Updated `DescriptionField` to render the `description` using the `RichDescription` field
+- Updated `FieldTemplate` to render the `description` for checkboxes 
+
+## @rjsf/fluentui-rc
+
+- Updated `DescriptionField` to render the `description` using the `RichDescription` field
+
+## @rjsf/mui
+
+- Updated `DescriptionField` to render the `description` using the `RichDescription` field
+
+## @rjsf/react-bootstrap
+
+- Updated `DescriptionField` to render the `description` using the `RichDescription` field
+- Updated `CheckboxField` to remove the `checkbox` class that breaks the UI
+
+## @rjsf/semantic-ui
+
+- Updated `DescriptionField` to render the `description` using the `RichDescription` field
+
+## @rjsf/shadcn
+
+- Updated `DescriptionField` to render the `description` using the `RichDescription` field
+
+## @rjsf/utils
+
+- Updated the `description` field in field props to be a `string | ReactElement` and added `enableMarkdownInDescription` to the `GlobalUISchemaOptions` interface
+
+## Dev / docs / playground
+
+- Updated the `snapshot-tests` to disable `getTestId()` for snapshots and updated the `formTests.tsx` to add tests for rich text descriptions for generic fields and the `CheckboxWidget`
+- Updated the `uiSchema.md` to document new `enableMarkdownInDescription` prop
+- Updated the `playground` to move `daisyui` theme choice after `chakra-ui`
+
 # 6.0.0-beta.1
 
 ## @rjsf/antd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Updated the `snapshot-tests` to disable `getTestId()` for snapshots and updated the `formTests.tsx` to add tests for rich text descriptions for generic fields and the `CheckboxWidget`
 - Updated the `uiSchema.md` to document new `enableMarkdownInDescription` prop
-- Updated the `playground` to move `daisyui` theme choice after `chakra-ui`
+- Updated the `playground` to move `daisyui` theme choice after `chakra-ui` and to stop freezing the samples to avoid an `AJV` validation issue
 
 # 6.0.0-beta.1
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,20 @@
 
 ## Supported Themes
 
-- [Ant Design](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/antd)
-- [Bootstrap 3](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/core)
-- [React-Bootstrap (Bootstrap 5)](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/react-bootstrap)
-- [Chakra UI](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/chakra-ui)
-- [Daisy UI](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/daisyui)
-- [Fluent UI 9](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/fluentui-rc)
-- [Material UI 5](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/mui)
-- [Semantic UI](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/semantic-ui)
+- [Ant Design v5](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/antd)
+- [Bootstrap v3](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/core)
+- [Chakra UI v3](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/chakra-ui)
+- [Daisy UI v5](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/daisyui)
+- [Fluent UI v9](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/fluentui-rc)
+- [Material UI v5 & v6](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/mui)
+- [React-Bootstrap (Bootstrap v5)](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/react-bootstrap)
+- [Semantic UI v2](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/semantic-ui)
+- [Shad CN](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/shadcn)
+
+## API Libraries
+
+- [@rjsf/utils](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/utils)
+- [@rjsf/validator-ajv8](https://github.com/rjsf-team/react-jsonschema-form/tree/main/packages/validator-ajv8)
 
 ## Documentation
 

--- a/packages/antd/src/templates/DescriptionField/index.tsx
+++ b/packages/antd/src/templates/DescriptionField/index.tsx
@@ -1,4 +1,5 @@
 import { DescriptionFieldProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
+import { RichDescription } from '@rjsf/core';
 
 /** The `DescriptionField` is the template to use to render the description of a field
  *
@@ -9,9 +10,13 @@ export default function DescriptionField<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: DescriptionFieldProps<T, S, F>) {
-  const { id, description } = props;
+  const { id, description, registry, uiSchema } = props;
   if (!description) {
     return null;
   }
-  return <span id={id}>{description}</span>;
+  return (
+    <span id={id}>
+      <RichDescription description={description} registry={registry} uiSchema={uiSchema} />
+    </span>
+  );
 }

--- a/packages/antd/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Form.test.tsx.snap
@@ -339,6 +339,206 @@ exports[`single fields checkbox field with label 1`] = `
 </form>
 `;
 
+exports[`single fields checkbox field with label and description 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-boolean"
+  >
+    <div
+      className="ant-form-item css-dev-only-do-not-override-1m63z2v"
+    >
+      <div
+        className="ant-row ant-form-item-row css-dev-only-do-not-override-1m63z2v"
+        style={
+          {
+            "rowGap": undefined,
+          }
+        }
+      >
+        <div
+          className="ant-col ant-col-24 ant-form-item-control css-dev-only-do-not-override-1m63z2v"
+          style={{}}
+        >
+          <div
+            className="ant-form-item-control-input"
+          >
+            <div
+              className="ant-form-item-control-input-content"
+            >
+              <label
+                className="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item css-dev-only-do-not-override-1m63z2v"
+                onClick={[Function]}
+                style={{}}
+              >
+                <span
+                  className="ant-checkbox ant-wave-target css-dev-only-do-not-override-1m63z2v"
+                >
+                  <input
+                    aria-describedby="root__error root__description root__help"
+                    autoFocus={false}
+                    checked={false}
+                    className="ant-checkbox-input"
+                    disabled={false}
+                    id="root"
+                    name="root"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    type="checkbox"
+                  />
+                  <span
+                    className="ant-checkbox-inner"
+                  />
+                </span>
+                <span
+                  className="ant-checkbox-label"
+                >
+                  test
+                </span>
+              </label>
+            </div>
+          </div>
+          <div
+            className="ant-form-item-additional"
+            style={{}}
+          >
+            <div
+              className="ant-form-item-extra"
+            >
+              <span
+                id="root__description"
+              >
+                test description
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="ant-btn css-dev-only-do-not-override-1m63z2v ant-btn-submit"
+    disabled={false}
+    onClick={[Function]}
+    style={{}}
+    type="submit"
+  >
+    <span>
+      Submit
+    </span>
+  </button>
+</form>
+`;
+
+exports[`single fields checkbox field with label and rich text description 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-boolean"
+  >
+    <div
+      className="ant-form-item css-dev-only-do-not-override-1m63z2v"
+    >
+      <div
+        className="ant-row ant-form-item-row css-dev-only-do-not-override-1m63z2v"
+        style={
+          {
+            "rowGap": undefined,
+          }
+        }
+      >
+        <div
+          className="ant-col ant-col-24 ant-form-item-control css-dev-only-do-not-override-1m63z2v"
+          style={{}}
+        >
+          <div
+            className="ant-form-item-control-input"
+          >
+            <div
+              className="ant-form-item-control-input-content"
+            >
+              <label
+                className="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item css-dev-only-do-not-override-1m63z2v"
+                onClick={[Function]}
+                style={{}}
+              >
+                <span
+                  className="ant-checkbox ant-wave-target css-dev-only-do-not-override-1m63z2v"
+                >
+                  <input
+                    aria-describedby="root__error root__description root__help"
+                    autoFocus={false}
+                    checked={false}
+                    className="ant-checkbox-input"
+                    disabled={false}
+                    id="root"
+                    name="root"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    type="checkbox"
+                  />
+                  <span
+                    className="ant-checkbox-inner"
+                  />
+                </span>
+                <span
+                  className="ant-checkbox-label"
+                >
+                  test
+                </span>
+              </label>
+            </div>
+          </div>
+          <div
+            className="ant-form-item-additional"
+            style={{}}
+          >
+            <div
+              className="ant-form-item-extra"
+            >
+              <span
+                id="root__description"
+              >
+                <span>
+                  <strong>
+                    test
+                  </strong>
+                   
+                  <strong>
+                    description
+                  </strong>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="ant-btn css-dev-only-do-not-override-1m63z2v ant-btn-submit"
+    disabled={false}
+    onClick={[Function]}
+    style={{}}
+    type="submit"
+  >
+    <span>
+      Submit
+    </span>
+  </button>
+</form>
+`;
+
 exports[`single fields checkboxes field 1`] = `
 <form
   className="rjsf"
@@ -834,6 +1034,336 @@ exports[`single fields field with description in uiSchema 1`] = `
                                   id="root_my-field__description"
                                 >
                                   some other description
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="ant-btn css-dev-only-do-not-override-1m63z2v ant-btn-submit"
+    disabled={false}
+    onClick={[Function]}
+    style={{}}
+    type="submit"
+  >
+    <span>
+      Submit
+    </span>
+  </button>
+</form>
+`;
+
+exports[`single fields field with markdown description 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="ant-form-item css-dev-only-do-not-override-1m63z2v"
+    >
+      <div
+        className="ant-row ant-form-item-row css-dev-only-do-not-override-1m63z2v"
+        style={
+          {
+            "rowGap": undefined,
+          }
+        }
+      >
+        <div
+          className="ant-col ant-col-24 ant-form-item-control css-dev-only-do-not-override-1m63z2v"
+          style={{}}
+        >
+          <div
+            className="ant-form-item-control-input"
+          >
+            <div
+              className="ant-form-item-control-input-content"
+            >
+              <fieldset
+                id="root"
+              >
+                <div
+                  className="ant-row css-dev-only-do-not-override-1m63z2v"
+                  style={
+                    {
+                      "marginLeft": -12,
+                      "marginRight": -12,
+                      "rowGap": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="ant-col ant-col-24 css-dev-only-do-not-override-1m63z2v"
+                    style={
+                      {
+                        "paddingLeft": 12,
+                        "paddingRight": 12,
+                      }
+                    }
+                  >
+                    <div
+                      className="rjsf-field rjsf-field-string"
+                    >
+                      <div
+                        className="ant-form-item css-dev-only-do-not-override-1m63z2v"
+                      >
+                        <div
+                          className="ant-row ant-form-item-row css-dev-only-do-not-override-1m63z2v"
+                          style={
+                            {
+                              "rowGap": undefined,
+                            }
+                          }
+                        >
+                          <div
+                            className="ant-col ant-col-24 ant-form-item-label css-dev-only-do-not-override-1m63z2v"
+                            style={{}}
+                          >
+                            <label
+                              className=""
+                              htmlFor="root_my-field"
+                              title="my-field"
+                            >
+                              my-field
+                            </label>
+                          </div>
+                          <div
+                            className="ant-col ant-col-24 ant-form-item-control css-dev-only-do-not-override-1m63z2v"
+                            style={{}}
+                          >
+                            <div
+                              className="ant-form-item-control-input"
+                            >
+                              <div
+                                className="ant-form-item-control-input-content"
+                              >
+                                <span
+                                  className="ant-input-affix-wrapper css-dev-only-do-not-override-1m63z2v ant-input-outlined"
+                                  onClick={[Function]}
+                                  style={
+                                    {
+                                      "width": "100%",
+                                    }
+                                  }
+                                >
+                                  <input
+                                    aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                                    className="ant-input css-dev-only-do-not-override-1m63z2v"
+                                    disabled={false}
+                                    id="root_my-field"
+                                    name="root_my-field"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onCompositionEnd={[Function]}
+                                    onCompositionStart={[Function]}
+                                    onFocus={[Function]}
+                                    onKeyDown={[Function]}
+                                    onKeyUp={[Function]}
+                                    placeholder=""
+                                    type="text"
+                                    value=""
+                                  />
+                                  <span
+                                    className="ant-input-suffix"
+                                  />
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              className="ant-form-item-additional"
+                              style={{}}
+                            >
+                              <div
+                                className="ant-form-item-extra"
+                              >
+                                <span
+                                  id="root_my-field__description"
+                                >
+                                  <span>
+                                    some 
+                                    <strong>
+                                      Rich
+                                    </strong>
+                                     description
+                                  </span>
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="ant-btn css-dev-only-do-not-override-1m63z2v ant-btn-submit"
+    disabled={false}
+    onClick={[Function]}
+    style={{}}
+    type="submit"
+  >
+    <span>
+      Submit
+    </span>
+  </button>
+</form>
+`;
+
+exports[`single fields field with markdown description in uiSchema 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="ant-form-item css-dev-only-do-not-override-1m63z2v"
+    >
+      <div
+        className="ant-row ant-form-item-row css-dev-only-do-not-override-1m63z2v"
+        style={
+          {
+            "rowGap": undefined,
+          }
+        }
+      >
+        <div
+          className="ant-col ant-col-24 ant-form-item-control css-dev-only-do-not-override-1m63z2v"
+          style={{}}
+        >
+          <div
+            className="ant-form-item-control-input"
+          >
+            <div
+              className="ant-form-item-control-input-content"
+            >
+              <fieldset
+                id="root"
+              >
+                <div
+                  className="ant-row css-dev-only-do-not-override-1m63z2v"
+                  style={
+                    {
+                      "marginLeft": -12,
+                      "marginRight": -12,
+                      "rowGap": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="ant-col ant-col-24 css-dev-only-do-not-override-1m63z2v"
+                    style={
+                      {
+                        "paddingLeft": 12,
+                        "paddingRight": 12,
+                      }
+                    }
+                  >
+                    <div
+                      className="rjsf-field rjsf-field-string"
+                    >
+                      <div
+                        className="ant-form-item css-dev-only-do-not-override-1m63z2v"
+                      >
+                        <div
+                          className="ant-row ant-form-item-row css-dev-only-do-not-override-1m63z2v"
+                          style={
+                            {
+                              "rowGap": undefined,
+                            }
+                          }
+                        >
+                          <div
+                            className="ant-col ant-col-24 ant-form-item-label css-dev-only-do-not-override-1m63z2v"
+                            style={{}}
+                          >
+                            <label
+                              className=""
+                              htmlFor="root_my-field"
+                              title="my-field"
+                            >
+                              my-field
+                            </label>
+                          </div>
+                          <div
+                            className="ant-col ant-col-24 ant-form-item-control css-dev-only-do-not-override-1m63z2v"
+                            style={{}}
+                          >
+                            <div
+                              className="ant-form-item-control-input"
+                            >
+                              <div
+                                className="ant-form-item-control-input-content"
+                              >
+                                <span
+                                  className="ant-input-affix-wrapper css-dev-only-do-not-override-1m63z2v ant-input-outlined"
+                                  onClick={[Function]}
+                                  style={
+                                    {
+                                      "width": "100%",
+                                    }
+                                  }
+                                >
+                                  <input
+                                    aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                                    className="ant-input css-dev-only-do-not-override-1m63z2v"
+                                    disabled={false}
+                                    id="root_my-field"
+                                    name="root_my-field"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onCompositionEnd={[Function]}
+                                    onCompositionStart={[Function]}
+                                    onFocus={[Function]}
+                                    onKeyDown={[Function]}
+                                    onKeyUp={[Function]}
+                                    placeholder=""
+                                    type="text"
+                                    value=""
+                                  />
+                                  <span
+                                    className="ant-input-suffix"
+                                  />
+                                </span>
+                              </div>
+                            </div>
+                            <div
+                              className="ant-form-item-additional"
+                              style={{}}
+                            >
+                              <div
+                                className="ant-form-item-extra"
+                              >
+                                <span
+                                  id="root_my-field__description"
+                                >
+                                  <span>
+                                    some other description
+                                  </span>
                                 </span>
                               </div>
                             </div>

--- a/packages/antd/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/GridSnap.test.tsx.snap
@@ -32,7 +32,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
             >
               <div
                 className="ant-row css-dev-only-do-not-override-1m63z2v"
-                data-testid="0"
                 style={
                   {
                     "rowGap": undefined,
@@ -41,7 +40,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               >
                 <div
                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                  data-testid="0"
                   style={
                     {
                       "rowGap": undefined,
@@ -50,7 +48,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={{}}
                   >
                     <div
@@ -95,7 +92,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                  data-testid="0"
                   style={
                     {
                       "marginLeft": -3,
@@ -106,7 +102,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -189,7 +184,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -272,7 +266,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -356,7 +349,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                  data-testid="0"
                   style={
                     {
                       "marginLeft": -3,
@@ -367,7 +359,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -473,7 +464,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ant-col ant-col-xs-16 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -715,7 +705,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                  data-testid="0"
                   style={
                     {
                       "marginLeft": -3,
@@ -726,7 +715,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -760,7 +748,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                               >
                                 <div
                                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                                  data-testid="0"
                                   style={
                                     {
                                       "rowGap": undefined,
@@ -769,7 +756,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                 >
                                   <div
                                     className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                                    data-testid="1"
                                     style={{}}
                                   >
                                     <div
@@ -847,7 +833,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                   </div>
                                   <div
                                     className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                                    data-testid="1"
                                     style={{}}
                                   >
                                     <div
@@ -925,7 +910,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                   </div>
                                   <div
                                     className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                                    data-testid="1"
                                     style={{}}
                                   >
                                     <div
@@ -1003,7 +987,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                   </div>
                                   <div
                                     className="ant-row css-dev-only-do-not-override-1m63z2v"
-                                    data-testid="0"
                                     style={
                                       {
                                         "marginLeft": -3,
@@ -1014,7 +997,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                   >
                                     <div
                                       className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                                      data-testid="1"
                                       style={
                                         {
                                           "paddingLeft": 3,
@@ -1162,7 +1144,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     </div>
                                     <div
                                       className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                                      data-testid="1"
                                       style={
                                         {
                                           "paddingLeft": 3,
@@ -1254,7 +1235,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -1264,7 +1244,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   >
                     <div
                       className="ant-row css-dev-only-do-not-override-1m63z2v"
-                      data-testid="0"
                       style={
                         {
                           "rowGap": undefined,
@@ -1273,7 +1252,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     >
                       <div
                         className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                        data-testid="1"
                         style={
                           {
                             "margin": "44px 0 30px",
@@ -1421,7 +1399,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                        data-testid="1"
                         style={{}}
                       >
                         <div
@@ -1499,7 +1476,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                        data-testid="1"
                         style={{}}
                       >
                         <div
@@ -1577,7 +1553,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="ant-row css-dev-only-do-not-override-1m63z2v"
-                        data-testid="0"
                         style={
                           {
                             "marginLeft": -3,
@@ -1588,7 +1563,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       >
                         <div
                           className="ant-col ant-col-xs-16 css-dev-only-do-not-override-1m63z2v"
-                          data-testid="1"
                           style={
                             {
                               "paddingLeft": 3,
@@ -1671,7 +1645,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         </div>
                         <div
                           className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                          data-testid="1"
                           style={
                             {
                               "paddingLeft": 3,
@@ -1874,7 +1847,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
             >
               <div
                 className="ant-row css-dev-only-do-not-override-1m63z2v"
-                data-testid="0"
                 style={
                   {
                     "rowGap": undefined,
@@ -1883,7 +1855,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               >
                 <div
                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                  data-testid="0"
                   style={
                     {
                       "rowGap": undefined,
@@ -1892,7 +1863,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={{}}
                   >
                     <div
@@ -1937,7 +1907,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                  data-testid="0"
                   style={
                     {
                       "marginLeft": -3,
@@ -1948,7 +1917,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -2031,7 +1999,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -2114,7 +2081,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -2198,7 +2164,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                  data-testid="0"
                   style={
                     {
                       "marginLeft": -3,
@@ -2209,7 +2174,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -2315,7 +2279,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ant-col ant-col-xs-16 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -2557,7 +2520,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                  data-testid="0"
                   style={
                     {
                       "marginLeft": -3,
@@ -2568,7 +2530,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -2602,7 +2563,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                               >
                                 <div
                                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                                  data-testid="0"
                                   style={
                                     {
                                       "rowGap": undefined,
@@ -2611,7 +2571,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                 >
                                   <div
                                     className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                                    data-testid="1"
                                     style={{}}
                                   >
                                     <div
@@ -2689,7 +2648,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                   </div>
                                   <div
                                     className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                                    data-testid="1"
                                     style={{}}
                                   >
                                     <div
@@ -2767,7 +2725,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                   </div>
                                   <div
                                     className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                                    data-testid="1"
                                     style={{}}
                                   >
                                     <div
@@ -2845,7 +2802,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                   </div>
                                   <div
                                     className="ant-row css-dev-only-do-not-override-1m63z2v"
-                                    data-testid="0"
                                     style={
                                       {
                                         "marginLeft": -3,
@@ -2856,7 +2812,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                   >
                                     <div
                                       className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                                      data-testid="1"
                                       style={
                                         {
                                           "paddingLeft": 3,
@@ -3004,7 +2959,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     </div>
                                     <div
                                       className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                                      data-testid="1"
                                       style={
                                         {
                                           "paddingLeft": 3,
@@ -3096,7 +3050,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -3106,7 +3059,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   >
                     <div
                       className="ant-row css-dev-only-do-not-override-1m63z2v"
-                      data-testid="0"
                       style={
                         {
                           "rowGap": undefined,
@@ -3115,7 +3067,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     >
                       <div
                         className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                        data-testid="1"
                         style={
                           {
                             "margin": "44px 0 30px",
@@ -3263,7 +3214,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                        data-testid="1"
                         style={{}}
                       >
                         <div
@@ -3341,7 +3291,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                        data-testid="1"
                         style={{}}
                       >
                         <div
@@ -3419,7 +3368,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                        data-testid="1"
                         style={{}}
                       >
                         <div
@@ -3497,7 +3445,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="ant-row css-dev-only-do-not-override-1m63z2v"
-                        data-testid="0"
                         style={
                           {
                             "marginLeft": -3,
@@ -3508,7 +3455,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       >
                         <div
                           className="ant-col ant-col-xs-16 css-dev-only-do-not-override-1m63z2v"
-                          data-testid="1"
                           style={
                             {
                               "paddingLeft": 3,
@@ -3591,7 +3537,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         </div>
                         <div
                           className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                          data-testid="1"
                           style={
                             {
                               "paddingLeft": 3,
@@ -3794,7 +3739,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
             >
               <div
                 className="ant-row css-dev-only-do-not-override-1m63z2v"
-                data-testid="0"
                 style={
                   {
                     "rowGap": undefined,
@@ -3803,7 +3747,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               >
                 <div
                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                  data-testid="0"
                   style={
                     {
                       "rowGap": undefined,
@@ -3812,7 +3755,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={{}}
                   >
                     <div
@@ -3857,7 +3799,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                  data-testid="0"
                   style={
                     {
                       "marginLeft": -3,
@@ -3868,7 +3809,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -3951,7 +3891,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -4034,7 +3973,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -4118,7 +4056,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                  data-testid="0"
                   style={
                     {
                       "marginLeft": -3,
@@ -4129,7 +4066,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -4235,7 +4171,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ant-col ant-col-xs-16 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -4477,7 +4412,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                  data-testid="0"
                   style={
                     {
                       "marginLeft": -3,
@@ -4488,7 +4422,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -4522,7 +4455,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                               >
                                 <div
                                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                                  data-testid="0"
                                   style={
                                     {
                                       "rowGap": undefined,
@@ -4531,7 +4463,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                 >
                                   <div
                                     className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                                    data-testid="1"
                                     style={{}}
                                   >
                                     <div
@@ -4609,7 +4540,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                   </div>
                                   <div
                                     className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                                    data-testid="1"
                                     style={{}}
                                   >
                                     <div
@@ -4687,7 +4617,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                   </div>
                                   <div
                                     className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                                    data-testid="1"
                                     style={{}}
                                   >
                                     <div
@@ -4765,7 +4694,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                   </div>
                                   <div
                                     className="ant-row css-dev-only-do-not-override-1m63z2v"
-                                    data-testid="0"
                                     style={
                                       {
                                         "marginLeft": -3,
@@ -4776,7 +4704,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                   >
                                     <div
                                       className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                                      data-testid="1"
                                       style={
                                         {
                                           "paddingLeft": 3,
@@ -4924,7 +4851,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     </div>
                                     <div
                                       className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                                      data-testid="1"
                                       style={
                                         {
                                           "paddingLeft": 3,
@@ -5016,7 +4942,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -5026,7 +4951,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   >
                     <div
                       className="ant-row css-dev-only-do-not-override-1m63z2v"
-                      data-testid="0"
                       style={
                         {
                           "rowGap": undefined,
@@ -5035,7 +4959,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     >
                       <div
                         className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                        data-testid="1"
                         style={
                           {
                             "margin": "44px 0 30px",
@@ -5183,7 +5106,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                        data-testid="1"
                         style={{}}
                       >
                         <div
@@ -5325,7 +5247,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
             >
               <div
                 className="ant-row css-dev-only-do-not-override-1m63z2v"
-                data-testid="0"
                 style={
                   {
                     "rowGap": undefined,
@@ -5334,7 +5255,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               >
                 <div
                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                  data-testid="0"
                   style={
                     {
                       "rowGap": undefined,
@@ -5343,7 +5263,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={{}}
                   >
                     <div
@@ -5388,7 +5307,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                  data-testid="0"
                   style={
                     {
                       "marginLeft": -3,
@@ -5399,7 +5317,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -5482,7 +5399,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -5565,7 +5481,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -5649,7 +5564,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                  data-testid="0"
                   style={
                     {
                       "marginLeft": -3,
@@ -5660,7 +5574,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -5766,7 +5679,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ant-col ant-col-xs-16 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -6008,7 +5920,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                  data-testid="0"
                   style={
                     {
                       "marginLeft": -3,
@@ -6019,7 +5930,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -6053,7 +5963,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                               >
                                 <div
                                   className="ant-row css-dev-only-do-not-override-1m63z2v"
-                                  data-testid="0"
                                   style={
                                     {
                                       "rowGap": undefined,
@@ -6062,7 +5971,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                 >
                                   <div
                                     className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                                    data-testid="1"
                                     style={{}}
                                   >
                                     <div
@@ -6140,7 +6048,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                   </div>
                                   <div
                                     className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                                    data-testid="1"
                                     style={{}}
                                   >
                                     <div
@@ -6218,7 +6125,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                   </div>
                                   <div
                                     className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                                    data-testid="1"
                                     style={{}}
                                   >
                                     <div
@@ -6296,7 +6202,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                   </div>
                                   <div
                                     className="ant-row css-dev-only-do-not-override-1m63z2v"
-                                    data-testid="0"
                                     style={
                                       {
                                         "marginLeft": -3,
@@ -6307,7 +6212,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                   >
                                     <div
                                       className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                                      data-testid="1"
                                       style={
                                         {
                                           "paddingLeft": 3,
@@ -6455,7 +6359,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                                     </div>
                                     <div
                                       className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                                      data-testid="1"
                                       style={
                                         {
                                           "paddingLeft": 3,
@@ -6547,7 +6450,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                    data-testid="1"
                     style={
                       {
                         "paddingLeft": 3,
@@ -6557,7 +6459,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   >
                     <div
                       className="ant-row css-dev-only-do-not-override-1m63z2v"
-                      data-testid="0"
                       style={
                         {
                           "rowGap": undefined,
@@ -6566,7 +6467,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     >
                       <div
                         className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                        data-testid="1"
                         style={
                           {
                             "margin": "44px 0 30px",
@@ -6714,7 +6614,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                        data-testid="1"
                         style={{}}
                       >
                         <div
@@ -6792,7 +6691,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                        data-testid="1"
                         style={{}}
                       >
                         <div
@@ -6870,7 +6768,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="ant-row css-dev-only-do-not-override-1m63z2v"
-                        data-testid="0"
                         style={
                           {
                             "marginLeft": -3,
@@ -6881,7 +6778,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       >
                         <div
                           className="ant-col ant-col-xs-16 css-dev-only-do-not-override-1m63z2v"
-                          data-testid="1"
                           style={
                             {
                               "paddingLeft": 3,
@@ -6964,7 +6860,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                         </div>
                         <div
                           className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                          data-testid="1"
                           style={
                             {
                               "paddingLeft": 3,
@@ -7167,7 +7062,6 @@ exports[`Three even column grid renders person and address in three columns, no 
             >
               <div
                 className="ant-row css-dev-only-do-not-override-1m63z2v"
-                data-testid="0"
                 style={
                   {
                     "rowGap": undefined,
@@ -7176,7 +7070,6 @@ exports[`Three even column grid renders person and address in three columns, no 
               >
                 <div
                   className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -7220,7 +7113,6 @@ exports[`Three even column grid renders person and address in three columns, no 
                 </div>
                 <div
                   className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -7298,7 +7190,6 @@ exports[`Three even column grid renders person and address in three columns, no 
                 </div>
                 <div
                   className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -7376,7 +7267,6 @@ exports[`Three even column grid renders person and address in three columns, no 
                 </div>
                 <div
                   className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -7454,7 +7344,6 @@ exports[`Three even column grid renders person and address in three columns, no 
                 </div>
                 <div
                   className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -7555,7 +7444,6 @@ exports[`Three even column grid renders person and address in three columns, no 
                 </div>
                 <div
                   className="ant-col ant-col-xs-16 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -7791,7 +7679,6 @@ exports[`Three even column grid renders person and address in three columns, no 
                 </div>
                 <div
                   className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -7869,7 +7756,6 @@ exports[`Three even column grid renders person and address in three columns, no 
                 </div>
                 <div
                   className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -7947,7 +7833,6 @@ exports[`Three even column grid renders person and address in three columns, no 
                 </div>
                 <div
                   className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -8025,7 +7910,6 @@ exports[`Three even column grid renders person and address in three columns, no 
                 </div>
                 <div
                   className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -8168,7 +8052,6 @@ exports[`Three even column grid renders person and address in three columns, no 
                 </div>
                 <div
                   className="ant-col ant-col-xs-8 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 />
               </div>
@@ -8224,7 +8107,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
             >
               <div
                 className="ant-row css-dev-only-do-not-override-1m63z2v"
-                data-testid="0"
                 style={
                   {
                     "rowGap": undefined,
@@ -8233,7 +8115,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
               >
                 <div
                   className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -8277,7 +8158,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
                 </div>
                 <div
                   className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -8355,7 +8235,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
                 </div>
                 <div
                   className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -8433,7 +8312,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
                 </div>
                 <div
                   className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -8511,7 +8389,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
                 </div>
                 <div
                   className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -8612,7 +8489,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
                 </div>
                 <div
                   className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -8848,7 +8724,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
                 </div>
                 <div
                   className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -8926,7 +8801,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
                 </div>
                 <div
                   className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -9004,7 +8878,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
                 </div>
                 <div
                   className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -9082,7 +8955,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
                 </div>
                 <div
                   className="ant-col ant-col-xs-12 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 >
                   <div
@@ -9225,7 +9097,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
                 </div>
                 <div
                   className="ant-col ant-col-xs-24 css-dev-only-do-not-override-1m63z2v"
-                  data-testid="1"
                   style={{}}
                 />
               </div>

--- a/packages/chakra-ui/src/ChakraFrameProvider.tsx
+++ b/packages/chakra-ui/src/ChakraFrameProvider.tsx
@@ -29,10 +29,7 @@ export const __createChakraFrameProvider =
     return (
       <div style={{ margin: 2 }}>
         <CacheProvider value={memoizedCreateCacheWithContainer(document.head)}>
-          <ChakraProvider value={defaultSystem}>
-            {/* <CSSReset /> TODO: figrue out styling issues */}
-            {props.children}
-          </ChakraProvider>
+          <ChakraProvider value={defaultSystem}>{props.children}</ChakraProvider>
         </CacheProvider>
       </div>
     );

--- a/packages/chakra-ui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/chakra-ui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -52,7 +52,7 @@ export default function CheckboxWidget<
 
   return (
     <Field mb={1} required={required}>
-      {!hideLabel && !!description && (
+      {!hideLabel && description && (
         <DescriptionFieldTemplate
           id={descriptionId<T>(id)}
           description={description}

--- a/packages/chakra-ui/src/DescriptionField/DescriptionField.tsx
+++ b/packages/chakra-ui/src/DescriptionField/DescriptionField.tsx
@@ -1,22 +1,23 @@
+import { RichDescription } from '@rjsf/core';
 import { DescriptionFieldProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
 import { Text } from '@chakra-ui/react';
 
+/** The `DescriptionField` is the template to use to render the description of a field
+ *
+ * @param props - The `DescriptionFieldProps` for this component
+ */
 export default function DescriptionField<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
->({ description, id }: DescriptionFieldProps<T, S, F>) {
+>({ description, id, registry, uiSchema }: DescriptionFieldProps<T, S, F>) {
   if (!description) {
     return null;
   }
 
-  if (typeof description === 'string') {
-    return (
-      <Text as='sup' fontSize='md' id={id}>
-        {description}
-      </Text>
-    );
-  }
-
-  return <>{description}</>;
+  return (
+    <Text as='sup' fontSize='md' id={id}>
+      <RichDescription description={description} registry={registry} uiSchema={uiSchema} />
+    </Text>
+  );
 }

--- a/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
@@ -716,6 +716,780 @@ exports[`single fields checkbox field with label 1`] = `
 </form>
 `;
 
+exports[`single fields checkbox field with label and description 1`] = `
+@layer recipes {
+  .emotion-0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+  }
+
+  .emotion-0>:not(style, [hidden])~:not(style, [hidden]) {
+    --space-y-reverse: 0;
+    margin-top: calc(var(--chakra-spacing-4) * calc(1 - var(--space-y-reverse)));
+    margin-bottom: calc(var(--chakra-spacing-4) * var(--space-y-reverse));
+  }
+}
+
+@layer recipes {
+  .emotion-1 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+    gap: var(--chakra-spacing-4);
+  }
+}
+
+.emotion-2 {
+  margin-bottom: var(--chakra-spacing-1);
+}
+
+@layer recipes {
+  .emotion-2 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    width: 100%;
+    position: relative;
+    gap: var(--chakra-spacing-1\\.5);
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    -webkit-align-items: flex-start;
+    -webkit-box-align: flex-start;
+    -ms-flex-align: flex-start;
+    align-items: flex-start;
+  }
+}
+
+.emotion-3 {
+  font-size: var(--chakra-font-sizes-md);
+}
+
+@layer recipes {
+  .emotion-4 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    gap: var(--chakra-spacing-2\\.5);
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    vertical-align: top;
+    position: relative;
+  }
+}
+
+@layer recipes {
+  .emotion-5 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    color: var(--chakra-colors-white);
+    border-width: 1px;
+    border-color: var(--chakra-colors-border);
+    border-radius: var(--chakra-radii-l1);
+    --focus-ring-color: var(--chakra-colors-color-palette-focus-ring);
+    width: var(--chakra-sizes-5);
+    height: var(--chakra-sizes-5);
+    padding: var(--chakra-spacing-0\\.5);
+  }
+
+  .emotion-5:is(:focus-visible, [data-focus-visible]) {
+    outline-width: var(--focus-ring-width, 2px);
+    outline-offset: var(--focus-ring-offset, 2px);
+    outline-style: var(--focus-ring-style, solid);
+    outline-color: var(--focus-ring-color);
+  }
+
+  .emotion-5 :where(svg) {
+    width: var(--chakra-sizes-full);
+    height: var(--chakra-sizes-full);
+  }
+
+  .emotion-5:is([data-invalid], [aria-invalid=true], [data-state=invalid]) {
+    --chakra-colors-color-palette-50: var(--chakra-colors-red-50);
+    --chakra-colors-color-palette-100: var(--chakra-colors-red-100);
+    --chakra-colors-color-palette-200: var(--chakra-colors-red-200);
+    --chakra-colors-color-palette-300: var(--chakra-colors-red-300);
+    --chakra-colors-color-palette-400: var(--chakra-colors-red-400);
+    --chakra-colors-color-palette-500: var(--chakra-colors-red-500);
+    --chakra-colors-color-palette-600: var(--chakra-colors-red-600);
+    --chakra-colors-color-palette-700: var(--chakra-colors-red-700);
+    --chakra-colors-color-palette-800: var(--chakra-colors-red-800);
+    --chakra-colors-color-palette-900: var(--chakra-colors-red-900);
+    --chakra-colors-color-palette-950: var(--chakra-colors-red-950);
+    --chakra-colors-color-palette-contrast: var(--chakra-colors-red-contrast);
+    --chakra-colors-color-palette-fg: var(--chakra-colors-red-fg);
+    --chakra-colors-color-palette-subtle: var(--chakra-colors-red-subtle);
+    --chakra-colors-color-palette-muted: var(--chakra-colors-red-muted);
+    --chakra-colors-color-palette-emphasized: var(--chakra-colors-red-emphasized);
+    --chakra-colors-color-palette-solid: var(--chakra-colors-red-solid);
+    --chakra-colors-color-palette-focus-ring: var(--chakra-colors-red-focus-ring);
+    border-color: var(--chakra-colors-border-error);
+  }
+
+  .emotion-5:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+  }
+
+  .emotion-5:is([data-state=checked], [data-state=indeterminate]) {
+    background: var(--chakra-colors-color-palette-solid);
+    --bg-currentcolor: var(--chakra-colors-color-palette-solid);
+    color: var(--chakra-colors-color-palette-contrast);
+    border-color: var(--chakra-colors-color-palette-solid);
+  }
+}
+
+.emotion-6 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 3px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+@layer recipes {
+  .emotion-7 {
+    font-weight: var(--chakra-font-weights-medium);
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    font-size: var(--chakra-font-sizes-sm);
+    line-height: 1.25rem;
+  }
+
+  .emotion-7:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+  }
+}
+
+.emotion-9 {
+  margin-top: var(--chakra-spacing-3);
+}
+
+@layer recipes {
+  .emotion-10 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    position: relative;
+    border-radius: var(--chakra-radii-l2);
+    white-space: nowrap;
+    vertical-align: middle;
+    border-width: 1px;
+    border-color: var(--chakra-colors-transparent);
+    cursor: var(--chakra-cursor-button);
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    outline: 0;
+    line-height: 1.25rem;
+    isolation: isolate;
+    font-weight: var(--chakra-font-weights-medium);
+    transition-property: background-color,border-color,color,fill,stroke,opacity,box-shadow,translate,transform;
+    transition-duration: var(--chakra-durations-moderate);
+    --focus-ring-color: var(--chakra-colors-color-palette-focus-ring);
+    height: var(--chakra-sizes-10);
+    min-width: var(--chakra-sizes-10);
+    font-size: var(--chakra-font-sizes-sm);
+    padding-inline: var(--chakra-spacing-4);
+    gap: var(--chakra-spacing-2);
+    background: var(--chakra-colors-color-palette-solid);
+    --bg-currentcolor: var(--chakra-colors-color-palette-solid);
+    color: var(--chakra-colors-color-palette-contrast);
+  }
+
+  .emotion-10:is(:focus-visible, [data-focus-visible]) {
+    outline-width: var(--focus-ring-width, 2px);
+    outline-offset: var(--focus-ring-offset, 2px);
+    outline-style: var(--focus-ring-style, solid);
+    outline-color: var(--focus-ring-color);
+  }
+
+  .emotion-10:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-10 :where(svg) {
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    width: var(--chakra-sizes-5);
+    height: var(--chakra-sizes-5);
+  }
+
+  .emotion-10:is([aria-expanded=true], [data-expanded], [data-state=expanded]) {
+    --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+    background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+  }
+
+  @media (hover: hover) {
+    .emotion-10:is(:hover, [data-hover]):not(:disabled, [data-disabled]) {
+      --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+      background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+      --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    }
+  }
+}
+
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-boolean"
+  >
+    <fieldset
+      className="fieldset__root emotion-0"
+      data-part="root"
+      data-scope="fieldset"
+      disabled={false}
+    >
+      <div
+        className="fieldset__content emotion-1"
+      >
+        <div
+          className="chakra-field__root emotion-2"
+          data-part="root"
+          data-scope="field"
+          id="field:::r2a:"
+          role="group"
+        >
+          <sup
+            className="emotion-3"
+            id="root__description"
+          >
+            test description
+          </sup>
+          <label
+            aria-describedby="root__error root__description root__help"
+            className="chakra-checkbox__root emotion-4"
+            data-part="root"
+            data-scope="checkbox"
+            data-state="unchecked"
+            dir="ltr"
+            htmlFor=":r2a:"
+            id="checkbox:root"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onPointerLeave={[Function]}
+            onPointerMove={[Function]}
+          >
+            <input
+              aria-invalid={false}
+              aria-labelledby="field:::r2a:::label"
+              defaultChecked={false}
+              disabled={false}
+              id=":r2a:"
+              name="root"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              required={false}
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                  "wordWrap": "normal",
+                }
+              }
+              type="checkbox"
+              value="on"
+            />
+            <div
+              aria-hidden={true}
+              className="chakra-checkbox__control emotion-5"
+              data-part="control"
+              data-scope="checkbox"
+              data-state="unchecked"
+              dir="ltr"
+              id="checkbox:root:control"
+            >
+              <svg
+                className="emotion-6"
+                data-state="unchecked"
+                viewBox="0 0 24 24"
+              />
+            </div>
+            <span
+              className="chakra-checkbox__label emotion-7"
+              data-part="label"
+              data-scope="checkbox"
+              data-state="unchecked"
+              dir="ltr"
+              id="field:::r2a:::label"
+            >
+              <p
+                className="emotion-8"
+              >
+                test
+              </p>
+            </span>
+          </label>
+        </div>
+      </div>
+    </fieldset>
+  </div>
+  <div
+    className="emotion-9"
+  >
+    <button
+      className="chakra-button emotion-10"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields checkbox field with label and rich text description 1`] = `
+@layer recipes {
+  .emotion-0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+  }
+
+  .emotion-0>:not(style, [hidden])~:not(style, [hidden]) {
+    --space-y-reverse: 0;
+    margin-top: calc(var(--chakra-spacing-4) * calc(1 - var(--space-y-reverse)));
+    margin-bottom: calc(var(--chakra-spacing-4) * var(--space-y-reverse));
+  }
+}
+
+@layer recipes {
+  .emotion-1 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+    gap: var(--chakra-spacing-4);
+  }
+}
+
+.emotion-2 {
+  margin-bottom: var(--chakra-spacing-1);
+}
+
+@layer recipes {
+  .emotion-2 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    width: 100%;
+    position: relative;
+    gap: var(--chakra-spacing-1\\.5);
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    -webkit-align-items: flex-start;
+    -webkit-box-align: flex-start;
+    -ms-flex-align: flex-start;
+    align-items: flex-start;
+  }
+}
+
+.emotion-3 {
+  font-size: var(--chakra-font-sizes-md);
+}
+
+@layer recipes {
+  .emotion-4 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    gap: var(--chakra-spacing-2\\.5);
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    vertical-align: top;
+    position: relative;
+  }
+}
+
+@layer recipes {
+  .emotion-5 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    color: var(--chakra-colors-white);
+    border-width: 1px;
+    border-color: var(--chakra-colors-border);
+    border-radius: var(--chakra-radii-l1);
+    --focus-ring-color: var(--chakra-colors-color-palette-focus-ring);
+    width: var(--chakra-sizes-5);
+    height: var(--chakra-sizes-5);
+    padding: var(--chakra-spacing-0\\.5);
+  }
+
+  .emotion-5:is(:focus-visible, [data-focus-visible]) {
+    outline-width: var(--focus-ring-width, 2px);
+    outline-offset: var(--focus-ring-offset, 2px);
+    outline-style: var(--focus-ring-style, solid);
+    outline-color: var(--focus-ring-color);
+  }
+
+  .emotion-5 :where(svg) {
+    width: var(--chakra-sizes-full);
+    height: var(--chakra-sizes-full);
+  }
+
+  .emotion-5:is([data-invalid], [aria-invalid=true], [data-state=invalid]) {
+    --chakra-colors-color-palette-50: var(--chakra-colors-red-50);
+    --chakra-colors-color-palette-100: var(--chakra-colors-red-100);
+    --chakra-colors-color-palette-200: var(--chakra-colors-red-200);
+    --chakra-colors-color-palette-300: var(--chakra-colors-red-300);
+    --chakra-colors-color-palette-400: var(--chakra-colors-red-400);
+    --chakra-colors-color-palette-500: var(--chakra-colors-red-500);
+    --chakra-colors-color-palette-600: var(--chakra-colors-red-600);
+    --chakra-colors-color-palette-700: var(--chakra-colors-red-700);
+    --chakra-colors-color-palette-800: var(--chakra-colors-red-800);
+    --chakra-colors-color-palette-900: var(--chakra-colors-red-900);
+    --chakra-colors-color-palette-950: var(--chakra-colors-red-950);
+    --chakra-colors-color-palette-contrast: var(--chakra-colors-red-contrast);
+    --chakra-colors-color-palette-fg: var(--chakra-colors-red-fg);
+    --chakra-colors-color-palette-subtle: var(--chakra-colors-red-subtle);
+    --chakra-colors-color-palette-muted: var(--chakra-colors-red-muted);
+    --chakra-colors-color-palette-emphasized: var(--chakra-colors-red-emphasized);
+    --chakra-colors-color-palette-solid: var(--chakra-colors-red-solid);
+    --chakra-colors-color-palette-focus-ring: var(--chakra-colors-red-focus-ring);
+    border-color: var(--chakra-colors-border-error);
+  }
+
+  .emotion-5:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+  }
+
+  .emotion-5:is([data-state=checked], [data-state=indeterminate]) {
+    background: var(--chakra-colors-color-palette-solid);
+    --bg-currentcolor: var(--chakra-colors-color-palette-solid);
+    color: var(--chakra-colors-color-palette-contrast);
+    border-color: var(--chakra-colors-color-palette-solid);
+  }
+}
+
+.emotion-6 {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 3px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+@layer recipes {
+  .emotion-7 {
+    font-weight: var(--chakra-font-weights-medium);
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    font-size: var(--chakra-font-sizes-sm);
+    line-height: 1.25rem;
+  }
+
+  .emotion-7:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+  }
+}
+
+.emotion-9 {
+  margin-top: var(--chakra-spacing-3);
+}
+
+@layer recipes {
+  .emotion-10 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    position: relative;
+    border-radius: var(--chakra-radii-l2);
+    white-space: nowrap;
+    vertical-align: middle;
+    border-width: 1px;
+    border-color: var(--chakra-colors-transparent);
+    cursor: var(--chakra-cursor-button);
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    outline: 0;
+    line-height: 1.25rem;
+    isolation: isolate;
+    font-weight: var(--chakra-font-weights-medium);
+    transition-property: background-color,border-color,color,fill,stroke,opacity,box-shadow,translate,transform;
+    transition-duration: var(--chakra-durations-moderate);
+    --focus-ring-color: var(--chakra-colors-color-palette-focus-ring);
+    height: var(--chakra-sizes-10);
+    min-width: var(--chakra-sizes-10);
+    font-size: var(--chakra-font-sizes-sm);
+    padding-inline: var(--chakra-spacing-4);
+    gap: var(--chakra-spacing-2);
+    background: var(--chakra-colors-color-palette-solid);
+    --bg-currentcolor: var(--chakra-colors-color-palette-solid);
+    color: var(--chakra-colors-color-palette-contrast);
+  }
+
+  .emotion-10:is(:focus-visible, [data-focus-visible]) {
+    outline-width: var(--focus-ring-width, 2px);
+    outline-offset: var(--focus-ring-offset, 2px);
+    outline-style: var(--focus-ring-style, solid);
+    outline-color: var(--focus-ring-color);
+  }
+
+  .emotion-10:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-10 :where(svg) {
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    width: var(--chakra-sizes-5);
+    height: var(--chakra-sizes-5);
+  }
+
+  .emotion-10:is([aria-expanded=true], [data-expanded], [data-state=expanded]) {
+    --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+    background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+  }
+
+  @media (hover: hover) {
+    .emotion-10:is(:hover, [data-hover]):not(:disabled, [data-disabled]) {
+      --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+      background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+      --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    }
+  }
+}
+
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-boolean"
+  >
+    <fieldset
+      className="fieldset__root emotion-0"
+      data-part="root"
+      data-scope="fieldset"
+      disabled={false}
+    >
+      <div
+        className="fieldset__content emotion-1"
+      >
+        <div
+          className="chakra-field__root emotion-2"
+          data-part="root"
+          data-scope="field"
+          id="field:::r2d:"
+          role="group"
+        >
+          <sup
+            className="emotion-3"
+            id="root__description"
+          >
+            <span>
+              <strong>
+                test
+              </strong>
+               
+              <strong>
+                description
+              </strong>
+            </span>
+          </sup>
+          <label
+            aria-describedby="root__error root__description root__help"
+            className="chakra-checkbox__root emotion-4"
+            data-part="root"
+            data-scope="checkbox"
+            data-state="unchecked"
+            dir="ltr"
+            htmlFor=":r2d:"
+            id="checkbox:root"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onPointerLeave={[Function]}
+            onPointerMove={[Function]}
+          >
+            <input
+              aria-invalid={false}
+              aria-labelledby="field:::r2d:::label"
+              defaultChecked={false}
+              disabled={false}
+              id=":r2d:"
+              name="root"
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              required={false}
+              style={
+                {
+                  "border": "0",
+                  "clip": "rect(0 0 0 0)",
+                  "height": "1px",
+                  "margin": "-1px",
+                  "overflow": "hidden",
+                  "padding": "0",
+                  "position": "absolute",
+                  "whiteSpace": "nowrap",
+                  "width": "1px",
+                  "wordWrap": "normal",
+                }
+              }
+              type="checkbox"
+              value="on"
+            />
+            <div
+              aria-hidden={true}
+              className="chakra-checkbox__control emotion-5"
+              data-part="control"
+              data-scope="checkbox"
+              data-state="unchecked"
+              dir="ltr"
+              id="checkbox:root:control"
+            >
+              <svg
+                className="emotion-6"
+                data-state="unchecked"
+                viewBox="0 0 24 24"
+              />
+            </div>
+            <span
+              className="chakra-checkbox__label emotion-7"
+              data-part="label"
+              data-scope="checkbox"
+              data-state="unchecked"
+              dir="ltr"
+              id="field:::r2d:::label"
+            >
+              <p
+                className="emotion-8"
+              >
+                test
+              </p>
+            </span>
+          </label>
+        </div>
+      </div>
+    </fieldset>
+  </div>
+  <div
+    className="emotion-9"
+  >
+    <button
+      className="chakra-button emotion-10"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields checkboxes field 1`] = `
 @layer recipes {
   .emotion-0 {
@@ -1627,15 +2401,15 @@ exports[`single fields field with description 1`] = `
                     className="chakra-field__root emotion-8"
                     data-part="root"
                     data-scope="field"
-                    id="field:::r2o:"
+                    id="field:::r2u:"
                     role="group"
                   >
                     <label
                       className="chakra-field__label emotion-9"
                       data-part="label"
                       data-scope="field"
-                      htmlFor=":r2o:"
-                      id="field:::r2o:::label"
+                      htmlFor=":r2u:"
+                      id="field:::r2u:::label"
                     >
                       my-field
                     </label>
@@ -1974,15 +2748,717 @@ exports[`single fields field with description in uiSchema 1`] = `
                     className="chakra-field__root emotion-8"
                     data-part="root"
                     data-scope="field"
-                    id="field:::r2r:"
+                    id="field:::r31:"
                     role="group"
                   >
                     <label
                       className="chakra-field__label emotion-9"
                       data-part="label"
                       data-scope="field"
-                      htmlFor=":r2r:"
-                      id="field:::r2r:::label"
+                      htmlFor=":r31:"
+                      id="field:::r31:::label"
+                    >
+                      my-field
+                    </label>
+                    <input
+                      aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                      autoFocus={false}
+                      className="chakra-input emotion-10"
+                      data-part="input"
+                      data-scope="field"
+                      disabled={false}
+                      id="root_my-field"
+                      name="root_my-field"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+      </div>
+    </fieldset>
+  </div>
+  <div
+    className="emotion-11"
+  >
+    <button
+      className="chakra-button emotion-12"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown description 1`] = `
+@layer recipes {
+  .emotion-0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+  }
+
+  .emotion-0>:not(style, [hidden])~:not(style, [hidden]) {
+    --space-y-reverse: 0;
+    margin-top: calc(var(--chakra-spacing-4) * calc(1 - var(--space-y-reverse)));
+    margin-bottom: calc(var(--chakra-spacing-4) * var(--space-y-reverse));
+  }
+}
+
+@layer recipes {
+  .emotion-1 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+    gap: var(--chakra-spacing-4);
+  }
+}
+
+.emotion-2 {
+  display: grid;
+  gap: var(--chakra-spacing-6);
+  margin-bottom: var(--chakra-spacing-4);
+}
+
+.emotion-5 {
+  margin-top: var(--chakra-spacing-2);
+}
+
+@layer recipes {
+  .emotion-5 {
+    color: var(--chakra-colors-fg);
+    font-weight: var(--chakra-font-weights-medium);
+    font-size: var(--chakra-font-sizes-sm);
+    line-height: 1.25rem;
+  }
+
+  .emotion-5:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+  }
+}
+
+.emotion-6 {
+  font-size: var(--chakra-font-sizes-md);
+}
+
+.emotion-8 {
+  margin-bottom: var(--chakra-spacing-1);
+}
+
+@layer recipes {
+  .emotion-8 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    width: 100%;
+    position: relative;
+    gap: var(--chakra-spacing-1\\.5);
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    -webkit-align-items: flex-start;
+    -webkit-box-align: flex-start;
+    -ms-flex-align: flex-start;
+    align-items: flex-start;
+  }
+}
+
+@layer recipes {
+  .emotion-9 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    text-align: start;
+    font-size: var(--chakra-font-sizes-sm);
+    line-height: 1.25rem;
+    font-weight: var(--chakra-font-weights-medium);
+    gap: var(--chakra-spacing-1);
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+
+  .emotion-9:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+  }
+}
+
+@layer recipes {
+  .emotion-10 {
+    width: 100%;
+    min-width: var(--input-height);
+    outline: 0;
+    position: relative;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
+    text-align: start;
+    border-radius: var(--chakra-radii-l2);
+    height: var(--input-height);
+    --focus-color: var(--chakra-colors-color-palette-focus-ring);
+    --error-color: var(--chakra-colors-border-error);
+    font-size: var(--chakra-font-sizes-sm);
+    line-height: 1.25rem;
+    padding-inline: var(--chakra-spacing-3);
+    --input-height: var(--chakra-sizes-10);
+    background: var(--chakra-colors-transparent);
+    --bg-currentcolor: var(--chakra-colors-transparent);
+    border-width: 1px;
+    border-color: var(--chakra-colors-border);
+    --focus-ring-color: var(--focus-color);
+  }
+
+  .emotion-10:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-10:is([data-invalid], [aria-invalid=true], [data-state=invalid]) {
+    --focus-ring-color: var(--error-color);
+    border-color: var(--error-color);
+  }
+
+  .emotion-10:is(:focus-visible, [data-focus-visible]) {
+    outline-offset: 0px;
+    outline-width: var(--focus-ring-width, 1px);
+    outline-color: var(--focus-ring-color);
+    outline-style: var(--focus-ring-style, solid);
+    border-color: var(--focus-ring-color);
+  }
+}
+
+.emotion-11 {
+  margin-top: var(--chakra-spacing-3);
+}
+
+@layer recipes {
+  .emotion-12 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    position: relative;
+    border-radius: var(--chakra-radii-l2);
+    white-space: nowrap;
+    vertical-align: middle;
+    border-width: 1px;
+    border-color: var(--chakra-colors-transparent);
+    cursor: var(--chakra-cursor-button);
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    outline: 0;
+    line-height: 1.25rem;
+    isolation: isolate;
+    font-weight: var(--chakra-font-weights-medium);
+    transition-property: background-color,border-color,color,fill,stroke,opacity,box-shadow,translate,transform;
+    transition-duration: var(--chakra-durations-moderate);
+    --focus-ring-color: var(--chakra-colors-color-palette-focus-ring);
+    height: var(--chakra-sizes-10);
+    min-width: var(--chakra-sizes-10);
+    font-size: var(--chakra-font-sizes-sm);
+    padding-inline: var(--chakra-spacing-4);
+    gap: var(--chakra-spacing-2);
+    background: var(--chakra-colors-color-palette-solid);
+    --bg-currentcolor: var(--chakra-colors-color-palette-solid);
+    color: var(--chakra-colors-color-palette-contrast);
+  }
+
+  .emotion-12:is(:focus-visible, [data-focus-visible]) {
+    outline-width: var(--focus-ring-width, 2px);
+    outline-offset: var(--focus-ring-offset, 2px);
+    outline-style: var(--focus-ring-style, solid);
+    outline-color: var(--focus-ring-color);
+  }
+
+  .emotion-12:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-12 :where(svg) {
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    width: var(--chakra-sizes-5);
+    height: var(--chakra-sizes-5);
+  }
+
+  .emotion-12:is([aria-expanded=true], [data-expanded], [data-state=expanded]) {
+    --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+    background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+  }
+
+  @media (hover: hover) {
+    .emotion-12:is(:hover, [data-hover]):not(:disabled, [data-disabled]) {
+      --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+      background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+      --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    }
+  }
+}
+
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <fieldset
+      className="fieldset__root emotion-0"
+      data-part="root"
+      data-scope="fieldset"
+      disabled={false}
+    >
+      <div
+        className="fieldset__content emotion-1"
+      >
+        <div
+          className="emotion-2"
+        >
+          <div
+            className="emotion-3"
+          >
+            <div
+              className="rjsf-field rjsf-field-string"
+            >
+              <fieldset
+                className="fieldset__root emotion-0"
+                data-part="root"
+                data-scope="fieldset"
+                disabled={false}
+              >
+                <legend
+                  className="fieldset__legend emotion-5"
+                  data-part="legend"
+                  data-scope="fieldset"
+                >
+                  <sup
+                    className="emotion-6"
+                    id="root_my-field__description"
+                  >
+                    <span>
+                      some 
+                      <strong>
+                        Rich
+                      </strong>
+                       description
+                    </span>
+                  </sup>
+                </legend>
+                <div
+                  className="fieldset__content emotion-1"
+                >
+                  <div
+                    className="chakra-field__root emotion-8"
+                    data-part="root"
+                    data-scope="field"
+                    id="field:::r34:"
+                    role="group"
+                  >
+                    <label
+                      className="chakra-field__label emotion-9"
+                      data-part="label"
+                      data-scope="field"
+                      htmlFor=":r34:"
+                      id="field:::r34:::label"
+                    >
+                      my-field
+                    </label>
+                    <input
+                      aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                      autoFocus={false}
+                      className="chakra-input emotion-10"
+                      data-part="input"
+                      data-scope="field"
+                      disabled={false}
+                      id="root_my-field"
+                      name="root_my-field"
+                      onBlur={[Function]}
+                      onChange={[Function]}
+                      onFocus={[Function]}
+                      placeholder=""
+                      readOnly={false}
+                      required={false}
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+      </div>
+    </fieldset>
+  </div>
+  <div
+    className="emotion-11"
+  >
+    <button
+      className="chakra-button emotion-12"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown description in uiSchema 1`] = `
+@layer recipes {
+  .emotion-0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+  }
+
+  .emotion-0>:not(style, [hidden])~:not(style, [hidden]) {
+    --space-y-reverse: 0;
+    margin-top: calc(var(--chakra-spacing-4) * calc(1 - var(--space-y-reverse)));
+    margin-bottom: calc(var(--chakra-spacing-4) * var(--space-y-reverse));
+  }
+}
+
+@layer recipes {
+  .emotion-1 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+    gap: var(--chakra-spacing-4);
+  }
+}
+
+.emotion-2 {
+  display: grid;
+  gap: var(--chakra-spacing-6);
+  margin-bottom: var(--chakra-spacing-4);
+}
+
+.emotion-5 {
+  margin-top: var(--chakra-spacing-2);
+}
+
+@layer recipes {
+  .emotion-5 {
+    color: var(--chakra-colors-fg);
+    font-weight: var(--chakra-font-weights-medium);
+    font-size: var(--chakra-font-sizes-sm);
+    line-height: 1.25rem;
+  }
+
+  .emotion-5:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+  }
+}
+
+.emotion-6 {
+  font-size: var(--chakra-font-sizes-md);
+}
+
+.emotion-8 {
+  margin-bottom: var(--chakra-spacing-1);
+}
+
+@layer recipes {
+  .emotion-8 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    width: 100%;
+    position: relative;
+    gap: var(--chakra-spacing-1\\.5);
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    -webkit-align-items: flex-start;
+    -webkit-box-align: flex-start;
+    -ms-flex-align: flex-start;
+    align-items: flex-start;
+  }
+}
+
+@layer recipes {
+  .emotion-9 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    text-align: start;
+    font-size: var(--chakra-font-sizes-sm);
+    line-height: 1.25rem;
+    font-weight: var(--chakra-font-weights-medium);
+    gap: var(--chakra-spacing-1);
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+
+  .emotion-9:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+  }
+}
+
+@layer recipes {
+  .emotion-10 {
+    width: 100%;
+    min-width: var(--input-height);
+    outline: 0;
+    position: relative;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
+    text-align: start;
+    border-radius: var(--chakra-radii-l2);
+    height: var(--input-height);
+    --focus-color: var(--chakra-colors-color-palette-focus-ring);
+    --error-color: var(--chakra-colors-border-error);
+    font-size: var(--chakra-font-sizes-sm);
+    line-height: 1.25rem;
+    padding-inline: var(--chakra-spacing-3);
+    --input-height: var(--chakra-sizes-10);
+    background: var(--chakra-colors-transparent);
+    --bg-currentcolor: var(--chakra-colors-transparent);
+    border-width: 1px;
+    border-color: var(--chakra-colors-border);
+    --focus-ring-color: var(--focus-color);
+  }
+
+  .emotion-10:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-10:is([data-invalid], [aria-invalid=true], [data-state=invalid]) {
+    --focus-ring-color: var(--error-color);
+    border-color: var(--error-color);
+  }
+
+  .emotion-10:is(:focus-visible, [data-focus-visible]) {
+    outline-offset: 0px;
+    outline-width: var(--focus-ring-width, 1px);
+    outline-color: var(--focus-ring-color);
+    outline-style: var(--focus-ring-style, solid);
+    border-color: var(--focus-ring-color);
+  }
+}
+
+.emotion-11 {
+  margin-top: var(--chakra-spacing-3);
+}
+
+@layer recipes {
+  .emotion-12 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    position: relative;
+    border-radius: var(--chakra-radii-l2);
+    white-space: nowrap;
+    vertical-align: middle;
+    border-width: 1px;
+    border-color: var(--chakra-colors-transparent);
+    cursor: var(--chakra-cursor-button);
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    outline: 0;
+    line-height: 1.25rem;
+    isolation: isolate;
+    font-weight: var(--chakra-font-weights-medium);
+    transition-property: background-color,border-color,color,fill,stroke,opacity,box-shadow,translate,transform;
+    transition-duration: var(--chakra-durations-moderate);
+    --focus-ring-color: var(--chakra-colors-color-palette-focus-ring);
+    height: var(--chakra-sizes-10);
+    min-width: var(--chakra-sizes-10);
+    font-size: var(--chakra-font-sizes-sm);
+    padding-inline: var(--chakra-spacing-4);
+    gap: var(--chakra-spacing-2);
+    background: var(--chakra-colors-color-palette-solid);
+    --bg-currentcolor: var(--chakra-colors-color-palette-solid);
+    color: var(--chakra-colors-color-palette-contrast);
+  }
+
+  .emotion-12:is(:focus-visible, [data-focus-visible]) {
+    outline-width: var(--focus-ring-width, 2px);
+    outline-offset: var(--focus-ring-offset, 2px);
+    outline-style: var(--focus-ring-style, solid);
+    outline-color: var(--focus-ring-color);
+  }
+
+  .emotion-12:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-12 :where(svg) {
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    width: var(--chakra-sizes-5);
+    height: var(--chakra-sizes-5);
+  }
+
+  .emotion-12:is([aria-expanded=true], [data-expanded], [data-state=expanded]) {
+    --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+    background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+  }
+
+  @media (hover: hover) {
+    .emotion-12:is(:hover, [data-hover]):not(:disabled, [data-disabled]) {
+      --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+      background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+      --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    }
+  }
+}
+
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <fieldset
+      className="fieldset__root emotion-0"
+      data-part="root"
+      data-scope="fieldset"
+      disabled={false}
+    >
+      <div
+        className="fieldset__content emotion-1"
+      >
+        <div
+          className="emotion-2"
+        >
+          <div
+            className="emotion-3"
+          >
+            <div
+              className="rjsf-field rjsf-field-string"
+            >
+              <fieldset
+                className="fieldset__root emotion-0"
+                data-part="root"
+                data-scope="fieldset"
+                disabled={false}
+              >
+                <legend
+                  className="fieldset__legend emotion-5"
+                  data-part="legend"
+                  data-scope="fieldset"
+                >
+                  <sup
+                    className="emotion-6"
+                    id="root_my-field__description"
+                  >
+                    <span>
+                      some other description
+                    </span>
+                  </sup>
+                </legend>
+                <div
+                  className="fieldset__content emotion-1"
+                >
+                  <div
+                    className="chakra-field__root emotion-8"
+                    data-part="root"
+                    data-scope="field"
+                    id="field:::r37:"
+                    role="group"
+                  >
+                    <label
+                      className="chakra-field__label emotion-9"
+                      data-part="label"
+                      data-scope="field"
+                      htmlFor=":r37:"
+                      id="field:::r37:::label"
                     >
                       my-field
                     </label>
@@ -3490,7 +4966,7 @@ exports[`single fields help and error display 1`] = `
           data-invalid=""
           data-part="root"
           data-scope="field"
-          id="field:::r36:"
+          id="field:::r3i:"
           role="group"
         >
           <input
@@ -3520,7 +4996,7 @@ exports[`single fields help and error display 1`] = `
         className="fieldset__errorText emotion-14"
         data-part="error-text"
         data-scope="fieldset"
-        id="fieldset:::r35:::error-text"
+        id="fieldset:::r3h:::error-text"
       >
         <ul
           className="chakra-list__root emotion-6"
@@ -3945,7 +5421,7 @@ exports[`single fields hidden label 1`] = `
           className="chakra-field__root emotion-2"
           data-part="root"
           data-scope="field"
-          id="field:::r30:"
+          id="field:::r3c:"
           role="group"
         >
           <input
@@ -5167,19 +6643,19 @@ exports[`single fields radio field 1`] = `
           className="chakra-field__root emotion-2"
           data-part="root"
           data-scope="field"
-          id="field:::r2g:"
+          id="field:::r2m:"
           role="group"
         >
           <div
             aria-describedby="root__error root__description root__help"
-            aria-labelledby="radio-group::r2h::label"
+            aria-labelledby="radio-group::r2n::label"
             aria-orientation="vertical"
             className="chakra-radio-group__root emotion-3"
             data-orientation="vertical"
             data-part="root"
             data-scope="radio-group"
             dir="ltr"
-            id="radio-group::r2h:"
+            id="radio-group::r2n:"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
@@ -5201,7 +6677,7 @@ exports[`single fields radio field 1`] = `
                 data-ssr=""
                 data-state="unchecked"
                 dir="ltr"
-                htmlFor="radio-group::r2h::radio:input:0"
+                htmlFor="radio-group::r2n::radio:input:0"
                 id="root-0"
                 onClick={[Function]}
                 onPointerDown={[Function]}
@@ -5210,10 +6686,10 @@ exports[`single fields radio field 1`] = `
                 onPointerUp={[Function]}
               >
                 <input
-                  data-ownedby="radio-group::r2h:"
+                  data-ownedby="radio-group::r2n:"
                   defaultChecked={false}
                   disabled={false}
-                  id="radio-group::r2h::radio:input:0"
+                  id="radio-group::r2n::radio:input:0"
                   name="root"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -5246,7 +6722,7 @@ exports[`single fields radio field 1`] = `
                   data-ssr=""
                   data-state="unchecked"
                   dir="ltr"
-                  id="radio-group::r2h::radio:control:0"
+                  id="radio-group::r2n::radio:control:0"
                 />
                 <span
                   className="chakra-radio-group__itemText emotion-3"
@@ -5256,7 +6732,7 @@ exports[`single fields radio field 1`] = `
                   data-ssr=""
                   data-state="unchecked"
                   dir="ltr"
-                  id="radio-group::r2h::radio:label:0"
+                  id="radio-group::r2n::radio:label:0"
                 >
                   Yes
                 </span>
@@ -5269,7 +6745,7 @@ exports[`single fields radio field 1`] = `
                 data-ssr=""
                 data-state="unchecked"
                 dir="ltr"
-                htmlFor="radio-group::r2h::radio:input:1"
+                htmlFor="radio-group::r2n::radio:input:1"
                 id="root-1"
                 onClick={[Function]}
                 onPointerDown={[Function]}
@@ -5278,10 +6754,10 @@ exports[`single fields radio field 1`] = `
                 onPointerUp={[Function]}
               >
                 <input
-                  data-ownedby="radio-group::r2h:"
+                  data-ownedby="radio-group::r2n:"
                   defaultChecked={false}
                   disabled={false}
-                  id="radio-group::r2h::radio:input:1"
+                  id="radio-group::r2n::radio:input:1"
                   name="root"
                   onBlur={[Function]}
                   onClick={[Function]}
@@ -5314,7 +6790,7 @@ exports[`single fields radio field 1`] = `
                   data-ssr=""
                   data-state="unchecked"
                   dir="ltr"
-                  id="radio-group::r2h::radio:control:1"
+                  id="radio-group::r2n::radio:control:1"
                 />
                 <span
                   className="chakra-radio-group__itemText emotion-3"
@@ -5324,7 +6800,7 @@ exports[`single fields radio field 1`] = `
                   data-ssr=""
                   data-state="unchecked"
                   dir="ltr"
-                  id="radio-group::r2h::radio:label:1"
+                  id="radio-group::r2n::radio:label:1"
                 >
                   No
                 </span>
@@ -5560,7 +7036,7 @@ exports[`single fields schema examples 1`] = `
           className="chakra-field__root emotion-2"
           data-part="root"
           data-scope="field"
-          id="field:::r34:"
+          id="field:::r3g:"
           role="group"
         >
           <input
@@ -13161,7 +14637,7 @@ exports[`single fields slider field 1`] = `
           className="chakra-field__root emotion-2"
           data-part="root"
           data-scope="field"
-          id="field:::r2j:"
+          id="field:::r2p:"
           role="group"
         >
           <div
@@ -15094,15 +16570,15 @@ exports[`single fields title field 1`] = `
                     className="chakra-field__root emotion-9"
                     data-part="root"
                     data-scope="field"
-                    id="field:::r2u:"
+                    id="field:::r3a:"
                     role="group"
                   >
                     <label
                       className="chakra-field__label emotion-10"
                       data-part="label"
                       data-scope="field"
-                      htmlFor=":r2u:"
-                      id="field:::r2u:::label"
+                      htmlFor=":r3a:"
+                      id="field:::r3a:::label"
                     >
                       Titre 2
                     </label>
@@ -16009,7 +17485,7 @@ exports[`single fields using custom tagName 1`] = `
           className="chakra-field__root emotion-2"
           data-part="root"
           data-scope="field"
-          id="field:::r32:"
+          id="field:::r3e:"
           role="group"
         >
           <input

--- a/packages/chakra-ui/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/GridSnap.test.tsx.snap
@@ -908,15 +908,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
       >
         <div
           className="emotion-2"
-          data-testid="0"
         >
           <div
             className="emotion-3"
-            data-testid="0"
           >
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-object"
@@ -952,11 +949,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="emotion-10"
-            data-testid="0"
           >
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-string"
@@ -1018,7 +1013,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
             </div>
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-string"
@@ -1073,7 +1067,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
             </div>
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-string"
@@ -1136,11 +1129,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="emotion-10"
-            data-testid="0"
           >
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-string"
@@ -1202,7 +1193,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
             </div>
             <div
               className="emotion-39"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-array"
@@ -1606,11 +1596,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="emotion-72"
-            data-testid="0"
           >
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-object"
@@ -1626,11 +1614,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   >
                     <div
                       className="emotion-72"
-                      data-testid="0"
                     >
                       <div
                         className="emotion-39"
-                        data-testid="1"
                       >
                         <div
                           className="rjsf-field rjsf-field-string"
@@ -1692,7 +1678,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="emotion-39"
-                        data-testid="1"
                       >
                         <div
                           className="rjsf-field rjsf-field-string"
@@ -1747,7 +1732,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="emotion-39"
-                        data-testid="1"
                       >
                         <div
                           className="rjsf-field rjsf-field-string"
@@ -1809,7 +1793,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="emotion-4"
-                        data-testid="1"
                         size={6}
                       >
                         <div
@@ -4182,7 +4165,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="emotion-4"
-                        data-testid="1"
                         size={6}
                       >
                         <div
@@ -4250,15 +4232,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
             </div>
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="emotion-10"
-                data-testid="0"
               >
                 <div
                   className="emotion-290"
-                  data-testid="1"
                   style={
                     {
                       "margin": "0 0 16px",
@@ -4532,7 +4511,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="emotion-290"
-                  data-testid="1"
                 >
                   <div
                     className="rjsf-field rjsf-field-string"
@@ -4594,7 +4572,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="emotion-290"
-                  data-testid="1"
                 >
                   <div
                     className="rjsf-field rjsf-field-string"
@@ -4649,7 +4626,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="emotion-39"
-                  data-testid="1"
                 >
                   <div
                     className="rjsf-field rjsf-field-string"
@@ -4711,7 +4687,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="emotion-4"
-                  data-testid="1"
                 >
                   <div
                     className="rjsf-field rjsf-field-string"
@@ -8010,15 +7985,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
       >
         <div
           className="emotion-2"
-          data-testid="0"
         >
           <div
             className="emotion-3"
-            data-testid="0"
           >
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-object"
@@ -8054,11 +8026,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="emotion-10"
-            data-testid="0"
           >
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-string"
@@ -8120,7 +8090,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
             </div>
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-string"
@@ -8175,7 +8144,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
             </div>
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-string"
@@ -8238,11 +8206,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="emotion-10"
-            data-testid="0"
           >
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-string"
@@ -8304,7 +8270,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
             </div>
             <div
               className="emotion-39"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-array"
@@ -8708,11 +8673,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="emotion-72"
-            data-testid="0"
           >
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-object"
@@ -8728,11 +8691,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   >
                     <div
                       className="emotion-72"
-                      data-testid="0"
                     >
                       <div
                         className="emotion-39"
-                        data-testid="1"
                       >
                         <div
                           className="rjsf-field rjsf-field-string"
@@ -8794,7 +8755,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="emotion-39"
-                        data-testid="1"
                       >
                         <div
                           className="rjsf-field rjsf-field-string"
@@ -8849,7 +8809,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="emotion-39"
-                        data-testid="1"
                       >
                         <div
                           className="rjsf-field rjsf-field-string"
@@ -8911,7 +8870,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="emotion-4"
-                        data-testid="1"
                         size={6}
                       >
                         <div
@@ -11284,7 +11242,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="emotion-4"
-                        data-testid="1"
                         size={6}
                       >
                         <div
@@ -11352,15 +11309,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
             </div>
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="emotion-10"
-                data-testid="0"
               >
                 <div
                   className="emotion-290"
-                  data-testid="1"
                   style={
                     {
                       "margin": "0 0 16px",
@@ -11634,7 +11588,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="emotion-290"
-                  data-testid="1"
                 >
                   <div
                     className="rjsf-field rjsf-field-string"
@@ -11689,7 +11642,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="emotion-290"
-                  data-testid="1"
                 >
                   <div
                     className="rjsf-field rjsf-field-string"
@@ -11751,7 +11703,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="emotion-290"
-                  data-testid="1"
                 >
                   <div
                     className="rjsf-field rjsf-field-string"
@@ -11806,7 +11757,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="emotion-39"
-                  data-testid="1"
                 >
                   <div
                     className="rjsf-field rjsf-field-string"
@@ -11868,7 +11818,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="emotion-4"
-                  data-testid="1"
                 >
                   <div
                     className="rjsf-field rjsf-field-string"
@@ -15212,15 +15161,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
       >
         <div
           className="emotion-2"
-          data-testid="0"
         >
           <div
             className="emotion-3"
-            data-testid="0"
           >
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-object"
@@ -15256,11 +15202,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="emotion-10"
-            data-testid="0"
           >
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-string"
@@ -15322,7 +15266,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
             </div>
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-string"
@@ -15377,7 +15320,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
             </div>
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-string"
@@ -15440,11 +15382,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="emotion-10"
-            data-testid="0"
           >
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-string"
@@ -15506,7 +15446,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
             </div>
             <div
               className="emotion-39"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-array"
@@ -15910,11 +15849,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="emotion-72"
-            data-testid="0"
           >
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-object"
@@ -15930,11 +15867,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   >
                     <div
                       className="emotion-72"
-                      data-testid="0"
                     >
                       <div
                         className="emotion-39"
-                        data-testid="1"
                       >
                         <div
                           className="rjsf-field rjsf-field-string"
@@ -15996,7 +15931,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="emotion-39"
-                        data-testid="1"
                       >
                         <div
                           className="rjsf-field rjsf-field-string"
@@ -16051,7 +15985,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="emotion-39"
-                        data-testid="1"
                       >
                         <div
                           className="rjsf-field rjsf-field-string"
@@ -16113,7 +16046,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="emotion-4"
-                        data-testid="1"
                         size={6}
                       >
                         <div
@@ -18486,7 +18418,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="emotion-4"
-                        data-testid="1"
                         size={6}
                       >
                         <div
@@ -18554,15 +18485,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
             </div>
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="emotion-10"
-                data-testid="0"
               >
                 <div
                   className="emotion-290"
-                  data-testid="1"
                   style={
                     {
                       "margin": "0 0 16px",
@@ -18836,7 +18764,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="emotion-290"
-                  data-testid="1"
                 >
                   <div
                     className="rjsf-field rjsf-field-string"
@@ -19830,15 +19757,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
       >
         <div
           className="emotion-2"
-          data-testid="0"
         >
           <div
             className="emotion-3"
-            data-testid="0"
           >
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-object"
@@ -19874,11 +19798,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="emotion-10"
-            data-testid="0"
           >
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-string"
@@ -19940,7 +19862,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
             </div>
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-string"
@@ -19995,7 +19916,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
             </div>
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-string"
@@ -20058,11 +19978,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="emotion-10"
-            data-testid="0"
           >
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-string"
@@ -20124,7 +20042,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
             </div>
             <div
               className="emotion-39"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-array"
@@ -20528,11 +20445,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="emotion-72"
-            data-testid="0"
           >
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="rjsf-field rjsf-field-object"
@@ -20548,11 +20463,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   >
                     <div
                       className="emotion-72"
-                      data-testid="0"
                     >
                       <div
                         className="emotion-39"
-                        data-testid="1"
                       >
                         <div
                           className="rjsf-field rjsf-field-string"
@@ -20614,7 +20527,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="emotion-39"
-                        data-testid="1"
                       >
                         <div
                           className="rjsf-field rjsf-field-string"
@@ -20669,7 +20581,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="emotion-39"
-                        data-testid="1"
                       >
                         <div
                           className="rjsf-field rjsf-field-string"
@@ -20731,7 +20642,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="emotion-4"
-                        data-testid="1"
                         size={6}
                       >
                         <div
@@ -23104,7 +23014,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                       <div
                         className="emotion-4"
-                        data-testid="1"
                         size={6}
                       >
                         <div
@@ -23172,15 +23081,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
             </div>
             <div
               className="emotion-4"
-              data-testid="1"
             >
               <div
                 className="emotion-10"
-                data-testid="0"
               >
                 <div
                   className="emotion-290"
-                  data-testid="1"
                   style={
                     {
                       "margin": "0 0 16px",
@@ -23454,7 +23360,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="emotion-290"
-                  data-testid="1"
                 >
                   <div
                     className="rjsf-field rjsf-field-string"
@@ -23516,7 +23421,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="emotion-290"
-                  data-testid="1"
                 >
                   <div
                     className="rjsf-field rjsf-field-string"
@@ -23571,7 +23475,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="emotion-39"
-                  data-testid="1"
                 >
                   <div
                     className="rjsf-field rjsf-field-string"
@@ -23633,7 +23536,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="emotion-4"
-                  data-testid="1"
                 >
                   <div
                     className="rjsf-field rjsf-field-string"
@@ -26796,11 +26698,9 @@ exports[`Three even column grid renders person and address in three columns, no 
       >
         <div
           className="emotion-2"
-          data-testid="0"
         >
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -26835,7 +26735,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -26897,7 +26796,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -26952,7 +26850,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -27014,7 +26911,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -27076,7 +26972,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-array"
@@ -27479,7 +27374,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -27541,7 +27435,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -27596,7 +27489,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -27658,7 +27550,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -30030,7 +29921,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           />
         </div>
       </div>
@@ -30822,11 +30712,9 @@ exports[`Two even column grid renders person and address in two columns, no empl
       >
         <div
           className="emotion-2"
-          data-testid="0"
         >
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -30861,7 +30749,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -30923,7 +30810,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -30978,7 +30864,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -31040,7 +30925,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -31102,7 +30986,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-array"
@@ -31505,7 +31388,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -31567,7 +31449,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -31622,7 +31503,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -31684,7 +31564,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -34056,7 +33935,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
           <div
             className="emotion-3"
-            data-testid="1"
           />
         </div>
       </div>

--- a/packages/core/src/components/RichDescription.tsx
+++ b/packages/core/src/components/RichDescription.tsx
@@ -1,0 +1,50 @@
+import { ReactElement } from 'react';
+import {
+  FormContextType,
+  Registry,
+  RJSFSchema,
+  StrictRJSFSchema,
+  UiSchema,
+  getTestIds,
+  getUiOptions,
+} from '@rjsf/utils';
+import Markdown from 'markdown-to-jsx';
+
+const TEST_IDS = getTestIds();
+
+export interface RichDescriptionProps<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any,
+> {
+  /** The description text for a field, potentially containing markdown */
+  description: string | ReactElement;
+  /** The uiSchema object for this base component */
+  uiSchema?: UiSchema<T, S, F>;
+  /** The `registry` object */
+  registry: Registry<T, S, F>;
+}
+
+/** Renders the given `description` in the props as
+ *
+ * @param props - The `RichDescriptionProps` for this component
+ */
+export default function RichDescription<
+  T = any,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = any,
+>({ description, registry, uiSchema = {} }: RichDescriptionProps<T, S, F>) {
+  const { globalUiOptions } = registry;
+  const uiOptions = getUiOptions<T, S, F>(uiSchema, globalUiOptions);
+
+  if (uiOptions.enableMarkdownInDescription && typeof description === 'string') {
+    return (
+      <Markdown options={{ disableParsingRawHTML: true }} data-testid={TEST_IDS.markdown}>
+        {description}
+      </Markdown>
+    );
+  }
+  return description;
+}
+
+RichDescription.TEST_IDS = TEST_IDS;

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -22,7 +22,6 @@ import {
 } from '@rjsf/utils';
 import isObject from 'lodash/isObject';
 import omit from 'lodash/omit';
-import Markdown from 'markdown-to-jsx';
 
 /** The map of component type to FieldName */
 const COMPONENT_TYPES: { [key: string]: string } = {
@@ -200,12 +199,6 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
   }
 
   const description = uiOptions.description || props.schema.description || schema.description || '';
-
-  const richDescription = uiOptions.enableMarkdownInDescription ? (
-    <Markdown options={{ disableParsingRawHTML: true }}>{description}</Markdown>
-  ) : (
-    description
-  );
   const help = uiOptions.help;
   const hidden = uiOptions.widget === 'hidden';
 
@@ -246,7 +239,7 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
     description: (
       <DescriptionFieldTemplate
         id={descriptionId<T>(id)}
-        description={richDescription}
+        description={description}
         schema={schema}
         uiSchema={uiSchema}
         registry={registry}

--- a/packages/core/src/components/templates/DescriptionField.tsx
+++ b/packages/core/src/components/templates/DescriptionField.tsx
@@ -1,5 +1,7 @@
 import { DescriptionFieldProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
 
+import RichDescription from '../RichDescription';
+
 /** The `DescriptionField` is the template to use to render the description of a field
  *
  * @param props - The `DescriptionFieldProps` for this component
@@ -9,21 +11,13 @@ export default function DescriptionField<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: DescriptionFieldProps<T, S, F>) {
-  const { id, description } = props;
+  const { id, description, registry, uiSchema } = props;
   if (!description) {
     return null;
   }
-  if (typeof description === 'string') {
-    return (
-      <p id={id} className='field-description'>
-        {description}
-      </p>
-    );
-  } else {
-    return (
-      <div id={id} className='field-description'>
-        {description}
-      </div>
-    );
-  }
+  return (
+    <div id={id} className='field-description'>
+      <RichDescription description={description} registry={registry} uiSchema={uiSchema} />
+    </div>
+  );
 }

--- a/packages/core/src/components/widgets/CheckboxWidget.tsx
+++ b/packages/core/src/components/widgets/CheckboxWidget.tsx
@@ -60,7 +60,7 @@ function CheckboxWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F exte
 
   return (
     <div className={`checkbox ${disabled || readonly ? 'disabled' : ''}`}>
-      {!hideLabel && !!description && (
+      {!hideLabel && description && (
         <DescriptionFieldTemplate
           id={descriptionId<T>(id)}
           description={description}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,8 +1,9 @@
 import Form, { FormProps, FormState, IChangeEvent } from './components/Form';
+import RichDescription, { RichDescriptionProps } from './components/RichDescription';
 import withTheme, { ThemeProps } from './withTheme';
 import getDefaultRegistry from './getDefaultRegistry';
 
-export type { FormProps, FormState, IChangeEvent, ThemeProps };
+export type { FormProps, FormState, IChangeEvent, ThemeProps, RichDescriptionProps };
 
-export { withTheme, getDefaultRegistry };
+export { withTheme, getDefaultRegistry, RichDescription };
 export default Form;

--- a/packages/core/test/ArraySnap.test.tsx
+++ b/packages/core/test/ArraySnap.test.tsx
@@ -1,4 +1,5 @@
-import Form from '../src';
 import { arrayTests } from '@rjsf/snapshot-tests';
+
+import Form from '../src';
 
 arrayTests(Form);

--- a/packages/core/test/DescriptionField.test.jsx
+++ b/packages/core/test/DescriptionField.test.jsx
@@ -29,6 +29,7 @@ describe('DescriptionField', () => {
   it('should return a div for a custom component', () => {
     const props = {
       description: <em>description</em>,
+      registry: {},
     };
     const { node } = createComponent(DescriptionFieldWrapper, props);
 
@@ -38,16 +39,18 @@ describe('DescriptionField', () => {
   it('should return a p for a description text', () => {
     const props = {
       description: 'description',
+      registry: {},
     };
     const { node } = createComponent(DescriptionFieldWrapper, props);
 
-    expect(node.tagName).to.equal('P');
+    expect(node.tagName).to.equal('DIV');
   });
 
   it('should have the expected id', () => {
     const props = {
       description: 'Field description',
       id: 'sample_id',
+      registry: {},
     };
     const { node } = createComponent(DescriptionFieldWrapper, props);
 

--- a/packages/core/test/FormSnap.test.tsx
+++ b/packages/core/test/FormSnap.test.tsx
@@ -1,4 +1,5 @@
-import Form from '../src';
 import { formTests } from '@rjsf/snapshot-tests';
+
+import Form from '../src';
 
 formTests(Form);

--- a/packages/core/test/ObjectField.test.jsx
+++ b/packages/core/test/ObjectField.test.jsx
@@ -1296,4 +1296,74 @@ describe('ObjectField', () => {
       });
     });
   });
+  describe('markdown', () => {
+    const schema = {
+      title: 'A list of tasks',
+      type: 'object',
+      properties: {
+        tasks: {
+          description: 'New *description*, with some Markdown.',
+          type: 'object',
+          title: 'Tasks',
+          properties: {
+            details: {
+              type: 'string',
+              title: 'Task details',
+              description: 'Description to renders Markdown **correctly**.',
+            },
+            has_markdown: {
+              type: 'boolean',
+              description: 'Checkbox with some `markdown`!',
+            },
+          },
+        },
+      },
+    };
+
+    const uiSchema = {
+      tasks: {
+        'ui:enableMarkdownInDescription': true,
+        details: {
+          'ui:enableMarkdownInDescription': true,
+          'ui:widget': 'textarea',
+        },
+        has_markdown: {
+          'ui:enableMarkdownInDescription': true,
+        },
+      },
+    };
+
+    it('should render markdown in description when enableMarkdownInDescription is set to true', () => {
+      const { node } = createFormComponent({ schema, uiSchema });
+
+      const { innerHTML: rootInnerHTML } = node.querySelector('form .form-group .form-group .field-description');
+      expect(rootInnerHTML).to.contains('New <em>description</em>, with some Markdown.');
+
+      const { innerHTML: detailsInnerHTML } = node.querySelector(
+        'form .form-group .form-group .rjsf-field-string .field-description',
+      );
+      expect(detailsInnerHTML).to.contains('Description to renders Markdown <strong>correctly</strong>.');
+
+      const { innerHTML: checkboxInnerHTML } = node.querySelector(
+        'form .form-group .form-group .rjsf-field-boolean .field-description',
+      );
+      expect(checkboxInnerHTML).to.contains('Checkbox with some <code>markdown</code>!');
+    });
+    it('should not render markdown in description when enableMarkdownInDescription is not present in uiSchema', () => {
+      const { node } = createFormComponent({ schema });
+
+      const { innerHTML: rootInnerHTML } = node.querySelector('form .form-group .form-group .field-description');
+      expect(rootInnerHTML).to.contains('New *description*, with some Markdown.');
+
+      const { innerHTML: detailsInnerHTML } = node.querySelector(
+        'form .form-group .form-group .rjsf-field-string .field-description',
+      );
+      expect(detailsInnerHTML).to.contains('Description to renders Markdown **correctly**.');
+
+      const { innerHTML: checkboxInnerHTML } = node.querySelector(
+        'form .form-group .form-group .rjsf-field-boolean .field-description',
+      );
+      expect(checkboxInnerHTML).to.contains('Checkbox with some `markdown`!');
+    });
+  });
 });

--- a/packages/core/test/ObjectSnap.test.tsx
+++ b/packages/core/test/ObjectSnap.test.tsx
@@ -1,4 +1,5 @@
-import Form from '../src';
 import { objectTests } from '@rjsf/snapshot-tests';
+
+import Form from '../src';
 
 objectTests(Form);

--- a/packages/core/test/RichDescription.test.tsx
+++ b/packages/core/test/RichDescription.test.tsx
@@ -1,0 +1,61 @@
+import { Registry } from '@rjsf/utils';
+import { render, within } from '@testing-library/react';
+
+import { RichDescription, RichDescriptionProps } from '../src';
+
+const TEST_ID = 'test-id';
+
+describe('RichDescription', () => {
+  function getProps(overrides: Partial<RichDescriptionProps> = {}) {
+    const { description = '', uiSchema = {}, registry = {} as Registry } = overrides;
+    return { description, uiSchema, registry };
+  }
+
+  test('simple text description', () => {
+    const text = 'text description';
+    const props = getProps({ description: text });
+    const { container } = render(<RichDescription {...props} />);
+    expect(container).toHaveTextContent(text);
+  });
+  test('react element description', () => {
+    const text = 'Text In P';
+    const props = getProps({ description: <p data-testid={TEST_ID}>{text}</p> });
+    const { container } = render(<RichDescription {...props} />);
+    expect(container).toBeInTheDocument();
+    const paragraph = within(container).getByTestId(TEST_ID);
+    expect(paragraph).toHaveTextContent(text);
+  });
+  test('react rich text description, not enabled', () => {
+    const text = '**Rich** Text';
+    const props = getProps({ description: text });
+    const { container } = render(<RichDescription {...props} />);
+    expect(container).toHaveTextContent(text);
+    const markdown = within(container).queryByTestId(RichDescription.TEST_IDS.markdown);
+    expect(markdown).not.toBeInTheDocument();
+  });
+  test('react element description, enabled enableMarkdownInDescription', () => {
+    const text = '**Text** In P';
+    const props = getProps({
+      description: <p data-testid={TEST_ID}>{text}</p>,
+      uiSchema: { 'ui:enableMarkdownInDescription': true },
+    });
+    const { container } = render(<RichDescription {...props} />);
+    expect(container).toBeInTheDocument();
+    const paragraph = within(container).getByTestId(TEST_ID);
+    expect(paragraph).toHaveTextContent(text);
+    const markdown = within(container).queryByTestId(RichDescription.TEST_IDS.markdown);
+    expect(markdown).not.toBeInTheDocument();
+  });
+  test('react rich text description, enabled enableMarkdownInDescription', () => {
+    const expectedBold = 'Rich';
+    const text = `**${expectedBold}** Text`;
+    const expected = `${expectedBold} Text`;
+    const props = getProps({ description: text, uiSchema: { 'ui:enableMarkdownInDescription': true } });
+    const { container } = render(<RichDescription {...props} />);
+    expect(container).toHaveTextContent(expected);
+    const markdown = within(container).getByTestId(RichDescription.TEST_IDS.markdown);
+    expect(markdown).toBeInTheDocument();
+    const bold = markdown.querySelector('strong');
+    expect(bold).toHaveTextContent(expectedBold);
+  });
+});

--- a/packages/core/test/__snapshots__/ArraySnap.test.tsx.snap
+++ b/packages/core/test/__snapshots__/ArraySnap.test.tsx.snap
@@ -635,12 +635,12 @@ exports[`with title and description array 1`] = `
       >
         Test field
       </legend>
-      <p
+      <div
         className="field-description"
         id="root__description"
       >
         a test description
-      </p>
+      </div>
       <div
         className="row array-item-list"
       />
@@ -695,12 +695,12 @@ exports[`with title and description array icons 1`] = `
       >
         Test field
       </legend>
-      <p
+      <div
         className="field-description"
         id="root__description"
       >
         a test description
-      </p>
+      </div>
       <div
         className="row array-item-list"
       >
@@ -724,12 +724,12 @@ exports[`with title and description array icons 1`] = `
                   *
                 </span>
               </label>
-              <p
+              <div
                 className="field-description"
                 id="root_0__description"
               >
                 a test item description
-              </p>
+              </div>
               <input
                 aria-describedby="root_0__error root_0__description root_0__help"
                 autoFocus={false}
@@ -832,12 +832,12 @@ exports[`with title and description array icons 1`] = `
                   *
                 </span>
               </label>
-              <p
+              <div
                 className="field-description"
                 id="root_1__description"
               >
                 a test item description
-              </p>
+              </div>
               <input
                 aria-describedby="root_1__error root_1__description root_1__help"
                 autoFocus={false}
@@ -969,12 +969,12 @@ exports[`with title and description checkboxes 1`] = `
     >
       Test field
     </label>
-    <p
+    <div
       className="field-description"
       id="root__description"
     >
       a test description
-    </p>
+    </div>
     <select
       aria-describedby="root__error root__description root__help"
       autoFocus={false}
@@ -1037,12 +1037,12 @@ exports[`with title and description fixed array 1`] = `
       >
         Test field
       </legend>
-      <p
+      <div
         className="field-description"
         id="root__description"
       >
         a test description
-      </p>
+      </div>
       <div
         className="row array-item-list"
       >
@@ -1066,12 +1066,12 @@ exports[`with title and description fixed array 1`] = `
                   *
                 </span>
               </label>
-              <p
+              <div
                 className="field-description"
                 id="root_0__description"
               >
                 a test item description
-              </p>
+              </div>
               <input
                 aria-describedby="root_0__error root_0__description root_0__help"
                 autoFocus={false}
@@ -1112,12 +1112,12 @@ exports[`with title and description fixed array 1`] = `
                   *
                 </span>
               </label>
-              <p
+              <div
                 className="field-description"
                 id="root_1__description"
               >
                 a test item description
-              </p>
+              </div>
               <input
                 aria-describedby="root_1__error root_1__description root_1__help"
                 autoFocus={false}
@@ -1172,12 +1172,12 @@ exports[`with title and description from both array 1`] = `
       >
         My Field
       </legend>
-      <p
+      <div
         className="field-description"
         id="root__description"
       >
         a fancier description
-      </p>
+      </div>
       <div
         className="row array-item-list"
       />
@@ -1232,12 +1232,12 @@ exports[`with title and description from both array icons 1`] = `
       >
         My Field
       </legend>
-      <p
+      <div
         className="field-description"
         id="root__description"
       >
         a fancier description
-      </p>
+      </div>
       <div
         className="row array-item-list"
       >
@@ -1261,12 +1261,12 @@ exports[`with title and description from both array icons 1`] = `
                   *
                 </span>
               </label>
-              <p
+              <div
                 className="field-description"
                 id="root_0__description"
               >
                 a fancier item description
-              </p>
+              </div>
               <input
                 aria-describedby="root_0__error root_0__description root_0__help"
                 autoFocus={false}
@@ -1369,12 +1369,12 @@ exports[`with title and description from both array icons 1`] = `
                   *
                 </span>
               </label>
-              <p
+              <div
                 className="field-description"
                 id="root_1__description"
               >
                 a fancier item description
-              </p>
+              </div>
               <input
                 aria-describedby="root_1__error root_1__description root_1__help"
                 autoFocus={false}
@@ -1506,12 +1506,12 @@ exports[`with title and description from both checkboxes 1`] = `
     >
       My Field
     </label>
-    <p
+    <div
       className="field-description"
       id="root__description"
     >
       a fancier description
-    </p>
+    </div>
     <select
       aria-describedby="root__error root__description root__help"
       autoFocus={false}
@@ -1574,12 +1574,12 @@ exports[`with title and description from both fixed array 1`] = `
       >
         My Field
       </legend>
-      <p
+      <div
         className="field-description"
         id="root__description"
       >
         a fancier description
-      </p>
+      </div>
       <div
         className="row array-item-list"
       >
@@ -1603,12 +1603,12 @@ exports[`with title and description from both fixed array 1`] = `
                   *
                 </span>
               </label>
-              <p
+              <div
                 className="field-description"
                 id="root_0__description"
               >
                 a fancier item description
-              </p>
+              </div>
               <input
                 aria-describedby="root_0__error root_0__description root_0__help"
                 autoFocus={false}
@@ -1649,12 +1649,12 @@ exports[`with title and description from both fixed array 1`] = `
                   *
                 </span>
               </label>
-              <p
+              <div
                 className="field-description"
                 id="root_1__description"
               >
                 a fancier item description
-              </p>
+              </div>
               <input
                 aria-describedby="root_1__error root_1__description root_1__help"
                 autoFocus={false}
@@ -1709,12 +1709,12 @@ exports[`with title and description from uiSchema array 1`] = `
       >
         My Field
       </legend>
-      <p
+      <div
         className="field-description"
         id="root__description"
       >
         a fancier description
-      </p>
+      </div>
       <div
         className="row array-item-list"
       />
@@ -1769,12 +1769,12 @@ exports[`with title and description from uiSchema array icons 1`] = `
       >
         My Field
       </legend>
-      <p
+      <div
         className="field-description"
         id="root__description"
       >
         a fancier description
-      </p>
+      </div>
       <div
         className="row array-item-list"
       >
@@ -1798,12 +1798,12 @@ exports[`with title and description from uiSchema array icons 1`] = `
                   *
                 </span>
               </label>
-              <p
+              <div
                 className="field-description"
                 id="root_0__description"
               >
                 a fancier item description
-              </p>
+              </div>
               <input
                 aria-describedby="root_0__error root_0__description root_0__help"
                 autoFocus={false}
@@ -1906,12 +1906,12 @@ exports[`with title and description from uiSchema array icons 1`] = `
                   *
                 </span>
               </label>
-              <p
+              <div
                 className="field-description"
                 id="root_1__description"
               >
                 a fancier item description
-              </p>
+              </div>
               <input
                 aria-describedby="root_1__error root_1__description root_1__help"
                 autoFocus={false}
@@ -2043,12 +2043,12 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
     >
       My Field
     </label>
-    <p
+    <div
       className="field-description"
       id="root__description"
     >
       a fancier description
-    </p>
+    </div>
     <select
       aria-describedby="root__error root__description root__help"
       autoFocus={false}
@@ -2111,12 +2111,12 @@ exports[`with title and description from uiSchema fixed array 1`] = `
       >
         My Field
       </legend>
-      <p
+      <div
         className="field-description"
         id="root__description"
       >
         a fancier description
-      </p>
+      </div>
       <div
         className="row array-item-list"
       >
@@ -2140,12 +2140,12 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                   *
                 </span>
               </label>
-              <p
+              <div
                 className="field-description"
                 id="root_0__description"
               >
                 a fancier item description
-              </p>
+              </div>
               <input
                 aria-describedby="root_0__error root_0__description root_0__help"
                 autoFocus={false}
@@ -2186,12 +2186,12 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                   *
                 </span>
               </label>
-              <p
+              <div
                 className="field-description"
                 id="root_1__description"
               >
                 a fancier item description
-              </p>
+              </div>
               <input
                 aria-describedby="root_1__error root_1__description root_1__help"
                 autoFocus={false}
@@ -2524,12 +2524,12 @@ exports[`with title and description with global label off checkboxes 1`] = `
     >
       Test field
     </label>
-    <p
+    <div
       className="field-description"
       id="root__description"
     >
       a test description
-    </p>
+    </div>
     <select
       aria-describedby="root__error root__description root__help"
       autoFocus={false}

--- a/packages/core/test/__snapshots__/FormSnap.test.tsx.snap
+++ b/packages/core/test/__snapshots__/FormSnap.test.tsx.snap
@@ -86,6 +86,114 @@ exports[`single fields checkbox field with label 1`] = `
 </form>
 `;
 
+exports[`single fields checkbox field with label and description 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group rjsf-field rjsf-field-boolean"
+  >
+    <div
+      className="checkbox "
+    >
+      <div
+        className="field-description"
+        id="root__description"
+      >
+        test description
+      </div>
+      <label>
+        <input
+          aria-describedby="root__error root__description root__help"
+          autoFocus={false}
+          checked={false}
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          required={false}
+          type="checkbox"
+        />
+        <span>
+          test
+        </span>
+      </label>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-info "
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields checkbox field with label and rich text description 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group rjsf-field rjsf-field-boolean"
+  >
+    <div
+      className="checkbox "
+    >
+      <div
+        className="field-description"
+        id="root__description"
+      >
+        <span>
+          <strong>
+            test
+          </strong>
+           
+          <strong>
+            description
+          </strong>
+        </span>
+      </div>
+      <label>
+        <input
+          aria-describedby="root__error root__description root__help"
+          autoFocus={false}
+          checked={false}
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          required={false}
+          type="checkbox"
+        />
+        <span>
+          test
+        </span>
+      </label>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-info "
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields checkboxes field 1`] = `
 <form
   className="rjsf"
@@ -236,12 +344,12 @@ exports[`single fields field with description 1`] = `
         >
           my-field
         </label>
-        <p
+        <div
           className="field-description"
           id="root_my-field__description"
         >
           some description
-        </p>
+        </div>
         <input
           aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
           autoFocus={false}
@@ -295,12 +403,138 @@ exports[`single fields field with description in uiSchema 1`] = `
         >
           my-field
         </label>
-        <p
+        <div
           className="field-description"
           id="root_my-field__description"
         >
           some other description
-        </p>
+        </div>
+        <input
+          aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root_my-field"
+          label="my-field"
+          name="root_my-field"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          required={false}
+          type="text"
+          value=""
+        />
+      </div>
+    </fieldset>
+  </div>
+  <div>
+    <button
+      className="btn btn-info "
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown description 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group rjsf-field rjsf-field-object"
+  >
+    <fieldset
+      id="root"
+    >
+      <div
+        className="form-group rjsf-field rjsf-field-string"
+      >
+        <label
+          className="control-label"
+          htmlFor="root_my-field"
+        >
+          my-field
+        </label>
+        <div
+          className="field-description"
+          id="root_my-field__description"
+        >
+          <span>
+            some 
+            <strong>
+              Rich
+            </strong>
+             description
+          </span>
+        </div>
+        <input
+          aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root_my-field"
+          label="my-field"
+          name="root_my-field"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          required={false}
+          type="text"
+          value=""
+        />
+      </div>
+    </fieldset>
+  </div>
+  <div>
+    <button
+      className="btn btn-info "
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown description in uiSchema 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group rjsf-field rjsf-field-object"
+  >
+    <fieldset
+      id="root"
+    >
+      <div
+        className="form-group rjsf-field rjsf-field-string"
+      >
+        <label
+          className="control-label"
+          htmlFor="root_my-field"
+        >
+          my-field
+        </label>
+        <div
+          className="field-description"
+          id="root_my-field__description"
+        >
+          <span>
+            some other description
+          </span>
+        </div>
         <input
           aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
           autoFocus={false}

--- a/packages/core/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/core/test/__snapshots__/GridSnap.test.tsx.snap
@@ -9,16 +9,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
   <div
     className="form-group rjsf-field rjsf-field-object"
   >
-    <div
-      data-testid="0"
-    >
+    <div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="col-xs-12"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-object"
@@ -33,11 +29,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
       </div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="col-xs-4"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -74,7 +68,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-4"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -106,7 +99,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-4"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -144,11 +136,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
       </div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="col-xs-3"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -185,7 +175,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-6"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-array"
@@ -201,12 +190,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 *
               </span>
             </label>
-            <p
+            <div
               className="field-description"
               id="root_person_race__description"
             >
               (Check all that apply)
-            </p>
+            </div>
             <div
               className="checkboxes"
               id="root_person_race"
@@ -337,22 +326,18 @@ exports[`Complex grid renders person and address and employment in a complex gri
       </div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="col-xs-6"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-object"
           >
             <div
               className="row"
-              data-testid="0"
             >
               <div
                 className="col-xs-12"
-                data-testid="1"
               >
                 <div
                   className="form-group rjsf-field rjsf-field-string"
@@ -389,7 +374,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-xs-12"
-                data-testid="1"
               >
                 <div
                   className="form-group rjsf-field rjsf-field-string"
@@ -421,7 +405,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-xs-12"
-                data-testid="1"
               >
                 <div
                   className="form-group rjsf-field rjsf-field-string"
@@ -456,12 +439,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   />
                 </div>
               </div>
-              <div
-                data-testid="0"
-              >
+              <div>
                 <div
                   className="col-xs-6"
-                  data-testid="1"
                 >
                   <div
                     className="form-group rjsf-field rjsf-field-string"
@@ -780,7 +760,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="col-xs-6"
-                  data-testid="1"
                 >
                   <div
                     className="form-group rjsf-field rjsf-field-string"
@@ -821,7 +800,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-6"
-          data-testid="1"
           style={
             {
               "margin": "26px 0",
@@ -913,7 +891,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-6"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -950,7 +927,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-6"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -982,7 +958,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-4"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -1019,7 +994,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-2"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -1360,16 +1334,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
   <div
     className="form-group rjsf-field rjsf-field-object"
   >
-    <div
-      data-testid="0"
-    >
+    <div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="col-xs-12"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-object"
@@ -1384,11 +1354,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
       </div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="col-xs-4"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -1425,7 +1393,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-4"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -1457,7 +1424,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-4"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -1495,11 +1461,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
       </div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="col-xs-3"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -1536,7 +1500,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-6"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-array"
@@ -1552,12 +1515,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 *
               </span>
             </label>
-            <p
+            <div
               className="field-description"
               id="root_person_race__description"
             >
               (Check all that apply)
-            </p>
+            </div>
             <div
               className="checkboxes"
               id="root_person_race"
@@ -1688,22 +1651,18 @@ exports[`Complex grid renders person and address and employment in a complex gri
       </div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="col-xs-6"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-object"
           >
             <div
               className="row"
-              data-testid="0"
             >
               <div
                 className="col-xs-12"
-                data-testid="1"
               >
                 <div
                   className="form-group rjsf-field rjsf-field-string"
@@ -1740,7 +1699,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-xs-12"
-                data-testid="1"
               >
                 <div
                   className="form-group rjsf-field rjsf-field-string"
@@ -1772,7 +1730,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-xs-12"
-                data-testid="1"
               >
                 <div
                   className="form-group rjsf-field rjsf-field-string"
@@ -1807,12 +1764,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   />
                 </div>
               </div>
-              <div
-                data-testid="0"
-              >
+              <div>
                 <div
                   className="col-xs-6"
-                  data-testid="1"
                 >
                   <div
                     className="form-group rjsf-field rjsf-field-string"
@@ -2131,7 +2085,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="col-xs-6"
-                  data-testid="1"
                 >
                   <div
                     className="form-group rjsf-field rjsf-field-string"
@@ -2172,7 +2125,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-6"
-          data-testid="1"
           style={
             {
               "margin": "26px 0",
@@ -2264,7 +2216,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-6"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -2296,7 +2247,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-6"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -2333,7 +2283,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-6"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -2365,7 +2314,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-4"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -2402,7 +2350,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-2"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -2743,16 +2690,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
   <div
     className="form-group rjsf-field rjsf-field-object"
   >
-    <div
-      data-testid="0"
-    >
+    <div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="col-xs-12"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-object"
@@ -2767,11 +2710,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
       </div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="col-xs-4"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -2808,7 +2749,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-4"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -2840,7 +2780,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-4"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -2878,11 +2817,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
       </div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="col-xs-3"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -2919,7 +2856,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-6"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-array"
@@ -2935,12 +2871,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 *
               </span>
             </label>
-            <p
+            <div
               className="field-description"
               id="root_person_race__description"
             >
               (Check all that apply)
-            </p>
+            </div>
             <div
               className="checkboxes"
               id="root_person_race"
@@ -3071,22 +3007,18 @@ exports[`Complex grid renders person and address and employment in a complex gri
       </div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="col-xs-6"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-object"
           >
             <div
               className="row"
-              data-testid="0"
             >
               <div
                 className="col-xs-12"
-                data-testid="1"
               >
                 <div
                   className="form-group rjsf-field rjsf-field-string"
@@ -3123,7 +3055,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-xs-12"
-                data-testid="1"
               >
                 <div
                   className="form-group rjsf-field rjsf-field-string"
@@ -3155,7 +3086,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-xs-12"
-                data-testid="1"
               >
                 <div
                   className="form-group rjsf-field rjsf-field-string"
@@ -3190,12 +3120,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   />
                 </div>
               </div>
-              <div
-                data-testid="0"
-              >
+              <div>
                 <div
                   className="col-xs-6"
-                  data-testid="1"
                 >
                   <div
                     className="form-group rjsf-field rjsf-field-string"
@@ -3514,7 +3441,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="col-xs-6"
-                  data-testid="1"
                 >
                   <div
                     className="form-group rjsf-field rjsf-field-string"
@@ -3555,7 +3481,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-6"
-          data-testid="1"
           style={
             {
               "margin": "26px 0",
@@ -3647,7 +3572,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-6"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -3705,16 +3629,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
   <div
     className="form-group rjsf-field rjsf-field-object"
   >
-    <div
-      data-testid="0"
-    >
+    <div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="col-xs-12"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-object"
@@ -3729,11 +3649,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
       </div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="col-xs-4"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -3770,7 +3688,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-4"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -3802,7 +3719,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-4"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -3840,11 +3756,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
       </div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="col-xs-3"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -3881,7 +3795,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-6"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-array"
@@ -3897,12 +3810,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 *
               </span>
             </label>
-            <p
+            <div
               className="field-description"
               id="root_person_race__description"
             >
               (Check all that apply)
-            </p>
+            </div>
             <div
               className="checkboxes"
               id="root_person_race"
@@ -4033,22 +3946,18 @@ exports[`Complex grid renders person and address and employment in a complex gri
       </div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="col-xs-6"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-object"
           >
             <div
               className="row"
-              data-testid="0"
             >
               <div
                 className="col-xs-12"
-                data-testid="1"
               >
                 <div
                   className="form-group rjsf-field rjsf-field-string"
@@ -4085,7 +3994,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-xs-12"
-                data-testid="1"
               >
                 <div
                   className="form-group rjsf-field rjsf-field-string"
@@ -4117,7 +4025,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-xs-12"
-                data-testid="1"
               >
                 <div
                   className="form-group rjsf-field rjsf-field-string"
@@ -4152,12 +4059,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   />
                 </div>
               </div>
-              <div
-                data-testid="0"
-              >
+              <div>
                 <div
                   className="col-xs-6"
-                  data-testid="1"
                 >
                   <div
                     className="form-group rjsf-field rjsf-field-string"
@@ -4476,7 +4380,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
                 <div
                   className="col-xs-6"
-                  data-testid="1"
                 >
                   <div
                     className="form-group rjsf-field rjsf-field-string"
@@ -4517,7 +4420,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-6"
-          data-testid="1"
           style={
             {
               "margin": "26px 0",
@@ -4609,7 +4511,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-6"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -4646,7 +4547,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-6"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -4678,7 +4578,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-4"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -4715,7 +4614,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="col-xs-2"
-          data-testid="1"
         >
           <div
             className="form-group rjsf-field rjsf-field-string"
@@ -5058,11 +4956,9 @@ exports[`Three even column grid renders person and address in three columns, no 
   >
     <div
       className="row"
-      data-testid="0"
     >
       <div
         className="col-xs-12"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-object"
@@ -5076,7 +4972,6 @@ exports[`Three even column grid renders person and address in three columns, no 
       </div>
       <div
         className="col-xs-4"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-string"
@@ -5113,7 +5008,6 @@ exports[`Three even column grid renders person and address in three columns, no 
       </div>
       <div
         className="col-xs-4"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-string"
@@ -5145,7 +5039,6 @@ exports[`Three even column grid renders person and address in three columns, no 
       </div>
       <div
         className="col-xs-4"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-string"
@@ -5182,7 +5075,6 @@ exports[`Three even column grid renders person and address in three columns, no 
       </div>
       <div
         className="col-xs-4"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-string"
@@ -5219,7 +5111,6 @@ exports[`Three even column grid renders person and address in three columns, no 
       </div>
       <div
         className="col-xs-8"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-array"
@@ -5235,12 +5126,12 @@ exports[`Three even column grid renders person and address in three columns, no 
               *
             </span>
           </label>
-          <p
+          <div
             className="field-description"
             id="root_person_race__description"
           >
             (Check all that apply)
-          </p>
+          </div>
           <div
             className="checkboxes"
             id="root_person_race"
@@ -5370,7 +5261,6 @@ exports[`Three even column grid renders person and address in three columns, no 
       </div>
       <div
         className="col-xs-6"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-string"
@@ -5407,7 +5297,6 @@ exports[`Three even column grid renders person and address in three columns, no 
       </div>
       <div
         className="col-xs-6"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-string"
@@ -5439,7 +5328,6 @@ exports[`Three even column grid renders person and address in three columns, no 
       </div>
       <div
         className="col-xs-4"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-string"
@@ -5476,7 +5364,6 @@ exports[`Three even column grid renders person and address in three columns, no 
       </div>
       <div
         className="col-xs-4"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-string"
@@ -5795,7 +5682,6 @@ exports[`Three even column grid renders person and address in three columns, no 
       </div>
       <div
         className="col-xs-4"
-        data-testid="1"
       />
     </div>
   </div>
@@ -5822,11 +5708,9 @@ exports[`Two even column grid renders person and address in two columns, no empl
   >
     <div
       className="row"
-      data-testid="0"
     >
       <div
         className="col-xs-12"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-object"
@@ -5840,7 +5724,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
       </div>
       <div
         className="col-xs-6"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-string"
@@ -5877,7 +5760,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
       </div>
       <div
         className="col-xs-6"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-string"
@@ -5909,7 +5791,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
       </div>
       <div
         className="col-xs-6"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-string"
@@ -5946,7 +5827,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
       </div>
       <div
         className="col-xs-6"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-string"
@@ -5983,7 +5863,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
       </div>
       <div
         className="col-xs-12"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-array"
@@ -5999,12 +5878,12 @@ exports[`Two even column grid renders person and address in two columns, no empl
               *
             </span>
           </label>
-          <p
+          <div
             className="field-description"
             id="root_person_race__description"
           >
             (Check all that apply)
-          </p>
+          </div>
           <div
             className="checkboxes"
             id="root_person_race"
@@ -6134,7 +6013,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
       </div>
       <div
         className="col-xs-6"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-string"
@@ -6171,7 +6049,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
       </div>
       <div
         className="col-xs-6"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-string"
@@ -6203,7 +6080,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
       </div>
       <div
         className="col-xs-6"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-string"
@@ -6240,7 +6116,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
       </div>
       <div
         className="col-xs-6"
-        data-testid="1"
       >
         <div
           className="form-group rjsf-field rjsf-field-string"
@@ -6559,7 +6434,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
       </div>
       <div
         className="col-xs-12"
-        data-testid="1"
       />
     </div>
   </div>

--- a/packages/core/test/__snapshots__/ObjectSnap.test.tsx.snap
+++ b/packages/core/test/__snapshots__/ObjectSnap.test.tsx.snap
@@ -342,12 +342,12 @@ exports[`object fields with title and description additionalProperties 1`] = `
       >
         Test field
       </legend>
-      <p
+      <div
         className="field-description"
         id="root__description"
       >
         a test description
-      </p>
+      </div>
       <div
         className="form-group rjsf-field rjsf-field-string"
       >
@@ -475,12 +475,12 @@ exports[`object fields with title and description from both additionalProperties
       >
         My Field
       </legend>
-      <p
+      <div
         className="field-description"
         id="root__description"
       >
         a fancier description
-      </p>
+      </div>
       <div
         className="form-group rjsf-field rjsf-field-string"
       >
@@ -608,12 +608,12 @@ exports[`object fields with title and description from both object 1`] = `
       >
         My Field
       </legend>
-      <p
+      <div
         className="field-description"
         id="root__description"
       >
         a fancier description
-      </p>
+      </div>
       <div
         className="form-group rjsf-field rjsf-field-string"
       >
@@ -623,12 +623,12 @@ exports[`object fields with title and description from both object 1`] = `
         >
           My Item A
         </label>
-        <p
+        <div
           className="field-description"
           id="root_a__description"
         >
           a fancier item A description
-        </p>
+        </div>
         <input
           aria-describedby="root_a__error root_a__description root_a__help"
           autoFocus={false}
@@ -656,12 +656,12 @@ exports[`object fields with title and description from both object 1`] = `
         >
           My Item B
         </label>
-        <p
+        <div
           className="field-description"
           id="root_b__description"
         >
           a fancier item B description
-        </p>
+        </div>
         <input
           aria-describedby="root_b__error root_b__description root_b__help"
           autoFocus={false}
@@ -712,12 +712,12 @@ exports[`object fields with title and description from uiSchema additionalProper
       >
         My Field
       </legend>
-      <p
+      <div
         className="field-description"
         id="root__description"
       >
         a fancier description
-      </p>
+      </div>
       <div
         className="form-group rjsf-field rjsf-field-string"
       >
@@ -845,12 +845,12 @@ exports[`object fields with title and description from uiSchema object 1`] = `
       >
         My Field
       </legend>
-      <p
+      <div
         className="field-description"
         id="root__description"
       >
         a fancier description
-      </p>
+      </div>
       <div
         className="form-group rjsf-field rjsf-field-string"
       >
@@ -860,12 +860,12 @@ exports[`object fields with title and description from uiSchema object 1`] = `
         >
           My Item A
         </label>
-        <p
+        <div
           className="field-description"
           id="root_a__description"
         >
           a fancier item A description
-        </p>
+        </div>
         <input
           aria-describedby="root_a__error root_a__description root_a__help"
           autoFocus={false}
@@ -893,12 +893,12 @@ exports[`object fields with title and description from uiSchema object 1`] = `
         >
           My Item B
         </label>
-        <p
+        <div
           className="field-description"
           id="root_b__description"
         >
           a fancier item B description
-        </p>
+        </div>
         <input
           aria-describedby="root_b__error root_b__description root_b__help"
           autoFocus={false}
@@ -949,12 +949,12 @@ exports[`object fields with title and description from uiSchema show add button 
       >
         My Field
       </legend>
-      <p
+      <div
         className="field-description"
         id="root__description"
       >
         a fancier description
-      </p>
+      </div>
       <div
         className="form-group rjsf-field rjsf-field-string"
       >
@@ -1082,12 +1082,12 @@ exports[`object fields with title and description object 1`] = `
       >
         Test field
       </legend>
-      <p
+      <div
         className="field-description"
         id="root__description"
       >
         a test description
-      </p>
+      </div>
       <div
         className="form-group rjsf-field rjsf-field-string"
       >
@@ -1097,12 +1097,12 @@ exports[`object fields with title and description object 1`] = `
         >
           A
         </label>
-        <p
+        <div
           className="field-description"
           id="root_a__description"
         >
           A description
-        </p>
+        </div>
         <input
           aria-describedby="root_a__error root_a__description root_a__help"
           autoFocus={false}
@@ -1130,12 +1130,12 @@ exports[`object fields with title and description object 1`] = `
         >
           B
         </label>
-        <p
+        <div
           className="field-description"
           id="root_b__description"
         >
           B description
-        </p>
+        </div>
         <input
           aria-describedby="root_b__error root_b__description root_b__help"
           autoFocus={false}
@@ -1186,12 +1186,12 @@ exports[`object fields with title and description show add button and fields if 
       >
         Test field
       </legend>
-      <p
+      <div
         className="field-description"
         id="root__description"
       >
         a test description
-      </p>
+      </div>
       <div
         className="form-group rjsf-field rjsf-field-string"
       >

--- a/packages/core/test/uiSchema.test.jsx
+++ b/packages/core/test/uiSchema.test.jsx
@@ -552,7 +552,7 @@ describe('uiSchema', () => {
 
       const { node } = createFormComponent({ schema, uiSchema });
 
-      expect(node.querySelector('p.field-description').textContent).eql('plop');
+      expect(node.querySelector('div.field-description').textContent).eql('plop');
     });
   });
 

--- a/packages/daisyui/package.json
+++ b/packages/daisyui/package.json
@@ -54,7 +54,8 @@
     "precommit": "lint-staged",
     "test": "jest",
     "test:update": "jest --u",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "test:debug": "node --inspect-brk ../../node_modules/.bin/jest"
   },
   "lint-staged": {
     "{src,test}/**/*.ts?(x)": [

--- a/packages/daisyui/src/templates/DescriptionField/DescriptionField.tsx
+++ b/packages/daisyui/src/templates/DescriptionField/DescriptionField.tsx
@@ -1,4 +1,5 @@
 import { DescriptionFieldProps, StrictRJSFSchema, RJSFSchema, FormContextType } from '@rjsf/utils';
+import { RichDescription } from '@rjsf/core';
 
 /** The `DescriptionField` component renders descriptive text for a form field
  * with DaisyUI styling. It displays the description in a subtle text color
@@ -11,10 +12,15 @@ export default function DescriptionField<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: DescriptionFieldProps<T, S, F>) {
-  const { id, description } = props;
+  const { id, description, registry, uiSchema } = props;
+  if (!description) {
+    return null;
+  }
   return (
     <div id={id} className='description-field my-4'>
-      <div className='text-sm text-base-content/80'>{description}</div>
+      <div className='text-sm text-base-content/80'>
+        <RichDescription description={description} registry={registry} uiSchema={uiSchema} />
+      </div>
     </div>
   );
 }

--- a/packages/daisyui/src/templates/FieldTemplate/FieldTemplate.tsx
+++ b/packages/daisyui/src/templates/FieldTemplate/FieldTemplate.tsx
@@ -38,7 +38,6 @@ export default function FieldTemplate<
     required,
     rawErrors,
     rawHelp,
-    description,
     rawDescription,
     hidden,
     onChange,
@@ -59,20 +58,7 @@ export default function FieldTemplate<
           </span>
         </label>
       )}
-      {isCheckbox ? (
-        <div className='form-control'>
-          {description}
-          <label className='label cursor-pointer justify-start'>
-            <div className='mr-2'>{children}</div>
-            <span className='label-text'>
-              {label}
-              {required && <span className='text-error ml-1'>*</span>}
-            </span>
-          </label>
-        </div>
-      ) : (
-        children
-      )}
+      {children}
       {errors}
       {help}
     </div>

--- a/packages/daisyui/src/templates/FieldTemplate/FieldTemplate.tsx
+++ b/packages/daisyui/src/templates/FieldTemplate/FieldTemplate.tsx
@@ -38,9 +38,11 @@ export default function FieldTemplate<
     required,
     rawErrors,
     rawHelp,
+    description,
     rawDescription,
     hidden,
     onChange,
+    registry,
     ...divProps
   } = props;
 
@@ -59,6 +61,7 @@ export default function FieldTemplate<
       )}
       {isCheckbox ? (
         <div className='form-control'>
+          {description}
           <label className='label cursor-pointer justify-start'>
             <div className='mr-2'>{children}</div>
             <span className='label-text'>

--- a/packages/daisyui/src/widgets/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/daisyui/src/widgets/CheckboxWidget/CheckboxWidget.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { WidgetProps, StrictRJSFSchema, RJSFSchema, FormContextType } from '@rjsf/utils';
+import { WidgetProps, StrictRJSFSchema, RJSFSchema, FormContextType, getTemplate, descriptionId } from '@rjsf/utils';
 
 /** The `CheckboxWidget` component renders a single checkbox input with DaisyUI styling.
  *
@@ -17,7 +17,28 @@ export default function CheckboxWidget<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: WidgetProps<T, S, F>) {
-  const { id, value, required, disabled, readonly, onChange, onFocus, onBlur } = props;
+  const {
+    id,
+    value,
+    required,
+    disabled,
+    hideLabel,
+    label,
+    readonly,
+    registry,
+    options,
+    schema,
+    uiSchema,
+    onChange,
+    onFocus,
+    onBlur,
+  } = props;
+  const DescriptionFieldTemplate = getTemplate<'DescriptionFieldTemplate', T, S, F>(
+    'DescriptionFieldTemplate',
+    registry,
+    options,
+  );
+  const description = options.description || schema.description;
 
   /** Handle focus events
    */
@@ -46,8 +67,7 @@ export default function CheckboxWidget<
     [onChange],
   );
 
-  // Don't display the label here since the FieldTemplate already handles it
-  return (
+  const input = (
     <input
       type='checkbox'
       id={id}
@@ -59,5 +79,30 @@ export default function CheckboxWidget<
       onBlur={handleBlur}
       className='checkbox'
     />
+  );
+
+  return (
+    <div className='form-control'>
+      {!hideLabel && !!description && (
+        <DescriptionFieldTemplate
+          id={descriptionId<T>(id)}
+          description={description}
+          schema={schema}
+          uiSchema={uiSchema}
+          registry={registry}
+        />
+      )}
+      {hideLabel || !label ? (
+        input
+      ) : (
+        <label className='label cursor-pointer justify-start'>
+          <div className='mr-2'>{input}</div>
+          <span className='label-text'>
+            {label}
+            {required && <span className='text-error ml-1'>*</span>}
+          </span>
+        </label>
+      )}
+    </div>
   );
 }

--- a/packages/daisyui/src/widgets/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/daisyui/src/widgets/CheckboxWidget/CheckboxWidget.tsx
@@ -83,7 +83,7 @@ export default function CheckboxWidget<
 
   return (
     <div className='form-control'>
-      {!hideLabel && !!description && (
+      {!hideLabel && description && (
         <DescriptionFieldTemplate
           id={descriptionId<T>(id)}
           description={description}

--- a/packages/docs/docs/api-reference/uiSchema.md
+++ b/packages/docs/docs/api-reference/uiSchema.md
@@ -207,6 +207,41 @@ The `ui:disabled` uiSchema directive will disable all child widgets from a given
 
 > Note: If you're wondering about the difference between a `disabled` field and a `readonly` one: Marking a field as read-only will render it greyed out, but its text value will be selectable. Disabling it will prevent its value to be selected at all.
 
+### enableMarkdownInDescription
+
+The `ui:enableMarkdownInDescription` uiSchema directive enables the support of Markdown syntax within the description of
+a field.
+
+```tsx
+import { Form } from '@rjsf/core';
+import { RJSFSchema, UiSchema } from '@rjsf/utils';
+import validator from '@rjsf/validator-ajv8';
+
+const schema: RJSFSchema = { type: 'string', description: '**bolded** text in the description' };
+const uiSchema: UiSchema = {
+  'ui:enableMarkdownInDescription': true,
+};
+render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />, document.getElementById('app'));
+```
+
+It can also be enabled globally by setting the `enableMarkdownInDescription` option to `true` in the `ui:globalOptions`
+uiSchema directive.
+
+```tsx
+import { Form } from '@rjsf/core';
+import { RJSFSchema, UiSchema } from '@rjsf/utils';
+import validator from '@rjsf/validator-ajv8';
+
+const schema: RJSFSchema = { type: 'string', description: '**bolded** text in the description' };
+const uiSchema: UiSchema = {
+  'ui:globalOptions': {
+    enableMarkdownInDescription: true,
+  },
+};
+
+render(<Form schema={schema} uiSchema={uiSchema} validator={validator} />, document.getElementById('app'));
+```
+
 ### emptyValue
 
 The `ui:emptyValue` uiSchema directive provides the default value to use when an input for a field is empty

--- a/packages/fluentui-rc/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/fluentui-rc/src/CheckboxWidget/CheckboxWidget.tsx
@@ -54,7 +54,7 @@ export default function CheckboxWidget<
 
   return (
     <>
-      {!hideLabel && !!description && (
+      {!hideLabel && description && (
         <DescriptionFieldTemplate
           id={descriptionId<T>(id)}
           description={description}

--- a/packages/fluentui-rc/src/DescriptionField/DescriptionField.tsx
+++ b/packages/fluentui-rc/src/DescriptionField/DescriptionField.tsx
@@ -1,5 +1,6 @@
 import { Text, makeStyles, tokens } from '@fluentui/react-components';
 import { DescriptionFieldProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
+import { RichDescription } from '@rjsf/core';
 
 const useStyles = makeStyles({
   label: {
@@ -17,15 +18,15 @@ export default function DescriptionField<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: DescriptionFieldProps<T, S, F>) {
-  const { id, description } = props;
+  const { id, description, registry, uiSchema } = props;
   const classes = useStyles();
-  if (description) {
-    return (
-      <Text block id={id} className={classes.label}>
-        {description}
-      </Text>
-    );
+  if (!description) {
+    return null;
   }
 
-  return null;
+  return (
+    <Text block id={id} className={classes.label}>
+      <RichDescription description={description} registry={registry} uiSchema={uiSchema} />
+    </Text>
+  );
 }

--- a/packages/fluentui-rc/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluentui-rc/test/__snapshots__/Form.test.tsx.snap
@@ -112,6 +112,140 @@ exports[`single fields checkbox field with label 1`] = `
 </form>
 `;
 
+exports[`single fields checkbox field with label and description 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-boolean"
+  >
+    <div
+      className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
+    >
+      <span
+        className="fui-Text ___6s2bv30_bwsv0h0 fk6fouc fkhj508 f1i3iumi figsok6 fpgzoln ftgm304 f6juhto f1gl81tg f2jf649 frnwi6n f18zxyen"
+        id="root__description"
+      >
+        test description
+      </span>
+      <span
+        className="fui-Checkbox r1q22k1j ___1v6wcsu_941lme0 f3p8bqa fium13f f1r2dosr f1729es6"
+      >
+        <input
+          aria-describedby="root__error root__description root__help"
+          autoFocus={false}
+          checked={false}
+          className="fui-Checkbox__input ruo9svu ___qlal8r0_1xrlghj f1vgc2s3"
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          required={false}
+          type="checkbox"
+        />
+        <div
+          aria-hidden={true}
+          className="fui-Checkbox__indicator rl7ci6d"
+        />
+        <label
+          className="fui-Label fui-Checkbox__label ___z217dr0_6ezprl0 fk6fouc f1ym3bx4 fkhj508 f1i3iumi f7nlbp4 fpo1scq fruq291 f1f5q0n8 fjzwpt6 fh6j2fo"
+          htmlFor="root"
+        >
+          test
+        </label>
+      </span>
+    </div>
+  </div>
+  <div
+    className="___fko12g0_0000000 f1wswflg"
+  >
+    <button
+      className="fui-Button r1alrhcs ___1akj6hk_ih97uj0 ffp7eso f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1phragk f15wkkf3 f1s2uweq fr80ssc f1ukrpxl fecsdlb f1rq72xc fnp9lpt f1h0usnq fs4ktlq f16h9ulv fx2bmrt f1d6v5y2 f1rirnrt f1uu00uk fkvaka8 f1ux7til f9a0qzu f1lkg8j3 fkc42ay fq7113v ff1wgvm fiob0tu f1j6scgf f1x4h75k f4xjyn1 fbgcvur f1ks1yx8 f1o6qegi fcnxywj fmxjhhp f9ddjv3 f17t0x8g f194v5ow f1qgg65p fk7jm04 fhgccpy f32wu9k fu5nqqq f13prjl2 f1czftr5 f1nl83rv f12k37oa fr96u23"
+      disabled={false}
+      onClick={[Function]}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields checkbox field with label and rich text description 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-boolean"
+  >
+    <div
+      className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
+    >
+      <span
+        className="fui-Text ___6s2bv30_bwsv0h0 fk6fouc fkhj508 f1i3iumi figsok6 fpgzoln ftgm304 f6juhto f1gl81tg f2jf649 frnwi6n f18zxyen"
+        id="root__description"
+      >
+        <span>
+          <strong>
+            test
+          </strong>
+           
+          <strong>
+            description
+          </strong>
+        </span>
+      </span>
+      <span
+        className="fui-Checkbox r1q22k1j ___1v6wcsu_941lme0 f3p8bqa fium13f f1r2dosr f1729es6"
+      >
+        <input
+          aria-describedby="root__error root__description root__help"
+          autoFocus={false}
+          checked={false}
+          className="fui-Checkbox__input ruo9svu ___qlal8r0_1xrlghj f1vgc2s3"
+          disabled={false}
+          id="root"
+          name="root"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          required={false}
+          type="checkbox"
+        />
+        <div
+          aria-hidden={true}
+          className="fui-Checkbox__indicator rl7ci6d"
+        />
+        <label
+          className="fui-Label fui-Checkbox__label ___z217dr0_6ezprl0 fk6fouc f1ym3bx4 fkhj508 f1i3iumi f7nlbp4 fpo1scq fruq291 f1f5q0n8 fjzwpt6 fh6j2fo"
+          htmlFor="root"
+        >
+          test
+        </label>
+      </span>
+    </div>
+  </div>
+  <div
+    className="___fko12g0_0000000 f1wswflg"
+  >
+    <button
+      className="fui-Button r1alrhcs ___1akj6hk_ih97uj0 ffp7eso f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1phragk f15wkkf3 f1s2uweq fr80ssc f1ukrpxl fecsdlb f1rq72xc fnp9lpt f1h0usnq fs4ktlq f16h9ulv fx2bmrt f1d6v5y2 f1rirnrt f1uu00uk fkvaka8 f1ux7til f9a0qzu f1lkg8j3 fkc42ay fq7113v ff1wgvm fiob0tu f1j6scgf f1x4h75k f4xjyn1 fbgcvur f1ks1yx8 f1o6qegi fcnxywj fmxjhhp f9ddjv3 f17t0x8g f194v5ow f1qgg65p fk7jm04 fhgccpy f32wu9k fu5nqqq f13prjl2 f1czftr5 f1nl83rv f12k37oa fr96u23"
+      disabled={false}
+      onClick={[Function]}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields checkboxes field 1`] = `
 <form
   className="rjsf"
@@ -418,6 +552,196 @@ exports[`single fields field with description in uiSchema 1`] = `
                   id="root_my-field__description"
                 >
                   some other description
+                </span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="___fko12g0_0000000 f1wswflg"
+  >
+    <button
+      className="fui-Button r1alrhcs ___1akj6hk_ih97uj0 ffp7eso f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1phragk f15wkkf3 f1s2uweq fr80ssc f1ukrpxl fecsdlb f1rq72xc fnp9lpt f1h0usnq fs4ktlq f16h9ulv fx2bmrt f1d6v5y2 f1rirnrt f1uu00uk fkvaka8 f1ux7til f9a0qzu f1lkg8j3 fkc42ay fq7113v ff1wgvm fiob0tu f1j6scgf f1x4h75k f4xjyn1 fbgcvur f1ks1yx8 f1o6qegi fcnxywj fmxjhhp f9ddjv3 f17t0x8g f194v5ow f1qgg65p fk7jm04 fhgccpy f32wu9k fu5nqqq f13prjl2 f1czftr5 f1nl83rv f12k37oa fr96u23"
+      disabled={false}
+      onClick={[Function]}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown description 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
+    >
+      <div
+        className="fui-Flex ___2axmsj0_qpg1ts0 f22iagw f1vx9l62 fly5x3f f1l02sjl f16r77es"
+      >
+        <div
+          className="fui-Flex ___13jx0ny_nlbnai0 f22iagw f1vx9l62 fly5x3f f1l02sjl"
+          style={
+            {
+              "marginBottom": "10px",
+            }
+          }
+        >
+          <div
+            className="rjsf-field rjsf-field-string"
+          >
+            <div
+              className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
+            >
+              <label
+                className="fui-Label ___zkh2gz0_1ef3qts fk6fouc f19n0e5 fkhj508 f1i3iumi fq1loh5 futqtb8 f14rdt9"
+                htmlFor="root_my-field"
+              >
+                my-field
+              </label>
+              <span
+                className="fui-Input r1oeeo9n ___1v9icnz_137yv9i fvcxoqz f1ub3y4t f1l4zc64 f1m52nbi f8vnjqi fz1etlk f1klwx88 f1hc16gm"
+              >
+                <input
+                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                  autoFocus={false}
+                  className="fui-Input__input r12stul0 ___cqaz2i0_9xw1o20 fly5x3f"
+                  disabled={false}
+                  id="root_my-field"
+                  name="root_my-field"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  required={false}
+                  type="text"
+                  value=""
+                />
+              </span>
+              <p
+                className="fui-Text ___3772g50_1srj68j fk6fouc fkhj508 f1i3iumi figsok6 fpgzoln ftgm304 f6juhto f1gl81tg f2jf649"
+                style={
+                  {
+                    "marginBottom": 0,
+                    "marginTop": 0,
+                  }
+                }
+              >
+                <span
+                  className="fui-Text ___6s2bv30_bwsv0h0 fk6fouc fkhj508 f1i3iumi figsok6 fpgzoln ftgm304 f6juhto f1gl81tg f2jf649 frnwi6n f18zxyen"
+                  id="root_my-field__description"
+                >
+                  <span>
+                    some 
+                    <strong>
+                      Rich
+                    </strong>
+                     description
+                  </span>
+                </span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="___fko12g0_0000000 f1wswflg"
+  >
+    <button
+      className="fui-Button r1alrhcs ___1akj6hk_ih97uj0 ffp7eso f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1phragk f15wkkf3 f1s2uweq fr80ssc f1ukrpxl fecsdlb f1rq72xc fnp9lpt f1h0usnq fs4ktlq f16h9ulv fx2bmrt f1d6v5y2 f1rirnrt f1uu00uk fkvaka8 f1ux7til f9a0qzu f1lkg8j3 fkc42ay fq7113v ff1wgvm fiob0tu f1j6scgf f1x4h75k f4xjyn1 fbgcvur f1ks1yx8 f1o6qegi fcnxywj fmxjhhp f9ddjv3 f17t0x8g f194v5ow f1qgg65p fk7jm04 fhgccpy f32wu9k fu5nqqq f13prjl2 f1czftr5 f1nl83rv f12k37oa fr96u23"
+      disabled={false}
+      onClick={[Function]}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown description in uiSchema 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
+    >
+      <div
+        className="fui-Flex ___2axmsj0_qpg1ts0 f22iagw f1vx9l62 fly5x3f f1l02sjl f16r77es"
+      >
+        <div
+          className="fui-Flex ___13jx0ny_nlbnai0 f22iagw f1vx9l62 fly5x3f f1l02sjl"
+          style={
+            {
+              "marginBottom": "10px",
+            }
+          }
+        >
+          <div
+            className="rjsf-field rjsf-field-string"
+          >
+            <div
+              className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
+            >
+              <label
+                className="fui-Label ___zkh2gz0_1ef3qts fk6fouc f19n0e5 fkhj508 f1i3iumi fq1loh5 futqtb8 f14rdt9"
+                htmlFor="root_my-field"
+              >
+                my-field
+              </label>
+              <span
+                className="fui-Input r1oeeo9n ___1v9icnz_137yv9i fvcxoqz f1ub3y4t f1l4zc64 f1m52nbi f8vnjqi fz1etlk f1klwx88 f1hc16gm"
+              >
+                <input
+                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                  autoFocus={false}
+                  className="fui-Input__input r12stul0 ___cqaz2i0_9xw1o20 fly5x3f"
+                  disabled={false}
+                  id="root_my-field"
+                  name="root_my-field"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  required={false}
+                  type="text"
+                  value=""
+                />
+              </span>
+              <p
+                className="fui-Text ___3772g50_1srj68j fk6fouc fkhj508 f1i3iumi figsok6 fpgzoln ftgm304 f6juhto f1gl81tg f2jf649"
+                style={
+                  {
+                    "marginBottom": 0,
+                    "marginTop": 0,
+                  }
+                }
+              >
+                <span
+                  className="fui-Text ___6s2bv30_bwsv0h0 fk6fouc fkhj508 f1i3iumi figsok6 fpgzoln ftgm304 f6juhto f1gl81tg f2jf649 frnwi6n f18zxyen"
+                  id="root_my-field__description"
+                >
+                  <span>
+                    some other description
+                  </span>
                 </span>
               </p>
             </div>

--- a/packages/fluentui-rc/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/fluentui-rc/test/__snapshots__/GridSnap.test.tsx.snap
@@ -14,7 +14,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
     >
       <div
         className="fui-Grid ___1jjz2ji_698obq0 f13qh94s figf6al f14wuttv"
-        data-testid="0"
         style={
           {
             "columnGap": "5px",
@@ -25,7 +24,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         }
       >
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 12",
@@ -58,7 +56,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -107,7 +104,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "5 / span 4",
@@ -150,7 +146,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "9 / span 4",
@@ -199,7 +194,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -248,7 +242,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "5 / span 8",
@@ -469,7 +462,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -478,7 +470,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         />
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -487,7 +478,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         />
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -496,7 +486,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         />
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -512,11 +501,8 @@ exports[`Complex grid renders person and address and employment in a complex gri
             >
               <div
                 className="row"
-                data-testid="0"
               >
-                <div
-                  data-testid="1"
-                >
+                <div>
                   <div
                     className="rjsf-field rjsf-field-string"
                   >
@@ -557,9 +543,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                   </div>
                 </div>
-                <div
-                  data-testid="1"
-                >
+                <div>
                   <div
                     className="rjsf-field rjsf-field-string"
                   >
@@ -594,9 +578,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                   </div>
                 </div>
-                <div
-                  data-testid="1"
-                >
+                <div>
                   <div
                     className="rjsf-field rjsf-field-string"
                   >
@@ -637,12 +619,8 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                   </div>
                 </div>
-                <div
-                  data-testid="0"
-                >
-                  <div
-                    data-testid="1"
-                  >
+                <div>
+                  <div>
                     <div
                       className="rjsf-field rjsf-field-string"
                     >
@@ -732,9 +710,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                     </div>
                   </div>
-                  <div
-                    data-testid="1"
-                  >
+                  <div>
                     <div
                       className="rjsf-field rjsf-field-string"
                     >
@@ -781,7 +757,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="0"
           style={
             {
               "gridColumn": "6 / span 7",
@@ -790,7 +765,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            data-testid="1"
             style={
               {
                 "padding": "3px 0",
@@ -892,9 +866,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
             </div>
           </div>
-          <div
-            data-testid="1"
-          >
+          <div>
             <div
               className="rjsf-field rjsf-field-string"
             >
@@ -935,9 +907,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
             </div>
           </div>
-          <div
-            data-testid="1"
-          >
+          <div>
             <div
               className="rjsf-field rjsf-field-string"
             >
@@ -972,12 +942,8 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
             </div>
           </div>
-          <div
-            data-testid="0"
-          >
-            <div
-              data-testid="1"
-            >
+          <div>
+            <div>
               <div
                 className="rjsf-field rjsf-field-string"
               >
@@ -1018,9 +984,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
               </div>
             </div>
-            <div
-              data-testid="1"
-            >
+            <div>
               <div
                 className="rjsf-field rjsf-field-string"
               >
@@ -1144,7 +1108,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
     >
       <div
         className="fui-Grid ___1jjz2ji_698obq0 f13qh94s figf6al f14wuttv"
-        data-testid="0"
         style={
           {
             "columnGap": "5px",
@@ -1155,7 +1118,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         }
       >
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 12",
@@ -1188,7 +1150,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -1237,7 +1198,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "5 / span 4",
@@ -1280,7 +1240,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "9 / span 4",
@@ -1329,7 +1288,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -1378,7 +1336,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "5 / span 8",
@@ -1599,7 +1556,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -1608,7 +1564,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         />
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -1617,7 +1572,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         />
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -1626,7 +1580,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         />
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -1642,11 +1595,8 @@ exports[`Complex grid renders person and address and employment in a complex gri
             >
               <div
                 className="row"
-                data-testid="0"
               >
-                <div
-                  data-testid="1"
-                >
+                <div>
                   <div
                     className="rjsf-field rjsf-field-string"
                   >
@@ -1687,9 +1637,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                   </div>
                 </div>
-                <div
-                  data-testid="1"
-                >
+                <div>
                   <div
                     className="rjsf-field rjsf-field-string"
                   >
@@ -1724,9 +1672,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                   </div>
                 </div>
-                <div
-                  data-testid="1"
-                >
+                <div>
                   <div
                     className="rjsf-field rjsf-field-string"
                   >
@@ -1767,12 +1713,8 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                   </div>
                 </div>
-                <div
-                  data-testid="0"
-                >
-                  <div
-                    data-testid="1"
-                  >
+                <div>
+                  <div>
                     <div
                       className="rjsf-field rjsf-field-string"
                     >
@@ -1862,9 +1804,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                     </div>
                   </div>
-                  <div
-                    data-testid="1"
-                  >
+                  <div>
                     <div
                       className="rjsf-field rjsf-field-string"
                     >
@@ -1911,7 +1851,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="0"
           style={
             {
               "gridColumn": "6 / span 7",
@@ -1920,7 +1859,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            data-testid="1"
             style={
               {
                 "padding": "3px 0",
@@ -2022,9 +1960,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
             </div>
           </div>
-          <div
-            data-testid="1"
-          >
+          <div>
             <div
               className="rjsf-field rjsf-field-string"
             >
@@ -2059,9 +1995,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
             </div>
           </div>
-          <div
-            data-testid="1"
-          >
+          <div>
             <div
               className="rjsf-field rjsf-field-string"
             >
@@ -2102,9 +2036,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
             </div>
           </div>
-          <div
-            data-testid="1"
-          >
+          <div>
             <div
               className="rjsf-field rjsf-field-string"
             >
@@ -2139,12 +2071,8 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
             </div>
           </div>
-          <div
-            data-testid="0"
-          >
-            <div
-              data-testid="1"
-            >
+          <div>
+            <div>
               <div
                 className="rjsf-field rjsf-field-string"
               >
@@ -2185,9 +2113,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
               </div>
             </div>
-            <div
-              data-testid="1"
-            >
+            <div>
               <div
                 className="rjsf-field rjsf-field-string"
               >
@@ -2311,7 +2237,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
     >
       <div
         className="fui-Grid ___1jjz2ji_698obq0 f13qh94s figf6al f14wuttv"
-        data-testid="0"
         style={
           {
             "columnGap": "5px",
@@ -2322,7 +2247,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         }
       >
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 12",
@@ -2355,7 +2279,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -2404,7 +2327,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "5 / span 4",
@@ -2447,7 +2369,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "9 / span 4",
@@ -2496,7 +2417,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -2545,7 +2465,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "5 / span 8",
@@ -2766,7 +2685,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -2775,7 +2693,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         />
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -2784,7 +2701,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         />
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -2793,7 +2709,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         />
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -2809,11 +2724,8 @@ exports[`Complex grid renders person and address and employment in a complex gri
             >
               <div
                 className="row"
-                data-testid="0"
               >
-                <div
-                  data-testid="1"
-                >
+                <div>
                   <div
                     className="rjsf-field rjsf-field-string"
                   >
@@ -2854,9 +2766,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                   </div>
                 </div>
-                <div
-                  data-testid="1"
-                >
+                <div>
                   <div
                     className="rjsf-field rjsf-field-string"
                   >
@@ -2891,9 +2801,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                   </div>
                 </div>
-                <div
-                  data-testid="1"
-                >
+                <div>
                   <div
                     className="rjsf-field rjsf-field-string"
                   >
@@ -2934,12 +2842,8 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                   </div>
                 </div>
-                <div
-                  data-testid="0"
-                >
-                  <div
-                    data-testid="1"
-                  >
+                <div>
+                  <div>
                     <div
                       className="rjsf-field rjsf-field-string"
                     >
@@ -3029,9 +2933,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                     </div>
                   </div>
-                  <div
-                    data-testid="1"
-                  >
+                  <div>
                     <div
                       className="rjsf-field rjsf-field-string"
                     >
@@ -3078,7 +2980,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="0"
           style={
             {
               "gridColumn": "6 / span 7",
@@ -3087,7 +2988,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            data-testid="1"
             style={
               {
                 "padding": "3px 0",
@@ -3189,9 +3089,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
             </div>
           </div>
-          <div
-            data-testid="1"
-          >
+          <div>
             <div
               className="rjsf-field rjsf-field-string"
             >
@@ -3265,7 +3163,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
     >
       <div
         className="fui-Grid ___1jjz2ji_698obq0 f13qh94s figf6al f14wuttv"
-        data-testid="0"
         style={
           {
             "columnGap": "5px",
@@ -3276,7 +3173,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         }
       >
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 12",
@@ -3309,7 +3205,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -3358,7 +3253,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "5 / span 4",
@@ -3401,7 +3295,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "9 / span 4",
@@ -3450,7 +3343,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -3499,7 +3391,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "5 / span 8",
@@ -3720,7 +3611,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -3729,7 +3619,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         />
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -3738,7 +3627,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         />
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -3747,7 +3635,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         />
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "1 / span 4",
@@ -3763,11 +3650,8 @@ exports[`Complex grid renders person and address and employment in a complex gri
             >
               <div
                 className="row"
-                data-testid="0"
               >
-                <div
-                  data-testid="1"
-                >
+                <div>
                   <div
                     className="rjsf-field rjsf-field-string"
                   >
@@ -3808,9 +3692,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                   </div>
                 </div>
-                <div
-                  data-testid="1"
-                >
+                <div>
                   <div
                     className="rjsf-field rjsf-field-string"
                   >
@@ -3845,9 +3727,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                   </div>
                 </div>
-                <div
-                  data-testid="1"
-                >
+                <div>
                   <div
                     className="rjsf-field rjsf-field-string"
                   >
@@ -3888,12 +3768,8 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                   </div>
                 </div>
-                <div
-                  data-testid="0"
-                >
-                  <div
-                    data-testid="1"
-                  >
+                <div>
+                  <div>
                     <div
                       className="rjsf-field rjsf-field-string"
                     >
@@ -3983,9 +3859,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                       </div>
                     </div>
                   </div>
-                  <div
-                    data-testid="1"
-                  >
+                  <div>
                     <div
                       className="rjsf-field rjsf-field-string"
                     >
@@ -4032,7 +3906,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
         </div>
         <div
-          data-testid="0"
           style={
             {
               "gridColumn": "6 / span 7",
@@ -4041,7 +3914,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           }
         >
           <div
-            data-testid="1"
             style={
               {
                 "padding": "3px 0",
@@ -4143,9 +4015,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
             </div>
           </div>
-          <div
-            data-testid="1"
-          >
+          <div>
             <div
               className="rjsf-field rjsf-field-string"
             >
@@ -4186,9 +4056,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
             </div>
           </div>
-          <div
-            data-testid="1"
-          >
+          <div>
             <div
               className="rjsf-field rjsf-field-string"
             >
@@ -4223,12 +4091,8 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
             </div>
           </div>
-          <div
-            data-testid="0"
-          >
-            <div
-              data-testid="1"
-            >
+          <div>
+            <div>
               <div
                 className="rjsf-field rjsf-field-string"
               >
@@ -4269,9 +4133,7 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 </div>
               </div>
             </div>
-            <div
-              data-testid="1"
-            >
+            <div>
               <div
                 className="rjsf-field rjsf-field-string"
               >
@@ -4395,7 +4257,6 @@ exports[`Three even column grid renders person and address in three columns, no 
     >
       <div
         className="fui-Grid ___1jjz2ji_698obq0 f13qh94s figf6al f14wuttv"
-        data-testid="0"
         style={
           {
             "columnGap": "5px",
@@ -4406,7 +4267,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         }
       >
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -4439,7 +4299,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -4488,7 +4347,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -4531,7 +4389,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -4580,7 +4437,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -4629,7 +4485,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -4849,7 +4704,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -4898,7 +4752,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -4941,7 +4794,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -4990,7 +4842,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -5088,7 +4939,6 @@ exports[`Three even column grid renders person and address in three columns, no 
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -5128,7 +4978,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
     >
       <div
         className="fui-Grid ___1jjz2ji_698obq0 f13qh94s figf6al f14wuttv"
-        data-testid="0"
         style={
           {
             "columnGap": "5px",
@@ -5139,7 +4988,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         }
       >
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -5172,7 +5020,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -5221,7 +5068,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -5264,7 +5110,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -5313,7 +5158,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -5362,7 +5206,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -5582,7 +5425,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -5631,7 +5473,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -5674,7 +5515,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -5723,7 +5563,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",
@@ -5821,7 +5660,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
           </div>
         </div>
         <div
-          data-testid="1"
           style={
             {
               "gridColumn": "auto / auto",

--- a/packages/mui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/mui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -56,7 +56,7 @@ export default function CheckboxWidget<
 
   return (
     <>
-      {!hideLabel && !!description && (
+      {!hideLabel && description && (
         <DescriptionFieldTemplate
           id={descriptionId<T>(id)}
           description={description}

--- a/packages/mui/src/DescriptionField/DescriptionField.tsx
+++ b/packages/mui/src/DescriptionField/DescriptionField.tsx
@@ -1,5 +1,6 @@
 import Typography from '@mui/material/Typography';
 import { DescriptionFieldProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
+import { RichDescription } from '@rjsf/core';
 
 /** The `DescriptionField` is the template to use to render the description of a field
  *
@@ -10,11 +11,11 @@ export default function DescriptionField<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: DescriptionFieldProps<T, S, F>) {
-  const { id, description } = props;
+  const { id, description, registry, uiSchema } = props;
   if (description) {
     return (
       <Typography id={id} variant='subtitle2' style={{ marginTop: '5px' }}>
-        {description}
+        <RichDescription description={description} registry={registry} uiSchema={uiSchema} />
       </Typography>
     );
   }

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -734,6 +734,790 @@ exports[`single fields checkbox field with label 1`] = `
 </form>
 `;
 
+exports[`single fields checkbox field with label and description 1`] = `
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
+.emotion-1 {
+  margin: 0;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.57;
+  letter-spacing: 0.00714em;
+}
+
+.emotion-2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  vertical-align: middle;
+  -webkit-tap-highlight-color: transparent;
+  margin-left: -11px;
+  margin-right: 16px;
+}
+
+.emotion-2.Mui-disabled {
+  cursor: default;
+}
+
+.emotion-2 .MuiFormControlLabel-label.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  padding: 9px;
+  border-radius: 50%;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.emotion-3::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-3.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-3 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-3:hover {
+  background-color: rgba(25, 118, 210, 0.04);
+}
+
+.emotion-3.Mui-checked,
+.emotion-3.MuiCheckbox-indeterminate {
+  color: #1976d2;
+}
+
+.emotion-3.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+@media (hover: none) {
+  .emotion-3:hover {
+    background-color: transparent;
+  }
+}
+
+.emotion-4 {
+  cursor: inherit;
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  margin: 0;
+  padding: 0;
+  z-index: 1;
+}
+
+.emotion-5 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  fill: currentColor;
+  font-size: 1.5rem;
+}
+
+.emotion-6 {
+  margin: 0;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.5;
+  letter-spacing: 0.00938em;
+}
+
+.emotion-7 {
+  margin-top: 24px;
+}
+
+.emotion-8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  letter-spacing: 0.02857em;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 6px 16px;
+  border: 0;
+  border-radius: 4px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  color: var(--variant-containedColor);
+  background-color: var(--variant-containedBg);
+  box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  --variant-textColor: #1976d2;
+  --variant-outlinedColor: #1976d2;
+  --variant-outlinedBorder: rgba(25, 118, 210, 0.5);
+  --variant-containedColor: #fff;
+  --variant-containedBg: #1976d2;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-8::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-8.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-8 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-8:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-8.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-8:hover {
+  box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+}
+
+@media (hover: none) {
+  .emotion-8:hover {
+    box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  }
+}
+
+.emotion-8:active {
+  box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+}
+
+.emotion-8.Mui-focusVisible {
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+}
+
+.emotion-8.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+@media (hover: hover) {
+  .emotion-8:hover {
+    --variant-containedBg: #1565c0;
+    --variant-textBg: rgba(25, 118, 210, 0.04);
+    --variant-outlinedBorder: #1976d2;
+    --variant-outlinedBg: rgba(25, 118, 210, 0.04);
+  }
+}
+
+.emotion-8.MuiButton-loading {
+  color: transparent;
+}
+
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-boolean"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    >
+      <h6
+        className="MuiTypography-root MuiTypography-subtitle2 emotion-1"
+        id="root__description"
+        style={
+          {
+            "marginTop": "5px",
+          }
+        }
+      >
+        test description
+      </h6>
+      <label
+        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-2"
+      >
+        <span
+          aria-describedby="root__error root__description root__help"
+          className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium emotion-3"
+          onBlur={[Function]}
+          onContextMenu={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={null}
+        >
+          <input
+            autoFocus={false}
+            checked={false}
+            className="PrivateSwitchBase-input emotion-4"
+            data-indeterminate={false}
+            disabled={false}
+            id="root"
+            name="root"
+            onChange={[Function]}
+            required={false}
+            type="checkbox"
+          />
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-5"
+            data-testid="CheckBoxOutlineBlankIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+            />
+          </svg>
+        </span>
+        <span
+          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-6"
+          style={{}}
+        >
+          test
+        </span>
+      </label>
+    </div>
+  </div>
+  <div
+    className="MuiBox-root emotion-7"
+  >
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary emotion-8"
+      disabled={null}
+      onBlur={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields checkbox field with label and rich text description 1`] = `
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
+.emotion-1 {
+  margin: 0;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.57;
+  letter-spacing: 0.00714em;
+}
+
+.emotion-2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  vertical-align: middle;
+  -webkit-tap-highlight-color: transparent;
+  margin-left: -11px;
+  margin-right: 16px;
+}
+
+.emotion-2.Mui-disabled {
+  cursor: default;
+}
+
+.emotion-2 .MuiFormControlLabel-label.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  padding: 9px;
+  border-radius: 50%;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.emotion-3::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-3.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-3 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-3:hover {
+  background-color: rgba(25, 118, 210, 0.04);
+}
+
+.emotion-3.Mui-checked,
+.emotion-3.MuiCheckbox-indeterminate {
+  color: #1976d2;
+}
+
+.emotion-3.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+@media (hover: none) {
+  .emotion-3:hover {
+    background-color: transparent;
+  }
+}
+
+.emotion-4 {
+  cursor: inherit;
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  margin: 0;
+  padding: 0;
+  z-index: 1;
+}
+
+.emotion-5 {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  width: 1em;
+  height: 1em;
+  display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: fill 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  fill: currentColor;
+  font-size: 1.5rem;
+}
+
+.emotion-6 {
+  margin: 0;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.5;
+  letter-spacing: 0.00938em;
+}
+
+.emotion-7 {
+  margin-top: 24px;
+}
+
+.emotion-8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  letter-spacing: 0.02857em;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 6px 16px;
+  border: 0;
+  border-radius: 4px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  color: var(--variant-containedColor);
+  background-color: var(--variant-containedBg);
+  box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  --variant-textColor: #1976d2;
+  --variant-outlinedColor: #1976d2;
+  --variant-outlinedBorder: rgba(25, 118, 210, 0.5);
+  --variant-containedColor: #fff;
+  --variant-containedBg: #1976d2;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-8::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-8.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-8 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-8:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-8.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-8:hover {
+  box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+}
+
+@media (hover: none) {
+  .emotion-8:hover {
+    box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  }
+}
+
+.emotion-8:active {
+  box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+}
+
+.emotion-8.Mui-focusVisible {
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+}
+
+.emotion-8.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+@media (hover: hover) {
+  .emotion-8:hover {
+    --variant-containedBg: #1565c0;
+    --variant-textBg: rgba(25, 118, 210, 0.04);
+    --variant-outlinedBorder: #1976d2;
+    --variant-outlinedBg: rgba(25, 118, 210, 0.04);
+  }
+}
+
+.emotion-8.MuiButton-loading {
+  color: transparent;
+}
+
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-boolean"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    >
+      <h6
+        className="MuiTypography-root MuiTypography-subtitle2 emotion-1"
+        id="root__description"
+        style={
+          {
+            "marginTop": "5px",
+          }
+        }
+      >
+        <span>
+          <strong>
+            test
+          </strong>
+           
+          <strong>
+            description
+          </strong>
+        </span>
+      </h6>
+      <label
+        className="MuiFormControlLabel-root MuiFormControlLabel-labelPlacementEnd emotion-2"
+      >
+        <span
+          aria-describedby="root__error root__description root__help"
+          className="MuiButtonBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium PrivateSwitchBase-root MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium MuiCheckbox-root MuiCheckbox-colorPrimary MuiCheckbox-sizeMedium emotion-3"
+          onBlur={[Function]}
+          onContextMenu={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={null}
+        >
+          <input
+            autoFocus={false}
+            checked={false}
+            className="PrivateSwitchBase-input emotion-4"
+            data-indeterminate={false}
+            disabled={false}
+            id="root"
+            name="root"
+            onChange={[Function]}
+            required={false}
+            type="checkbox"
+          />
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium emotion-5"
+            data-testid="CheckBoxOutlineBlankIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+            />
+          </svg>
+        </span>
+        <span
+          className="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label emotion-6"
+          style={{}}
+        >
+          test
+        </span>
+      </label>
+    </div>
+  </div>
+  <div
+    className="MuiBox-root emotion-7"
+  >
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary emotion-8"
+      disabled={null}
+      onBlur={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields checkboxes field 1`] = `
 .emotion-0 {
   display: -webkit-inline-box;
@@ -2432,6 +3216,1178 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
                   }
                 >
                   some other description
+                </h6>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="MuiBox-root emotion-12"
+  >
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary emotion-13"
+      disabled={null}
+      onBlur={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown description 1`] = `
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
+.emotion-1 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
+}
+
+.emotion-1>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-1>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-1>* {
+  --Grid-parent-rowSpacing: 16px;
+}
+
+.emotion-2 {
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
+  min-width: 0;
+  box-sizing: border-box;
+}
+
+.emotion-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+}
+
+.emotion-5 {
+  color: rgba(0, 0, 0, 0.6);
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  padding: 0;
+  position: relative;
+  display: block;
+  transform-origin: top left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+  -webkit-transform: translate(0, 20px) scale(1);
+  -moz-transform: translate(0, 20px) scale(1);
+  -ms-transform: translate(0, 20px) scale(1);
+  transform: translate(0, 20px) scale(1);
+  -webkit-transition: color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,-webkit-transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,max-width 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,max-width 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  z-index: 1;
+  pointer-events: none;
+  -webkit-transform: translate(14px, 16px) scale(1);
+  -moz-transform: translate(14px, 16px) scale(1);
+  -ms-transform: translate(14px, 16px) scale(1);
+  transform: translate(14px, 16px) scale(1);
+  max-width: calc(100% - 24px);
+}
+
+.emotion-5.Mui-focused {
+  color: #1976d2;
+}
+
+.emotion-5.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-5.Mui-error {
+  color: #d32f2f;
+}
+
+.emotion-6 {
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  color: rgba(0, 0, 0, 0.87);
+  box-sizing: border-box;
+  position: relative;
+  cursor: text;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border-radius: 4px;
+}
+
+.emotion-6.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+  cursor: default;
+}
+
+.emotion-6:hover .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.87);
+}
+
+@media (hover: none) {
+  .emotion-6:hover .MuiOutlinedInput-notchedOutline {
+    border-color: rgba(0, 0, 0, 0.23);
+  }
+}
+
+.emotion-6.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-width: 2px;
+}
+
+.emotion-6.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-color: #1976d2;
+}
+
+.emotion-6.Mui-error .MuiOutlinedInput-notchedOutline {
+  border-color: #d32f2f;
+}
+
+.emotion-6.Mui-disabled .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-7 {
+  font: inherit;
+  letter-spacing: inherit;
+  color: currentColor;
+  padding: 4px 0 5px;
+  border: 0;
+  box-sizing: content-box;
+  background: none;
+  height: 1.4375em;
+  margin: 0;
+  -webkit-tap-highlight-color: transparent;
+  display: block;
+  min-width: 0;
+  width: 100%;
+  -webkit-animation-name: mui-auto-fill-cancel;
+  animation-name: mui-auto-fill-cancel;
+  -webkit-animation-duration: 10ms;
+  animation-duration: 10ms;
+  padding: 16.5px 14px;
+}
+
+.emotion-7::-webkit-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-7::-moz-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-7::-ms-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-7:focus {
+  outline: 0;
+}
+
+.emotion-7:invalid {
+  box-shadow: none;
+}
+
+.emotion-7::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7::-webkit-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7::-moz-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7::-ms-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-webkit-input-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-moz-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-placeholder {
+  opacity: 0.42;
+}
+
+.emotion-7.Mui-disabled {
+  opacity: 1;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-7:-webkit-autofill {
+  -webkit-animation-duration: 5000s;
+  animation-duration: 5000s;
+  -webkit-animation-name: mui-auto-fill;
+  animation-name: mui-auto-fill;
+}
+
+.emotion-7:-webkit-autofill {
+  border-radius: inherit;
+}
+
+.emotion-8 {
+  text-align: left;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  top: -5px;
+  left: 0;
+  margin: 0;
+  padding: 0 8px;
+  pointer-events: none;
+  border-radius: inherit;
+  border-style: solid;
+  border-width: 1px;
+  overflow: hidden;
+  min-width: 0%;
+  border-color: rgba(0, 0, 0, 0.23);
+}
+
+.emotion-9 {
+  float: unset;
+  width: auto;
+  overflow: hidden;
+  display: block;
+  padding: 0;
+  height: 11px;
+  font-size: 0.75em;
+  visibility: hidden;
+  max-width: 0.01px;
+  -webkit-transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  white-space: nowrap;
+}
+
+.emotion-9>span {
+  padding-left: 5px;
+  padding-right: 5px;
+  display: inline-block;
+  opacity: 0;
+  visibility: visible;
+}
+
+.emotion-10 {
+  margin: 0;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 0.75rem;
+  line-height: 1.66;
+  letter-spacing: 0.03333em;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.emotion-11 {
+  margin: 0;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.57;
+  letter-spacing: 0.00714em;
+}
+
+.emotion-12 {
+  margin-top: 24px;
+}
+
+.emotion-13 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  letter-spacing: 0.02857em;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 6px 16px;
+  border: 0;
+  border-radius: 4px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  color: var(--variant-containedColor);
+  background-color: var(--variant-containedBg);
+  box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  --variant-textColor: #1976d2;
+  --variant-outlinedColor: #1976d2;
+  --variant-outlinedBorder: rgba(25, 118, 210, 0.5);
+  --variant-containedColor: #fff;
+  --variant-containedBg: #1976d2;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-13::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-13.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-13 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-13:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-13.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-13:hover {
+  box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+}
+
+@media (hover: none) {
+  .emotion-13:hover {
+    box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  }
+}
+
+.emotion-13:active {
+  box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+}
+
+.emotion-13.Mui-focusVisible {
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+}
+
+.emotion-13.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+@media (hover: hover) {
+  .emotion-13:hover {
+    --variant-containedBg: #1565c0;
+    --variant-textBg: rgba(25, 118, 210, 0.04);
+    --variant-outlinedBorder: #1976d2;
+    --variant-outlinedBg: rgba(25, 118, 210, 0.04);
+  }
+}
+
+.emotion-13.MuiButton-loading {
+  color: transparent;
+}
+
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    >
+      <div
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
+        style={
+          {
+            "marginTop": "10px",
+          }
+        }
+      >
+        <div
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-2"
+          style={
+            {
+              "marginBottom": "10px",
+            }
+          }
+        >
+          <div
+            className="rjsf-field rjsf-field-string"
+          >
+            <div
+              className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+            >
+              <div
+                aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                className="MuiFormControl-root MuiTextField-root emotion-4"
+              >
+                <label
+                  className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-5"
+                  data-shrink={false}
+                  htmlFor="root_my-field"
+                  id="root_my-field-label"
+                >
+                  my-field
+                </label>
+                <div
+                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-6"
+                  onClick={[Function]}
+                >
+                  <input
+                    aria-invalid={false}
+                    autoFocus={false}
+                    className="MuiInputBase-input MuiOutlinedInput-input emotion-7"
+                    disabled={false}
+                    id="root_my-field"
+                    name="root_my-field"
+                    onAnimationStart={[Function]}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                  <fieldset
+                    aria-hidden={true}
+                    className="MuiOutlinedInput-notchedOutline emotion-8"
+                  >
+                    <legend
+                      className="emotion-9"
+                    >
+                      <span>
+                        my-field
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+              <span
+                className="MuiTypography-root MuiTypography-caption emotion-10"
+                style={{}}
+              >
+                <h6
+                  className="MuiTypography-root MuiTypography-subtitle2 emotion-11"
+                  id="root_my-field__description"
+                  style={
+                    {
+                      "marginTop": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    some 
+                    <strong>
+                      Rich
+                    </strong>
+                     description
+                  </span>
+                </h6>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="MuiBox-root emotion-12"
+  >
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary emotion-13"
+      disabled={null}
+      onBlur={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown description in uiSchema 1`] = `
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
+.emotion-1 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
+}
+
+.emotion-1>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-1>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-1>* {
+  --Grid-parent-rowSpacing: 16px;
+}
+
+.emotion-2 {
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
+  min-width: 0;
+  box-sizing: border-box;
+}
+
+.emotion-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+}
+
+.emotion-5 {
+  color: rgba(0, 0, 0, 0.6);
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  padding: 0;
+  position: relative;
+  display: block;
+  transform-origin: top left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+  -webkit-transform: translate(0, 20px) scale(1);
+  -moz-transform: translate(0, 20px) scale(1);
+  -ms-transform: translate(0, 20px) scale(1);
+  transform: translate(0, 20px) scale(1);
+  -webkit-transition: color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,-webkit-transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,max-width 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,max-width 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  z-index: 1;
+  pointer-events: none;
+  -webkit-transform: translate(14px, 16px) scale(1);
+  -moz-transform: translate(14px, 16px) scale(1);
+  -ms-transform: translate(14px, 16px) scale(1);
+  transform: translate(14px, 16px) scale(1);
+  max-width: calc(100% - 24px);
+}
+
+.emotion-5.Mui-focused {
+  color: #1976d2;
+}
+
+.emotion-5.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-5.Mui-error {
+  color: #d32f2f;
+}
+
+.emotion-6 {
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  color: rgba(0, 0, 0, 0.87);
+  box-sizing: border-box;
+  position: relative;
+  cursor: text;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border-radius: 4px;
+}
+
+.emotion-6.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+  cursor: default;
+}
+
+.emotion-6:hover .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.87);
+}
+
+@media (hover: none) {
+  .emotion-6:hover .MuiOutlinedInput-notchedOutline {
+    border-color: rgba(0, 0, 0, 0.23);
+  }
+}
+
+.emotion-6.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-width: 2px;
+}
+
+.emotion-6.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-color: #1976d2;
+}
+
+.emotion-6.Mui-error .MuiOutlinedInput-notchedOutline {
+  border-color: #d32f2f;
+}
+
+.emotion-6.Mui-disabled .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-7 {
+  font: inherit;
+  letter-spacing: inherit;
+  color: currentColor;
+  padding: 4px 0 5px;
+  border: 0;
+  box-sizing: content-box;
+  background: none;
+  height: 1.4375em;
+  margin: 0;
+  -webkit-tap-highlight-color: transparent;
+  display: block;
+  min-width: 0;
+  width: 100%;
+  -webkit-animation-name: mui-auto-fill-cancel;
+  animation-name: mui-auto-fill-cancel;
+  -webkit-animation-duration: 10ms;
+  animation-duration: 10ms;
+  padding: 16.5px 14px;
+}
+
+.emotion-7::-webkit-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-7::-moz-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-7::-ms-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-7:focus {
+  outline: 0;
+}
+
+.emotion-7:invalid {
+  box-shadow: none;
+}
+
+.emotion-7::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7::-webkit-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7::-moz-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7::-ms-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-webkit-input-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-moz-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-placeholder {
+  opacity: 0.42;
+}
+
+.emotion-7.Mui-disabled {
+  opacity: 1;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-7:-webkit-autofill {
+  -webkit-animation-duration: 5000s;
+  animation-duration: 5000s;
+  -webkit-animation-name: mui-auto-fill;
+  animation-name: mui-auto-fill;
+}
+
+.emotion-7:-webkit-autofill {
+  border-radius: inherit;
+}
+
+.emotion-8 {
+  text-align: left;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  top: -5px;
+  left: 0;
+  margin: 0;
+  padding: 0 8px;
+  pointer-events: none;
+  border-radius: inherit;
+  border-style: solid;
+  border-width: 1px;
+  overflow: hidden;
+  min-width: 0%;
+  border-color: rgba(0, 0, 0, 0.23);
+}
+
+.emotion-9 {
+  float: unset;
+  width: auto;
+  overflow: hidden;
+  display: block;
+  padding: 0;
+  height: 11px;
+  font-size: 0.75em;
+  visibility: hidden;
+  max-width: 0.01px;
+  -webkit-transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  white-space: nowrap;
+}
+
+.emotion-9>span {
+  padding-left: 5px;
+  padding-right: 5px;
+  display: inline-block;
+  opacity: 0;
+  visibility: visible;
+}
+
+.emotion-10 {
+  margin: 0;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 0.75rem;
+  line-height: 1.66;
+  letter-spacing: 0.03333em;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.emotion-11 {
+  margin: 0;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.57;
+  letter-spacing: 0.00714em;
+}
+
+.emotion-12 {
+  margin-top: 24px;
+}
+
+.emotion-13 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  letter-spacing: 0.02857em;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 6px 16px;
+  border: 0;
+  border-radius: 4px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  color: var(--variant-containedColor);
+  background-color: var(--variant-containedBg);
+  box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  --variant-textColor: #1976d2;
+  --variant-outlinedColor: #1976d2;
+  --variant-outlinedBorder: rgba(25, 118, 210, 0.5);
+  --variant-containedColor: #fff;
+  --variant-containedBg: #1976d2;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-13::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-13.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-13 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-13:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-13.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-13:hover {
+  box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+}
+
+@media (hover: none) {
+  .emotion-13:hover {
+    box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  }
+}
+
+.emotion-13:active {
+  box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+}
+
+.emotion-13.Mui-focusVisible {
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+}
+
+.emotion-13.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+@media (hover: hover) {
+  .emotion-13:hover {
+    --variant-containedBg: #1565c0;
+    --variant-textBg: rgba(25, 118, 210, 0.04);
+    --variant-outlinedBorder: #1976d2;
+    --variant-outlinedBg: rgba(25, 118, 210, 0.04);
+  }
+}
+
+.emotion-13.MuiButton-loading {
+  color: transparent;
+}
+
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    >
+      <div
+        className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
+        style={
+          {
+            "marginTop": "10px",
+          }
+        }
+      >
+        <div
+          className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-2"
+          style={
+            {
+              "marginBottom": "10px",
+            }
+          }
+        >
+          <div
+            className="rjsf-field rjsf-field-string"
+          >
+            <div
+              className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+            >
+              <div
+                aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                className="MuiFormControl-root MuiTextField-root emotion-4"
+              >
+                <label
+                  className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-sizeMedium MuiInputLabel-outlined emotion-5"
+                  data-shrink={false}
+                  htmlFor="root_my-field"
+                  id="root_my-field-label"
+                >
+                  my-field
+                </label>
+                <div
+                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-6"
+                  onClick={[Function]}
+                >
+                  <input
+                    aria-invalid={false}
+                    autoFocus={false}
+                    className="MuiInputBase-input MuiOutlinedInput-input emotion-7"
+                    disabled={false}
+                    id="root_my-field"
+                    name="root_my-field"
+                    onAnimationStart={[Function]}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                  <fieldset
+                    aria-hidden={true}
+                    className="MuiOutlinedInput-notchedOutline emotion-8"
+                  >
+                    <legend
+                      className="emotion-9"
+                    >
+                      <span>
+                        my-field
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+              <span
+                className="MuiTypography-root MuiTypography-caption emotion-10"
+                style={{}}
+              >
+                <h6
+                  className="MuiTypography-root MuiTypography-subtitle2 emotion-11"
+                  id="root_my-field__description"
+                  style={
+                    {
+                      "marginTop": "5px",
+                    }
+                  }
+                >
+                  <span>
+                    some other description
+                  </span>
                 </h6>
               </span>
             </div>

--- a/packages/mui/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/GridSnap.test.tsx.snap
@@ -1241,15 +1241,12 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
     >
       <div
         className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-        data-testid="0"
       >
         <div
           className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-spacing-xs-2 emotion-2"
-          data-testid="0"
         >
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -1277,11 +1274,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-          data-testid="0"
         >
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -1349,7 +1344,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
           </div>
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -1408,7 +1402,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
           </div>
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -1477,11 +1470,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-          data-testid="0"
         >
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -1549,7 +1540,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
           </div>
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-8 emotion-45"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-array"
@@ -1852,11 +1842,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-          data-testid="0"
         >
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-5 emotion-78"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -1866,11 +1854,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
               >
                 <div
                   className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-                  data-testid="0"
                 >
                   <div
                     className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -1938,7 +1924,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                   </div>
                   <div
                     className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -1997,7 +1982,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                   </div>
                   <div
                     className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -2065,11 +2049,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                   </div>
                   <div
                     className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-                    data-testid="0"
                   >
                     <div
                       className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-6 emotion-108"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -2167,7 +2149,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     </div>
                     <div
                       className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-6 emotion-108"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -2240,15 +2221,12 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
           </div>
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-7 emotion-128"
-            data-testid="1"
           >
             <div
               className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-129"
-              data-testid="0"
             >
               <div
                 className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                data-testid="1"
               >
                 <div>
                   <div
@@ -2460,7 +2438,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
               </div>
               <div
                 className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -2528,7 +2505,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
               </div>
               <div
                 className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -2587,7 +2563,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
               </div>
               <div
                 className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-8 emotion-45"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -2655,7 +2630,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
               </div>
               <div
                 className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -4025,15 +3999,12 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
     >
       <div
         className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-        data-testid="0"
       >
         <div
           className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-spacing-xs-2 emotion-2"
-          data-testid="0"
         >
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -4061,11 +4032,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-          data-testid="0"
         >
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -4133,7 +4102,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
           </div>
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -4192,7 +4160,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
           </div>
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -4261,11 +4228,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-          data-testid="0"
         >
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -4333,7 +4298,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
           </div>
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-8 emotion-45"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-array"
@@ -4636,11 +4600,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-          data-testid="0"
         >
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-5 emotion-78"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -4650,11 +4612,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
               >
                 <div
                   className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-                  data-testid="0"
                 >
                   <div
                     className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -4722,7 +4682,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                   </div>
                   <div
                     className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -4781,7 +4740,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                   </div>
                   <div
                     className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -4849,11 +4807,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                   </div>
                   <div
                     className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-                    data-testid="0"
                   >
                     <div
                       className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-6 emotion-108"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -4951,7 +4907,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     </div>
                     <div
                       className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-6 emotion-108"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -5024,15 +4979,12 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
           </div>
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-7 emotion-128"
-            data-testid="1"
           >
             <div
               className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-129"
-              data-testid="0"
             >
               <div
                 className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                data-testid="1"
               >
                 <div>
                   <div
@@ -5244,7 +5196,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
               </div>
               <div
                 className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -5303,7 +5254,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
               </div>
               <div
                 className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -5371,7 +5321,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
               </div>
               <div
                 className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -5430,7 +5379,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
               </div>
               <div
                 className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-8 emotion-45"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -5498,7 +5446,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
               </div>
               <div
                 className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -7022,15 +6969,12 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
     >
       <div
         className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-        data-testid="0"
       >
         <div
           className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-spacing-xs-2 emotion-2"
-          data-testid="0"
         >
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -7058,11 +7002,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-          data-testid="0"
         >
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -7130,7 +7072,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
           </div>
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -7189,7 +7130,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
           </div>
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -7258,11 +7198,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-          data-testid="0"
         >
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -7330,7 +7268,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
           </div>
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-8 emotion-45"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-array"
@@ -7633,11 +7570,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-          data-testid="0"
         >
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-5 emotion-78"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -7647,11 +7582,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
               >
                 <div
                   className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-                  data-testid="0"
                 >
                   <div
                     className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -7719,7 +7652,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
                   </div>
                   <div
                     className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -7778,7 +7710,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
                   </div>
                   <div
                     className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -7846,11 +7777,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
                   </div>
                   <div
                     className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-                    data-testid="0"
                   >
                     <div
                       className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-6 emotion-108"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -7948,7 +7877,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
                     </div>
                     <div
                       className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-6 emotion-108"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -8021,15 +7949,12 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
           </div>
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-7 emotion-128"
-            data-testid="1"
           >
             <div
               className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-129"
-              data-testid="0"
             >
               <div
                 className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                data-testid="1"
               >
                 <div>
                   <div
@@ -8241,7 +8166,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-160:focus::-ms-input
               </div>
               <div
                 className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -9600,15 +9524,12 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
     >
       <div
         className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-        data-testid="0"
       >
         <div
           className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-spacing-xs-2 emotion-2"
-          data-testid="0"
         >
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -9636,11 +9557,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-          data-testid="0"
         >
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -9708,7 +9627,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
           </div>
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -9767,7 +9685,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
           </div>
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -9836,11 +9753,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-          data-testid="0"
         >
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -9908,7 +9823,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
           </div>
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-8 emotion-45"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-array"
@@ -10211,11 +10125,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-          data-testid="0"
         >
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-5 emotion-78"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -10225,11 +10137,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
               >
                 <div
                   className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-                  data-testid="0"
                 >
                   <div
                     className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -10297,7 +10207,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                   </div>
                   <div
                     className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -10356,7 +10265,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                   </div>
                   <div
                     className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -10424,11 +10332,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                   </div>
                   <div
                     className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-                    data-testid="0"
                   >
                     <div
                       className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-6 emotion-108"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -10526,7 +10432,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
                     </div>
                     <div
                       className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-6 emotion-108"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -10599,15 +10504,12 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
           </div>
           <div
             className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-7 emotion-128"
-            data-testid="1"
           >
             <div
               className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-129"
-              data-testid="0"
             >
               <div
                 className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                data-testid="1"
               >
                 <div>
                   <div
@@ -10819,7 +10721,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
               </div>
               <div
                 className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -10887,7 +10788,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
               </div>
               <div
                 className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-3"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -10946,7 +10846,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
               </div>
               <div
                 className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-8 emotion-45"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -11014,7 +10913,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-114:focus::-ms-input
               </div>
               <div
                 className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-9"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -12111,11 +12009,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
     >
       <div
         className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-        data-testid="0"
       >
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-2"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-object"
@@ -12142,7 +12038,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-7"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -12210,7 +12105,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-7"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -12269,7 +12163,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-7"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -12337,7 +12230,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-7"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -12405,7 +12297,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-8 emotion-42"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-array"
@@ -12707,7 +12598,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-6 emotion-74"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -12775,7 +12665,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-6 emotion-74"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -12834,7 +12723,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-7"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -12902,7 +12790,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-7"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -13000,7 +12887,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-4 emotion-7"
-          data-testid="1"
         />
       </div>
     </div>
@@ -13974,11 +13860,9 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
     >
       <div
         className="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 emotion-1"
-        data-testid="0"
       >
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-2"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-object"
@@ -14005,7 +13889,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-6 emotion-7"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -14073,7 +13956,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-6 emotion-7"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -14132,7 +14014,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-6 emotion-7"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -14200,7 +14081,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-6 emotion-7"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -14268,7 +14148,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-2"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-array"
@@ -14570,7 +14449,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-6 emotion-7"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -14638,7 +14516,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-6 emotion-7"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -14697,7 +14574,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-6 emotion-7"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -14765,7 +14641,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-6 emotion-7"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -14863,7 +14738,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-106:focus::-ms-input
         </div>
         <div
           className="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 emotion-2"
-          data-testid="1"
         />
       </div>
     </div>

--- a/packages/playground/src/app.tsx
+++ b/packages/playground/src/app.tsx
@@ -14,7 +14,6 @@ import localize_es from 'ajv-i18n/localize/es';
 import Layout from './layout';
 import Playground, { PlaygroundProps } from './components';
 
-// @ts-expect-error todo: error TS2345: Argument of type 'Localize' is not assignable to parameter of type 'Localizer'.
 const esV8Validator = customizeValidator({}, localize_es);
 const AJV8_2019 = customizeValidator({ AjvClass: Ajv2019 });
 const AJV8_2020 = customizeValidator({ AjvClass: Ajv2020 });
@@ -91,6 +90,14 @@ const themes: PlaygroundProps['themes'] = {
       },
     },
   },
+  antd: {
+    stylesheet: '//cdnjs.cloudflare.com/ajax/libs/antd/5.23.3/reset.min.css',
+    theme: AntdTheme,
+  },
+  'chakra-ui': {
+    stylesheet: '',
+    theme: ChakraUITheme,
+  },
   'daisy-ui': {
     stylesheet: 'https://cdn.jsdelivr.net/npm/daisyui@5.0.0-beta.7/daisyui.min.css',
     theme: DaisyUITheme,
@@ -131,14 +138,6 @@ const themes: PlaygroundProps['themes'] = {
       abyss: { dataTheme: 'abyss' },
       silk: { dataTheme: 'silk' },
     },
-  },
-  antd: {
-    stylesheet: '//cdnjs.cloudflare.com/ajax/libs/antd/5.23.3/reset.min.css',
-    theme: AntdTheme,
-  },
-  'chakra-ui': {
-    stylesheet: '',
-    theme: ChakraUITheme,
   },
   'fluentui-rc': {
     stylesheet: '',

--- a/packages/playground/src/samples/index.ts
+++ b/packages/playground/src/samples/index.ts
@@ -33,7 +33,6 @@ import ifThenElse from './ifThenElse';
 import customField from './customField';
 import layoutGrid from './layoutGrid';
 import { Sample } from './Sample';
-import deepFreeze from 'deep-freeze-es6';
 import patternProperties from './patternProperties';
 
 export type { Sample };
@@ -77,4 +76,4 @@ const _samples: Record<string, Sample> = {
   'Layout Grid': layoutGrid,
 };
 
-export const samples = deepFreeze(_samples);
+export const samples = _samples;

--- a/packages/react-bootstrap/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/react-bootstrap/src/CheckboxWidget/CheckboxWidget.tsx
@@ -49,10 +49,7 @@ export default function CheckboxWidget<
 
   const description = options.description || schema.description;
   return (
-    <Form.Group
-      className={`checkbox ${disabled || readonly ? 'disabled' : ''}`}
-      aria-describedby={ariaDescribedByIds<T>(id)}
-    >
+    <Form.Group className={disabled || readonly ? 'disabled' : ''} aria-describedby={ariaDescribedByIds<T>(id)}>
       {!hideLabel && !!description && (
         <DescriptionFieldTemplate
           id={descriptionId<T>(id)}

--- a/packages/react-bootstrap/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/react-bootstrap/src/CheckboxWidget/CheckboxWidget.tsx
@@ -50,7 +50,7 @@ export default function CheckboxWidget<
   const description = options.description || schema.description;
   return (
     <Form.Group className={disabled || readonly ? 'disabled' : ''} aria-describedby={ariaDescribedByIds<T>(id)}>
-      {!hideLabel && !!description && (
+      {!hideLabel && description && (
         <DescriptionFieldTemplate
           id={descriptionId<T>(id)}
           description={description}

--- a/packages/react-bootstrap/src/DescriptionField/DescriptionField.tsx
+++ b/packages/react-bootstrap/src/DescriptionField/DescriptionField.tsx
@@ -1,19 +1,24 @@
 import { DescriptionFieldProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
+import { RichDescription } from '@rjsf/core';
 
+/** The `DescriptionField` is the template to use to render the description of a field
+ *
+ * @param props - The `DescriptionFieldProps` for this component
+ */
 export default function DescriptionField<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
->({ id, description }: DescriptionFieldProps<T, S, F>) {
-  if (description) {
-    return (
-      <div>
-        <div id={id} className='mb-3'>
-          {description}
-        </div>
-      </div>
-    );
+>({ id, description, registry, uiSchema }: DescriptionFieldProps<T, S, F>) {
+  if (!description) {
+    return null;
   }
 
-  return null;
+  return (
+    <div>
+      <div id={id} className='mb-3'>
+        <RichDescription description={description} registry={registry} uiSchema={uiSchema} />
+      </div>
+    </div>
+  );
 }

--- a/packages/react-bootstrap/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/react-bootstrap/test/__snapshots__/Form.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`single fields checkbox field 1`] = `
     <div>
       <div
         aria-describedby="root__error root__description root__help"
-        className="checkbox "
+        className=""
       >
         <div
           className=""
@@ -58,8 +58,138 @@ exports[`single fields checkbox field with label 1`] = `
     <div>
       <div
         aria-describedby="root__error root__description root__help"
-        className="checkbox "
+        className=""
       >
+        <div
+          className="form-check"
+        >
+          <input
+            autoFocus={false}
+            checked={false}
+            className="form-check-input"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={false}
+            type="checkbox"
+          />
+          <label
+            className="form-check-label"
+            htmlFor="root"
+            title=""
+          >
+            test
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields checkbox field with label and description 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-boolean"
+  >
+    <div>
+      <div
+        aria-describedby="root__error root__description root__help"
+        className=""
+      >
+        <div>
+          <div
+            className="mb-3"
+            id="root__description"
+          >
+            test description
+          </div>
+        </div>
+        <div
+          className="form-check"
+        >
+          <input
+            autoFocus={false}
+            checked={false}
+            className="form-check-input"
+            disabled={false}
+            id="root"
+            name="root"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={false}
+            type="checkbox"
+          />
+          <label
+            className="form-check-label"
+            htmlFor="root"
+            title=""
+          >
+            test
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields checkbox field with label and rich text description 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-boolean"
+  >
+    <div>
+      <div
+        aria-describedby="root__error root__description root__help"
+        className=""
+      >
+        <div>
+          <div
+            className="mb-3"
+            id="root__description"
+          >
+            <span>
+              <strong>
+                test
+              </strong>
+               
+              <strong>
+                description
+              </strong>
+            </span>
+          </div>
+        </div>
         <div
           className="form-check"
         >
@@ -373,6 +503,178 @@ exports[`single fields field with description in uiSchema 1`] = `
                       id="root_my-field__description"
                     >
                       some other description
+                    </div>
+                  </div>
+                </small>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown description 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div>
+      <div
+        className="p-0 container-fluid"
+      >
+        <div
+          className="row"
+          style={
+            {
+              "marginBottom": "10px",
+            }
+          }
+        >
+          <div
+            className="col-12"
+          >
+             
+            <div
+              className="rjsf-field rjsf-field-string"
+            >
+              <div>
+                <label
+                  className="form-label"
+                  htmlFor="root_my-field"
+                >
+                  my-field
+                </label>
+                <input
+                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                  autoFocus={false}
+                  className="form-control"
+                  disabled={false}
+                  id="root_my-field"
+                  name="root_my-field"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
+                <small
+                  className="text-muted form-text"
+                >
+                  <div>
+                    <div
+                      className="mb-3"
+                      id="root_my-field__description"
+                    >
+                      <span>
+                        some 
+                        <strong>
+                          Rich
+                        </strong>
+                         description
+                      </span>
+                    </div>
+                  </div>
+                </small>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown description in uiSchema 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div>
+      <div
+        className="p-0 container-fluid"
+      >
+        <div
+          className="row"
+          style={
+            {
+              "marginBottom": "10px",
+            }
+          }
+        >
+          <div
+            className="col-12"
+          >
+             
+            <div
+              className="rjsf-field rjsf-field-string"
+            >
+              <div>
+                <label
+                  className="form-label"
+                  htmlFor="root_my-field"
+                >
+                  my-field
+                </label>
+                <input
+                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                  autoFocus={false}
+                  className="form-control"
+                  disabled={false}
+                  id="root_my-field"
+                  name="root_my-field"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
+                <small
+                  className="text-muted form-text"
+                >
+                  <div>
+                    <div
+                      className="mb-3"
+                      id="root_my-field__description"
+                    >
+                      <span>
+                        some other description
+                      </span>
                     </div>
                   </div>
                 </small>

--- a/packages/react-bootstrap/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/react-bootstrap/test/__snapshots__/GridSnap.test.tsx.snap
@@ -12,15 +12,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
     <div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="row"
-          data-testid="0"
         >
           <div
             className="col-12"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -48,11 +45,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="row"
-          data-testid="0"
         >
           <div
             className="col-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -86,7 +81,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="col-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -119,7 +113,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="col-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -154,11 +147,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="row"
-          data-testid="0"
         >
           <div
             className="col-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -192,7 +183,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="col-8"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-array"
@@ -350,11 +340,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="row"
-          data-testid="0"
         >
           <div
             className="col-5"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -362,11 +350,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
               <div>
                 <div
                   className="row"
-                  data-testid="0"
                 >
                   <div
                     className="col-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -400,7 +386,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="col-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -433,7 +418,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="col-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -467,12 +451,10 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="row"
-                    data-testid="0"
                     spacing={2}
                   >
                     <div
                       className="col-6"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -899,7 +881,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                     <div
                       className="col-6"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -938,15 +919,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="col-7"
-            data-testid="1"
           >
             <div
               className="row"
-              data-testid="0"
             >
               <div
                 className="col-12"
-                data-testid="1"
                 style={
                   {
                     "margin": "38px 0 6px",
@@ -1045,7 +1023,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-12"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -1079,7 +1056,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-12"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -1112,7 +1088,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-8"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -1146,7 +1121,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-4"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -1601,15 +1575,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
     <div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="row"
-          data-testid="0"
         >
           <div
             className="col-12"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -1637,11 +1608,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="row"
-          data-testid="0"
         >
           <div
             className="col-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -1675,7 +1644,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="col-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -1708,7 +1676,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="col-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -1743,11 +1710,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="row"
-          data-testid="0"
         >
           <div
             className="col-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -1781,7 +1746,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="col-8"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-array"
@@ -1939,11 +1903,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="row"
-          data-testid="0"
         >
           <div
             className="col-5"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -1951,11 +1913,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
               <div>
                 <div
                   className="row"
-                  data-testid="0"
                 >
                   <div
                     className="col-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -1989,7 +1949,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="col-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -2022,7 +1981,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="col-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -2056,12 +2014,10 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="row"
-                    data-testid="0"
                     spacing={2}
                   >
                     <div
                       className="col-6"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -2488,7 +2444,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                     <div
                       className="col-6"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -2527,15 +2482,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="col-7"
-            data-testid="1"
           >
             <div
               className="row"
-              data-testid="0"
             >
               <div
                 className="col-12"
-                data-testid="1"
                 style={
                   {
                     "margin": "38px 0 6px",
@@ -2634,7 +2586,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-12"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -2667,7 +2618,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-12"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -2701,7 +2651,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-12"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -2734,7 +2683,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-8"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -2768,7 +2716,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-4"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -3223,15 +3170,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
     <div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="row"
-          data-testid="0"
         >
           <div
             className="col-12"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -3259,11 +3203,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="row"
-          data-testid="0"
         >
           <div
             className="col-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -3297,7 +3239,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="col-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -3330,7 +3271,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="col-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -3365,11 +3305,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="row"
-          data-testid="0"
         >
           <div
             className="col-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -3403,7 +3341,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="col-8"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-array"
@@ -3561,11 +3498,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="row"
-          data-testid="0"
         >
           <div
             className="col-5"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -3573,11 +3508,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
               <div>
                 <div
                   className="row"
-                  data-testid="0"
                 >
                   <div
                     className="col-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -3611,7 +3544,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="col-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -3644,7 +3576,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="col-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -3678,12 +3609,10 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="row"
-                    data-testid="0"
                     spacing={2}
                   >
                     <div
                       className="col-6"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -4110,7 +4039,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                     <div
                       className="col-6"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -4149,15 +4077,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="col-7"
-            data-testid="1"
           >
             <div
               className="row"
-              data-testid="0"
             >
               <div
                 className="col-12"
-                data-testid="1"
                 style={
                   {
                     "margin": "38px 0 6px",
@@ -4256,7 +4181,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-12"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -4321,15 +4245,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
     <div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="row"
-          data-testid="0"
         >
           <div
             className="col-12"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -4357,11 +4278,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="row"
-          data-testid="0"
         >
           <div
             className="col-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -4395,7 +4314,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="col-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -4428,7 +4346,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="col-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -4463,11 +4380,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="row"
-          data-testid="0"
         >
           <div
             className="col-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -4501,7 +4416,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="col-8"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-array"
@@ -4659,11 +4573,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="row"
-          data-testid="0"
         >
           <div
             className="col-5"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -4671,11 +4583,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
               <div>
                 <div
                   className="row"
-                  data-testid="0"
                 >
                   <div
                     className="col-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -4709,7 +4619,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="col-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -4742,7 +4651,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="col-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -4776,12 +4684,10 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="row"
-                    data-testid="0"
                     spacing={2}
                   >
                     <div
                       className="col-6"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -5208,7 +5114,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                     <div
                       className="col-6"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -5247,15 +5152,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="col-7"
-            data-testid="1"
           >
             <div
               className="row"
-              data-testid="0"
             >
               <div
                 className="col-12"
-                data-testid="1"
                 style={
                   {
                     "margin": "38px 0 6px",
@@ -5354,7 +5256,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-12"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -5388,7 +5289,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-12"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -5421,7 +5321,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-8"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -5455,7 +5354,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="col-4"
-                data-testid="1"
               >
                 <div
                   className="rjsf-field rjsf-field-string"
@@ -5910,11 +5808,9 @@ exports[`Three even column grid renders person and address in three columns, no 
     <div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="col-12"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-object"
@@ -5941,7 +5837,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="col-4"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -5975,7 +5870,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="col-4"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -6008,7 +5902,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="col-4"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -6042,7 +5935,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="col-4"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -6076,7 +5968,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="col-8"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-array"
@@ -6233,7 +6124,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="col-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -6267,7 +6157,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="col-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -6300,7 +6189,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="col-4"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -6334,7 +6222,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="col-4"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -6761,7 +6648,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="col-4"
-          data-testid="1"
         />
       </div>
     </div>
@@ -6790,11 +6676,9 @@ exports[`Two even column grid renders person and address in two columns, no empl
     <div>
       <div
         className="row"
-        data-testid="0"
       >
         <div
           className="col-12"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-object"
@@ -6821,7 +6705,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="col-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -6855,7 +6738,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="col-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -6888,7 +6770,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="col-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -6922,7 +6803,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="col-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -6956,7 +6836,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="col-12"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-array"
@@ -7113,7 +6992,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="col-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -7147,7 +7025,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="col-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -7180,7 +7057,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="col-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -7214,7 +7090,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="col-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -7641,7 +7516,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="col-12"
-          data-testid="1"
         />
       </div>
     </div>

--- a/packages/semantic-ui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/semantic-ui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -66,7 +66,7 @@ export default function CheckboxWidget<
 
   return (
     <>
-      {!hideLabel && !!description && (
+      {!hideLabel && description && (
         <DescriptionFieldTemplate
           id={descriptionId<T>(id)}
           description={description}

--- a/packages/semantic-ui/src/DescriptionField/DescriptionField.tsx
+++ b/packages/semantic-ui/src/DescriptionField/DescriptionField.tsx
@@ -1,4 +1,5 @@
 import { DescriptionFieldProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
+import { RichDescription } from '@rjsf/core';
 
 /** The `DescriptionField` is the template to use to render the description of a field
  *
@@ -9,13 +10,13 @@ export default function DescriptionField<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: DescriptionFieldProps<T, S, F>) {
-  const { id, description } = props;
+  const { id, description, registry, uiSchema } = props;
   if (!description) {
     return null;
   }
   return (
     <p id={id} className='sui-description'>
-      {description}
+      <RichDescription description={description} registry={registry} uiSchema={uiSchema} />
     </p>
   );
 }

--- a/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
@@ -275,6 +275,140 @@ exports[`single fields checkbox field with label 1`] = `
 </form>
 `;
 
+exports[`single fields checkbox field with label and description 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-boolean"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      <p
+        className="sui-description"
+        id="root__description"
+      >
+        test description
+      </p>
+      <div
+        className="field"
+      >
+        <div
+          className="ui checkbox"
+          inverted="false"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            autoFocus={false}
+            checked={false}
+            className="hidden"
+            disabled={false}
+            id="root"
+            name="root"
+            readOnly={true}
+            required={false}
+            tabIndex={0}
+            type="checkbox"
+          />
+          <label
+            htmlFor="root"
+          >
+            test
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
+exports[`single fields checkbox field with label and rich text description 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-boolean"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      <p
+        className="sui-description"
+        id="root__description"
+      >
+        <span>
+          <strong>
+            test
+          </strong>
+           
+          <strong>
+            description
+          </strong>
+        </span>
+      </p>
+      <div
+        className="field"
+      >
+        <div
+          className="ui checkbox"
+          inverted="false"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseDown={[Function]}
+          onMouseUp={[Function]}
+        >
+          <input
+            aria-describedby="root__error root__description root__help"
+            autoFocus={false}
+            checked={false}
+            className="hidden"
+            disabled={false}
+            id="root"
+            name="root"
+            readOnly={true}
+            required={false}
+            tabIndex={0}
+            type="checkbox"
+          />
+          <label
+            htmlFor="root"
+          >
+            test
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
 exports[`single fields checkboxes field 1`] = `
 <form
   className="ui form rjsf"
@@ -554,6 +688,144 @@ exports[`single fields field with description in uiSchema 1`] = `
             id="root_my-field__description"
           >
             some other description
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
+exports[`single fields field with markdown description 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      <div
+        className="rjsf-field rjsf-field-string"
+      >
+        <div
+          className="grouped equal width fields"
+        >
+          <div
+            className="field"
+          >
+            <label
+              htmlFor="root_my-field"
+            >
+              my-field
+            </label>
+            <div
+              className="ui fluid input"
+            >
+              <input
+                aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                autoFocus={false}
+                disabled={false}
+                id="root_my-field"
+                name="root_my-field"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                placeholder=""
+                required={false}
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <p
+            className="sui-description"
+            id="root_my-field__description"
+          >
+            <span>
+              some 
+              <strong>
+                Rich
+              </strong>
+               description
+            </span>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
+exports[`single fields field with markdown description in uiSchema 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      <div
+        className="rjsf-field rjsf-field-string"
+      >
+        <div
+          className="grouped equal width fields"
+        >
+          <div
+            className="field"
+          >
+            <label
+              htmlFor="root_my-field"
+            >
+              my-field
+            </label>
+            <div
+              className="ui fluid input"
+            >
+              <input
+                aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                autoFocus={false}
+                disabled={false}
+                id="root_my-field"
+                name="root_my-field"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                placeholder=""
+                required={false}
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <p
+            className="sui-description"
+            id="root_my-field__description"
+          >
+            <span>
+              some other description
+            </span>
           </p>
         </div>
       </div>

--- a/packages/semantic-ui/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/GridSnap.test.tsx.snap
@@ -14,11 +14,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
     >
       <div
         className="ui container grid"
-        data-testid="0"
       >
         <div
           className="ui grid"
-          data-testid="0"
           style={
             {
               "width": "100%",
@@ -27,7 +25,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         >
           <div
             className="18 wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -52,7 +49,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="ui grid"
-          data-testid="0"
           style={
             {
               "width": "100%",
@@ -61,7 +57,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         >
           <div
             className="five wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -106,7 +101,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="five wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -151,7 +145,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="five wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -197,7 +190,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="ui grid"
-          data-testid="0"
           style={
             {
               "marginTop": 0,
@@ -208,7 +200,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         >
           <div
             className="six wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -253,7 +244,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="ten wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -450,7 +440,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="ui grid"
-          data-testid="0"
           style={
             {
               "marginTop": 0,
@@ -460,7 +449,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         >
           <div
             className="seven wide column"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -470,7 +458,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               >
                 <div
                   className="ui grid"
-                  data-testid="0"
                   style={
                     {
                       "marginTop": 0,
@@ -480,7 +467,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="sixteen wide column"
-                    data-testid="1"
                     style={
                       {
                         "paddingBottom": 0,
@@ -526,7 +512,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="sixteen wide column"
-                    data-testid="1"
                     style={
                       {
                         "paddingBottom": 0,
@@ -572,7 +557,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="sixteen wide column"
-                    data-testid="1"
                     style={
                       {
                         "paddingBottom": 0,
@@ -618,7 +602,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ui grid"
-                    data-testid="0"
                     style={
                       {
                         "width": "100%",
@@ -627,7 +610,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   >
                     <div
                       className="eight wide column"
-                      data-testid="1"
                       style={
                         {
                           "paddingBottom": 0,
@@ -1771,7 +1753,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                     <div
                       className="eight wide column"
-                      data-testid="1"
                       style={
                         {
                           "paddingBottom": 0,
@@ -1821,15 +1802,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="nine wide column"
-            data-testid="1"
           >
             <div
               className="ui grid"
-              data-testid="0"
             >
               <div
                 className="sixteen wide column"
-                data-testid="1"
                 style={
                   {
                     "paddingTop": "56px",
@@ -1948,7 +1926,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="sixteen wide column"
-                data-testid="1"
                 style={
                   {
                     "paddingBottom": 0,
@@ -1994,7 +1971,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="sixteen wide column"
-                data-testid="1"
                 style={
                   {
                     "paddingBottom": 0,
@@ -2040,7 +2016,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="ten wide column"
-                data-testid="1"
                 style={
                   {
                     "paddingBottom": 0,
@@ -2086,7 +2061,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="six wide column"
-                data-testid="1"
                 style={
                   {
                     "paddingBottom": 0,
@@ -3259,11 +3233,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
     >
       <div
         className="ui container grid"
-        data-testid="0"
       >
         <div
           className="ui grid"
-          data-testid="0"
           style={
             {
               "width": "100%",
@@ -3272,7 +3244,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         >
           <div
             className="18 wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -3297,7 +3268,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="ui grid"
-          data-testid="0"
           style={
             {
               "width": "100%",
@@ -3306,7 +3276,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         >
           <div
             className="five wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -3351,7 +3320,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="five wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -3396,7 +3364,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="five wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -3442,7 +3409,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="ui grid"
-          data-testid="0"
           style={
             {
               "marginTop": 0,
@@ -3453,7 +3419,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         >
           <div
             className="six wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -3498,7 +3463,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="ten wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -3695,7 +3659,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="ui grid"
-          data-testid="0"
           style={
             {
               "marginTop": 0,
@@ -3705,7 +3668,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         >
           <div
             className="seven wide column"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -3715,7 +3677,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               >
                 <div
                   className="ui grid"
-                  data-testid="0"
                   style={
                     {
                       "marginTop": 0,
@@ -3725,7 +3686,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="sixteen wide column"
-                    data-testid="1"
                     style={
                       {
                         "paddingBottom": 0,
@@ -3771,7 +3731,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="sixteen wide column"
-                    data-testid="1"
                     style={
                       {
                         "paddingBottom": 0,
@@ -3817,7 +3776,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="sixteen wide column"
-                    data-testid="1"
                     style={
                       {
                         "paddingBottom": 0,
@@ -3863,7 +3821,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ui grid"
-                    data-testid="0"
                     style={
                       {
                         "width": "100%",
@@ -3872,7 +3829,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   >
                     <div
                       className="eight wide column"
-                      data-testid="1"
                       style={
                         {
                           "paddingBottom": 0,
@@ -5016,7 +4972,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                     <div
                       className="eight wide column"
-                      data-testid="1"
                       style={
                         {
                           "paddingBottom": 0,
@@ -5066,15 +5021,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="nine wide column"
-            data-testid="1"
           >
             <div
               className="ui grid"
-              data-testid="0"
             >
               <div
                 className="sixteen wide column"
-                data-testid="1"
                 style={
                   {
                     "paddingTop": "56px",
@@ -5193,7 +5145,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="sixteen wide column"
-                data-testid="1"
                 style={
                   {
                     "paddingBottom": 0,
@@ -5239,7 +5190,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="sixteen wide column"
-                data-testid="1"
                 style={
                   {
                     "paddingBottom": 0,
@@ -5285,7 +5235,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="sixteen wide column"
-                data-testid="1"
                 style={
                   {
                     "paddingBottom": 0,
@@ -5331,7 +5280,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="ten wide column"
-                data-testid="1"
                 style={
                   {
                     "paddingBottom": 0,
@@ -5377,7 +5325,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="six wide column"
-                data-testid="1"
                 style={
                   {
                     "paddingBottom": 0,
@@ -6550,11 +6497,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
     >
       <div
         className="ui container grid"
-        data-testid="0"
       >
         <div
           className="ui grid"
-          data-testid="0"
           style={
             {
               "width": "100%",
@@ -6563,7 +6508,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         >
           <div
             className="18 wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -6588,7 +6532,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="ui grid"
-          data-testid="0"
           style={
             {
               "width": "100%",
@@ -6597,7 +6540,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         >
           <div
             className="five wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -6642,7 +6584,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="five wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -6687,7 +6628,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="five wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -6733,7 +6673,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="ui grid"
-          data-testid="0"
           style={
             {
               "marginTop": 0,
@@ -6744,7 +6683,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         >
           <div
             className="six wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -6789,7 +6727,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="ten wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -6986,7 +6923,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="ui grid"
-          data-testid="0"
           style={
             {
               "marginTop": 0,
@@ -6996,7 +6932,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         >
           <div
             className="seven wide column"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -7006,7 +6941,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               >
                 <div
                   className="ui grid"
-                  data-testid="0"
                   style={
                     {
                       "marginTop": 0,
@@ -7016,7 +6950,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="sixteen wide column"
-                    data-testid="1"
                     style={
                       {
                         "paddingBottom": 0,
@@ -7062,7 +6995,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="sixteen wide column"
-                    data-testid="1"
                     style={
                       {
                         "paddingBottom": 0,
@@ -7108,7 +7040,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="sixteen wide column"
-                    data-testid="1"
                     style={
                       {
                         "paddingBottom": 0,
@@ -7154,7 +7085,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ui grid"
-                    data-testid="0"
                     style={
                       {
                         "width": "100%",
@@ -7163,7 +7093,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   >
                     <div
                       className="eight wide column"
-                      data-testid="1"
                       style={
                         {
                           "paddingBottom": 0,
@@ -8307,7 +8236,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                     <div
                       className="eight wide column"
-                      data-testid="1"
                       style={
                         {
                           "paddingBottom": 0,
@@ -8357,15 +8285,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="nine wide column"
-            data-testid="1"
           >
             <div
               className="ui grid"
-              data-testid="0"
             >
               <div
                 className="sixteen wide column"
-                data-testid="1"
                 style={
                   {
                     "paddingTop": "56px",
@@ -8484,7 +8409,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="sixteen wide column"
-                data-testid="1"
                 style={
                   {
                     "paddingBottom": 0,
@@ -8556,11 +8480,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
     >
       <div
         className="ui container grid"
-        data-testid="0"
       >
         <div
           className="ui grid"
-          data-testid="0"
           style={
             {
               "width": "100%",
@@ -8569,7 +8491,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         >
           <div
             className="18 wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -8594,7 +8515,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="ui grid"
-          data-testid="0"
           style={
             {
               "width": "100%",
@@ -8603,7 +8523,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         >
           <div
             className="five wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -8648,7 +8567,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="five wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -8693,7 +8611,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="five wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -8739,7 +8656,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="ui grid"
-          data-testid="0"
           style={
             {
               "marginTop": 0,
@@ -8750,7 +8666,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         >
           <div
             className="six wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -8795,7 +8710,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="ten wide column"
-            data-testid="1"
             style={
               {
                 "paddingBottom": 0,
@@ -8992,7 +8906,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="ui grid"
-          data-testid="0"
           style={
             {
               "marginTop": 0,
@@ -9002,7 +8915,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
         >
           <div
             className="seven wide column"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -9012,7 +8924,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               >
                 <div
                   className="ui grid"
-                  data-testid="0"
                   style={
                     {
                       "marginTop": 0,
@@ -9022,7 +8933,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                 >
                   <div
                     className="sixteen wide column"
-                    data-testid="1"
                     style={
                       {
                         "paddingBottom": 0,
@@ -9068,7 +8978,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="sixteen wide column"
-                    data-testid="1"
                     style={
                       {
                         "paddingBottom": 0,
@@ -9114,7 +9023,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="sixteen wide column"
-                    data-testid="1"
                     style={
                       {
                         "paddingBottom": 0,
@@ -9160,7 +9068,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="ui grid"
-                    data-testid="0"
                     style={
                       {
                         "width": "100%",
@@ -9169,7 +9076,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   >
                     <div
                       className="eight wide column"
-                      data-testid="1"
                       style={
                         {
                           "paddingBottom": 0,
@@ -10313,7 +10219,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                     <div
                       className="eight wide column"
-                      data-testid="1"
                       style={
                         {
                           "paddingBottom": 0,
@@ -10363,15 +10268,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="nine wide column"
-            data-testid="1"
           >
             <div
               className="ui grid"
-              data-testid="0"
             >
               <div
                 className="sixteen wide column"
-                data-testid="1"
                 style={
                   {
                     "paddingTop": "56px",
@@ -10490,7 +10392,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="sixteen wide column"
-                data-testid="1"
                 style={
                   {
                     "paddingBottom": 0,
@@ -10536,7 +10437,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="sixteen wide column"
-                data-testid="1"
                 style={
                   {
                     "paddingBottom": 0,
@@ -10582,7 +10482,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="ten wide column"
-                data-testid="1"
                 style={
                   {
                     "paddingBottom": 0,
@@ -10628,7 +10527,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
               </div>
               <div
                 className="six wide column"
-                data-testid="1"
                 style={
                   {
                     "paddingBottom": 0,
@@ -11801,7 +11699,6 @@ exports[`Three even column grid renders person and address in three columns, no 
     >
       <div
         className="ui container grid"
-        data-testid="0"
         style={
           {
             "width": "100%",
@@ -11810,7 +11707,6 @@ exports[`Three even column grid renders person and address in three columns, no 
       >
         <div
           className="18 wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -11834,7 +11730,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="five wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -11879,7 +11774,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="five wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -11924,7 +11818,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="five wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -11969,7 +11862,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="five wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -12014,7 +11906,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="eleven wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -12210,7 +12101,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="eight wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -12255,7 +12145,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="eight wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -12300,7 +12189,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="five wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -12345,7 +12233,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="five wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -13489,7 +13376,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="five wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -13523,7 +13409,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
     >
       <div
         className="ui container grid"
-        data-testid="0"
         style={
           {
             "width": "100%",
@@ -13532,7 +13417,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
       >
         <div
           className="18 wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -13556,7 +13440,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="eight wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -13601,7 +13484,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="eight wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -13646,7 +13528,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="eight wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -13691,7 +13572,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="eight wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -13736,7 +13616,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="18 wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -13932,7 +13811,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="eight wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -13977,7 +13855,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="eight wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -14022,7 +13899,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="eight wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -14067,7 +13943,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="eight wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,
@@ -15211,7 +15086,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="18 wide column"
-          data-testid="1"
           style={
             {
               "paddingBottom": 0,

--- a/packages/shadcn/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/shadcn/src/CheckboxWidget/CheckboxWidget.tsx
@@ -58,7 +58,7 @@ export default function CheckboxWidget<
       className={`relative ${disabled || readonly ? 'cursor-not-allowed opacity-50' : ''}`}
       aria-describedby={ariaDescribedByIds<T>(id)}
     >
-      {!hideLabel && !!description && (
+      {!hideLabel && description && (
         <DescriptionFieldTemplate
           id={descriptionId<T>(id)}
           description={description}

--- a/packages/shadcn/src/DescriptionField/DescriptionField.tsx
+++ b/packages/shadcn/src/DescriptionField/DescriptionField.tsx
@@ -1,4 +1,5 @@
 import { DescriptionFieldProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
+import { RichDescription } from '@rjsf/core';
 
 /** The `DescriptionField` is the template to use to render the description of a field
  *
@@ -8,16 +9,16 @@ export default function DescriptionField<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
->({ id, description }: DescriptionFieldProps<T, S, F>) {
-  if (description) {
-    return (
-      <div>
-        <div id={id} className='text-sm text-muted-foreground'>
-          {description}
-        </div>
-      </div>
-    );
+>({ id, description, registry, uiSchema }: DescriptionFieldProps<T, S, F>) {
+  if (!description) {
+    return null;
   }
 
-  return null;
+  return (
+    <div>
+      <div id={id} className='text-sm text-muted-foreground'>
+        <RichDescription description={description} registry={registry} uiSchema={uiSchema} />
+      </div>
+    </div>
+  );
 }

--- a/packages/shadcn/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/shadcn/test/__snapshots__/Form.test.tsx.snap
@@ -152,6 +152,184 @@ exports[`single fields checkbox field with label 1`] = `
 </form>
 `;
 
+exports[`single fields checkbox field with label and description 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-boolean"
+  >
+    <div
+      className="flex flex-col gap-2"
+    >
+      <div
+        aria-describedby="root__error root__description root__help"
+        className="relative "
+      >
+        <div>
+          <div
+            className="text-sm text-muted-foreground"
+            id="root__description"
+          >
+            test description
+          </div>
+        </div>
+        <div
+          className="flex items-center gap-2 my-2"
+        >
+          <button
+            aria-checked={false}
+            aria-required={false}
+            autoFocus={false}
+            className="peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground"
+            data-state="unchecked"
+            disabled={false}
+            id="root"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role="checkbox"
+            type="button"
+            value="on"
+          />
+          <input
+            aria-hidden={true}
+            defaultChecked={false}
+            disabled={false}
+            name="root"
+            required={false}
+            style={
+              {
+                "margin": 0,
+                "opacity": 0,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "transform": "translateX(-100%)",
+              }
+            }
+            tabIndex={-1}
+            type="checkbox"
+            value="on"
+          />
+          <label
+            className="text-sm font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70 leading-tight"
+            htmlFor="root"
+            onMouseDown={[Function]}
+          >
+            test
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground shadow hover:bg-primary/90 h-9 px-4 py-2 my-2"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields checkbox field with label and rich text description 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-boolean"
+  >
+    <div
+      className="flex flex-col gap-2"
+    >
+      <div
+        aria-describedby="root__error root__description root__help"
+        className="relative "
+      >
+        <div>
+          <div
+            className="text-sm text-muted-foreground"
+            id="root__description"
+          >
+            <span>
+              <strong>
+                test
+              </strong>
+               
+              <strong>
+                description
+              </strong>
+            </span>
+          </div>
+        </div>
+        <div
+          className="flex items-center gap-2 my-2"
+        >
+          <button
+            aria-checked={false}
+            aria-required={false}
+            autoFocus={false}
+            className="peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground"
+            data-state="unchecked"
+            disabled={false}
+            id="root"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            role="checkbox"
+            type="button"
+            value="on"
+          />
+          <input
+            aria-hidden={true}
+            defaultChecked={false}
+            disabled={false}
+            name="root"
+            required={false}
+            style={
+              {
+                "margin": 0,
+                "opacity": 0,
+                "pointerEvents": "none",
+                "position": "absolute",
+                "transform": "translateX(-100%)",
+              }
+            }
+            tabIndex={-1}
+            type="checkbox"
+            value="on"
+          />
+          <label
+            className="text-sm font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70 leading-tight"
+            htmlFor="root"
+            onMouseDown={[Function]}
+          >
+            test
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground shadow hover:bg-primary/90 h-9 px-4 py-2 my-2"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields checkboxes field 1`] = `
 <form
   className="rjsf"
@@ -524,6 +702,184 @@ exports[`single fields field with description in uiSchema 1`] = `
                       id="root_my-field__description"
                     >
                       some other description
+                    </div>
+                  </div>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground shadow hover:bg-primary/90 h-9 px-4 py-2 my-2"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown description 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="flex flex-col gap-2"
+    >
+      <div
+        className="flex flex-col gap-2"
+      >
+        <div
+          className=" flex"
+        >
+          <div
+            className="w-full"
+          >
+             
+            <div
+              className="rjsf-field rjsf-field-string"
+            >
+              <div
+                className="flex flex-col gap-2"
+              >
+                <label
+                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                  htmlFor="root_my-field"
+                >
+                  my-field
+                </label>
+                <div
+                  className="p-0.5"
+                >
+                  <input
+                    aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                    autoFocus={false}
+                    className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                    disabled={false}
+                    id="root_my-field"
+                    name="root_my-field"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    readOnly={false}
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <span
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  <div>
+                    <div
+                      className="text-sm text-muted-foreground"
+                      id="root_my-field__description"
+                    >
+                      <span>
+                        some 
+                        <strong>
+                          Rich
+                        </strong>
+                         description
+                      </span>
+                    </div>
+                  </div>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground shadow hover:bg-primary/90 h-9 px-4 py-2 my-2"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown description in uiSchema 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="flex flex-col gap-2"
+    >
+      <div
+        className="flex flex-col gap-2"
+      >
+        <div
+          className=" flex"
+        >
+          <div
+            className="w-full"
+          >
+             
+            <div
+              className="rjsf-field rjsf-field-string"
+            >
+              <div
+                className="flex flex-col gap-2"
+              >
+                <label
+                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                  htmlFor="root_my-field"
+                >
+                  my-field
+                </label>
+                <div
+                  className="p-0.5"
+                >
+                  <input
+                    aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                    autoFocus={false}
+                    className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                    disabled={false}
+                    id="root_my-field"
+                    name="root_my-field"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    readOnly={false}
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <span
+                  className="text-xs font-medium text-muted-foreground"
+                >
+                  <div>
+                    <div
+                      className="text-sm text-muted-foreground"
+                      id="root_my-field__description"
+                    >
+                      <span>
+                        some other description
+                      </span>
                     </div>
                   </div>
                 </span>

--- a/packages/shadcn/test/__snapshots__/GridSnap.test.tsx.snap
+++ b/packages/shadcn/test/__snapshots__/GridSnap.test.tsx.snap
@@ -14,15 +14,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
     >
       <div
         className="grid gap-2"
-        data-testid="0"
       >
         <div
           className="grid grid-cols-1 gap-4 col-span-12"
-          data-testid="0"
         >
           <div
             className="grid gap-2"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -55,11 +52,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="grid grid-cols-12 gap-4 col-span-12"
-          data-testid="0"
         >
           <div
             className="grid gap-2 col-span-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -99,7 +94,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -138,7 +132,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -179,11 +172,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="grid grid-cols-12 gap-4 col-span-12"
-          data-testid="0"
         >
           <div
             className="grid gap-2 col-span-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -223,7 +214,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-6"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-array"
@@ -495,11 +485,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="grid grid-cols-12 gap-4 col-span-12 grid-rows-4"
-          data-testid="0"
         >
           <div
             className="grid gap-2 col-span-6 row-span-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -509,11 +497,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
               >
                 <div
                   className="grid grid-cols-12 gap-4"
-                  data-testid="0"
                 >
                   <div
                     className="grid gap-2 col-span-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -553,7 +539,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="grid gap-2 col-span-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -592,7 +577,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="grid gap-2 col-span-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -632,11 +616,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="grid gap-2 grid-cols-12 col-span-12"
-                    data-testid="0"
                   >
                     <div
                       className="grid gap-2 col-span-6"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -718,7 +700,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                     <div
                       className="grid gap-2 col-span-6"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -763,7 +744,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="gap-2 col-span-6 row-span-1 flex items-center"
-            data-testid="1"
           >
             <div>
               <div
@@ -959,7 +939,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-6 row-span-1"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -999,7 +978,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-6 row-span-1"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -1038,7 +1016,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-4 row-span-1"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -1078,7 +1055,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-2 row-span-1"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -1188,15 +1164,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
     >
       <div
         className="grid gap-2"
-        data-testid="0"
       >
         <div
           className="grid grid-cols-1 gap-4 col-span-12"
-          data-testid="0"
         >
           <div
             className="grid gap-2"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -1229,11 +1202,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="grid grid-cols-12 gap-4 col-span-12"
-          data-testid="0"
         >
           <div
             className="grid gap-2 col-span-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -1273,7 +1244,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -1312,7 +1282,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -1353,11 +1322,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="grid grid-cols-12 gap-4 col-span-12"
-          data-testid="0"
         >
           <div
             className="grid gap-2 col-span-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -1397,7 +1364,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-6"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-array"
@@ -1669,11 +1635,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="grid grid-cols-12 gap-4 col-span-12 grid-rows-4"
-          data-testid="0"
         >
           <div
             className="grid gap-2 col-span-6 row-span-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -1683,11 +1647,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
               >
                 <div
                   className="grid grid-cols-12 gap-4"
-                  data-testid="0"
                 >
                   <div
                     className="grid gap-2 col-span-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -1727,7 +1689,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="grid gap-2 col-span-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -1766,7 +1727,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="grid gap-2 col-span-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -1806,11 +1766,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="grid gap-2 grid-cols-12 col-span-12"
-                    data-testid="0"
                   >
                     <div
                       className="grid gap-2 col-span-6"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -1892,7 +1850,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                     <div
                       className="grid gap-2 col-span-6"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -1937,7 +1894,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="gap-2 col-span-6 row-span-1 flex items-center"
-            data-testid="1"
           >
             <div>
               <div
@@ -2133,7 +2089,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-6 row-span-1"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -2172,7 +2127,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-6 row-span-1"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -2212,7 +2166,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-6 row-span-1"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -2251,7 +2204,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-4 row-span-1"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -2291,7 +2243,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-2 row-span-1"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -2401,15 +2352,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
     >
       <div
         className="grid gap-2"
-        data-testid="0"
       >
         <div
           className="grid grid-cols-1 gap-4 col-span-12"
-          data-testid="0"
         >
           <div
             className="grid gap-2"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -2442,11 +2390,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="grid grid-cols-12 gap-4 col-span-12"
-          data-testid="0"
         >
           <div
             className="grid gap-2 col-span-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -2486,7 +2432,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -2525,7 +2470,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -2566,11 +2510,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="grid grid-cols-12 gap-4 col-span-12"
-          data-testid="0"
         >
           <div
             className="grid gap-2 col-span-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -2610,7 +2552,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-6"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-array"
@@ -2882,11 +2823,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="grid grid-cols-12 gap-4 col-span-12 grid-rows-4"
-          data-testid="0"
         >
           <div
             className="grid gap-2 col-span-6 row-span-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -2896,11 +2835,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
               >
                 <div
                   className="grid grid-cols-12 gap-4"
-                  data-testid="0"
                 >
                   <div
                     className="grid gap-2 col-span-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -2940,7 +2877,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="grid gap-2 col-span-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -2979,7 +2915,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="grid gap-2 col-span-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -3019,11 +2954,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="grid gap-2 grid-cols-12 col-span-12"
-                    data-testid="0"
                   >
                     <div
                       className="grid gap-2 col-span-6"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -3105,7 +3038,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                     <div
                       className="grid gap-2 col-span-6"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -3150,7 +3082,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="gap-2 col-span-6 row-span-1 flex items-center"
-            data-testid="1"
           >
             <div>
               <div
@@ -3346,7 +3277,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-6 row-span-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -3414,15 +3344,12 @@ exports[`Complex grid renders person and address and employment in a complex gri
     >
       <div
         className="grid gap-2"
-        data-testid="0"
       >
         <div
           className="grid grid-cols-1 gap-4 col-span-12"
-          data-testid="0"
         >
           <div
             className="grid gap-2"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -3455,11 +3382,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="grid grid-cols-12 gap-4 col-span-12"
-          data-testid="0"
         >
           <div
             className="grid gap-2 col-span-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -3499,7 +3424,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -3538,7 +3462,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -3579,11 +3502,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="grid grid-cols-12 gap-4 col-span-12"
-          data-testid="0"
         >
           <div
             className="grid gap-2 col-span-3"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -3623,7 +3544,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-6"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-array"
@@ -3895,11 +3815,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
         </div>
         <div
           className="grid grid-cols-12 gap-4 col-span-12 grid-rows-4"
-          data-testid="0"
         >
           <div
             className="grid gap-2 col-span-6 row-span-4"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-object"
@@ -3909,11 +3827,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
               >
                 <div
                   className="grid grid-cols-12 gap-4"
-                  data-testid="0"
                 >
                   <div
                     className="grid gap-2 col-span-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -3953,7 +3869,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="grid gap-2 col-span-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -3992,7 +3907,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="grid gap-2 col-span-12"
-                    data-testid="1"
                   >
                     <div
                       className="rjsf-field rjsf-field-string"
@@ -4032,11 +3946,9 @@ exports[`Complex grid renders person and address and employment in a complex gri
                   </div>
                   <div
                     className="grid gap-2 grid-cols-12 col-span-12"
-                    data-testid="0"
                   >
                     <div
                       className="grid gap-2 col-span-6"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -4118,7 +4030,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
                     </div>
                     <div
                       className="grid gap-2 col-span-6"
-                      data-testid="1"
                     >
                       <div
                         className="rjsf-field rjsf-field-string"
@@ -4163,7 +4074,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="gap-2 col-span-6 row-span-1 flex items-center"
-            data-testid="1"
           >
             <div>
               <div
@@ -4359,7 +4269,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-6 row-span-1"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -4399,7 +4308,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-6 row-span-1"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -4438,7 +4346,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-4 row-span-1"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -4478,7 +4385,6 @@ exports[`Complex grid renders person and address and employment in a complex gri
           </div>
           <div
             className="grid gap-2 col-span-2 row-span-1"
-            data-testid="1"
           >
             <div
               className="rjsf-field rjsf-field-string"
@@ -4588,11 +4494,9 @@ exports[`Three even column grid renders person and address in three columns, no 
     >
       <div
         className="grid grid-cols-12 gap-4 col-span-12"
-        data-testid="0"
       >
         <div
           className="grid gap-2 col-span-12"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-object"
@@ -4624,7 +4528,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="grid gap-2 col-span-4"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -4664,7 +4567,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="grid gap-2 col-span-4"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -4703,7 +4605,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="grid gap-2 col-span-4"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -4743,7 +4644,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="grid gap-2 col-span-4"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -4783,7 +4683,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="grid gap-2 col-span-8"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-array"
@@ -5054,7 +4953,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="grid gap-2 col-span-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -5094,7 +4992,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="grid gap-2 col-span-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -5133,7 +5030,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="grid gap-2 col-span-4"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -5173,7 +5069,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="grid gap-2 col-span-4"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -5255,7 +5150,6 @@ exports[`Three even column grid renders person and address in three columns, no 
         </div>
         <div
           className="grid gap-2 col-span-4"
-          data-testid="1"
         />
       </div>
     </div>
@@ -5286,11 +5180,9 @@ exports[`Two even column grid renders person and address in two columns, no empl
     >
       <div
         className="grid grid-cols-12 gap-4 col-span-12"
-        data-testid="0"
       >
         <div
           className="grid gap-2 col-span-12"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-object"
@@ -5322,7 +5214,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="grid gap-2 col-span-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -5362,7 +5253,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="grid gap-2 col-span-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -5401,7 +5291,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="grid gap-2 col-span-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -5441,7 +5330,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="grid gap-2 col-span-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -5481,7 +5369,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="grid gap-2 col-span-12"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-array"
@@ -5752,7 +5639,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="grid gap-2 col-span-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -5792,7 +5678,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="grid gap-2 col-span-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -5831,7 +5716,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="grid gap-2 col-span-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -5871,7 +5755,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="grid gap-2 col-span-6"
-          data-testid="1"
         >
           <div
             className="rjsf-field rjsf-field-string"
@@ -5953,7 +5836,6 @@ exports[`Two even column grid renders person and address in two columns, no empl
         </div>
         <div
           className="grid gap-2 col-span-12"
-          data-testid="1"
         />
       </div>
     </div>

--- a/packages/snapshot-tests/src/arrayTests.tsx
+++ b/packages/snapshot-tests/src/arrayTests.tsx
@@ -4,6 +4,12 @@ import { FormProps } from '@rjsf/core';
 import { RJSFSchema, ErrorSchema, UiSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 
+jest.mock('@rjsf/utils', () => ({
+  ...jest.requireActual('@rjsf/utils'),
+  // Disable the getTestIds within the snapshot tests by returning an empty object
+  getTestIds: jest.fn(() => ({})),
+}));
+
 const titleAndDesc = {
   title: 'Test field',
   description: 'a test description',

--- a/packages/snapshot-tests/src/formTests.tsx
+++ b/packages/snapshot-tests/src/formTests.tsx
@@ -1,8 +1,14 @@
 import { ComponentType } from 'react';
 import renderer, { TestRendererOptions } from 'react-test-renderer';
 import { FormProps } from '@rjsf/core';
-import { RJSFSchema, ErrorSchema } from '@rjsf/utils';
+import { RJSFSchema, ErrorSchema, UiSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
+
+jest.mock('@rjsf/utils', () => ({
+  ...jest.requireActual('@rjsf/utils'),
+  // Disable the getTestIds within the snapshot tests by returning an empty object
+  getTestIds: jest.fn(() => ({})),
+}));
 
 export const SELECT_CUSTOMIZE = 'selectMulti';
 export const SLIDER_CUSTOMIZE = 'slider';
@@ -323,6 +329,25 @@ export function formTests(Form: ComponentType<FormProps>, customOptions: FormRen
       const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
       expect(tree).toMatchSnapshot();
     });
+    test('checkbox field with label and description', () => {
+      const schema: RJSFSchema = {
+        type: 'boolean',
+        title: 'test',
+        description: 'test description',
+      };
+      const tree = renderer.create(<Form schema={schema} validator={validator} />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+    test('checkbox field with label and rich text description', () => {
+      const schema: RJSFSchema = {
+        type: 'boolean',
+        title: 'test',
+        description: '**test** __description__',
+      };
+      const uiSchema: UiSchema = { 'ui:enableMarkdownInDescription': true };
+      const tree = renderer.create(<Form schema={schema} uiSchema={uiSchema} validator={validator} />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
     test('checkboxes field', () => {
       const schema: RJSFSchema = {
         type: 'array',
@@ -409,6 +434,41 @@ export function formTests(Form: ComponentType<FormProps>, customOptions: FormRen
       const uiSchema = {
         'my-field': {
           'ui:description': 'some other description',
+        },
+      };
+      const tree = renderer.create(<Form schema={schema} validator={validator} uiSchema={uiSchema} />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+    test('field with markdown description', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          'my-field': {
+            type: 'string',
+            description: 'some **Rich** description',
+          },
+        },
+      };
+      const uiSchema = {
+        'my-field': { 'ui:enableMarkdownInDescription': true },
+      };
+      const tree = renderer.create(<Form schema={schema} uiSchema={uiSchema} validator={validator} />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+    test('field with markdown description in uiSchema', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          'my-field': {
+            type: 'string',
+            description: 'some **Rich** description',
+          },
+        },
+      };
+      const uiSchema = {
+        'my-field': {
+          'ui:description': 'some other description',
+          'ui:enableMarkdownInDescription': true,
         },
       };
       const tree = renderer.create(<Form schema={schema} validator={validator} uiSchema={uiSchema} />).toJSON();

--- a/packages/snapshot-tests/src/gridTests.tsx
+++ b/packages/snapshot-tests/src/gridTests.tsx
@@ -6,22 +6,8 @@ import { FormProps } from '@rjsf/core';
 
 jest.mock('@rjsf/utils', () => ({
   ...jest.requireActual('@rjsf/utils'),
-  getTestIds: jest.fn(() => {
-    const ids = new Map();
-    // For test repeatability purposes and snapshots, we render the snapshot data-testid using a simple counter
-    let counter = 0;
-    return new Proxy(
-      {},
-      {
-        get(_obj, prop) {
-          if (!ids.has(prop)) {
-            ids.set(prop, `${counter++}`);
-          }
-          return ids.get(prop);
-        },
-      },
-    );
-  }),
+  // Disable the getTestIds within the snapshot tests by returning an empty object
+  getTestIds: jest.fn(() => ({})),
 }));
 
 export type GridRenderCustomOptions = {

--- a/packages/snapshot-tests/src/objectTests.tsx
+++ b/packages/snapshot-tests/src/objectTests.tsx
@@ -4,6 +4,12 @@ import { FormProps } from '@rjsf/core';
 import { RJSFSchema, UiSchema } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 
+jest.mock('@rjsf/utils', () => ({
+  ...jest.requireActual('@rjsf/utils'),
+  // Disable the getTestIds within the snapshot tests by returning an empty object
+  getTestIds: jest.fn(() => ({})),
+}));
+
 const titleAndDesc = {
   title: 'Test field',
   description: 'a test description',

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -245,7 +245,7 @@ export type FormValidation<T = any> = FieldValidation & {
 export type RJSFBaseProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any> = {
   /** The schema object for the field being described */
   schema: S;
-  /** The uiSchema object for this description field */
+  /** The uiSchema object for this base component */
   uiSchema?: UiSchema<T, S, F>;
   /** The `registry` object */
   registry: Registry<T, S, F>;
@@ -387,6 +387,9 @@ export type GlobalUISchemaOptions = {
    * This option allows you to change the separator between the original key name and the integer. Default is "-"
    */
   duplicateKeySuffixSeparator?: string;
+  /** Enables the displaying of description text that contains markdown
+   */
+  enableMarkdownInDescription?: boolean;
 };
 
 /** The object containing the registered core, theme and custom fields and widgets as well as the root schema, form
@@ -422,11 +425,8 @@ export interface Registry<T = any, S extends StrictRJSFSchema = RJSFSchema, F ex
 /** The properties that are passed to a Field implementation */
 export interface FieldProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>
   extends GenericObjectType,
+    RJSFBaseProps<T, S, F>,
     Pick<HTMLAttributes<HTMLElement>, Exclude<keyof HTMLAttributes<HTMLElement>, 'onBlur' | 'onFocus' | 'onChange'>> {
-  /** The JSON subschema object for this field */
-  schema: S;
-  /** The uiSchema for this field */
-  uiSchema?: UiSchema<T, S, F>;
   /** The tree of unique ids for every child field */
   idSchema: IdSchema<T>;
   /** The data for this field */
@@ -463,8 +463,6 @@ export interface FieldProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F 
   idSeparator?: string;
   /** An array of strings listing all generated error messages from encountered errors for this field */
   rawErrors?: string[];
-  /** The `registry` object */
-  registry: Registry<T, S, F>;
 }
 
 /** The definition of a React-based Field component */
@@ -726,7 +724,7 @@ export type ObjectFieldTemplateProps<
   /** A string value containing the title for the object */
   title: string;
   /** A string value containing the description for the object */
-  description?: string;
+  description?: string | ReactElement;
   /** A boolean value stating if the object is disabled */
   disabled?: boolean;
   /** An array of objects representing the properties in the object */


### PR DESCRIPTION
Fixes https://github.com/rjsf-team/react-jsonschema-form/issues/4527

Reimplements #4405 in v6

In the fields of type `object` and type `boolean`, markdown will be rendered in the description when `enableMarkdownInDescription` is set to `true`.

Issue reporting this bug: https://github.com/rjsf-team/react-jsonschema-form/issues/3975
Previous PR to add the feature: https://github.com/rjsf-team/react-jsonschema-form/pull/3665

The result:

https://github.com/user-attachments/assets/f26df22e-5ab1-412a-a78d-d747ecb54fc6


### Reasons for making this change

[Please describe them here]

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

If your PR is non-trivial and you'd like to schedule a synchronous review, please add it to the weekly meeting agenda: https://docs.google.com/document/d/12PjTvv21k6LIky6bNQVnsplMLLnmEuypTLQF8a-8Wss/edit

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
