### PR TITLE
Fixed CHANGELOG.md due to duplicate beta.13 sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,6 @@ should change the heading of the (upcoming) version to include a major version b
 - Extended `Registry` interface to include optional `experimental_componentUpdateStrategy` property
 - Added `shallowEquals()` utility function for shallow equality comparisons
 - Fixed boolean fields incorrectly set to `{}` when switching oneOf/anyOf options with `mergeDefaultsIntoFormData` set to `useDefaultIfFormDataUndefined`, fixing [#4709](https://github.com/rjsf-team/react-jsonschema-form/issues/4709) ([#4710](https://github.com/rjsf-team/react-jsonschema-form/pull/4710))
-
-# 6.0.0-beta.13
-
-## rjsf/utils
-
 - Always make all references absolute in nested bundled schemas
 
 # 6.0.0-beta.12


### PR DESCRIPTION
### Reasons for making this change

After releasing beta.13 I noticed that there were two sections for it in the `CHANGELOG.md`, fixing that for future releases

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
