### PR TITLE
Fix #4678 by using the lodashReplacer during the shadcn package build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ should change the heading of the (upcoming) version to include a major version b
 
 -->
 
+# 6.0.0-beta.12
+
+## @rjsf/shadcn
+
+- Updated the building of `shadcn` to use the `lodashReplacer` with `tsc-alias` fixing [#4678](https://github.com/rjsf-team/react-jsonschema-form/issues/4678)
+
 # 6.0.0-beta.11
 
 ## @rjsf/antd

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -44,7 +44,8 @@
   },
   "scripts": {
     "build:css": "tsx build-css.ts",
-    "build:ts": "tsc -b tsconfig.build.json && tsc-alias -p tsconfig.build.json",
+    "compileReplacer": "tsc -p tsconfig.replacer.json && move-file lodashReplacer.js lodashReplacer.cjs",
+    "build:ts": "npm run compileReplacer && rimraf ./lib && tsc -b tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:cjs": "esbuild ./src/index.ts --bundle --outfile=dist/index.js --sourcemap --packages=external --format=cjs",
     "build:esm": "esbuild ./src/index.ts --bundle --outfile=dist/rjsf-shadcn.esm.js --sourcemap --packages=external --format=esm",
     "build:umd": "rollup dist/rjsf-shadcn.esm.js --format=umd --file=dist/rjsf-shadcn.umd.js --name=@rjsf/rjsf-shadcn",

--- a/packages/shadcn/tsconfig.build.json
+++ b/packages/shadcn/tsconfig.build.json
@@ -11,6 +11,12 @@
   ],
   "tsc-alias": {
     "resolveFullPaths": true,
-    "verbose": true
+    "verbose": true,
+    "replacers": {
+      "lodash": {
+        "enabled": true,
+        "file": "lodashReplacer.cjs"
+      }
+    }
   }
 }

--- a/packages/shadcn/tsconfig.replacer.json
+++ b/packages/shadcn/tsconfig.replacer.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "outDir": "./",
+    "skipLibCheck": true,
+  },
+  "files": [
+    "../../tsc-alias-replacer/lodashReplacer.ts"
+  ],
+  "exclude": [
+    "./src",
+    "./test"
+  ]
+}


### PR DESCRIPTION
### Reasons for making this change

Fixed #4678 by using the lodashReplacer during the shadcn package build
- In `@rjsf/shadcn` fixed the esm build to use lodash-es as follows:
  - Copied the `tsconfig.replacer.json` from `core`
  - Updated the `package.json` to compile the replacer as part of the esm build
  - Updated the `tsconfig.build.json` to add the `lodashReplacer` to the `tsc-alias` config
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
