### PR TITLE
Chore remove unnecessary formContext from all interfaces but Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Updated `ArrayField`, `Form`, `LayoutMultiSchemaField` and `SchemaField` to stop passing `formContext`
 
+## @rjsf/semantic-ui
+
+- Updated the `ArrayFieldTemplate`, `BaseInputTemplate`, `CheckboxWidget`, `FieldTemplate`, `RadioWidget`, `RangeSelect`, `SelectWidget`, `TextareaWidget` and `ObjectFieldTemplate` to get `formContext` from the `registry`
+
 ## @rjsf/utils
 
 - BREAKING CHANGE: Removed `formContext` from the following interfaces because it is available on `registry`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+# 6.0.0-beta.16
+
+## @rjsf/antd
+
+- Updated the `ArrayFieldTemplate`, `FieldTemplate` and `ObjectFieldTemplate` to get `formContext` from the `registry`
+
+## @rjsf/core
+
+- Updated `ArrayField`, `Form`, `LayoutMultiSchemaField` and `SchemaField` to stop passing `formContext`
+
+## @rjsf/utils
+
+- BREAKING CHANGE: Removed `formContext` from the following interfaces because it is available on `registry`:
+  - `ErrorListProps`, `FieldProps`, `FieldTemplateProps`, `ArrayFieldTemplateProps` and `WidgetProps`
+
+## Dev / docs / playground
+
+- Updated the documentation to remove `formContext` from the interface documentation, adding a BREAKING CHANGE notification in the `v6.x upgrade guide`
+
 # 6.0.0-beta.15
 
 ## @rjsf/chakra-ui

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Updated `ArrayField`, `Form`, `LayoutMultiSchemaField` and `SchemaField` to stop passing `formContext`
 
+## @rjsf/daisyui
+
+- Updated `FieldTemplate` to remove `formContext` as it is never used
+
 ## @rjsf/semantic-ui
 
 - Updated the `ArrayFieldTemplate`, `BaseInputTemplate`, `CheckboxWidget`, `FieldTemplate`, `RadioWidget`, `RangeSelect`, `SelectWidget`, `TextareaWidget` and `ObjectFieldTemplate` to get `formContext` from the `registry`

--- a/packages/antd/src/templates/ArrayFieldTemplate/index.tsx
+++ b/packages/antd/src/templates/ArrayFieldTemplate/index.tsx
@@ -30,7 +30,6 @@ export default function ArrayFieldTemplate<
     canAdd,
     className,
     disabled,
-    formContext,
     idSchema,
     items,
     onAddClick,
@@ -57,6 +56,7 @@ export default function ArrayFieldTemplate<
     registry,
     uiOptions,
   );
+  const { formContext } = registry;
   // Button templates are not overridden in the uiSchema
   const {
     ButtonTemplates: { AddButton },

--- a/packages/antd/src/templates/FieldTemplate/index.tsx
+++ b/packages/antd/src/templates/FieldTemplate/index.tsx
@@ -30,7 +30,6 @@ export default function FieldTemplate<
     disabled,
     displayLabel,
     errors,
-    formContext,
     help,
     hidden,
     id,
@@ -46,6 +45,7 @@ export default function FieldTemplate<
     schema,
     uiSchema,
   } = props;
