### PR TITLE
Fixed optional data controls images in docs

### DIFF
--- a/packages/docs/docs/api-reference/uiSchema.md
+++ b/packages/docs/docs/api-reference/uiSchema.md
@@ -310,11 +310,11 @@ render(
 
 #### Add Optional Data Controls
 
-<img width="600" alt="add optional data controls" src="./OptionalDataControlsAdd.png" />
+![add optional data controls](./OptionalDataControlsAdd.png)
 
 #### Remove Optional Data Controls
 
-<img width="600" alt="remove optional data controls" src="./OptionalDataControlsRemove.png" />
+![remove optional data controls](./OptionalDataControlsRemove.png)
 
 ### emptyValue
 


### PR DESCRIPTION
### Reasons for making this change

Fixed the syntax for the optional data controls to use the proper Markdown syntax per their [docs](https://docusaurus.io/docs/markdown-features/assets#images)

right now they are broken, see the [docs](https://rjsf-team.github.io/react-jsonschema-form/docs/api-reference/uiSchema#add-optional-data-controls)

### Checklist

- [x] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature

Before:

<img width="267" height="162" alt="Screenshot 2025-10-08 at 3 29 21 PM" src="https://github.com/user-attachments/assets/fe11ef71-8fcb-4d2a-9504-686e943a6788" />

After:

<img width="907" height="781" alt="Screenshot 2025-10-08 at 3 30 01 PM" src="https://github.com/user-attachments/assets/22b5c5b3-f6f8-4f32-a311-c56cacacdd27" />

