### PR TITLE
Fix 4696 by updating lodash import to be direct import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 6.0.0-beta.13
+
+## @rjsf/shadcn
+
+- Updated `lodash` import in `fancy-multi-select.tsx` to to be direct import, fixing [#4696](https://github.com/rjsf-team/react-jsonschema-form/issues/4696)
 
 # 6.0.0-beta.12
 

--- a/packages/shadcn/src/components/ui/fancy-multi-select.tsx
+++ b/packages/shadcn/src/components/ui/fancy-multi-select.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Command as CommandPrimitive } from 'cmdk';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { X } from 'lucide-react';
 import {
   FocusEvent,


### PR DESCRIPTION
### Reasons for making this change

- Fixes #4696 by updating the `lodash` import from `import { isEqual } from 'lodash';` to `import isEqual from 'lodash/isEqual';` so that the `tsc-alias` reducer updates it
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
