### PR TITLE
Improve Form to stash schemaUtils.rootSchema as state.schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,17 @@ should change the heading of the (upcoming) version to include a major version b
 
 # 6.0.0-beta.12
 
+## @rjsf/core
+
+- Updated `Form` to store the `schemaUtils.getRootSchema()` into the `state.schema` and use that everywhere as the `schema`
+
 ## @rjsf/shadcn
 
 - Updated the building of `shadcn` to use the `lodashReplacer` with `tsc-alias` fixing [#4678](https://github.com/rjsf-team/react-jsonschema-form/issues/4678)
+
+## @rjsf/utils
+
+- Updated `SchemaUtils` and `createSchemaUtils()` to add a new `getRootSchema()` function
 
 # 6.0.0-beta.11
 

--- a/packages/core/test/test_utils.js
+++ b/packages/core/test/test_utils.js
@@ -33,7 +33,7 @@ export function createSandbox() {
 }
 
 export function setProps(comp, newProps) {
-  render(createElement(Form, newProps), {
+  render(createElement(Form, { validator, ...newProps }), {
     container: comp.ref.current.formElement.current.parentNode,
   });
 }

--- a/packages/utils/src/createSchemaUtils.ts
+++ b/packages/utils/src/createSchemaUtils.ts
@@ -63,6 +63,14 @@ class SchemaUtils<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
     this.experimental_customMergeAllOf = experimental_customMergeAllOf;
   }
 
+  /** Returns the `rootSchema` in the `SchemaUtilsType`
+   *
+   * @returns - The `rootSchema`
+   */
+  getRootSchema() {
+    return this.rootSchema;
+  }
+
   /** Returns the `ValidatorType` in the `SchemaUtilsType`
    *
    * @returns - The `ValidatorType`

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1114,6 +1114,11 @@ export interface FoundFieldType<S extends StrictRJSFSchema = RJSFSchema> {
  * set of APIs to the `@rjsf/core` components and the various themes as well.
  */
 export interface SchemaUtilsType<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any> {
+  /** Returns the `rootSchema` in the `SchemaUtilsType`
+   *
+   * @returns - The rootSchema
+   */
+  getRootSchema(): S;
   /** Returns the `ValidatorType` in the `SchemaUtilsType`
    *
    * @returns - The `ValidatorType`

--- a/packages/utils/test/createSchemaUtils.test.ts
+++ b/packages/utils/test/createSchemaUtils.test.ts
@@ -15,6 +15,10 @@ describe('createSchemaUtils()', () => {
   };
   const schemaUtils: SchemaUtilsType = createSchemaUtils(testValidator, rootSchema, defaultFormStateBehavior);
 
+  it('getRootSchema()', () => {
+    expect(schemaUtils.getRootSchema()).toEqual(rootSchema);
+  });
+
   it('getValidator()', () => {
     expect(schemaUtils.getValidator()).toBe(testValidator);
   });


### PR DESCRIPTION
### Reasons for making this change

To assist potential future transformations of the `rootSchema` in the `schemaUtils` updated `Form` to always use that as the `state.schema`
- In `@rjsf/utils`:
  - Added `getRootSchema()` to the `SchemaUtilsType` and `createSchemaUtils()`
  - Updated the tests to maintain 100% coverage
- In `@rjsf/core`:
  - Updated `Form` to always pull the `rootSchema` from the `schemaUtils` and put it into the `state.schema`, making sure to use that in the `render()`, `getStateFromProps()` and `getRegistry()`
  - Updated the `test_utils.js` to pass the `validator` in the `setProps()` function
- Updated `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
