### PR TITLE
Fix 4763 so that additional properties work properly again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,14 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # 6.0.0-beta.17
 
+## @rjsf/core
+
+- Updated `ObjectField` to remove the `name` from the path passed to `onChange()` callback in `handleAddClick()` and `onDropPropertyClick()`, fixing [#4763](https://github.com/rjsf-team/react-jsonschema-form/issues/4763)
+- Updated `Form` to restore the passing of an empty string for `name` to avoid accidentally showing it as the title for the whole schema
+
 ## @rjsf/shadcn
 
-- Update ArrayFieldItemTemplate to align buttons with the input field [#4753](https://github.com/rjsf-team/react-jsonschema-form/pull/4753)
+- Update `ArrayFieldItemTemplate` to align buttons with the input field, fixing [#4753](https://github.com/rjsf-team/react-jsonschema-form/pull/4753)
 
 # 6.0.0-beta.16
 

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -1153,7 +1153,7 @@ export default class Form<
       >
         {showErrorList === 'top' && this.renderErrors(registry)}
         <_SchemaField
-          name={idPrefix}
+          name=''
           schema={schema}
           uiSchema={uiSchema}
           errorSchema={errorSchema}

--- a/packages/core/src/components/fields/ObjectField.tsx
+++ b/packages/core/src/components/fields/ObjectField.tsx
@@ -94,11 +94,11 @@ class ObjectField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
   onDropPropertyClick = (key: string) => {
     return (event: DragEvent) => {
       event.preventDefault();
-      const { onChange, formData, name } = this.props;
+      const { onChange, formData } = this.props;
       const copiedFormData = { ...formData } as T;
       unset(copiedFormData, key);
       // drop property will pass the name in `path` array
-      onChange(copiedFormData, [name]);
+      onChange(copiedFormData, []);
     };
   };
 
@@ -187,7 +187,7 @@ class ObjectField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
     if (!(schema.additionalProperties || schema.patternProperties)) {
       return;
     }
-    const { formData, name, onChange, registry } = this.props;
+    const { formData, onChange, registry } = this.props;
     const newFormData = { ...formData } as T;
     const newKey = this.getAvailableKey('newKey', newFormData);
     if (schema.patternProperties) {
@@ -220,7 +220,7 @@ class ObjectField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
     }
 
     // add will pass the name in `path` array
-    onChange(newFormData, [name]);
+    onChange(newFormData, []);
   };
 
   /** Renders the `ObjectField` from the given props


### PR DESCRIPTION

### Reasons for making this change

Fixes #4763 by removing the `name` from the `path` passed to `onChange()` for additional properties callbacks
- Updated `ObjectField` as described
- Updated `Form` to not pass `idPrefix` as the `name` to avoid it showing up as the title of the schema
- Updated `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
