### PR TITLE
feat(templates): align buttons with input field in type array

### DIFF
--- a/packages/shadcn/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
+++ b/packages/shadcn/src/ArrayFieldItemTemplate/ArrayFieldItemTemplate.tsx
@@ -25,7 +25,7 @@ export default function ArrayFieldItemTemplate<
   );
   return (
     <div>
-      <div className='mb-2 flex flex-row flex-wrap'>
+      <div className='mb-2 flex flex-row flex-wrap items-center'>
         <div className='grow shrink'>{children}</div>
         <div className='flex items-end justify-end p-0.5'>
           {hasToolbar && (


### PR DESCRIPTION
### Reasons for making this change

The buttons are not aligned.
We can add "items-center" to align the buttons (move up, move down, delete) with the field

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
