### PR TITLE
Fix 4765 by supporting objects and arrays as elements in a grid

### DIFF
--- a/packages/core/test/LayoutGridField.test.tsx
+++ b/packages/core/test/LayoutGridField.test.tsx
@@ -1592,7 +1592,7 @@ describe('LayoutGridField', () => {
     expect(props.onFocus).toHaveBeenCalledWith(fieldId, '');
     // Type to trigger the onChange
     await userEvent.type(input, 'foo');
-    // Due to the selection of schema type = `array` the path is appended to the fieldName, duplicating it
+    // Due to the selection of schema type = `object` the path is appended to the fieldName, duplicating it
     expect(props.onChange).toHaveBeenCalledWith('foo', [fieldName, fieldName], props.errorSchema, fieldId);
     // Tab out of the input field to cause the blur
     await userEvent.tab();

--- a/packages/core/test/LayoutGridField.test.tsx
+++ b/packages/core/test/LayoutGridField.test.tsx
@@ -752,7 +752,7 @@ function getExpectedPropsForField(
     required = result?.required?.includes(name) || false;
     return schema1;
   }, props.schema);
-  // Null out nested properties that can show up for when additionalProperties is specified
+  // Null out nested properties that can show up when additionalProperties is specified
   if (!isEmpty(schema?.properties)) {
     schema.properties = {};
   }

--- a/packages/core/test/testData/getTestRegistry.tsx
+++ b/packages/core/test/testData/getTestRegistry.tsx
@@ -11,6 +11,7 @@ export default function getTestRegistry(
   templates: Partial<Registry['templates']> = {},
   widgets: Registry['widgets'] = {},
   formContext: Registry['formContext'] = {},
+  globalFormOptions: Registry['globalFormOptions'] = {},
 ): Registry {
   const defaults = getDefaultRegistry();
   const schemaUtils = createSchemaUtils(validator, rootSchema);
@@ -22,6 +23,6 @@ export default function getTestRegistry(
     rootSchema,
     schemaUtils,
     translateString: englishStringTranslator,
-    globalFormOptions: {},
+    globalFormOptions,
   };
 }


### PR DESCRIPTION
### Reasons for making this change

Fixed #4765 by supporting objects and arrays as elements in a grid, specifically fixing the `onFieldChange()` to support them
- Updated `LayoutGridField` to update the `onFieldChange()` method to take an additional parameter, `schemaType`
  - If `schemaType` is `object` or `array`, then the `actualPath` returned to the parent `onChange` will append the `path` from the `onChange()` to the `dottedPath`
  - Updated the tests to verify this new behavior
- Updated `getTestRegistry()` to support passing in `globalFormOptions` instead of just setting an empty object

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature


This [example](https://rjsf-team.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6eyJsaXN0T2ZTdHJpbmdzIjpbXX0sInNjaGVtYSI6eyJ0eXBlIjoib2JqZWN0IiwicHJvcGVydGllcyI6eyJsaXN0T2ZTdHJpbmdzIjp7InR5cGUiOiJhcnJheSIsInRpdGxlIjoiQSBsaXN0IG9mIHN0cmluZ3MiLCJpdGVtcyI6eyJ0eXBlIjoic3RyaW5nIiwiZGVmYXVsdCI6ImJhemluZ2EifX0sIm1hcE9mU3RyaW5ncyI6eyJ0eXBlIjoib2JqZWN0IiwidGl0bGUiOiJBIG1hcCBvZiBzdHJpbmdzIiwiYWRkaXRpb25hbFByb3BlcnRpZXMiOnsidHlwZSI6InN0cmluZyIsImRlZmF1bHQiOiJiYXppbmdhIn19fX0sInVpU2NoZW1hIjp7InVpOmZpZWxkIjoiTGF5b3V0R3JpZEZpZWxkIiwidWk6bGF5b3V0R3JpZCI6eyJ1aTpyb3ciOnsiY2hpbGRyZW4iOlt7InVpOmNvbHVtbnMiOnsic3BhbiI6NiwiY2hpbGRyZW4iOlsibGlzdE9mU3RyaW5ncyIsIm1hcE9mU3RyaW5ncyJdfX1dfX19LCJ0aGVtZSI6Im1hbnRpbmUiLCJsaXZlU2V0dGluZ3MiOnsic2hvd0Vycm9yTGlzdCI6InRvcCIsInZhbGlkYXRlIjpmYWxzZSwiZGlzYWJsZWQiOmZhbHNlLCJub0h0bWw1VmFsaWRhdGUiOmZhbHNlLCJyZWFkb25seSI6ZmFsc2UsIm9taXRFeHRyYURhdGEiOmZhbHNlLCJsaXZlT21pdCI6ZmFsc2UsImV4cGVyaW1lbnRhbF9jb21wb25lbnRVcGRhdGVTdHJhdGVneSI6ImN1c3RvbURlZXAiLCJleHBlcmltZW50YWxfZGVmYXVsdEZvcm1TdGF0ZUJlaGF2aW9yIjp7ImFycmF5TWluSXRlbXMiOiJwb3B1bGF0ZSIsImFsbE9mIjoic2tpcERlZmF1bHRzIiwiY29uc3RBc0RlZmF1bHRzIjoiYWx3YXlzIiwiZW1wdHlPYmplY3RGaWVsZHMiOiJwb3B1bGF0ZUFsbERlZmF1bHRzIiwibWVyZ2VEZWZhdWx0c0ludG9Gb3JtRGF0YSI6InVzZUZvcm1EYXRhSWZQcmVzZW50In19LCJ2YWxpZGF0b3IiOiJBSlY4Iiwic2FtcGxlTmFtZSI6IkJsYW5rIn0=) will work when merged as shown here:


https://github.com/user-attachments/assets/c822a251-7c7d-4dc2-ae4a-2b1d6dbd5db8

