### PR TITLE
Fix 4733 by fixing the ArrayField.onSelectChange function

### DIFF
--- a/packages/core/src/components/fields/ArrayField.tsx
+++ b/packages/core/src/components/fields/ArrayField.tsx
@@ -418,9 +418,9 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
 
   /** Callback handler used to change the value for a checkbox */
   onSelectChange = (value: any) => {
-    const { name, onChange, idSchema } = this.props;
+    const { onChange, idSchema } = this.props;
     // select change will pass the `path` array with the name
-    onChange(value, [name], undefined, idSchema && idSchema.$id);
+    onChange(value, [], undefined, idSchema && idSchema.$id);
   };
 
   /** Helper method to compute item UI schema for both normal and fixed arrays


### PR DESCRIPTION
### Reasons for making this change

Fixes #4733 by fixing how the `ArrayField.onSelectChange()` callback passes the path
- Updated `ArrayField` `onSelectChange` to not pass `name` in the `path` since the `ObjectField` will automatically add it
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
