### PR TITLE
Fix 4772 by always generating the outer grid regardless of the number of properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # 6.0.0-beta.17
 
+## @rjsf/chakra-ui
+
+- Updated `ObjectFieldTemplate` to always generate the "Add" button when `canExpand()` is true, fixing [#4772](https://github.com/rjsf-team/react-jsonschema-form/issues/4772)
+
 ## @rjsf/core
 
 - Updated `ObjectField` to remove the `name` from the path passed to `onChange()` callback in `handleAddClick()` and `onDropPropertyClick()`, fixing [#4763](https://github.com/rjsf-team/react-jsonschema-form/issues/4763)

--- a/packages/chakra-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
+++ b/packages/chakra-ui/src/ObjectFieldTemplate/ObjectFieldTemplate.tsx
@@ -64,29 +64,27 @@ export default function ObjectFieldTemplate<
           registry={registry}
         />
       )}
-      {properties.length > 0 && (
-        <Grid gap={description ? 2 : 6} mb={4}>
-          {properties.map((element, index) =>
-            element.hidden ? (
-              element.content
-            ) : (
-              <GridItem key={`${idSchema.$id}-${element.name}-${index}`}>{element.content}</GridItem>
-            ),
-          )}
-          {canExpand<T, S, F>(schema, uiSchema, formData) && (
-            <GridItem justifySelf='flex-end'>
-              <AddButton
-                id={buttonId<T>(idSchema, 'add')}
-                className='rjsf-object-property-expand'
-                onClick={onAddClick(schema)}
-                disabled={disabled || readonly}
-                uiSchema={uiSchema}
-                registry={registry}
-              />
-            </GridItem>
-          )}
-        </Grid>
-      )}
+      <Grid gap={description ? 2 : 6} mb={4}>
+        {properties.map((element, index) =>
+          element.hidden ? (
+            element.content
+          ) : (
+            <GridItem key={`${idSchema.$id}-${element.name}-${index}`}>{element.content}</GridItem>
+          ),
+        )}
+        {canExpand<T, S, F>(schema, uiSchema, formData) && (
+          <GridItem justifySelf='flex-end'>
+            <AddButton
+              id={buttonId<T>(idSchema, 'add')}
+              className='rjsf-object-property-expand'
+              onClick={onAddClick(schema)}
+              disabled={disabled || readonly}
+              uiSchema={uiSchema}
+              registry={registry}
+            />
+          </GridItem>
+        )}
+      </Grid>
     </>
   );
 }


### PR DESCRIPTION
### Reasons for making this change

Fixed #4772 by always genering the outer grid
- Updated `chakra-ui`'s `ObjectFieldTemplate` to render the outer `Grid` regardless of the number of properties
- Updated the `CHANGELOG.md` accordingly


### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
