### PR TITLE
Full URL for logo in Primereact README

### DIFF
--- a/packages/primereact/README.md
+++ b/packages/primereact/README.md
@@ -7,7 +7,7 @@
 <br />
 <p align="center">
   <a href="https://github.com/rjsf-team/react-jsonschema-form">
-    <img src="logo.png" alt="Logo" width="120" height="120">
+    <img src="https://raw.githubusercontent.com/rjsf-team/react-jsonschema-form/main/packages/primereact/logo.png" alt="Logo" width="120" height="120">
   </a>
 
 <h3 align="center">@rjsf/primereact</h3>


### PR DESCRIPTION
The logo is not displayed on [npmjs.com](https://www.npmjs.com/package/@rjsf/primereact), because the image url is relative.

![screenshot-www_npmjs_com-2025_06_19-00_12_03](https://github.com/user-attachments/assets/19eb8819-df0f-4027-bf27-fae336c4ab29)
