### PR TITLE
Fix 4623 by properly handling chakra-ui's onChange for single select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,19 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 6.0.0-beta.9
+
+## @rjsf/chakra-ui
+
+- Updated `SelectWidget` to only pick the first element in a list when single selection is active, fixing [#4623](https://github.com/rjsf-team/react-jsonschema-form/issues/4623)
+
 # 6.0.0-beta.8
 
 ## @rjsf/chakra-ui
 
 - Added `getChakra` to package exports
 - Restored the `ui:options` customization
+- Updated `SelectWidget` to only pick the first element in a list when single selection is active, fixing [#4623](https://github.com/rjsf-team/react-jsonschema-form/issues/4623)
 
 ## @rjsf/core
 

--- a/packages/chakra-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/chakra-ui/src/SelectWidget/SelectWidget.tsx
@@ -43,19 +43,12 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
   const { enumOptions, enumDisabled, emptyValue } = options;
 
   const _onMultiChange = ({ value }: SelectValueChangeDetails) => {
-    return onChange(
-      enumOptionsValueForIndex<S>(
-        value.map((item) => {
-          return item;
-        }),
-        enumOptions,
-        emptyValue,
-      ),
-    );
+    return onChange(enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
   };
 
-  const _onChange = ({ value }: SelectValueChangeDetails) => {
-    return onChange(enumOptionsValueForIndex<S>(value, enumOptions, emptyValue));
+  const _onSingleChange = ({ value }: SelectValueChangeDetails) => {
+    const selected = enumOptionsValueForIndex<S>(value, enumOptions, emptyValue);
+    return onChange(Array.isArray(selected) && selected.length === 1 ? selected[0] : selected);
   };
 
   const _onBlur = ({ target }: FocusEvent<HTMLInputElement>) =>
@@ -137,7 +130,7 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
         multiple={isMultiple}
         closeOnSelect={!isMultiple}
         onBlur={_onBlur}
-        onValueChange={isMultiple ? _onMultiChange : _onChange}
+        onValueChange={isMultiple ? _onMultiChange : _onSingleChange}
         onFocus={_onFocus}
         autoFocus={autofocus}
         value={formValue}


### PR DESCRIPTION
### Reasons for making this change

Fixed #4623 by having the single select version return the element in the returned array
- Updated chakra-ui's `SelectWidget` to return a single value from the array

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
