### PR TITLE
Fixed form data propagation with `patternProperties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 6.0.0-beta.8
+
+## @rjsf/util
+
+- Fixed form data propagation with `patternProperties` [#4617](https://github.com/rjsf-team/react-jsonschema-form/pull/4617)
+
 # 6.0.0-beta.7
 
 ## @rjsf/core

--- a/packages/utils/src/findSchemaDefinition.ts
+++ b/packages/utils/src/findSchemaDefinition.ts
@@ -6,6 +6,7 @@ import { GenericObjectType, RJSFSchema, StrictRJSFSchema } from './types';
 import isObject from 'lodash/isObject';
 import isEmpty from 'lodash/isEmpty';
 import UriResolver from 'fast-uri';
+import get from 'lodash/get';
 
 /** Looks for the `$id` pointed by `ref` in the schema definitions embedded in
  * a JSON Schema bundle
@@ -51,7 +52,7 @@ export function splitKeyElementFromObject(key: string, object: GenericObjectType
  * @param $ref - The ref string for which the schema definition is desired
  * @param [rootSchema={}] - The root schema in which to search for the definition
  * @param recurseList - List of $refs already resolved to prevent recursion
- * @param baseURI - The base URI to be used for resolving relative references
+ * @param [baseURI=rootSchema['$id']] - The base URI to be used for resolving relative references
  * @returns - The sub-schema within the `rootSchema` which matches the `$ref` if it exists
  * @throws - Error indicating that no schema for that reference could be resolved
  */
@@ -59,7 +60,7 @@ export function findSchemaDefinitionRecursive<S extends StrictRJSFSchema = RJSFS
   $ref?: string,
   rootSchema: S = {} as S,
   recurseList: string[] = [],
-  baseURI: string | undefined = ID_KEY in rootSchema ? rootSchema[ID_KEY] : undefined,
+  baseURI: string | undefined = get(rootSchema, [ID_KEY]),
 ): S {
   const ref = $ref || '';
   let current: S | undefined = undefined;
@@ -123,7 +124,7 @@ export function findSchemaDefinitionRecursive<S extends StrictRJSFSchema = RJSFS
 export default function findSchemaDefinition<S extends StrictRJSFSchema = RJSFSchema>(
   $ref?: string,
   rootSchema: S = {} as S,
-  baseURI: string | undefined = ID_KEY in rootSchema ? rootSchema[ID_KEY] : undefined,
+  baseURI: string | undefined = get(rootSchema, [ID_KEY]),
 ): S {
   const recurseList: string[] = [];
   return findSchemaDefinitionRecursive($ref, rootSchema, recurseList, baseURI);

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -334,7 +334,7 @@ export function resolveReference<T = any, S extends StrictRJSFSchema = RJSFSchem
  * @param schema - The schema for which resolving all references is desired
  * @param rootSchema - The root schema that will be forwarded to all the APIs
  * @param recurseList - List of $refs already resolved to prevent recursion
- * @param baseURI - The base URI to be used for resolving relative references
+ * @param [baseURI] - The base URI to be used for resolving relative references
  * @returns - given schema will all references resolved or the original schema if no internal `$refs` were resolved
  */
 export function resolveAllReferences<S extends StrictRJSFSchema = RJSFSchema>(
@@ -432,7 +432,7 @@ export function stubExistingAdditionalProperties<
           validator,
           { allOf: Object.values(matchingProperties) } as S,
           rootSchema,
-          formData as T,
+          get(formData, [key]) as T,
           experimental_customMergeAllOf,
         );
         set(schema.properties, [key, ADDITIONAL_PROPERTY_FLAG], true);
@@ -578,7 +578,7 @@ export function retrieveSchemaInternal<
               validator,
               { allOf: [schema.properties[key], ...Object.values(matchingProperties)] } as S,
               rootSchema,
-              rawFormData as T,
+              get(rawFormData, [key]) as T,
               experimental_customMergeAllOf,
             );
           }


### PR DESCRIPTION
### Reasons for making this change

The `formData` elements were not correctly propagated for inner schema evaluation. As a result, the `resolveCondition` method was failing when conditions were declared inside a `patternProperties` schema. This PR fixes this issue and adds a test to avoid regressions.
