### PR TITLE
fix(utils): Remove fixed package-type

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,7 +4,6 @@
   "main": "dist/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
-  "type": "module",
   "description": "Utility functions for @rjsf/core",
   "exports": {
     ".": {


### PR DESCRIPTION
Removing the `type` allows consumer to choose between cjs/esm

### Reasons for making this change

Using `type:"module"` forces the consumer to ONLY use esm. Removing the type will allow the consumer to decide between cjs/esm based on the `exports` configuration below.