### PR TITLE
Update @rjsf/daisyui package.json

### DIFF
--- a/packages/daisyui/package.json
+++ b/packages/daisyui/package.json
@@ -87,6 +87,9 @@
     "type": "git",
     "url": "git+https://github.com/rjsf-team/react-jsonschema-form.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "author": "Jason Vertrees <jason.vertrees@gmail.com>",
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
### Reasons for making this change

The package release failed for DaisyUI ([here](https://github.com/rjsf-team/react-jsonschema-form/actions/runs/14799116198/job/41553453900#step:11:2126)) because the package is private by default on scoped packages, this should fix this issue.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
