### PR TITLE
Fix 4739 by making lucide-react a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # 6.0.0-beta.15
 
+## @rjsf/chakra-ui
+
+- Updated `package.json` for to make `lucide-react` a dependency rather than a devDependency, fixing [#4739](https://github.com/rjsf-team/react-jsonschema-form/issues/4739)
+
 ## @rjsf/semantic-ui
 
 - Updated `ArrayField` to stop using `nanoid` and instead use `lodash/uniqueId` to fix [#4762](https://github.com/rjsf-team/react-jsonschema-form/issues/4726)

--- a/package-lock.json
+++ b/package-lock.json
@@ -38462,6 +38462,7 @@
       "version": "6.0.0-beta.14",
       "license": "Apache-2.0",
       "dependencies": {
+        "lucide-react": "^0.539.0",
         "react-icons": "^5.5.0",
         "react-select": "^5.10.2"
       },
@@ -38476,8 +38477,7 @@
         "@rjsf/utils": "^6.0.0-beta.14",
         "@rjsf/validator-ajv8": "^6.0.0-beta.14",
         "chakra-react-select": "^6.1.0",
-        "eslint": "^8.57.1",
-        "lucide-react": "^0.539.0"
+        "eslint": "^8.57.1"
       },
       "engines": {
         "node": ">=20"

--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -91,10 +91,10 @@
     "@rjsf/utils": "^6.0.0-beta.14",
     "@rjsf/validator-ajv8": "^6.0.0-beta.14",
     "chakra-react-select": "^6.1.0",
-    "eslint": "^8.57.1",
-    "lucide-react": "^0.539.0"
+    "eslint": "^8.57.1"
   },
   "dependencies": {
+    "lucide-react": "^0.539.0",
     "react-icons": "^5.5.0",
     "react-select": "^5.10.2"
   }


### PR DESCRIPTION
### Reasons for making this change

Fixes #4739 by making `lucide-react` a dependency instead of a devDependency
- Updated the `package.json` for `@rjsf/chakra-ui` making `lucide-react` a dependency
- Updated `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
