### PR TITLE
Bug: schema references in combinators(allOf, anyOf, oneOf) cannot be modified when defaults were set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.24.11
+
+## @rjsf/utils
+
+- Fixed issue with schema references in combinators(allOf, anyOf, oneOf) could not be modified when defaults were set, fixing [#4555](https://github.com/rjsf-team/react-jsonschema-form/issues/4555)
+
+
 # 6.0.0-beta.1
 
 ## @rjsf/antd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,6 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
-# 5.24.11
-
-## @rjsf/utils
-
-- Fixed issue with schema references in combinators(allOf, anyOf, oneOf) could not be modified when defaults were set, fixing [#4555](https://github.com/rjsf-team/react-jsonschema-form/issues/4555)
 
 # 6.0.0-beta.2
 
@@ -67,6 +62,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/utils
 
 - Updated the `description` field in field props to be a `string | ReactElement` and added `enableMarkdownInDescription` to the `GlobalUISchemaOptions` interface
+- Fixed issue with schema references in combinators(allOf, anyOf, oneOf) could not be modified when defaults were set, fixing [#4555](https://github.com/rjsf-team/react-jsonschema-form/issues/4555)
 
 ## Dev / docs / playground
 

--- a/packages/core/test/Form.test.jsx
+++ b/packages/core/test/Form.test.jsx
@@ -1429,6 +1429,70 @@ describeRepeated('Form common', (createFormComponent) => {
 
       expect(node.querySelector(secondInputID).value).to.equal('changed!');
     });
+    it('Should modify anyOf definition references when the defaults are set.', () => {
+      const schema = {
+        definitions: {
+          option1: {
+            properties: {
+              first: {
+                type: 'string',
+              },
+            },
+          },
+          option2: {
+            properties: {
+              second: {
+                type: 'string',
+              },
+            },
+          },
+        },
+        properties: {
+          any_of_field: {
+            anyOf: [
+              {
+                $ref: '#/definitions/option1',
+              },
+              {
+                $ref: '#/definitions/option2',
+              },
+            ],
+            default: {
+              second: 'second!',
+            },
+          },
+        },
+        type: 'object',
+      };
+
+      const { node, onChange } = createFormComponent({
+        schema,
+      });
+
+      const secondInputID = '#root_any_of_field_second';
+      expect(node.querySelector(secondInputID).value).to.equal('second!');
+
+      act(() => {
+        fireEvent.change(node.querySelector(secondInputID), {
+          target: { value: 'changed!' },
+        });
+      });
+
+      sinon.assert.calledWithMatch(
+        onChange.lastCall,
+        {
+          formData: {
+            any_of_field: {
+              second: 'changed!',
+            },
+          },
+          schema,
+        },
+        'root_any_of_field_second',
+      );
+
+      expect(node.querySelector(secondInputID).value).to.equal('changed!');
+    });
   });
 
   describe('Blur handler', () => {

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -223,7 +223,7 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
     // For object defaults, only override parent defaults that are defined in
     // schema.default.
     defaults = mergeObjects(defaults!, schema.default as GenericObjectType) as T;
-  } else if (DEFAULT_KEY in schema && !schema[ANY_OF_KEY] && !schema[ONE_OF_KEY]) {
+  } else if (DEFAULT_KEY in schema && !schema[ANY_OF_KEY] && !schema[ONE_OF_KEY] && !schema[REF_KEY]) {
     // If the schema has a default value, then we should use it as the default.
     // And if the schema does not have anyOf or oneOf, this is done because we need to merge the defaults with the formData.
     defaults = schema.default as unknown as T;
@@ -233,6 +233,12 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
     if (!_recurseList.includes(refName!)) {
       updatedRecurseList = _recurseList.concat(refName!);
       schemaToCompute = findSchemaDefinition<S>(refName, rootSchema);
+    }
+
+    // If the referenced schema exists and parentDefaults is not set
+    // Then set the defaults from the current schema for the referenced schema
+    if (schemaToCompute && !defaults) {
+      defaults = schema.default as T | undefined;
     }
   } else if (DEPENDENCIES_KEY in schema) {
     // Get the default if set from properties to ensure the dependencies conditions are resolved based on it


### PR DESCRIPTION
### Reasons for making this change

Fixes #4555

### Checklist

- [X] **I'm adding or updating code**
  - [X] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a 
