### PR TITLE
Always make all references absolute in nested bundled schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 6.0.0-beta.11
 
+## rjsf/utils
+
+- Always make all references absolute in nested bundled schemas
+
+
+# 6.0.0-beta.11
+
 ## @rjsf/antd
 
 - Set peerDependency for `@ant-design/icons` to `^6.0.0`, fixing [#4643](https://github.com/rjsf-team/react-jsonschema-form/issues/4643)

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -46,4 +46,5 @@ export const UI_GLOBAL_OPTIONS_KEY = 'ui:globalOptions';
 
 /** The JSON Schema version strings
  */
+export const JSON_SCHEMA_DRAFT_2019_09 = 'https://json-schema.org/draft/2019-09/schema';
 export const JSON_SCHEMA_DRAFT_2020_12 = 'https://json-schema.org/draft/2020-12/schema';

--- a/packages/utils/src/schema/retrieveSchema.ts
+++ b/packages/utils/src/schema/retrieveSchema.ts
@@ -430,7 +430,7 @@ export function stubExistingAdditionalProperties<
       if (!isEmpty(matchingProperties)) {
         schema.properties[key] = retrieveSchema<T, S, F>(
           validator,
-          { allOf: Object.values(matchingProperties) } as S,
+          { [ALL_OF_KEY]: Object.values(matchingProperties) } as S,
           rootSchema,
           get(formData, [key]) as T,
           experimental_customMergeAllOf,
@@ -445,7 +445,7 @@ export function stubExistingAdditionalProperties<
         if (REF_KEY in schema.additionalProperties!) {
           additionalProperties = retrieveSchema<T, S, F>(
             validator,
-            { $ref: get(schema.additionalProperties, [REF_KEY]) } as S,
+            { [REF_KEY]: get(schema.additionalProperties, [REF_KEY]) } as S,
             rootSchema,
             formData as T,
             experimental_customMergeAllOf,

--- a/packages/utils/test/findSchemaDefinition.test.ts
+++ b/packages/utils/test/findSchemaDefinition.test.ts
@@ -46,40 +46,96 @@ const schema: RJSFSchema = {
   },
 };
 
+const internalSchema: RJSFSchema = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://example.com/bundled.ref.json',
+  type: 'object',
+  $defs: {
+    colors: {
+      type: 'string',
+      enum: ['red', 'green', 'blue'],
+    },
+    string: {
+      type: 'string',
+    },
+    circularRef: {
+      $ref: '/bundled.schema.json/#/$defs/circularRef',
+    },
+    undefinedRef: {
+      $ref: '#/$defs/undefined',
+    },
+  },
+  properties: {
+    num: {
+      type: 'integer',
+    },
+    string: {
+      $ref: '#/$defs/string',
+    },
+    allOf: {
+      allOf: [
+        {
+          $ref: '#/$defs/string',
+        },
+        {
+          title: 'String',
+        },
+      ],
+    },
+  },
+};
+
+const absoluteInternalSchema: RJSFSchema = {
+  ...internalSchema,
+  $defs: {
+    ...internalSchema.$defs,
+    circularRef: { $ref: 'https://example.com/bundled.schema.json/#/$defs/circularRef' },
+    undefinedRef: { $ref: 'https://example.com/bundled.ref.json#/$defs/undefined' },
+  },
+  properties: {
+    ...internalSchema.properties,
+    string: { $ref: 'https://example.com/bundled.ref.json#/$defs/string' },
+    allOf: {
+      allOf: [
+        {
+          $ref: 'https://example.com/bundled.ref.json#/$defs/string',
+        },
+        {
+          title: 'String',
+        },
+      ],
+    },
+  },
+};
+
 const bundledSchema: RJSFSchema = {
   $schema: 'https://json-schema.org/draft/2020-12/schema',
   type: 'object',
   $id: 'https://example.com/bundled.schema.json',
   $defs: {
-    bundledSchema: {
-      $schema: 'https://json-schema.org/draft/2020-12/schema',
-      $id: 'https://example.com/bundled.ref.json',
-      type: 'object',
-      $defs: {
-        string: {
-          type: 'string',
+    bundledSchema: internalSchema,
+    bundledSchemaArray: {
+      anyOf: [
+        {
+          $schema: 'https://json-schema.org/draft/2020-12/schema',
+          $id: 'https://example.com/bundled.ref.array.1.json',
+          type: 'object',
         },
-        circularRef: {
-          $ref: '/bundled.schema.json/#/$defs/circularRef',
+        {
+          $schema: 'https://json-schema.org/draft/2020-12/schema',
+          $id: 'https://example.com/bundled.ref.array.2.json',
+          type: 'object',
         },
-        undefinedRef: {
-          $ref: '#/$defs/undefined',
-        },
-      },
-      properties: {
-        num: {
-          type: 'integer',
-        },
-        string: {
-          $ref: '#/$defs/string',
-        },
-      },
+      ],
     },
     bundledAbsoluteRef: {
       $ref: 'https://example.com/bundled.ref.json',
     },
     bundledAbsoluteRefWithAnchor: {
       $ref: 'https://example.com/bundled.ref.json/#/properties/num',
+    },
+    bundledAbsoluteRefWithinArray: {
+      $ref: 'https://example.com/bundled.ref.array.1.json',
     },
     bundledRelativeRef: {
       $ref: '/bundled.ref.json',
@@ -95,6 +151,9 @@ const bundledSchema: RJSFSchema = {
     },
     undefinedRef: {
       $ref: '/undefined.ref.json',
+    },
+    undefinedRefWithAnchor: {
+      $ref: '/bundled.ref.json#/$defs/undefinedRef',
     },
   },
   properties: {
@@ -150,43 +209,53 @@ describe('findSchemaDefinition()', () => {
     );
   });
   it('correctly resolves absolute bundled refs when JSON Schema Draft 2020-12', () => {
-    expect(findSchemaDefinition('#/$defs/bundledAbsoluteRef', bundledSchema)).toBe(bundledSchema.$defs!.bundledSchema);
+    expect(findSchemaDefinition('#/$defs/bundledAbsoluteRef', bundledSchema)).toStrictEqual(absoluteInternalSchema);
   });
   it('correctly resolves absolute bundled refs with anchors within a JSON Schema Draft 2020-12', () => {
     expect(findSchemaDefinition('#/$defs/bundledAbsoluteRefWithAnchor', bundledSchema)).toBe(
-      (bundledSchema.$defs!.bundledSchema as RJSFSchema).properties!.num,
+      absoluteInternalSchema.properties!.num,
+    );
+  });
+  it('correctly resolves absolute bundled refs in arrays within a JSON Schema Draft 2020-12', () => {
+    expect(findSchemaDefinition('#/$defs/bundledAbsoluteRefWithinArray', bundledSchema)).toBe(
+      (bundledSchema.$defs!.bundledSchemaArray as RJSFSchema).anyOf![0],
     );
   });
   it('correctly resolves absolute bundled refs within a JSON Schema Draft 2020-12 without an `$id`', () => {
     const { $id: d, ...bundledSchemaWithoutId } = bundledSchema;
-    expect(findSchemaDefinition('#/$defs/bundledAbsoluteRef', bundledSchemaWithoutId)).toBe(
-      bundledSchema.$defs!.bundledSchema,
+    expect(findSchemaDefinition('#/$defs/bundledAbsoluteRef', bundledSchemaWithoutId)).toStrictEqual(
+      absoluteInternalSchema,
     );
   });
   it('correctly resolves relative bundled refs within a JSON Schema Draft 2020-12', () => {
-    expect(findSchemaDefinition('#/$defs/bundledRelativeRef', bundledSchema)).toBe(bundledSchema.$defs!.bundledSchema);
+    expect(findSchemaDefinition('#/$defs/bundledRelativeRef', bundledSchema)).toStrictEqual(absoluteInternalSchema);
   });
   it('correctly resolves relative bundled refs with anchors within a JSON Schema Draft 2020-12', () => {
     expect(findSchemaDefinition('#/$defs/bundledRelativeRefWithAnchor', bundledSchema)).toBe(
-      (bundledSchema.$defs!.bundledSchema as RJSFSchema).$defs!.string,
+      absoluteInternalSchema.$defs!.string,
     );
   });
   it('correctly resolves indirect bundled refs within a JSON Schema Draft 2020-12', () => {
-    expect(findSchemaDefinition('#/$defs/indirectRef', bundledSchema)).toBe(bundledSchema.$defs!.bundledSchema);
+    expect(findSchemaDefinition('#/$defs/indirectRef', bundledSchema)).toStrictEqual(absoluteInternalSchema);
   });
   it('correctly resolves refs with explicit base URI in a bundled JSON Schema', () => {
-    expect(findSchemaDefinition('bundled.ref.json', bundledSchema, 'https://example.com/undefined.ref.json')).toBe(
-      bundledSchema.$defs!.bundledSchema,
-    );
+    expect(
+      findSchemaDefinition('bundled.ref.json', bundledSchema, 'https://example.com/undefined.ref.json'),
+    ).toStrictEqual(absoluteInternalSchema);
   });
   it('correctly resolves local refs with explicit base URI in a bundled JSON Schema', () => {
     expect(findSchemaDefinition('#/properties/num', bundledSchema, 'https://example.com/bundled.ref.json')).toBe(
-      (bundledSchema.$defs!.bundledSchema as RJSFSchema).properties!.num,
+      absoluteInternalSchema.properties!.num,
     );
   });
   it('throws error when relative ref is undefined in a bundled JSON Schema', () => {
     expect(() => findSchemaDefinition('#/$defs/undefinedRef', bundledSchema)).toThrowError(
       'Could not find a definition for /undefined.ref.json',
+    );
+  });
+  it('throws error when relative ref with anchor is undefined in a bundled JSON Schema', () => {
+    expect(() => findSchemaDefinition('#/$defs/undefinedRefWithAnchor', bundledSchema)).toThrowError(
+      'Could not find a definition for https://example.com/bundled.ref.json#/$defs/undefined',
     );
   });
   it('throws error when local ref is undefined in a bundled JSON Schema with explicit base URI', () => {
@@ -201,7 +270,7 @@ describe('findSchemaDefinition()', () => {
   });
   it('throws error when ref is a deep circular reference in a bundled JSON Schema', () => {
     expect(() => findSchemaDefinition('#/$defs/circularRef', bundledSchema)).toThrowError(
-      'Definition for #/$defs/circularRef contains a circular reference through /bundled.ref.json/#/$defs/circularRef -> /bundled.schema.json/#/$defs/circularRef -> #/$defs/circularRef',
+      'Definition for #/$defs/circularRef contains a circular reference through /bundled.ref.json/#/$defs/circularRef -> https://example.com/bundled.schema.json/#/$defs/circularRef',
     );
   });
 });
@@ -250,49 +319,57 @@ describe('findSchemaDefinitionRecursive()', () => {
     ).toThrowError('Could not find a definition for #/properties/num');
   });
   it('correctly resolves absolute bundled refs within a JSON Schema Draft 2020-12', () => {
-    expect(findSchemaDefinitionRecursive('#/$defs/bundledAbsoluteRef', bundledSchema)).toBe(
-      bundledSchema.$defs!.bundledSchema,
+    expect(findSchemaDefinitionRecursive('#/$defs/bundledAbsoluteRef', bundledSchema)).toStrictEqual(
+      absoluteInternalSchema,
     );
   });
   it('correctly resolves absolute bundled refs with anchors within a JSON Schema Draft 2020-12', () => {
     expect(findSchemaDefinitionRecursive('#/$defs/bundledAbsoluteRefWithAnchor', bundledSchema)).toBe(
-      (bundledSchema.$defs!.bundledSchema as RJSFSchema).properties!.num,
+      absoluteInternalSchema.properties!.num,
+    );
+  });
+  it('correctly resolves absolute bundled refs in arrays within a JSON Schema Draft 2020-12', () => {
+    expect(findSchemaDefinitionRecursive('#/$defs/bundledAbsoluteRefWithinArray', bundledSchema)).toBe(
+      (bundledSchema.$defs!.bundledSchemaArray as RJSFSchema).anyOf![0],
     );
   });
   it('correctly resolves absolute bundled refs within a JSON Schema Draft 2020-12 without an `$id`', () => {
     const { $id: d, ...bundledSchemaWithoutId } = bundledSchema;
-    expect(findSchemaDefinitionRecursive('#/$defs/bundledAbsoluteRef', bundledSchemaWithoutId)).toBe(
-      bundledSchema.$defs!.bundledSchema,
+    expect(findSchemaDefinitionRecursive('#/$defs/bundledAbsoluteRef', bundledSchemaWithoutId)).toStrictEqual(
+      absoluteInternalSchema,
     );
   });
   it('correctly resolves relative bundled refs within a JSON Schema Draft 2020-12', () => {
-    expect(findSchemaDefinitionRecursive('#/$defs/bundledRelativeRef', bundledSchema)).toBe(
-      bundledSchema.$defs!.bundledSchema,
+    expect(findSchemaDefinitionRecursive('#/$defs/bundledRelativeRef', bundledSchema)).toStrictEqual(
+      absoluteInternalSchema,
     );
   });
   it('correctly resolves relative bundled refs with anchors within a JSON Schema Draft 2020-12', () => {
     expect(findSchemaDefinitionRecursive('#/$defs/bundledRelativeRefWithAnchor', bundledSchema)).toBe(
-      (bundledSchema.$defs!.bundledSchema as RJSFSchema).$defs!.string,
+      absoluteInternalSchema.$defs!.string,
     );
   });
   it('correctly resolves indirect bundled refs within a JSON Schema Draft 2020-12', () => {
-    expect(findSchemaDefinitionRecursive('#/$defs/indirectRef', bundledSchema)).toBe(
-      bundledSchema.$defs!.bundledSchema,
-    );
+    expect(findSchemaDefinitionRecursive('#/$defs/indirectRef', bundledSchema)).toStrictEqual(absoluteInternalSchema);
   });
   it('correctly resolves relative refs with explicit base URI in a bundled JSON Schema', () => {
     expect(
       findSchemaDefinitionRecursive('bundled.ref.json', bundledSchema, [], 'https://example.com/undefined.ref.json'),
-    ).toBe(bundledSchema.$defs!.bundledSchema);
+    ).toStrictEqual(absoluteInternalSchema);
   });
   it('correctly resolves local refs with explicit base URI in a bundled JSON Schema', () => {
     expect(
       findSchemaDefinitionRecursive('#/properties/num', bundledSchema, [], 'https://example.com/bundled.ref.json'),
-    ).toBe((bundledSchema.$defs!.bundledSchema as RJSFSchema).properties!.num);
+    ).toBe(absoluteInternalSchema.properties!.num);
   });
   it('throws error when relative ref is undefined in a bundled JSON Schema', () => {
     expect(() => findSchemaDefinitionRecursive('#/$defs/undefinedRef', bundledSchema)).toThrowError(
       'Could not find a definition for /undefined.ref.json',
+    );
+  });
+  it('throws error when relative ref with anchor is undefined in a bundled JSON Schema', () => {
+    expect(() => findSchemaDefinitionRecursive('#/$defs/undefinedRefWithAnchor', bundledSchema)).toThrowError(
+      'Could not find a definition for https://example.com/bundled.ref.json#/$defs/undefined',
     );
   });
   it('throws error when local ref is undefined in a bundled JSON Schema with explicit base URI', () => {
@@ -312,7 +389,7 @@ describe('findSchemaDefinitionRecursive()', () => {
   });
   it('throws error when ref is a deep circular reference in a bundled JSON Schema', () => {
     expect(() => findSchemaDefinitionRecursive('#/$defs/circularRef', bundledSchema, [])).toThrowError(
-      'Definition for #/$defs/circularRef contains a circular reference through /bundled.ref.json/#/$defs/circularRef -> /bundled.schema.json/#/$defs/circularRef -> #/$defs/circularRef',
+      'Definition for #/$defs/circularRef contains a circular reference through /bundled.ref.json/#/$defs/circularRef -> https://example.com/bundled.schema.json/#/$defs/circularRef',
     );
   });
 });


### PR DESCRIPTION
This commit adjusts all internal references of a bundled schema to be absolute, allowing subschemas to be correctly resolved.

### Reasons for making this change

Field renderers often resolve references on subsets of the original subschema, with are always validated against the whole root schema. However, bundled schemas may contain relative references, which should be resolved against an internal `$id` field. To resolve this problem, all references in nested bundled schema are now transformed into absolute references, so that they are always resolvable against the root schema.