### PR TITLE
Fix 1581 by supporting null defaults for object and array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ should change the heading of the (upcoming) version to include a major version b
 
 - Update `ArrayFieldItemTemplate` to align buttons with the input field, fixing [#4753](https://github.com/rjsf-team/react-jsonschema-form/pull/4753)
 
+## @rjsf/utils
+
+- Update `getDefaultFormState()` to add support for `null` defaults for `["null", "object"]` and `["null", "array"]`, fixing [#1581](https://github.com/rjsf-team/react-jsonschema-form/issues/1581)
+
 # 6.0.0-beta.16
 
 ## @rjsf/antd

--- a/packages/utils/test/schema/getDefaultFormStateTest.ts
+++ b/packages/utils/test/schema/getDefaultFormStateTest.ts
@@ -1,6 +1,7 @@
 import { createSchemaUtils, Experimental_DefaultFormStateBehavior, getDefaultFormState, RJSFSchema } from '../../src';
 import {
   AdditionalItemsHandling,
+  computeDefaultBasedOnSchemaTypeAndDefaults,
   computeDefaults,
   getArrayDefaults,
   getDefaultBasedOnSchemaType,
@@ -1969,7 +1970,119 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         ]);
       });
     });
-
+    describe('computeDefaultBasedOnSchemaTypeAndDefaults()', () => {
+      let schema: RJSFSchema;
+      describe('Object', () => {
+        beforeAll(() => {
+          schema = {
+            type: 'object',
+            default: null,
+          };
+        });
+        it('computedDefaults is undefined', () => {
+          expect(computeDefaultBasedOnSchemaTypeAndDefaults(schema, undefined)).toBeUndefined();
+        });
+        it('computedDefaults is empty object', () => {
+          expect(computeDefaultBasedOnSchemaTypeAndDefaults(schema, {})).toEqual({});
+        });
+        it('computedDefaults is non-empty object', () => {
+          const computedDefault = { foo: 'bar' };
+          expect(computeDefaultBasedOnSchemaTypeAndDefaults(schema, computedDefault)).toEqual(computedDefault);
+        });
+      });
+      describe('Nullable Object', () => {
+        beforeAll(() => {
+          schema = {
+            type: ['null', 'object'],
+            default: null,
+          };
+        });
+        it('computedDefaults is undefined', () => {
+          expect(computeDefaultBasedOnSchemaTypeAndDefaults(schema, undefined)).toBeNull();
+        });
+        it('computedDefaults is empty object', () => {
+          expect(computeDefaultBasedOnSchemaTypeAndDefaults(schema, {})).toBeNull();
+        });
+        it('computedDefaults is non-empty object', () => {
+          const computedDefault = { foo: 'bar' };
+          expect(computeDefaultBasedOnSchemaTypeAndDefaults(schema, computedDefault)).toEqual(computedDefault);
+        });
+      });
+      describe('Array', () => {
+        beforeAll(() => {
+          schema = {
+            type: 'array',
+            default: null,
+            items: { type: 'string' },
+          };
+        });
+        it('computedDefaults is undefined', () => {
+          expect(computeDefaultBasedOnSchemaTypeAndDefaults(schema, undefined)).toBeUndefined();
+        });
+        it('computedDefaults is empty object', () => {
+          expect(computeDefaultBasedOnSchemaTypeAndDefaults(schema, [])).toEqual([]);
+        });
+        it('computedDefaults is non-empty object', () => {
+          const computedDefault = ['bar'];
+          expect(computeDefaultBasedOnSchemaTypeAndDefaults(schema, computedDefault)).toEqual(computedDefault);
+        });
+      });
+      describe('Nullable Array', () => {
+        beforeAll(() => {
+          schema = {
+            type: ['null', 'array'],
+            default: null,
+            items: { type: 'string' },
+          };
+        });
+        it('computedDefaults is undefined', () => {
+          expect(computeDefaultBasedOnSchemaTypeAndDefaults(schema, undefined)).toBeNull();
+        });
+        it('computedDefaults is empty object', () => {
+          expect(computeDefaultBasedOnSchemaTypeAndDefaults(schema, [])).toBeNull();
+        });
+        it('computedDefaults is non-empty object', () => {
+          const computedDefault = ['bar'];
+          expect(computeDefaultBasedOnSchemaTypeAndDefaults(schema, computedDefault)).toEqual(computedDefault);
+        });
+      });
+      describe('Nullable String', () => {
+        beforeAll(() => {
+          schema = {
+            type: 'string',
+            default: null,
+          };
+        });
+        it('computedDefaults is undefined', () => {
+          expect(computeDefaultBasedOnSchemaTypeAndDefaults(schema, undefined)).toBeUndefined();
+        });
+        it('computedDefaults is empty object', () => {
+          expect(computeDefaultBasedOnSchemaTypeAndDefaults(schema, '')).toEqual('');
+        });
+        it('computedDefaults is non-empty object', () => {
+          const computedDefault = 'bar';
+          expect(computeDefaultBasedOnSchemaTypeAndDefaults(schema, computedDefault)).toEqual(computedDefault);
+        });
+      });
+      describe('Nullable String', () => {
+        beforeAll(() => {
+          schema = {
+            type: ['null', 'string'],
+            default: null,
+          };
+        });
+        it('computedDefaults is undefined', () => {
+          expect(computeDefaultBasedOnSchemaTypeAndDefaults(schema, undefined)).toBeNull();
+        });
+        it('computedDefaults is empty object', () => {
+          expect(computeDefaultBasedOnSchemaTypeAndDefaults(schema, '')).toBeNull();
+        });
+        it('computedDefaults is non-empty object', () => {
+          const computedDefault = 'bar';
+          expect(computeDefaultBasedOnSchemaTypeAndDefaults(schema, computedDefault)).toEqual(computedDefault);
+        });
+      });
+    });
     describe('getValidFormData', () => {
       let schema: RJSFSchema;
       it('Test schema with non valid formData for enum property', () => {
@@ -5091,12 +5204,12 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         expect(Array.isArray(result)).toBe(true);
 
         // Verify objects are independent instances
-        (result[0] as any).field = 'test-value-1';
-        (result[1] as any).field = 'test-value-2';
-        expect((result[2] as any).field).toBeUndefined();
-        expect(result[0]).not.toBe(result[1]);
-        expect(result[1]).not.toBe(result[2]);
-        expect(result[0]).not.toBe(result[2]);
+        (result![0] as any).field = 'test-value-1';
+        (result![1] as any).field = 'test-value-2';
+        expect((result![2] as any).field).toBeUndefined();
+        expect(result![0]).not.toBe(result![1]);
+        expect(result![1]).not.toBe(result![2]);
+        expect(result![0]).not.toBe(result![2]);
       });
 
       it('should ensure array items with default values are independent instances', () => {
@@ -5125,9 +5238,9 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         expect(Array.isArray(result)).toBe(true);
 
         // Verify objects are independent instances - modifying one shouldn't affect the other
-        (result[0] as any).field = 'modified-value';
-        expect((result[1] as any).field).toBe('default-value');
-        expect(result[0]).not.toBe(result[1]);
+        (result![0] as any).field = 'modified-value';
+        expect((result![1] as any).field).toBe('default-value');
+        expect(result![0]).not.toBe(result![1]);
       });
 
       it('should ensure nested objects in arrays are independent instances', () => {
@@ -5164,10 +5277,10 @@ export default function getDefaultFormStateTest(testValidator: TestValidatorType
         expect(Array.isArray(result)).toBe(true);
 
         // Verify nested objects are independent instances
-        (result[0] as any).nested.value = 'modified-nested-value';
-        expect((result[1] as any).nested.value).toBe('nested-default');
-        expect(result[0]).not.toBe(result[1]);
-        expect((result[0] as any).nested).not.toBe((result[1] as any).nested);
+        (result![0] as any).nested.value = 'modified-nested-value';
+        expect((result![1] as any).nested.value).toBe('nested-default');
+        expect(result![0]).not.toBe(result![1]);
+        expect((result![0] as any).nested).not.toBe((result![1] as any).nested);
       });
     });
   });


### PR DESCRIPTION
### Reasons for making this change

Fixed #1581 by fixing `getDefaultFormState()` to support `null` defaults for `object` and `array` types
- Updated `getDefaultFormState()` to add `computeDefaultBasedOnSchemaTypeAndDefaults()` to detect when `["null", "object"|"array"]`, default as `null` and the computed default was empty
  - Updated the tests for `getDefaultFormState()` to tests all of the `computeDefaultBasedOnSchemaTypeAndDefaults()`
- Updated `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