+  const { formContext } = registry;
   const {
     colon,
     labelCol = VERTICAL_LABEL_COL,

--- a/packages/antd/src/templates/ObjectFieldTemplate/index.tsx
+++ b/packages/antd/src/templates/ObjectFieldTemplate/index.tsx
@@ -38,7 +38,6 @@ export default function ObjectFieldTemplate<
   const {
     description,
     disabled,
-    formContext,
     formData,
     idSchema,
     onAddClick,
@@ -57,6 +56,7 @@ export default function ObjectFieldTemplate<
     registry,
     uiOptions,
   );
+  const { formContext } = registry;
   // Button templates are not overridden in the uiSchema
   const {
     ButtonTemplates: { AddButton },

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -597,7 +597,6 @@ export default class Form<
   /** Renders any errors contained in the `state` in using the `ErrorList`, if not disabled by `showErrorList`. */
   renderErrors(registry: Registry<T, S, F>) {
     const { errors, errorSchema, schema, uiSchema } = this.state;
-    const { formContext } = this.props;
     const options = getUiOptions<T, S, F>(uiSchema);
     const ErrorListTemplate = getTemplate<'ErrorListTemplate', T, S, F>('ErrorListTemplate', registry, options);
 
@@ -608,7 +607,6 @@ export default class Form<
           errorSchema={errorSchema || {}}
           schema={schema}
           uiSchema={uiSchema}
-          formContext={formContext}
           registry={registry}
         />
       );
@@ -1117,7 +1115,6 @@ export default class Form<
       noHtml5Validate = false,
       disabled,
       readonly,
-      formContext,
       showErrorList = 'top',
       _internalFormWrapper,
     } = this.props;
@@ -1163,7 +1160,6 @@ export default class Form<
           idSchema={idSchema}
           idPrefix={idPrefix}
           idSeparator={idSeparator}
-          formContext={formContext}
           formData={formData}
           onChange={this.onChange}
           onBlur={this.onBlur}

--- a/packages/core/src/components/fields/ArrayField.tsx
+++ b/packages/core/src/components/fields/ArrayField.tsx
@@ -566,7 +566,6 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
       required,
       schema,
       title: fieldTitle,
-      formContext,
       formData,
       rawErrors,
       registry,
@@ -832,7 +831,6 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
       schema,
       uiSchema,
       title: fieldTitle,
-      formContext,
       errorSchema,
       rawErrors,
     };

--- a/packages/core/src/components/fields/LayoutMultiSchemaField.tsx
+++ b/packages/core/src/components/fields/LayoutMultiSchemaField.tsx
@@ -190,7 +190,6 @@ export default function LayoutMultiSchemaField<
       label={(title || schema.title) ?? ''}
       disabled={disabled || (Array.isArray(enumOptions) && isEmpty(enumOptions))}
       uiSchema={uiSchema}
-      formContext={formContext}
       required={required}
       readonly={!!readonly}
       registry={registry}

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -263,7 +263,6 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
     displayLabel,
     classNames: classNames.join(' ').trim(),
     style: uiOptions.style,
-    formContext,
     formData,
     schema,
     uiSchema,

