### PR TITLE
Fix 4371 by adding schema to thrown errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ should change the heading of the (upcoming) version to include a major version b
   - `ErrorListProps`, `FieldProps`, `FieldTemplateProps`, `ArrayFieldTemplateProps` and `WidgetProps`
 - Update `mergeDefaultsWithFormData` to properly handle overriding `undefined` formData with a `null` default value, fixing [#4734](https://github.com/rjsf-team/react-jsonschema-form/issues/4734)
 - Fixed object reference sharing in arrays with minItems when using oneOf schemas, fixing [#4756](https://github.com/rjsf-team/react-jsonschema-form/issues/4756)
+- Updated `getWigets()` to output the `schema` when throwing errors, fixing [#4731](https://github.com/rjsf-team/react-jsonschema-form/issues/4731)
 
 ## Dev / docs / playground
 

--- a/packages/utils/src/getWidget.tsx
+++ b/packages/utils/src/getWidget.tsx
@@ -110,7 +110,7 @@ export default function getWidget<T = any, S extends StrictRJSFSchema = RJSFSche
   }
 
   if (typeof widget !== 'string') {
-    throw new Error(`Unsupported widget definition: ${typeof widget}`);
+    throw new Error(`Unsupported widget definition: ${typeof widget} in schema: ${JSON.stringify(schema)}`);
   }
 
   if (widget in registeredWidgets) {
@@ -120,7 +120,7 @@ export default function getWidget<T = any, S extends StrictRJSFSchema = RJSFSche
 
   if (typeof type === 'string') {
     if (!(type in widgetMap)) {
-      throw new Error(`No widget for type '${type}'`);
+      throw new Error(`No widget for type '${type}' in schema: ${JSON.stringify(schema)}`);
     }
 
     if (widget in widgetMap[type]) {
@@ -129,5 +129,5 @@ export default function getWidget<T = any, S extends StrictRJSFSchema = RJSFSche
     }
   }
 
-  throw new Error(`No widget '${widget}' for type '${type}'`);
+  throw new Error(`No widget '${widget}' for type '${type}' in schema: ${JSON.stringify(schema)}`);
 }

--- a/packages/utils/test/getWidget.test.tsx
+++ b/packages/utils/test/getWidget.test.tsx
@@ -8,6 +8,8 @@ const subschema: RJSFSchema = {
   default: true,
 };
 
+const subschemaStr = JSON.stringify(subschema);
+
 const schema: RJSFSchema = {
   type: 'object',
   properties: {
@@ -26,6 +28,7 @@ const schema: RJSFSchema = {
     },
   },
 };
+const schemaStr = JSON.stringify(schema);
 
 const TestRefWidget: Widget = forwardRef<HTMLSpanElement, Partial<WidgetProps>>(function TestRefWidget(
   props: Partial<WidgetProps>,
@@ -88,19 +91,21 @@ const widgetProps: WidgetProps = {
 
 describe('getWidget()', () => {
   it('should fail if widget has incorrect type', () => {
-    expect(() => getWidget(schema)).toThrow('Unsupported widget definition: undefined');
+    expect(() => getWidget(schema)).toThrow(`Unsupported widget definition: undefined in schema: ${schemaStr}`);
   });
 
   it('should fail if widget has no type property', () => {
-    expect(() => getWidget(schema, 'blabla')).toThrow(`No widget for type 'object'`);
+    expect(() => getWidget(schema, 'blabla')).toThrow(`No widget for type 'object' in schema: ${schemaStr}`);
   });
 
   it('should fail if schema `type` has no widget property', () => {
-    expect(() => getWidget(subschema, 'blabla')).toThrow(`No widget 'blabla' for type 'boolean'`);
+    expect(() => getWidget(subschema, 'blabla')).toThrow(
+      `No widget 'blabla' for type 'boolean' in schema: ${subschemaStr}`,
+    );
   });
 
   it('should fail if schema has no type property', () => {
-    expect(() => getWidget({}, 'blabla')).toThrow(`No widget 'blabla' for type 'undefined'`);
+    expect(() => getWidget({}, 'blabla')).toThrow(`No widget 'blabla' for type 'undefined' in schema: {}`);
   });
 
   it('should return widget if in registered widgets', () => {


### PR DESCRIPTION
### Reasons for making this change

Fixes #4371 by updating thrown errors to output the stringified schema
- In `@rjsf/utils` updated `getWidget()` to output the stringified schema in thrown errors

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
