### PR TITLE
Fix @ant-design/icons peerDependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 6.0.0-beta.11
 
+## @rjsf/antd
+
+- Set peerDependency for `@ant-design/icons` to `^6.0.0`, fixing [#4643](https://github.com/rjsf-team/react-jsonschema-form/issues/4643)
+
 ## @rjsf/utils
 
 - Fixed issue where oneOf radio button could not be modified when defaults were set, fixing [#4634](https://github.com/rjsf-team/react-jsonschema-form/issues/4634)

--- a/package-lock.json
+++ b/package-lock.json
@@ -37831,7 +37831,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@ant-design/icons": "^5.0.0",
+        "@ant-design/icons": "^6.0.0",
         "@rjsf/core": "^6.0.0-beta",
         "@rjsf/utils": "^6.0.0-beta",
         "antd": "^5.8.5",

--- a/packages/antd/package.json
+++ b/packages/antd/package.json
@@ -62,7 +62,7 @@
     "node": ">=20"
   },
   "peerDependencies": {
-    "@ant-design/icons": "^5.0.0",
+    "@ant-design/icons": "^6.0.0",
     "@rjsf/core": "^6.0.0-beta",
     "@rjsf/utils": "^6.0.0-beta",
     "antd": "^5.8.5",


### PR DESCRIPTION
Fixes #4643

Set peerDependency for @ant-design/icons to "^6.0.0"
