### PR TITLE
Backport #4665 to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.24.12
+
+## @rjsf/utils
+
+- (Backported change from 6.0.0-beta.11) Fixed issue where oneOf radio button could not be modified when constAsDefaults is set to 'never', fixing [#4634](https://github.com/rjsf-team/react-jsonschema-form/issues/4634).
+
 # 5.24.11
 
 ## @rjsf/utils

--- a/packages/utils/src/schema/getDefaultFormState.ts
+++ b/packages/utils/src/schema/getDefaultFormState.ts
@@ -334,7 +334,7 @@ export function computeDefaults<T = any, S extends StrictRJSFSchema = RJSFSchema
       experimental_defaultFormStateBehavior: experimental_dfsb_to_compute,
       experimental_customMergeAllOf,
       parentDefaults: defaults as T | undefined,
-      rawFormData: formData as T,
+      rawFormData: (rawFormData ?? formData) as T,
       required,
       shouldMergeDefaultsIntoFormData,
     });


### PR DESCRIPTION
Backports #4665 for #4634

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
…s set to 'never' (#4665)

Co-authored-by: Heath C <51679588+heath-freenome@users.noreply.github.com>