--- a/packages/core/test/ArrayField.test.jsx
+++ b/packages/core/test/ArrayField.test.jsx
@@ -2988,7 +2988,10 @@ describe('ArrayField', () => {
         root_1: 'root_1-id',
       };
       function CustomSchemaField(props) {
-        const { formContext, idSchema } = props;
+        const {
+          registry: { formContext },
+          idSchema,
+        } = props;
         return (
           <>
             <code id={formContext[idSchema.$id]}>Ha</code>
@@ -3015,7 +3018,10 @@ describe('ArrayField', () => {
         root_1: 'root_1-id',
       };
       function CustomSchemaField(props) {
-        const { formContext, idSchema } = props;
+        const {
+          registry: { formContext },
+          idSchema,
+        } = props;
         return (
           <>
             <code id={formContext[idSchema.$id]}>Ha</code>

--- a/packages/core/test/FormContext.test.jsx
+++ b/packages/core/test/FormContext.test.jsx
@@ -58,7 +58,7 @@ describe('FormContext', () => {
   });
 
   it('should be passed to TemplateField', () => {
-    function CustomTemplateField({ formContext }) {
+    function CustomTemplateField({ registry: { formContext } }) {
       return <div id={formContext.foo} />;
     }
 
@@ -79,7 +79,7 @@ describe('FormContext', () => {
   });
 
   it('should be passed to ArrayTemplateField', () => {
-    function CustomArrayTemplateField({ formContext }) {
+    function CustomArrayTemplateField({ registry: { formContext } }) {
       return <div id={formContext.foo} />;
     }
 

--- a/packages/core/test/ObjectField.test.jsx
+++ b/packages/core/test/ObjectField.test.jsx
@@ -204,7 +204,10 @@ describe('ObjectField', () => {
         root_bar: 'bar-id',
       };
       function CustomSchemaField(props) {
-        const { formContext, idSchema } = props;
+        const {
+          registry: { formContext },
+          idSchema,
+        } = props;
         return (
           <>
             <code id={formContext[idSchema.$id]}>Ha</code>

--- a/packages/core/test/allOf.test.jsx
+++ b/packages/core/test/allOf.test.jsx
@@ -58,7 +58,10 @@ describe('allOf', () => {
     };
     const formContext = { root: 'root-id', root_foo: 'foo-id' };
     function CustomSchemaField(props) {
-      const { formContext, idSchema } = props;
+      const {
+        registry: { formContext },
+        idSchema,
+      } = props;
       return (
         <>
           <code id={formContext[idSchema.$id]}>Ha</code>

--- a/packages/core/test/oneOf.test.jsx
+++ b/packages/core/test/oneOf.test.jsx
@@ -606,7 +606,10 @@ describe('oneOf', () => {
     const formContext = { root: 'root-id', root_userId: 'userId-id' };
 
     function CustomSchemaField(props) {
-      const { formContext, idSchema } = props;
+      const {
+        registry: { formContext },
+        idSchema,
+      } = props;
       return (
         <>
           <code id={formContext[idSchema.$id]}>Ha</code>

--- a/packages/core/test/validate.test.js
+++ b/packages/core/test/validate.test.js
@@ -394,7 +394,15 @@ describe('Validation', () => {
 
       const formData = 0;
 
-      const CustomErrorList = ({ errors, errorSchema, schema, uiSchema, formContext: { className } }) => (
+      const CustomErrorList = ({
+        errors,
+        errorSchema,
+        schema,
+        uiSchema,
+        registry: {
+          formContext: { className },
+        },
+      }) => (
         <div>
           <div className='CustomErrorList'>{errors.length} custom</div>
           <div className={'ErrorSchema'}>{errorSchema.__errors[0]}</div>

--- a/packages/daisyui/src/templates/FieldTemplate/FieldTemplate.tsx
+++ b/packages/daisyui/src/templates/FieldTemplate/FieldTemplate.tsx
@@ -30,7 +30,6 @@ export default function FieldTemplate<
     label,
     children,
     errors,
-    formContext,
     formData,
     help,
     hideError,

--- a/packages/docs/docs/advanced-customization/custom-templates.md
+++ b/packages/docs/docs/advanced-customization/custom-templates.md
@@ -116,7 +116,6 @@ The following props are passed to each `ArrayFieldTemplate`:
 - `schema`: The schema object for this array.
 - `uiSchema`: The uiSchema object for this array field.
 - `title`: A string value containing the title for the array.
-- `formContext`: The `formContext` object that you passed to Form.
 - `formData`: The formData for this array.
 - `errorSchema`: The optional validation errors for the array field and the items within it, in the form of an `ErrorSchema`
 - `rawErrors`: An array of strings listing all generated error messages from encountered errors for this widget
@@ -419,7 +418,6 @@ function BaseInputTemplate(props: BaseInputTemplateProps) {
     hideError,
     uiSchema,
     registry,
-    formContext,
     ...rest
   } = props;
   const onTextChange = ({ target: { value: val } }: ChangeEvent<HTMLInputElement>) => {
@@ -500,7 +498,6 @@ The following props are passed to the `BaseInputTemplate`:
 - `onFocus`: The input focus event handler; call it with the widget id and value;
 - `options`: A map of options passed as a prop to the component (see [Custom widget options](./custom-widgets-fields.md#custom-widget-options)).
 - `options.enumOptions`: For enum fields, this property contains the list of options for the enum as an array of \{ label, value } objects. If the enum is defined using the oneOf/anyOf syntax, the entire schema object for each option is appended onto the \{ schema, label, value } object.
-- `formContext`: The `formContext` object that you passed to `Form`.
 - `rawErrors`: An array of strings listing all generated error messages from encountered errors for this widget.
 - `registry`: The `registry` object
 
@@ -587,7 +584,6 @@ The following props are passed to the `ErrorListTemplate`:
 
 - `schema`: The schema that was passed to `Form`
 - `uiSchema`: The uiSchema that was passed to `Form`
-- `formContext`: The `formContext` object that you passed to `Form`.
 - `errors`: An array of all errors in this `Form`.
 - `errorSchema`: The `ErrorSchema` constructed by `Form`
 
@@ -755,7 +751,6 @@ The following props are passed to a custom field template component:
 - `schema`: The schema object for this field.
 - `uiSchema`: The uiSchema object for this field.
 - `onChange`: The value change event handler; Can be called with a new value to change the value for this field.
-- `formContext`: The `formContext` object that you passed to `Form`.
 - `formData`: The formData for this field.
 - `registry`: The `registry` object.
 
@@ -926,7 +921,6 @@ The following props are passed to each `ObjectFieldTemplate` as defined by the `
 - `idSchema`: An object containing the id for this object & ids for its properties.
 - `errorSchema`: The optional validation errors in the form of an `ErrorSchema`
 - `formData`: The form data for the object.
-- `formContext`: The `formContext` object that you passed to Form.
 - `registry`: The `registry` object.
 
 The following props are part of each element in `properties`:

--- a/packages/docs/docs/advanced-customization/custom-widgets-fields.md
+++ b/packages/docs/docs/advanced-customization/custom-widgets-fields.md
@@ -205,7 +205,6 @@ The following props are passed to custom widget components:
 - `onFocus`: The input focus event handler; call it with the widget id and value;
 - `options`: A map of options passed as a prop to the component (see [Custom widget options](#custom-widget-options)).
 - `options.enumOptions`: For enum fields, this property contains the list of options for the enum as an array of \{ label, value } objects. If the enum is defined using the oneOf/anyOf syntax, the entire schema object for each option is appended onto the \{ schema, label, value } object.
-- `formContext`: The `formContext` object that you passed to `Form`.
 - `rawErrors`: An array of strings listing all generated error messages from encountered errors for this widget.
 - `registry`: A [registry](#the-registry-object) object (read next).
 
@@ -393,7 +392,6 @@ A field component will always be passed the following props:
 - `formData`: The data for this field;
 - `errorSchema`: The tree of errors for this field and its children;
 - `registry`: A [registry](#the-registry-object) object (read next).
-- `formContext`: A [formContext](../api-reference/form-props.md#formcontext) object (read next).
 - `required`: The required status of this field;
 - `disabled`: A boolean value stating if the field is disabled;
 - `readonly`: A boolean value stating if the field is read-only;
@@ -413,7 +411,6 @@ The `registry` is an object containing the registered core, theme and custom fie
 - `fields`: The set of all fields used by the `Form`. Includes fields from `core`, theme-specific fields and any [custom registered fields](#custom-field-components);
 - `widgets`: The set of all widgets used by the `Form`. Includes widgets from `core`, theme-specific widgets and any [custom registered widgets](#custom-component-registration), if any;
 - `rootSchema`: The root schema, as passed to the `Form`, which can contain referenced [definitions](../json-schema/definitions.md);
-- `formContext`: The [formContext](../api-reference/form-props.md#formcontext) that was passed to `Form`;
 - `schemaUtils`: The current implementation of the `SchemaUtilsType` (from `@rjsf/utils`) in use by the `Form`. Used to call any of the validation-schema-based utility functions.
 
 The registry is passed down the component tree, so you can access it from your custom field, custom widget, custom template and `SchemaField` components.

--- a/packages/docs/docs/migration-guides/v6.x upgrade guide.md
+++ b/packages/docs/docs/migration-guides/v6.x upgrade guide.md
@@ -67,6 +67,19 @@ React 18 is officially supported on all the themes.
 
 React 19 support is expected before the end of beta (although several developers have already upgraded with no problems).
 
+### formContext BREAKING CHANGES
+
+Removed the unnecessary `formContext` property from the following interfaces since it is readily available in the `registry`.
+If you were using the `formContext` in your custom `template`, `field` or `widget`, simply get it from the `registry` instead.
+
+Interfaces with `formContext` removed:
+
+- `ErrorListProps` - The properties that are passed to an `ErrorListTemplate` implementation
+- `FieldProps` - The properties that are passed to a `Field` implementation
+- `FieldTemplateProps` - The properties that are passed to a `FieldTemplate` implementation
+- `ArrayFieldTemplateProps` - The properties that are passed to an `ArrayFieldTemplate` implementation
+- `WidgetProps` - The properties that are passed to a `Widget` implementation
+
 ### Fields BREAKING CHANGES
 
 ### FieldProps.onChange

--- a/packages/primereact/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/primereact/test/__snapshots__/Array.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`array fields array 1`] = `
 <form
@@ -35,7 +35,6 @@ exports[`array fields array 1`] = `
         className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields p-fieldset p-component"
         data-pc-name="fieldset"
         data-pc-section="root"
-        formContext={{}}
         formData={[]}
         id="root"
         onClick={null}
@@ -143,7 +142,6 @@ exports[`array fields array icons 1`] = `
         className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields p-fieldset p-component"
         data-pc-name="fieldset"
         data-pc-section="root"
-        formContext={{}}
         formData={
           [
             "a",
@@ -727,7 +725,6 @@ exports[`array fields fixed array 1`] = `
         data-pc-name="fieldset"
         data-pc-section="root"
         errorSchema={{}}
-        formContext={{}}
         formData={
           [
             undefined,
@@ -1180,7 +1177,6 @@ exports[`with title and description array 1`] = `
         className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields p-fieldset p-component"
         data-pc-name="fieldset"
         data-pc-section="root"
-        formContext={{}}
         formData={[]}
         id="root"
         onClick={null}
@@ -1294,7 +1290,6 @@ exports[`with title and description array icons 1`] = `
         className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields p-fieldset p-component"
         data-pc-name="fieldset"
         data-pc-section="root"
-        formContext={{}}
         formData={
           [
             "a",
@@ -1844,7 +1839,6 @@ exports[`with title and description fixed array 1`] = `
         data-pc-name="fieldset"
         data-pc-section="root"
         errorSchema={{}}
-        formContext={{}}
         formData={
           [
             undefined,
@@ -2051,7 +2045,6 @@ exports[`with title and description from both array 1`] = `
         className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields p-fieldset p-component"
         data-pc-name="fieldset"
         data-pc-section="root"
-        formContext={{}}
         formData={[]}
         id="root"
         onClick={null}
@@ -2165,7 +2158,6 @@ exports[`with title and description from both array icons 1`] = `
         className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields p-fieldset p-component"
         data-pc-name="fieldset"
         data-pc-section="root"
-        formContext={{}}
         formData={
           [
             "a",
@@ -2715,7 +2707,6 @@ exports[`with title and description from both fixed array 1`] = `
         data-pc-name="fieldset"
         data-pc-section="root"
         errorSchema={{}}
-        formContext={{}}
         formData={
           [
             undefined,
@@ -2922,7 +2913,6 @@ exports[`with title and description from uiSchema array 1`] = `
         className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields p-fieldset p-component"
         data-pc-name="fieldset"
         data-pc-section="root"
-        formContext={{}}
         formData={[]}
         id="root"
         onClick={null}
@@ -3036,7 +3026,6 @@ exports[`with title and description from uiSchema array icons 1`] = `
         className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields p-fieldset p-component"
         data-pc-name="fieldset"
         data-pc-section="root"
-        formContext={{}}
         formData={
           [
             "a",
@@ -3586,7 +3575,6 @@ exports[`with title and description from uiSchema fixed array 1`] = `
         data-pc-name="fieldset"
         data-pc-section="root"
         errorSchema={{}}
-        formContext={{}}
         formData={
           [
             undefined,
@@ -3793,7 +3781,6 @@ exports[`with title and description with global label off array 1`] = `
         className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields p-fieldset p-component"
         data-pc-name="fieldset"
         data-pc-section="root"
-        formContext={{}}
         formData={[]}
         id="root"
         onClick={null}
@@ -3902,7 +3889,6 @@ exports[`with title and description with global label off array icons 1`] = `
         className="rjsf-field rjsf-field-array rjsf-field-array-of-string sortable-form-fields p-fieldset p-component"
         data-pc-name="fieldset"
         data-pc-section="root"
-        formContext={{}}
         formData={
           [
             "a",
@@ -4419,7 +4405,6 @@ exports[`with title and description with global label off fixed array 1`] = `
         data-pc-name="fieldset"
         data-pc-section="root"
         errorSchema={{}}
-        formContext={{}}
         formData={
           [
             undefined,

--- a/packages/semantic-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
+++ b/packages/semantic-ui/src/ArrayFieldTemplate/ArrayFieldTemplate.tsx
@@ -29,7 +29,6 @@ export default function ArrayFieldTemplate<
     className,
     // classNames, This is not part of the type, so it is likely never passed in
     disabled,
-    formContext,
     items,
     onAddClick,
     // options, This is not part of the type, so it is likely never passed in
@@ -41,7 +40,7 @@ export default function ArrayFieldTemplate<
   } = props;
   const semanticProps = getSemanticProps<T, S, F>({
     uiSchema,
-    formContext,
+    formContext: registry.formContext,
     defaultSchemaProps: { horizontalButtons: true, wrapItem: false },
   });
   const { horizontalButtons, wrapItem } = semanticProps;

--- a/packages/semantic-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/semantic-ui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -40,14 +40,14 @@ export default function BaseInputTemplate<
     options,
     schema,
     uiSchema,
-    formContext,
+    registry,
     type,
     rawErrors = [],
   } = props;
   const inputProps = getInputProps<T, S, F>(schema, type, options);
   const semanticProps = getSemanticProps<T, S, F>({
     uiSchema,
-    formContext,
+    formContext: registry.formContext,
     options,
   });
   const _onChange = ({ target: { value } }: ChangeEvent<HTMLInputElement>) =>

--- a/packages/semantic-ui/src/CheckboxWidget/CheckboxWidget.tsx
+++ b/packages/semantic-ui/src/CheckboxWidget/CheckboxWidget.tsx
@@ -35,7 +35,6 @@ export default function CheckboxWidget<
     onBlur,
     options,
     onFocus,
-    formContext,
     schema,
     uiSchema,
     rawErrors = [],
@@ -43,7 +42,7 @@ export default function CheckboxWidget<
   } = props;
   const semanticProps = getSemanticProps<T, S, F>({
     options,
-    formContext,
+    formContext: registry.formContext,
     uiSchema,
     defaultSchemaProps: {
       inverted: 'false',

--- a/packages/semantic-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
+++ b/packages/semantic-ui/src/CheckboxesWidget/CheckboxesWidget.tsx
@@ -37,7 +37,6 @@ export default function CheckboxesWidget<
     onChange,
     onBlur,
     onFocus,
-    formContext,
     schema,
     uiSchema,
     rawErrors = [],
@@ -48,7 +47,7 @@ export default function CheckboxesWidget<
   const checkboxesValues = Array.isArray(value) ? value : [value];
   const semanticProps = getSemanticProps<T, S, F>({
     options,
-    formContext,
+    formContext: registry.formContext,
     uiSchema,
     defaultSchemaProps: {
       inverted: 'false',

--- a/packages/semantic-ui/src/FieldTemplate/FieldTemplate.tsx
+++ b/packages/semantic-ui/src/FieldTemplate/FieldTemplate.tsx
@@ -36,7 +36,10 @@ export default function FieldTemplate<
     uiSchema,
     ...otherProps
   } = props;
-  const semanticProps = getSemanticProps<T, S, F>(otherProps);
+  const semanticProps = getSemanticProps<T, S, F>({
+    ...otherProps,
+    formContext: registry.formContext,
+  });
   const { wrapLabel, wrapContent } = semanticProps;
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
   const WrapIfAdditionalTemplate = getTemplate<'WrapIfAdditionalTemplate', T, S, F>(

--- a/packages/semantic-ui/src/RadioWidget/RadioWidget.tsx
+++ b/packages/semantic-ui/src/RadioWidget/RadioWidget.tsx
@@ -30,13 +30,13 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
     onBlur,
     onFocus,
     options,
-    formContext,
+    registry,
     uiSchema,
     rawErrors = [],
   } = props;
   const { enumOptions, enumDisabled, emptyValue } = options;
   const semanticProps = getSemanticProps<T, S, F>({
-    formContext,
+    formContext: registry.formContext,
     options,
     uiSchema,
   });

--- a/packages/semantic-ui/src/RangeWidget/RangeWidget.tsx
+++ b/packages/semantic-ui/src/RangeWidget/RangeWidget.tsx
@@ -23,11 +23,11 @@ export default function RangeWidget<T = any, S extends StrictRJSFSchema = RJSFSc
     options,
     schema,
     uiSchema,
-    formContext,
+    registry,
     rawErrors = [],
   } = props;
   const semanticProps = getSemanticProps<T, S, F>({
-    formContext,
+    formContext: registry.formContext,
     options,
     uiSchema,
     defaultSchemaProps: {

--- a/packages/semantic-ui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/semantic-ui/src/SelectWidget/SelectWidget.tsx
@@ -52,7 +52,7 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
 ) {
   const {
     uiSchema,
-    formContext,
+    registry,
     id,
     options,
     label,
@@ -72,7 +72,7 @@ export default function SelectWidget<T = any, S extends StrictRJSFSchema = RJSFS
   } = props;
   const semanticProps = getSemanticProps<T, S, F>({
     uiSchema,
-    formContext,
+    formContext: registry.formContext,
     options,
     defaultSchemaProps: {
       inverted: 'false',

--- a/packages/semantic-ui/src/TextareaWidget/TextareaWidget.tsx
+++ b/packages/semantic-ui/src/TextareaWidget/TextareaWidget.tsx
@@ -33,11 +33,11 @@ export default function TextareaWidget<
     onFocus,
     onChange,
     options,
-    formContext,
+    registry,
     rawErrors = [],
   } = props;
   const semanticProps = getSemanticProps<T, S, F>({
-    formContext,
+    formContext: registry.formContext,
     options,
     defaultSchemaProps: { inverted: 'false' },
   });

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -263,8 +263,6 @@ export type ErrorListProps<
   errorSchema: ErrorSchema<T>;
   /** An array of the errors */
   errors: RJSFValidationError[];
-  /** The `formContext` object that was passed to `Form` */
-  formContext?: F;
 };
 
 /** The properties that are passed to an `FieldErrorTemplate` implementation */
@@ -429,7 +427,7 @@ export interface Registry<T = any, S extends StrictRJSFSchema = RJSFSchema, F ex
   experimental_componentUpdateStrategy?: 'customDeep' | 'shallow' | 'always';
 }
 
-/** The properties that are passed to a Field implementation */
+/** The properties that are passed to a `Field` implementation */
 export interface FieldProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>
   extends GenericObjectType,
     RJSFBaseProps<T, S, F>,
@@ -448,8 +446,6 @@ export interface FieldProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F 
   onBlur: (id: string, value: any) => void;
   /** The input focus event handler; call it with the field id and value */
   onFocus: (id: string, value: any) => void;
-  /** The `formContext` object that you passed to `Form` */
-  formContext?: F;
   /** A boolean value stating if the field should autofocus */
   autofocus?: boolean;
   /** A boolean value stating if the field is disabled */
@@ -482,7 +478,7 @@ export type Field<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
   TEST_IDS?: TestIdShape;
 };
 
-/** The properties that are passed to a FieldTemplate implementation */
+/** The properties that are passed to a `FieldTemplate` implementation */
 export type FieldTemplateProps<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
@@ -528,8 +524,6 @@ export type FieldTemplateProps<
    * you don't want to clutter the UI
    */
   displayLabel?: boolean;
-  /** The `formContext` object that was passed to `Form` */
-  formContext?: F;
   /** The formData for this field */
   formData?: T;
   /** The value change event handler; Can be called with a new value to change the value for this field */
@@ -677,7 +671,7 @@ export type ArrayFieldTemplateItemType<
   F extends FormContextType = any,
 > = ArrayFieldItemTemplateType<T, S, F>;
 
-/** The properties that are passed to an ArrayFieldTemplate implementation */
+/** The properties that are passed to an `ArrayFieldTemplate` implementation */
 export type ArrayFieldTemplateProps<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
@@ -703,8 +697,6 @@ export type ArrayFieldTemplateProps<
   hideError?: boolean;
   /** A string value containing the title for the array */
   title: string;
-  /** The `formContext` object that was passed to Form */
-  formContext?: F;
   /** The formData for this array */
   formData?: T;
   /** The tree of errors for this field and its children */
@@ -755,8 +747,6 @@ export type ObjectFieldTemplateProps<
   errorSchema?: ErrorSchema<T>;
   /** The form data for the object */
   formData?: T;
-  /** The `formContext` object that was passed to Form */
-  formContext?: F;
 };
 
 /** The properties that are passed to a WrapIfAdditionalTemplate implementation */
@@ -797,7 +787,7 @@ export interface MultiSchemaFieldTemplateProps<
   optionSchemaField: ReactNode;
 }
 
-/** The properties that are passed to a Widget implementation */
+/** The properties that are passed to a `Widget` implementation */
 export interface WidgetProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>
   extends GenericObjectType,
     RJSFBaseProps<T, S, F>,
@@ -831,8 +821,6 @@ export interface WidgetProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F
     /** The enum options list for a type that supports them */
     enumOptions?: EnumOptionsType<S>[];
   };
-  /** The `formContext` object that you passed to `Form` */
-  formContext?: F;
   /** The input blur event handler; call it with the widget id and value */
   onBlur: (id: string, value: any) => void;
   /** The value change event handler; call it with the new value every time it changes */


### PR DESCRIPTION
### Reasons for making this change

Since the `registry` contains `formContext` and it is part of all interfaces that had `formContext`, removed `formContext`
- In `@rjsf/utils`, removed `formContext` from the following interfaces:
  - `ErrorListProps`, `FieldProps`, `FieldTemplateProps`, `ArrayFieldTemplateProps` and `WidgetProps`
- In `@rjsf/core`, updated `ArrayField`, `Form`, `LayoutMultiSchemaField` and `SchemaField` to stop passing `formContext`
  - Updated tests to get the `formContext` from the `registry`
- In `@rjsf/antd`, updated the `ArrayFieldTemplate`, `FieldTemplate` and `ObjectFieldTemplate` to get `formContext` from the `registry`
- In `@rjsf/daisyui`, removed `formContext` usages
- In `@rjsf/primereact`, updated the snapshots to remove `formContext`
- Updated the documentation to remove `formContext` from the interface documentation, adding a BREAKING CHANGE notification in the `v6.x upgrade guide`
- In `@rjsf/semantic-ui`, updated the use of `formContext` to get it from `registry`
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
