### PR TITLE
fix: path duplication

### DIFF
--- a/packages/core/src/components/fields/ObjectField.tsx
+++ b/packages/core/src/components/fields/ObjectField.tsx
@@ -1,28 +1,28 @@
-import { Component } from 'react';
 import {
-  getTemplate,
-  getUiOptions,
-  orderProperties,
+  ADDITIONAL_PROPERTY_FLAG,
+  ANY_OF_KEY,
   ErrorSchema,
   FieldProps,
   FormContextType,
   GenericObjectType,
+  getTemplate,
+  getUiOptions,
   IdSchema,
+  ONE_OF_KEY,
+  orderProperties,
+  PROPERTIES_KEY,
+  REF_KEY,
   RJSFSchema,
   StrictRJSFSchema,
   TranslatableString,
-  ADDITIONAL_PROPERTY_FLAG,
-  PROPERTIES_KEY,
-  REF_KEY,
-  ANY_OF_KEY,
-  ONE_OF_KEY,
 } from '@rjsf/utils';
-import Markdown from 'markdown-to-jsx';
 import get from 'lodash/get';
 import has from 'lodash/has';
 import isObject from 'lodash/isObject';
 import set from 'lodash/set';
 import unset from 'lodash/unset';
+import Markdown from 'markdown-to-jsx';
+import { Component } from 'react';
 
 /** Type used for the state of the `ObjectField` component */
 type ObjectFieldState = {
@@ -80,7 +80,10 @@ class ObjectField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
       }
       // Copy the current path and insert in the property name into the first location
       const changePath = Array.isArray(path) ? path.slice() : [];
-      changePath.unshift(name);
+      // Ensure we are not duplicating the path
+      if (!changePath.length || changePath[0] !== name) {
+        changePath.unshift(name);
+      }
       onChange(value, changePath, newErrorSchema, id);
     };
   };


### PR DESCRIPTION
### Reasons for making this change
Fixed #4721 that broke multiselect fields onchange by duplicating the path with `slice()` 

This fixes #4733

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [X] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
