### PR TITLE
chore(deps): bump @fortawesome/react-fontawesome from 0.2.6 to 3.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7476,16 +7476,16 @@
       }
     },
     "node_modules/@fortawesome/react-fontawesome": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.6.tgz",
-      "integrity": "sha512-mtBFIi1UsYQo7rYonYFkjgYKGoL8T+fEH6NGUpvuqtY3ytMsAoDaPo5rk25KuMtKDipY4bGYM/CkmCHA1N3FUg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.0.2.tgz",
+      "integrity": "sha512-cmp/nT0pPC7HUALF8uc3+D5ECwEBWxYQbOIHwtGUWEu72sWtZc26k5onr920HWOViF0nYaC+Qzz6Ln56SQcaVg==",
       "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.8.1"
+      "engines": {
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1 || ~6 || ~7",
-        "react": "^16.3 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+        "@fortawesome/fontawesome-svg-core": "~6 || ~7",
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@griffel/core": {
@@ -38906,7 +38906,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^7.0.1",
         "@fortawesome/free-solid-svg-icons": "^7.0.1",
-        "@fortawesome/react-fontawesome": "^0.2.6",
+        "@fortawesome/react-fontawesome": "^3.0.2",
         "date-fns": "^4.1.0",
         "react-day-picker": "^9.9.0",
         "tailwindcss": "^4.1.12"

--- a/packages/daisyui/package.json
+++ b/packages/daisyui/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^7.0.1",
     "@fortawesome/free-solid-svg-icons": "^7.0.1",
-    "@fortawesome/react-fontawesome": "^0.2.6",
+    "@fortawesome/react-fontawesome": "^3.0.2",
     "date-fns": "^4.1.0",
     "react-day-picker": "^9.9.0",
     "tailwindcss": "^4.1.12"

--- a/packages/daisyui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/daisyui/test/__snapshots__/Array.test.tsx.snap
@@ -52,13 +52,11 @@ exports[`array fields array 1`] = `
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>
@@ -206,13 +204,11 @@ exports[`array fields array icons 1`] = `
                       data-icon="arrow-up"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M214.6 17.4c-12.5-12.5-32.8-12.5-45.3 0l-160 160c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 117.3 160 488c0 17.7 14.3 32 32 32s32-14.3 32-32l0-370.7 105.4 105.4c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3l-160-160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -231,13 +227,11 @@ exports[`array fields array icons 1`] = `
                       data-icon="arrow-down"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M169.4 502.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 402.7 224 32c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 370.7-105.4-105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -256,13 +250,11 @@ exports[`array fields array icons 1`] = `
                       data-icon="copy"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-200.6c0-17.4-7.1-34.1-19.7-46.2L370.6 17.8C358.7 6.4 342.8 0 326.3 0L192 0zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-16-64 0 0 16-192 0 0-256 16 0 0-64-16 0z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -281,13 +273,11 @@ exports[`array fields array icons 1`] = `
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -385,13 +375,11 @@ exports[`array fields array icons 1`] = `
                       data-icon="arrow-up"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M214.6 17.4c-12.5-12.5-32.8-12.5-45.3 0l-160 160c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 117.3 160 488c0 17.7 14.3 32 32 32s32-14.3 32-32l0-370.7 105.4 105.4c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3l-160-160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -410,13 +398,11 @@ exports[`array fields array icons 1`] = `
                       data-icon="arrow-down"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M169.4 502.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 402.7 224 32c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 370.7-105.4-105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -435,13 +421,11 @@ exports[`array fields array icons 1`] = `
                       data-icon="copy"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-200.6c0-17.4-7.1-34.1-19.7-46.2L370.6 17.8C358.7 6.4 342.8 0 326.3 0L192 0zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-16-64 0 0 16-192 0 0-256 16 0 0-64-16 0z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -460,13 +444,11 @@ exports[`array fields array icons 1`] = `
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -498,13 +480,11 @@ exports[`array fields array icons 1`] = `
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>
@@ -1311,13 +1291,11 @@ exports[`with title and description array 1`] = `
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>
@@ -1491,13 +1469,11 @@ exports[`with title and description array icons 1`] = `
                       data-icon="arrow-up"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M214.6 17.4c-12.5-12.5-32.8-12.5-45.3 0l-160 160c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 117.3 160 488c0 17.7 14.3 32 32 32s32-14.3 32-32l0-370.7 105.4 105.4c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3l-160-160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -1516,13 +1492,11 @@ exports[`with title and description array icons 1`] = `
                       data-icon="arrow-down"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M169.4 502.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 402.7 224 32c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 370.7-105.4-105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -1541,13 +1515,11 @@ exports[`with title and description array icons 1`] = `
                       data-icon="copy"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-200.6c0-17.4-7.1-34.1-19.7-46.2L370.6 17.8C358.7 6.4 342.8 0 326.3 0L192 0zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-16-64 0 0 16-192 0 0-256 16 0 0-64-16 0z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -1566,13 +1538,11 @@ exports[`with title and description array icons 1`] = `
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -1673,13 +1643,11 @@ exports[`with title and description array icons 1`] = `
                       data-icon="arrow-up"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M214.6 17.4c-12.5-12.5-32.8-12.5-45.3 0l-160 160c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 117.3 160 488c0 17.7 14.3 32 32 32s32-14.3 32-32l0-370.7 105.4 105.4c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3l-160-160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -1698,13 +1666,11 @@ exports[`with title and description array icons 1`] = `
                       data-icon="arrow-down"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M169.4 502.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 402.7 224 32c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 370.7-105.4-105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -1723,13 +1689,11 @@ exports[`with title and description array icons 1`] = `
                       data-icon="copy"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-200.6c0-17.4-7.1-34.1-19.7-46.2L370.6 17.8C358.7 6.4 342.8 0 326.3 0L192 0zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-16-64 0 0 16-192 0 0-256 16 0 0-64-16 0z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -1748,13 +1712,11 @@ exports[`with title and description array icons 1`] = `
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -1786,13 +1748,11 @@ exports[`with title and description array icons 1`] = `
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>
@@ -2267,13 +2227,11 @@ exports[`with title and description from both array 1`] = `
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>
@@ -2447,13 +2405,11 @@ exports[`with title and description from both array icons 1`] = `
                       data-icon="arrow-up"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M214.6 17.4c-12.5-12.5-32.8-12.5-45.3 0l-160 160c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 117.3 160 488c0 17.7 14.3 32 32 32s32-14.3 32-32l0-370.7 105.4 105.4c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3l-160-160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -2472,13 +2428,11 @@ exports[`with title and description from both array icons 1`] = `
                       data-icon="arrow-down"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M169.4 502.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 402.7 224 32c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 370.7-105.4-105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -2497,13 +2451,11 @@ exports[`with title and description from both array icons 1`] = `
                       data-icon="copy"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-200.6c0-17.4-7.1-34.1-19.7-46.2L370.6 17.8C358.7 6.4 342.8 0 326.3 0L192 0zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-16-64 0 0 16-192 0 0-256 16 0 0-64-16 0z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -2522,13 +2474,11 @@ exports[`with title and description from both array icons 1`] = `
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -2629,13 +2579,11 @@ exports[`with title and description from both array icons 1`] = `
                       data-icon="arrow-up"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M214.6 17.4c-12.5-12.5-32.8-12.5-45.3 0l-160 160c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 117.3 160 488c0 17.7 14.3 32 32 32s32-14.3 32-32l0-370.7 105.4 105.4c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3l-160-160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -2654,13 +2602,11 @@ exports[`with title and description from both array icons 1`] = `
                       data-icon="arrow-down"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M169.4 502.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 402.7 224 32c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 370.7-105.4-105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -2679,13 +2625,11 @@ exports[`with title and description from both array icons 1`] = `
                       data-icon="copy"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-200.6c0-17.4-7.1-34.1-19.7-46.2L370.6 17.8C358.7 6.4 342.8 0 326.3 0L192 0zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-16-64 0 0 16-192 0 0-256 16 0 0-64-16 0z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -2704,13 +2648,11 @@ exports[`with title and description from both array icons 1`] = `
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -2742,13 +2684,11 @@ exports[`with title and description from both array icons 1`] = `
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>
@@ -3223,13 +3163,11 @@ exports[`with title and description from uiSchema array 1`] = `
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>
@@ -3403,13 +3341,11 @@ exports[`with title and description from uiSchema array icons 1`] = `
                       data-icon="arrow-up"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M214.6 17.4c-12.5-12.5-32.8-12.5-45.3 0l-160 160c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 117.3 160 488c0 17.7 14.3 32 32 32s32-14.3 32-32l0-370.7 105.4 105.4c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3l-160-160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -3428,13 +3364,11 @@ exports[`with title and description from uiSchema array icons 1`] = `
                       data-icon="arrow-down"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M169.4 502.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 402.7 224 32c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 370.7-105.4-105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -3453,13 +3387,11 @@ exports[`with title and description from uiSchema array icons 1`] = `
                       data-icon="copy"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-200.6c0-17.4-7.1-34.1-19.7-46.2L370.6 17.8C358.7 6.4 342.8 0 326.3 0L192 0zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-16-64 0 0 16-192 0 0-256 16 0 0-64-16 0z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -3478,13 +3410,11 @@ exports[`with title and description from uiSchema array icons 1`] = `
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -3585,13 +3515,11 @@ exports[`with title and description from uiSchema array icons 1`] = `
                       data-icon="arrow-up"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M214.6 17.4c-12.5-12.5-32.8-12.5-45.3 0l-160 160c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 117.3 160 488c0 17.7 14.3 32 32 32s32-14.3 32-32l0-370.7 105.4 105.4c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3l-160-160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -3610,13 +3538,11 @@ exports[`with title and description from uiSchema array icons 1`] = `
                       data-icon="arrow-down"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M169.4 502.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 402.7 224 32c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 370.7-105.4-105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -3635,13 +3561,11 @@ exports[`with title and description from uiSchema array icons 1`] = `
                       data-icon="copy"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-200.6c0-17.4-7.1-34.1-19.7-46.2L370.6 17.8C358.7 6.4 342.8 0 326.3 0L192 0zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-16-64 0 0 16-192 0 0-256 16 0 0-64-16 0z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -3660,13 +3584,11 @@ exports[`with title and description from uiSchema array icons 1`] = `
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -3698,13 +3620,11 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>
@@ -4156,13 +4076,11 @@ exports[`with title and description with global label off array 1`] = `
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>
@@ -4298,13 +4216,11 @@ exports[`with title and description with global label off array icons 1`] = `
                       data-icon="arrow-up"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M214.6 17.4c-12.5-12.5-32.8-12.5-45.3 0l-160 160c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 117.3 160 488c0 17.7 14.3 32 32 32s32-14.3 32-32l0-370.7 105.4 105.4c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3l-160-160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -4323,13 +4239,11 @@ exports[`with title and description with global label off array icons 1`] = `
                       data-icon="arrow-down"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M169.4 502.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 402.7 224 32c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 370.7-105.4-105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -4348,13 +4262,11 @@ exports[`with title and description with global label off array icons 1`] = `
                       data-icon="copy"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-200.6c0-17.4-7.1-34.1-19.7-46.2L370.6 17.8C358.7 6.4 342.8 0 326.3 0L192 0zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-16-64 0 0 16-192 0 0-256 16 0 0-64-16 0z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -4373,13 +4285,11 @@ exports[`with title and description with global label off array icons 1`] = `
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -4465,13 +4375,11 @@ exports[`with title and description with global label off array icons 1`] = `
                       data-icon="arrow-up"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M214.6 17.4c-12.5-12.5-32.8-12.5-45.3 0l-160 160c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L160 117.3 160 488c0 17.7 14.3 32 32 32s32-14.3 32-32l0-370.7 105.4 105.4c12.5 12.5 32.8 12.5 45.3 0s12.5-32.8 0-45.3l-160-160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -4490,13 +4398,11 @@ exports[`with title and description with global label off array icons 1`] = `
                       data-icon="arrow-down"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 384 512"
                     >
                       <path
                         d="M169.4 502.6c12.5 12.5 32.8 12.5 45.3 0l160-160c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L224 402.7 224 32c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 370.7-105.4-105.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l160 160z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -4515,13 +4421,11 @@ exports[`with title and description with global label off array icons 1`] = `
                       data-icon="copy"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M192 0c-35.3 0-64 28.7-64 64l0 256c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-200.6c0-17.4-7.1-34.1-19.7-46.2L370.6 17.8C358.7 6.4 342.8 0 326.3 0L192 0zM64 128c-35.3 0-64 28.7-64 64L0 448c0 35.3 28.7 64 64 64l192 0c35.3 0 64-28.7 64-64l0-16-64 0 0 16-192 0 0-256 16 0 0-64-16 0z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -4540,13 +4444,11 @@ exports[`with title and description with global label off array icons 1`] = `
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -4578,13 +4480,11 @@ exports[`with title and description with global label off array icons 1`] = `
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>

--- a/packages/daisyui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/daisyui/test/__snapshots__/Form.test.tsx.snap
@@ -1011,13 +1011,11 @@ exports[`single fields format date 1`] = `
               data-icon="calendar"
               data-prefix="fas"
               role="img"
-              style={{}}
               viewBox="0 0 448 512"
             >
               <path
                 d="M128 0C110.3 0 96 14.3 96 32l0 32-32 0C28.7 64 0 92.7 0 128l0 48 448 0 0-48c0-35.3-28.7-64-64-64l-32 0 0-32c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 32-128 0 0-32c0-17.7-14.3-32-32-32zM0 224L0 416c0 35.3 28.7 64 64 64l320 0c35.3 0 64-28.7 64-64l0-192-448 0z"
                 fill="currentColor"
-                style={{}}
               />
             </svg>
           </div>
@@ -1098,13 +1096,11 @@ exports[`single fields format datetime 1`] = `
               data-icon="calendar"
               data-prefix="fas"
               role="img"
-              style={{}}
               viewBox="0 0 448 512"
             >
               <path
                 d="M128 0C110.3 0 96 14.3 96 32l0 32-32 0C28.7 64 0 92.7 0 128l0 48 448 0 0-48c0-35.3-28.7-64-64-64l-32 0 0-32c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 32-128 0 0-32c0-17.7-14.3-32-32-32zM0 224L0 416c0 35.3 28.7 64 64 64l320 0c35.3 0 64-28.7 64-64l0-192-448 0z"
                 fill="currentColor"
-                style={{}}
               />
             </svg>
           </div>

--- a/packages/daisyui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/daisyui/test/__snapshots__/Object.test.tsx.snap
@@ -132,13 +132,11 @@ exports[`object fields additionalProperties 1`] = `
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -170,13 +168,11 @@ exports[`object fields additionalProperties 1`] = `
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>
@@ -529,13 +525,11 @@ exports[`object fields show add button and fields if additionalProperties is tru
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -567,13 +561,11 @@ exports[`object fields show add button and fields if additionalProperties is tru
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>
@@ -763,13 +755,11 @@ exports[`object fields with title and description additionalProperties 1`] = `
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -801,13 +791,11 @@ exports[`object fields with title and description additionalProperties 1`] = `
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>
@@ -997,13 +985,11 @@ exports[`object fields with title and description from both additionalProperties
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -1035,13 +1021,11 @@ exports[`object fields with title and description from both additionalProperties
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>
@@ -1440,13 +1424,11 @@ exports[`object fields with title and description from uiSchema additionalProper
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -1478,13 +1460,11 @@ exports[`object fields with title and description from uiSchema additionalProper
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>
@@ -1883,13 +1863,11 @@ exports[`object fields with title and description from uiSchema show add button 
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -1921,13 +1899,11 @@ exports[`object fields with title and description from uiSchema show add button 
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>
@@ -2326,13 +2302,11 @@ exports[`object fields with title and description show add button and fields if 
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -2364,13 +2338,11 @@ exports[`object fields with title and description show add button and fields if 
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>
@@ -2527,13 +2499,11 @@ exports[`object fields with title and description with global label off addition
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -2565,13 +2535,11 @@ exports[`object fields with title and description with global label off addition
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>
@@ -2894,13 +2862,11 @@ exports[`object fields with title and description with global label off show add
                       data-icon="trash"
                       data-prefix="fas"
                       role="img"
-                      style={{}}
                       viewBox="0 0 448 512"
                     >
                       <path
                         d="M136.7 5.9L128 32 32 32C14.3 32 0 46.3 0 64S14.3 96 32 96l384 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-96 0-8.7-26.1C306.9-7.2 294.7-16 280.9-16L167.1-16c-13.8 0-26 8.8-30.4 21.9zM416 144L32 144 53.1 467.1C54.7 492.4 75.7 512 101 512L347 512c25.3 0 46.3-19.6 47.9-44.9L416 144z"
                         fill="currentColor"
-                        style={{}}
                       />
                     </svg>
                   </button>
@@ -2932,13 +2898,11 @@ exports[`object fields with title and description with global label off show add
                     data-icon="plus"
                     data-prefix="fas"
                     role="img"
-                    style={{}}
                     viewBox="0 0 448 512"
                   >
                     <path
                       d="M256 64c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 160-160 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l160 0 0 160c0 17.7 14.3 32 32 32s32-14.3 32-32l0-160 160 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-160 0 0-160z"
                       fill="currentColor"
-                      style={{}}
                     />
                   </svg>
                 </button>


### PR DESCRIPTION

### Reasons for making this change

Bumps [@fortawesome/react-fontawesome](https://github.com/FortAwesome/react-fontawesome) from 0.2.6 to 3.0.2.
- [Release notes](https://github.com/FortAwesome/react-fontawesome/releases)
- [Changelog](https://github.com/FortAwesome/react-fontawesome/blob/main/CHANGELOG.md)
- [Commits](https://github.com/FortAwesome/react-fontawesome/compare/0.2.6...v3.0.2)

---
updated-dependencies:
- dependency-name: "@fortawesome/react-fontawesome" dependency-version: 3.0.2 dependency-type: direct:production update-type: version-update:semver-major ...

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
