### PR TITLE
fix: `mergeDefaultsWithFormData` should treat `null` as a defined default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ should change the heading of the (upcoming) version to include a major version b
 
 - BREAKING CHANGE: Removed `formContext` from the following interfaces because it is available on `registry`:
   - `ErrorListProps`, `FieldProps`, `FieldTemplateProps`, `ArrayFieldTemplateProps` and `WidgetProps`
+- Update `mergeDefaultsWithFormData` to properly handle overriding `undefined` formData with a `null` default value, fixing [#4734](https://github.com/rjsf-team/react-jsonschema-form/issues/4734)
 
 ## Dev / docs / playground
 

--- a/packages/utils/src/mergeDefaultsWithFormData.ts
+++ b/packages/utils/src/mergeDefaultsWithFormData.ts
@@ -102,7 +102,7 @@ export default function mergeDefaultsWithFormData<T = any>(
    */
   if (
     (defaultSupercedesUndefined &&
-      ((!isNil(defaults) && isNil(formData)) || (typeof formData === 'number' && isNaN(formData)))) ||
+      ((!(defaults === undefined) && isNil(formData)) || (typeof formData === 'number' && isNaN(formData)))) ||
     (overrideFormDataWithDefaults && !isNil(formData))
   ) {
     return defaults;

--- a/packages/utils/test/mergeDefaultsWithFormData.test.ts
+++ b/packages/utils/test/mergeDefaultsWithFormData.test.ts
@@ -29,6 +29,13 @@ describe('mergeDefaultsWithFormData()', () => {
     expect(mergeDefaultsWithFormData({}, null, undefined, true)).toEqual({});
   });
 
+  it('should return null if default is null and formData is undefined and defaultSupercedesUndefined is true', () => {
+    const defaultValue = null;
+    const formData = undefined;
+    const defaultSupercedesUndefined = true;
+    expect(mergeDefaultsWithFormData(defaultValue, formData, undefined, defaultSupercedesUndefined)).toBeNull();
+  });
+
   it('should return undefined when formData is undefined', () => {
     expect(mergeDefaultsWithFormData(undefined, undefined)).toBeUndefined();
   });

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -4990,5 +4990,19 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         }),
       ).toEqual({ stringArray: [undefined], numberArray: [] });
     });
+    it('handles a `null` default value', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          empty: {
+            type: 'null',
+            default: null,
+          },
+        },
+      };
+      expect(getDefaultFormState(testValidator, schema, {}, schema)).toEqual({
+        empty: null,
+      });
+    });
   });
 }


### PR DESCRIPTION
### Reasons for making this change

Fixes #4734 

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

If your PR is non-trivial and you'd like to schedule a synchronous review, please add it to the weekly meeting agenda: https://docs.google.com/document/d/12PjTvv21k6LIky6bNQVnsplMLLnmEuypTLQF8a-8Wss/edit

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
