### PR TITLE
chore: Add Tailwind setup instructions for v3 and v4 to README

### DIFF
--- a/packages/shadcn/README.md
+++ b/packages/shadcn/README.md
@@ -93,6 +93,20 @@ Follow shadCN installation guide [here](https://ui.shadcn.com/docs/installation)
 
 The color of the RJSF will automatically apply with your shadCN config.
 
+#### Tailwind v3
+Add the following line to your tailwind.config.ts
+```typescript
+  content: [
+    "./src/**/*.{html,js}",
+    "node_modules/@rjsf/shadcn/src/**/*.{js,ts,jsx,tsx,mdx}" // Add this line
+  ],
+```
+#### Tailwind v4
+Add the following line to your equivalent global.css
+```css
+@source "../node_modules/@rjsf/shadcn";
+```
+
 ### Not using Tailwind
 
 #### Use the theme on demo site


### PR DESCRIPTION
### Reasons for making this change

Updated README.md to include configuration steps for integrating Tailwind v3 and v4 with the package. This ensures users can correctly set up Tailwind for compatibility with RJSF and shadCN components.

[`fixes #[4633]` ](https://github.com/rjsf-team/react-jsonschema-form/issues/4633)

### Checklist

- [X] **I'm updating documentation**
  - [X] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
