### PR TITLE
Fix 4726 by removing nanoid in favor of lodash.uniqueId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 5.24.13
+
+## @rjsf/core
+
+- Updated `ArrayField` to stop using `nanoid` and instead use `lodash/uniqueId` to fix [#4762](https://github.com/rjsf-team/react-jsonschema-form/issues/4726)
+
+## @rjsf/semantic-ui
+
+- Updated `ArrayField` to stop using `nanoid` and instead use `lodash/uniqueId` to fix [#4762](https://github.com/rjsf-team/react-jsonschema-form/issues/4726)
+
+## Dev / docs / playground
+
+- Removed `nanoid` from the build system and `jest.config.js` files
+
 # 5.24.12
 
 ## @rjsf/utils

--- a/package-lock.json
+++ b/package-lock.json
@@ -34351,7 +34351,6 @@
         "lodash": "^4.17.21",
         "lodash-es": "^4.17.21",
         "markdown-to-jsx": "^7.4.1",
-        "nanoid": "^3.3.7",
         "prop-types": "^15.8.1"
       },
       "devDependencies": {
@@ -34784,7 +34783,6 @@
         "eslint": "^8.56.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "nanoid": "^3.3.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-test-renderer": "^18.2.0",

--- a/packages/antd/jest.config.js
+++ b/packages/antd/jest.config.js
@@ -7,5 +7,4 @@ module.exports = {
   moduleNameMapper: {
     '\\.(css|less)$': '<rootDir>/__mocks__/styleMock.js',
   },
-  transformIgnorePatterns: [`/node_modules/(?!nanoid)`],
 };

--- a/packages/chakra-ui/jest.config.js
+++ b/packages/chakra-ui/jest.config.js
@@ -4,5 +4,4 @@ module.exports = {
   testEnvironmentOptions: {
     browsers: ['chrome', 'firefox', 'safari'],
   },
-  transformIgnorePatterns: [`/node_modules/(?!nanoid)`],
 };

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -3,5 +3,4 @@ module.exports = {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['./test/setup-jest-env.js'],
   testMatch: ['**/test/**/*.test.[jt]s?(x)'],
-  transformIgnorePatterns: [`/node_modules/(?!nanoid)`],
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,6 @@
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
     "markdown-to-jsx": "^7.4.1",
-    "nanoid": "^3.3.7",
     "prop-types": "^15.8.1"
   },
   "devDependencies": {

--- a/packages/core/src/components/fields/ArrayField.tsx
+++ b/packages/core/src/components/fields/ArrayField.tsx
@@ -22,7 +22,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
 import isObject from 'lodash/isObject';
 import set from 'lodash/set';
-import { nanoid } from 'nanoid';
+import uniqueId from 'lodash/uniqueId';
 
 /** Type used to represent the keyed form data used in the state */
 type KeyedFormDataType<T> = { key: string; item: T };
@@ -37,7 +37,7 @@ type ArrayFieldState<T> = {
 
 /** Used to generate a unique ID for an element in a row */
 function generateRowId() {
-  return nanoid();
+  return uniqueId('rjsf-array-item-');
 }
 
 /** Converts the `formData` into `KeyedFormDataType` data, using the `generateRowId()` function to create the key

--- a/packages/fluent-ui/jest.config.js
+++ b/packages/fluent-ui/jest.config.js
@@ -6,5 +6,4 @@ module.exports = {
   testEnvironmentOptions: {
     browsers: ['chrome', 'firefox', 'safari'],
   },
-  transformIgnorePatterns: [`/node_modules/(?!nanoid)`],
 };

--- a/packages/fluentui-rc/jest.config.js
+++ b/packages/fluentui-rc/jest.config.js
@@ -4,5 +4,4 @@ module.exports = {
   testEnvironmentOptions: {
     browsers: ['chrome', 'firefox', 'safari'],
   },
-  transformIgnorePatterns: [`/node_modules/(?!nanoid)`],
 };

--- a/packages/mui/jest.config.js
+++ b/packages/mui/jest.config.js
@@ -4,5 +4,4 @@ module.exports = {
   testEnvironmentOptions: {
     browsers: ['chrome', 'firefox', 'safari'],
   },
-  transformIgnorePatterns: [`/node_modules/(?!nanoid)`],
 };

--- a/packages/playground/jest.config.js
+++ b/packages/playground/jest.config.js
@@ -2,5 +2,4 @@ module.exports = {
   verbose: true,
   testEnvironment: 'jsdom',
   testMatch: ['**/test/**/*.test.[jt]s?(x)'],
-  transformIgnorePatterns: [`/node_modules/(?!nanoid)`],
 };

--- a/packages/semantic-ui/jest.config.js
+++ b/packages/semantic-ui/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
   verbose: true,
   testEnvironment: 'jsdom',
-  transformIgnorePatterns: [`/node_modules/(?!nanoid)`],
 };

--- a/packages/semantic-ui/package.json
+++ b/packages/semantic-ui/package.json
@@ -59,7 +59,6 @@
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "nanoid": "^3.3.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-test-renderer": "^18.2.0",

--- a/packages/semantic-ui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
+++ b/packages/semantic-ui/src/FieldErrorTemplate/FieldErrorTemplate.tsx
@@ -1,5 +1,5 @@
 import { errorId, FieldErrorProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
-import { nanoid } from 'nanoid';
+import uniqueId from 'lodash/uniqueId';
 import { Label, List } from 'semantic-ui-react';
 
 import { getSemanticErrorProps } from '../util';
@@ -33,7 +33,7 @@ export default function FieldErrorTemplate<
       <Label id={id} color='red' pointing={pointing || 'above'} size={size || 'small'} basic>
         <List bulleted>
           {errors.map((error) => (
-            <List.Item key={nanoid()}>{error}</List.Item>
+            <List.Item key={uniqueId('field-error-')}>{error}</List.Item>
           ))}
         </List>
       </Label>


### PR DESCRIPTION
### Reasons for making this change
Fixed #4726 by removing nanoid in favor of lodash.uniqueId
- Uninstalled `nanoid` from `@rjsf/core` and `@rjsf/semantic-ui`, switching to use `uniqueId` from lodash in `core`'s `ArrayField` and `semantic-ui`'s `FieldErrorTemplate`
- Updated all of the `jest.config.js` file to remove `nanoid`
### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
