### PR TITLE
Bug: schema oneOf radio button could not be modified when defaults were set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 6.0.0-beta.11
+
+## @rjsf/utils
+
+- Fixed issue where oneOf radio button could not be modified when defaults were set, fixing [#4634](https://github.com/rjsf-team/react-jsonschema-form/issues/4634)
+
 # 6.0.0-beta.10
 
 ## @rjsf/mui
@@ -61,7 +67,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Updated the `README.md` file for dependencies
 
-## @rjsf/util
+## @rjsf/utils
 
 - Fixed form data propagation with `patternProperties` [#4617](https://github.com/rjsf-team/react-jsonschema-form/pull/4617)
 - Updated the `GlobalUISchemaOptions` types to extend `GenericObjectType` to support user-defined values for their extensions
@@ -83,7 +89,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Updated `LayoutGridField` to use the pre-existing `UI_GLOBAL_OPTIONS_KEY` instead of its own incorrect one.
 
-## @rjsf/util
+## @rjsf/utils
 
 - Fixed form data propagation with `patternProperties` [#4617](https://github.com/rjsf-team/react-jsonschema-form/pull/4617)
 - Fixed issue where oneOf schema references could not be modified when defaults were set, fixing [#4580](https://github.com/rjsf-team/react-jsonschema-form/issues/4580).
@@ -101,7 +107,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 6.0.0-beta.6
 
-## @rjsf/util
+## @rjsf/utils
 
 - Updated the `Field` type to add the optional `TEST_IDS?: TestIdShape` prop to it to support exposing the `TEST_IDS` static prop on `LayoutGridField`, `LayoutHeaderField` and `LayoutMultiSchemaField` for external users
 

--- a/packages/core/test/Form.test.jsx
+++ b/packages/core/test/Form.test.jsx
@@ -1547,6 +1547,83 @@ describeRepeated('Form common', (createFormComponent) => {
 
       expect(node.querySelector(protocolInputID).value).to.equal('1');
     });
+    it('Should modify oneOf radio button when the defaults are set.', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          a: {
+            type: ['boolean', 'null'],
+            default: null,
+            oneOf: [
+              {
+                const: false,
+                title: 'No',
+              },
+              {
+                const: null,
+                title: 'N/A',
+              },
+            ],
+          },
+        },
+        allOf: [
+          {
+            if: {
+              required: ['a'],
+              properties: {
+                a: {
+                  const: false,
+                },
+              },
+            },
+            then: {
+              required: ['b'],
+              properties: {
+                b: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        ],
+      };
+
+      const uiSchema = {
+        a: {
+          'ui:widget': 'radio',
+          'ui:label': false,
+        },
+      };
+
+      const { node, onChange } = createFormComponent({
+        schema,
+        uiSchema,
+      });
+
+      const notApplicableInputID = '#root_a-1';
+      const NoInputID = '#root_a-0';
+      expect(node.querySelector(notApplicableInputID).checked).to.equal(true);
+
+      act(() => {
+        fireEvent.click(node.querySelector(NoInputID));
+      });
+
+      sinon.assert.calledWithMatch(
+        onChange.lastCall,
+        {
+          formData: {
+            a: false,
+          },
+          schema,
+          uiSchema,
+        },
+        'root_a',
+      );
+
+      expect(node.querySelector(NoInputID).checked).to.equal(true);
+      expect(node.querySelector(notApplicableInputID).checked).to.equal(false);
+      expect(node.querySelector('#root_b')).to.exist;
+    });
   });
 
   describe('Blur handler', () => {

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -213,7 +213,7 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
   let experimental_dfsb_to_compute = experimental_defaultFormStateBehavior;
   let updatedRecurseList = _recurseList;
   if (
-    schema[CONST_KEY] &&
+    schema[CONST_KEY] !== undefined &&
     experimental_defaultFormStateBehavior?.constAsDefaults !== 'never' &&
     !constIsAjvDataReference(schema)
   ) {


### PR DESCRIPTION
### Reasons for making this change

Fixes #4634 

### Checklist

- [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [X] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [X] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a 
