### PR TITLE
Chore: cleaned up unnecessary formContext and IdSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,30 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # 6.0.0-beta.22
 
+## @rjsf/antd
+
+- Updated most of the widgets to get `formContext` from the `registry` instead of the `props` since it will no longer be passed
+
 ## @rjsf/core
 
 - Updated `MultiSchemaField` and `SchemaField` to properly display `anyOf`/`oneOf` optional data fields by hiding the label and selector control when it is an optional field AND there is no form data
+- Updated `ArrayField`, `BooleanField`, `LayoutMultiSchemaField`, `MultiSchemaField`, `ObjectField`, `SchemaField`, `StringField` and `BaseInputTemplate` to remove `formContext` from the props
+
+## @rjsf/daisyui
+
+- Updated the test mocks to remove `formContext` for the widget mock
+
+## @rjsf/mui
+
+- Updated `BaseInputTemplate` and `SelectWidget` to remove `formContext` from the props
+
+## @rjsf/primereact
+
+- Updated `SelectWidget` to remove `formContext` from the props
+
+## @rjsf/shadcn
+
+- Updated the test mocks to remove `formContext` for the widget mock and added `globalFormOptions` in the registry mock
 
 ## Dev / docs / playground
 - Updated the `formTests.tsx` snapshots to add an `anyOf` of all arrays with different item types and removed the disabling of the optional data controls feature for the optional object with oneOfs
@@ -27,6 +48,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated the playground to make the same changes as `formTests.tsx` in the `optionalDataControls.ts` sample, moving the `experimental_defaultFormStateBehavior` inside of a `liveSettings` block
 - Updated the `Sample` and `LiveSettings` types to support the `liveSettings` inside of a sample
 - Updated the `Playground`'s `onSampleSelected` callback to merge any `liveSettings` in the sample on top of those already used in the playground
+- Updated the `customFieldAnyOf` sample to switch `IdSchema` to `FieldPathId`
 
 # 6.0.0-beta.21
 

--- a/packages/antd/src/templates/BaseInputTemplate/index.tsx
+++ b/packages/antd/src/templates/BaseInputTemplate/index.tsx
@@ -28,7 +28,7 @@ export default function BaseInputTemplate<
 >(props: BaseInputTemplateProps<T, S, F>) {
   const {
     disabled,
-    formContext,
+    registry,
     id,
     onBlur,
     onChange,
@@ -41,6 +41,7 @@ export default function BaseInputTemplate<
     value,
     type,
   } = props;
+  const { formContext } = registry;
   const inputProps = getInputProps<T, S, F>(schema, type, options, false);
   const { readonlyAsDisabled = true } = formContext as GenericObjectType;
 

--- a/packages/antd/src/widgets/AltDateWidget/index.tsx
+++ b/packages/antd/src/widgets/AltDateWidget/index.tsx
@@ -34,21 +34,8 @@ export default function AltDateWidget<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: WidgetProps<T, S, F>) {
-  const {
-    autofocus,
-    disabled,
-    formContext,
-    id,
-    onBlur,
-    onChange,
-    onFocus,
-    options,
-    readonly,
-    registry,
-    showTime,
-    value,
-  } = props;
-  const { translateString, widgets } = registry;
+  const { autofocus, disabled, id, onBlur, onChange, onFocus, options, readonly, registry, showTime, value } = props;
+  const { formContext, translateString, widgets } = registry;
   const { SelectWidget } = widgets;
   const { rowGutter = 24 } = formContext as GenericObjectType;
 

--- a/packages/antd/src/widgets/CheckboxWidget/index.tsx
+++ b/packages/antd/src/widgets/CheckboxWidget/index.tsx
@@ -20,7 +20,8 @@ export default function CheckboxWidget<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: WidgetProps<T, S, F>) {
-  const { autofocus, disabled, formContext, id, label, hideLabel, onBlur, onChange, onFocus, readonly, value } = props;
+  const { autofocus, disabled, registry, id, label, hideLabel, onBlur, onChange, onFocus, readonly, value } = props;
+  const { formContext } = registry;
   const { readonlyAsDisabled = true } = formContext as GenericObjectType;
 
   const handleChange: NonNullable<CheckboxProps['onChange']> = ({ target }) => onChange(target.checked);

--- a/packages/antd/src/widgets/CheckboxesWidget/index.tsx
+++ b/packages/antd/src/widgets/CheckboxesWidget/index.tsx
@@ -21,7 +21,8 @@ export default function CheckboxesWidget<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
->({ autofocus, disabled, formContext, id, onBlur, onChange, onFocus, options, readonly, value }: WidgetProps<T, S, F>) {
+>({ autofocus, disabled, registry, id, onBlur, onChange, onFocus, options, readonly, value }: WidgetProps<T, S, F>) {
+  const { formContext } = registry;
   const { readonlyAsDisabled = true } = formContext as GenericObjectType;
 
   const { enumOptions, enumDisabled, inline, emptyValue } = options;

--- a/packages/antd/src/widgets/DateTimeWidget/index.tsx
+++ b/packages/antd/src/widgets/DateTimeWidget/index.tsx
@@ -24,7 +24,8 @@ export default function DateTimeWidget<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: WidgetProps<T, S, F>) {
-  const { disabled, formContext, id, onBlur, onChange, onFocus, placeholder, readonly, value } = props;
+  const { disabled, registry, id, onBlur, onChange, onFocus, placeholder, readonly, value } = props;
+  const { formContext } = registry;
   const { readonlyAsDisabled = true } = formContext as GenericObjectType;
 
   const handleChange = (nextValue: any) => onChange(nextValue && nextValue.toISOString());

--- a/packages/antd/src/widgets/DateWidget/index.tsx
+++ b/packages/antd/src/widgets/DateWidget/index.tsx
@@ -22,7 +22,8 @@ const DATE_PICKER_STYLE = {
 export default function DateWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>(
   props: WidgetProps<T, S, F>,
 ) {
-  const { disabled, formContext, id, onBlur, onChange, onFocus, placeholder, readonly, value } = props;
+  const { disabled, registry, id, onBlur, onChange, onFocus, placeholder, readonly, value } = props;
+  const { formContext } = registry;
   const { readonlyAsDisabled = true } = formContext as GenericObjectType;
 
   const handleChange = (nextValue: any) => onChange(nextValue && nextValue.format('YYYY-MM-DD'));

--- a/packages/antd/src/widgets/PasswordWidget/index.tsx
+++ b/packages/antd/src/widgets/PasswordWidget/index.tsx
@@ -18,7 +18,8 @@ export default function PasswordWidget<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: WidgetProps<T, S, F>) {
-  const { disabled, formContext, id, onBlur, onChange, onFocus, options, placeholder, readonly, value } = props;
+  const { disabled, registry, id, onBlur, onChange, onFocus, options, placeholder, readonly, value } = props;
+  const { formContext } = registry;
   const { readonlyAsDisabled = true } = formContext as GenericObjectType;
 
   const emptyValue = options.emptyValue || '';

--- a/packages/antd/src/widgets/RadioWidget/index.tsx
+++ b/packages/antd/src/widgets/RadioWidget/index.tsx
@@ -20,7 +20,7 @@ import {
 export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>({
   autofocus,
   disabled,
-  formContext,
+  registry,
   id,
   onBlur,
   onChange,
@@ -29,6 +29,7 @@ export default function RadioWidget<T = any, S extends StrictRJSFSchema = RJSFSc
   readonly,
   value,
 }: WidgetProps<T, S, F>) {
+  const { formContext } = registry;
   const { readonlyAsDisabled = true } = formContext as GenericObjectType;
 
   const { enumOptions, enumDisabled, emptyValue } = options;

--- a/packages/antd/src/widgets/RangeWidget/index.tsx
+++ b/packages/antd/src/widgets/RangeWidget/index.tsx
@@ -20,7 +20,7 @@ export default function RangeWidget<T = any, S extends StrictRJSFSchema = RJSFSc
   const {
     autofocus,
     disabled,
-    formContext,
+    registry,
     id,
     onBlur,
     onChange,
@@ -31,6 +31,7 @@ export default function RangeWidget<T = any, S extends StrictRJSFSchema = RJSFSc
     schema,
     value,
   } = props;
+  const { formContext } = registry;
   const { readonlyAsDisabled = true } = formContext as GenericObjectType;
 
   const { min, max, step } = rangeSpec(schema);

--- a/packages/antd/src/widgets/SelectWidget/index.tsx
+++ b/packages/antd/src/widgets/SelectWidget/index.tsx
@@ -29,7 +29,7 @@ export default function SelectWidget<
 >({
   autofocus,
   disabled,
-  formContext = {} as F,
+  registry,
   id,
   multiple,
   onBlur,
@@ -41,6 +41,7 @@ export default function SelectWidget<
   value,
   schema,
 }: WidgetProps<T, S, F>) {
+  const { formContext } = registry;
   const { readonlyAsDisabled = true } = formContext as GenericObjectType;
 
   const { enumOptions, enumDisabled, emptyValue } = options;

--- a/packages/antd/src/widgets/TextareaWidget/index.tsx
+++ b/packages/antd/src/widgets/TextareaWidget/index.tsx
@@ -21,18 +21,8 @@ export default function TextareaWidget<
   T = any,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
->({
-  disabled,
-  formContext,
-  id,
-  onBlur,
-  onChange,
-  onFocus,
-  options,
-  placeholder,
-  readonly,
-  value,
-}: WidgetProps<T, S, F>) {
+>({ disabled, registry, id, onBlur, onChange, onFocus, options, placeholder, readonly, value }: WidgetProps<T, S, F>) {
+  const { formContext } = registry;
   const { readonlyAsDisabled = true } = formContext as GenericObjectType;
 
   const handleChange = ({ target }: ChangeEvent<HTMLTextAreaElement>) =>

--- a/packages/core/src/components/fields/ArrayField.tsx
+++ b/packages/core/src/components/fields/ArrayField.tsx
@@ -597,7 +597,7 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
       rawErrors,
       name,
     } = this.props;
-    const { widgets, formContext, globalUiOptions, schemaUtils } = registry;
+    const { widgets, globalUiOptions, schemaUtils } = registry;
     const { widget, title: uiTitle, ...options } = getUiOptions<T[], S, F>(uiSchema, globalUiOptions);
     const Widget = getWidget<T[], S, F>(schema, widget, widgets);
     const label = uiTitle ?? schema.title ?? name;
@@ -622,7 +622,6 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
         label={label}
         hideLabel={!displayLabel}
         placeholder={placeholder}
-        formContext={formContext}
         autofocus={autofocus}
         rawErrors={rawErrors}
       />
@@ -648,7 +647,7 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
       rawErrors,
       name,
     } = this.props;
-    const { widgets, schemaUtils, formContext, globalUiOptions } = registry;
+    const { widgets, schemaUtils, globalUiOptions } = registry;
     const itemsSchema = schemaUtils.retrieveSchema(schema.items as S, items);
     const enumOptions = optionsList<T[], S, F>(itemsSchema, uiSchema);
     const { widget = 'select', title: uiTitle, ...options } = getUiOptions<T[], S, F>(uiSchema, globalUiOptions);
@@ -674,7 +673,6 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
         label={label}
         hideLabel={!displayLabel}
         placeholder={placeholder}
-        formContext={formContext}
         autofocus={autofocus}
         rawErrors={rawErrors}
       />
@@ -699,7 +697,7 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
       formData: items = [],
       rawErrors,
     } = this.props;
-    const { widgets, formContext, globalUiOptions, schemaUtils } = registry;
+    const { widgets, globalUiOptions, schemaUtils } = registry;
     const { widget = 'files', title: uiTitle, ...options } = getUiOptions<T[], S, F>(uiSchema, globalUiOptions);
     const Widget = getWidget<T[], S, F>(schema, widget, widgets);
     const label = uiTitle ?? schema.title ?? name;
@@ -720,7 +718,6 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
         readonly={readonly}
         required={required}
         registry={registry}
-        formContext={formContext}
         autofocus={autofocus}
         rawErrors={rawErrors}
         label={label}
@@ -889,7 +886,7 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
       totalItems,
       title,
     } = props;
-    const { disabled, hideError, readonly, uiSchema, registry, formContext } = this.props;
+    const { disabled, hideError, readonly, uiSchema, registry } = this.props;
     const {
       fields: { ArraySchemaField, SchemaField },
       globalUiOptions,
@@ -914,7 +911,6 @@ class ArrayField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
           schema={itemSchema}
           uiSchema={itemUiSchema}
           formData={itemData}
-          formContext={formContext}
           errorSchema={itemErrorSchema}
           fieldPathId={itemFieldPathId}
           required={this.isItemRequired(itemSchema)}

--- a/packages/core/src/components/fields/BooleanField.tsx
+++ b/packages/core/src/components/fields/BooleanField.tsx
@@ -40,7 +40,7 @@ function BooleanField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
     rawErrors,
   } = props;
   const { title: schemaTitle } = schema;
-  const { widgets, formContext, translateString, globalUiOptions } = registry;
+  const { widgets, translateString, globalUiOptions } = registry;
   const {
     widget = 'checkbox',
     title: uiTitle,
@@ -114,7 +114,6 @@ function BooleanField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extend
       readonly={readonly}
       hideError={hideError}
       registry={registry}
-      formContext={formContext}
       autofocus={autofocus}
       rawErrors={rawErrors}
     />

--- a/packages/core/src/components/fields/LayoutMultiSchemaField.tsx
+++ b/packages/core/src/components/fields/LayoutMultiSchemaField.tsx
@@ -104,7 +104,6 @@ export default function LayoutMultiSchemaField<
     registry,
     uiSchema,
     schema,
-    formContext,
     autofocus,
     readonly,
     required,
@@ -206,7 +205,6 @@ export default function LayoutMultiSchemaField<
         label={(title || schema.title) ?? ''}
         disabled={disabled || (Array.isArray(enumOptions) && isEmpty(enumOptions))}
         uiSchema={uiSchema}
-        formContext={formContext}
         autofocus={autofocus}
         readonly={readonly}
         required={required}

--- a/packages/core/src/components/fields/MultiSchemaField.tsx
+++ b/packages/core/src/components/fields/MultiSchemaField.tsx
@@ -149,7 +149,6 @@ class AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
       name,
       disabled = false,
       errorSchema = {},
-      formContext,
       formData,
       onBlur,
       onFocus,
@@ -244,7 +243,6 @@ class AnyOfField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends For
           value={selectedOption >= 0 ? selectedOption : undefined}
           options={{ enumOptions, ...uiOptions }}
           registry={registry}
-          formContext={formContext}
           placeholder={placeholder}
           autocomplete={autocomplete}
           autofocus={autofocus}

--- a/packages/core/src/components/fields/ObjectField.tsx
+++ b/packages/core/src/components/fields/ObjectField.tsx
@@ -242,7 +242,7 @@ class ObjectField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
       title,
     } = this.props;
 
-    const { fields, formContext, schemaUtils, translateString, globalFormOptions, globalUiOptions } = registry;
+    const { fields, schemaUtils, translateString, globalFormOptions, globalUiOptions } = registry;
     const { OptionalDataControlsField, SchemaField } = fields;
     const schema: S = schemaUtils.retrieveSchema(rawSchema, formData, true);
     const uiOptions = getUiOptions<T, S, F>(uiSchema, globalUiOptions);
@@ -297,7 +297,6 @@ class ObjectField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
               errorSchema={get(errorSchema, name)}
               fieldPathId={innerFieldIdPathId}
               formData={get(formData, name)}
-              formContext={formContext}
               wasPropertyKeyModified={this.state.wasPropertyKeyModified}
               onKeyChange={this.onKeyChange(name)}
               onChange={this.onPropertyChange(name, addedByAdditionalProperties)}
@@ -325,7 +324,6 @@ class ObjectField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends Fo
       errorSchema,
       schema,
       formData,
-      formContext,
       registry,
       optionalDataControl,
       className: renderOptionalField ? 'rjsf-optional-object-field' : undefined,

--- a/packages/core/src/components/fields/SchemaField.tsx
+++ b/packages/core/src/components/fields/SchemaField.tsx
@@ -123,7 +123,7 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
     registry,
     wasPropertyKeyModified = false,
   } = props;
-  const { formContext, schemaUtils, globalUiOptions, fields } = registry;
+  const { schemaUtils, globalUiOptions, fields } = registry;
   const { AnyOfField: _AnyOfField, OneOfField: _OneOfField } = fields;
   const uiOptions = getUiOptions<T, S, F>(uiSchema, globalUiOptions);
   const FieldTemplate = getTemplate<'FieldTemplate', T, S, F>('FieldTemplate', registry, uiOptions);
@@ -204,7 +204,6 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
       hideError={hideError}
       autofocus={autofocus}
       errorSchema={fieldErrorSchema as ErrorSchema}
-      formContext={formContext}
       rawErrors={__errors}
     />
   );
@@ -305,7 +304,6 @@ function SchemaFieldRender<T = any, S extends StrictRJSFSchema = RJSFSchema, F e
             hideError={hideError}
             errorSchema={errorSchema}
             formData={formData}
-            formContext={formContext}
             fieldPathId={fieldPathId}
             onBlur={props.onBlur}
             onChange={props.onChange}

--- a/packages/core/src/components/fields/StringField.tsx
+++ b/packages/core/src/components/fields/StringField.tsx
@@ -36,7 +36,7 @@ function StringField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends
     hideError,
   } = props;
   const { title, format } = schema;
-  const { widgets, formContext, schemaUtils, globalUiOptions } = registry;
+  const { widgets, schemaUtils, globalUiOptions } = registry;
   const enumOptions = schemaUtils.isSelect(schema) ? optionsList<T, S, F>(schema, uiSchema) : undefined;
   let defaultWidget = enumOptions ? 'select' : 'text';
   if (format && hasWidget<T, S, F>(schema, format, widgets)) {
@@ -70,7 +70,6 @@ function StringField<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends
       required={required}
       disabled={disabled}
       readonly={readonly}
-      formContext={formContext}
       autofocus={autofocus}
       registry={registry}
       placeholder={placeholder}

--- a/packages/core/src/components/templates/BaseInputTemplate.tsx
+++ b/packages/core/src/components/templates/BaseInputTemplate.tsx
@@ -34,7 +34,6 @@ export default function BaseInputTemplate<
     options,
     schema,
     uiSchema,
-    formContext,
     registry,
     rawErrors,
     type,

--- a/packages/core/test/LayoutGridField.test.tsx
+++ b/packages/core/test/LayoutGridField.test.tsx
@@ -830,7 +830,6 @@ describe('LayoutGridField', () => {
       formData,
       errorSchema,
       fieldPathId: FIELD_PATH_ID,
-      formContext: registry.formContext,
       registry,
       schema,
       uiSchema,

--- a/packages/core/test/LayoutHeaderField.test.tsx
+++ b/packages/core/test/LayoutHeaderField.test.tsx
@@ -37,7 +37,6 @@ describe('LayoutHeaderField', () => {
       autofocus: false,
       disabled: false,
       errorSchema: {},
-      formContext: undefined,
       formData: undefined,
       onBlur: noop,
       onChange: noop,

--- a/packages/core/test/LayoutMultiSchemaField.test.tsx
+++ b/packages/core/test/LayoutMultiSchemaField.test.tsx
@@ -195,7 +195,6 @@ describe('LayoutMultiSchemaField', () => {
     return {
       // required FieldProps stubbed
       autofocus,
-      formContext: {},
       name: '',
       readonly: false,
       required,

--- a/packages/daisyui/test/helpers/createMocks.ts
+++ b/packages/daisyui/test/helpers/createMocks.ts
@@ -55,7 +55,6 @@ export function makeWidgetMockProps(props: Partial<WidgetProps> = {}): WidgetPro
     rawErrors: [''],
     value: 'test-value',
     options: {},
-    formContext: {},
     id: 'test-id',
     name: 'test-name',
     placeholder: 'Enter value...',

--- a/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
+++ b/packages/mui/src/BaseInputTemplate/BaseInputTemplate.tsx
@@ -46,7 +46,6 @@ export default function BaseInputTemplate<
     uiSchema,
     rawErrors = [],
     errorSchema,
-    formContext,
     registry,
     InputLabelProps,
     ...textFieldProps

--- a/packages/mui/src/SelectWidget/SelectWidget.tsx
+++ b/packages/mui/src/SelectWidget/SelectWidget.tsx
@@ -43,7 +43,6 @@ export default function SelectWidget<
   registry,
   uiSchema,
   hideError,
-  formContext,
   ...textFieldProps
 }: WidgetProps<T, S, F>) {
   const { enumOptions, enumDisabled, emptyValue: optEmptyVal } = options;

--- a/packages/playground/src/samples/customFieldAnyOf.tsx
+++ b/packages/playground/src/samples/customFieldAnyOf.tsx
@@ -1,4 +1,4 @@
-import { FieldProps, FieldTemplateProps, ID_KEY, IdSchema, RJSFSchema, getTemplate } from '@rjsf/utils';
+import { FieldProps, FieldTemplateProps, ID_KEY, FieldPathId, RJSFSchema, getTemplate } from '@rjsf/utils';
 import noop from 'lodash/noop';
 
 import { Sample } from './Sample';
@@ -23,15 +23,14 @@ function UiField(props: FieldProps) {
   const citySchema = schemaUtils.findFieldInSchema(schema1, cityKey, {} as RJSFSchema);
   const latSchema = schemaUtils.findFieldInSchema(schema2, latKey, {} as RJSFSchema);
   const lonSchema = schemaUtils.findFieldInSchema(schema2, lonKey, {} as RJSFSchema);
-  const cityIdSchema: IdSchema = { [ID_KEY]: cityKey };
-  const latIdSchema: IdSchema = { [ID_KEY]: latKey };
-  const lonIdSchema: IdSchema = { [ID_KEY]: lonKey };
+  const cityFieldPathId: FieldPathId = { [ID_KEY]: cityKey, path: [cityKey] };
+  const latFieldPathId: FieldPathId = { [ID_KEY]: latKey, path: [latKey] };
+  const lonFieldPathId: FieldPathId = { [ID_KEY]: lonKey, path: [lonKey] };
 
   const fieldTemplateProps: Omit<FieldTemplateProps, 'label' | 'id' | 'children'> = {
     registry,
     schema,
     uiSchema,
-    formContext: props.formContext,
     displayLabel: true,
     disabled: false,
     readonly: false,
@@ -52,14 +51,14 @@ function UiField(props: FieldProps) {
             margin: '1rem',
           }}
         >
-          <FieldTemplate {...fieldTemplateProps} id={cityIdSchema[ID_KEY]} label={cityLabel}>
+          <FieldTemplate {...fieldTemplateProps} id={cityFieldPathId[ID_KEY]} label={cityLabel}>
             <StringField
               schema={citySchema.field!}
               registry={registry}
               {...otherProps}
               name={cityLabel}
               required={citySchema.isRequired}
-              fieldPathId={cityIdSchema}
+              fieldPathId={cityFieldPathId}
               formData={formData.city}
               onChange={changeHandlerFactory(cityKey)}
             />
@@ -73,26 +72,26 @@ function UiField(props: FieldProps) {
             margin: '1rem',
           }}
         >
-          <FieldTemplate {...fieldTemplateProps} id={latIdSchema[ID_KEY]} label={latLabel}>
+          <FieldTemplate {...fieldTemplateProps} id={latFieldPathId[ID_KEY]} label={latLabel}>
             <NumberField
               schema={latSchema.field!}
               registry={registry}
               {...otherProps}
               name={latLabel}
               required={latSchema.isRequired}
-              fieldPathId={latIdSchema}
+              fieldPathId={latFieldPathId}
               formData={formData.lat}
               onChange={changeHandlerFactory(latKey)}
             />
           </FieldTemplate>
-          <FieldTemplate {...fieldTemplateProps} id={lonIdSchema[ID_KEY]} label={lonLabel}>
+          <FieldTemplate {...fieldTemplateProps} id={lonFieldPathId[ID_KEY]} label={lonLabel}>
             <NumberField
               schema={lonSchema.field!}
               registry={registry}
               {...otherProps}
               name={lonLabel}
               required={lonSchema.isRequired}
-              fieldPathId={lonIdSchema}
+              fieldPathId={lonFieldPathId}
               formData={formData.lon}
               onChange={changeHandlerFactory(lonKey)}
             />

--- a/packages/primereact/src/SelectWidget/SelectWidget.tsx
+++ b/packages/primereact/src/SelectWidget/SelectWidget.tsx
@@ -46,7 +46,6 @@ function SingleSelectWidget<T = any, S extends StrictRJSFSchema = RJSFSchema, F 
   registry,
   uiSchema,
   hideError,
-  formContext,
   ...dropdownProps
 }: WidgetProps<T, S, F>) {
   const { enumOptions, enumDisabled, emptyValue: optEmptyVal } = options;

--- a/packages/shadcn/test/helpers/createMocks.ts
+++ b/packages/shadcn/test/helpers/createMocks.ts
@@ -1,4 +1,11 @@
-import { createSchemaUtils, englishStringTranslator, WidgetProps, RJSFSchema } from '@rjsf/utils';
+import {
+  createSchemaUtils,
+  englishStringTranslator,
+  WidgetProps,
+  RJSFSchema,
+  DEFAULT_ID_SEPARATOR,
+  DEFAULT_ID_PREFIX,
+} from '@rjsf/utils';
 import { getDefaultRegistry } from '@rjsf/core';
 import validator from '@rjsf/validator-ajv8';
 
@@ -25,6 +32,7 @@ export function mockRegistry() {
     rootSchema: {},
     schemaUtils: mockSchemaUtils,
     translateString: englishStringTranslator,
+    globalFormOptions: { idPrefix: DEFAULT_ID_PREFIX, idSeparator: DEFAULT_ID_SEPARATOR },
   };
 }
 
@@ -44,7 +52,6 @@ export function makeWidgetMockProps(props: Partial<WidgetProps> = {}): WidgetPro
     rawErrors: [''],
     value: 'value',
     options: {},
-    formContext: {},
     id: '_id',
     name: '_name',
     placeholder: '',


### PR DESCRIPTION

### Reasons for making this change

There were still some places were the `formContext` was being obtained from or passed as props

- In `@rjsf/antd` replaced getting `formContext` from props with getting it from the registry
- In `@rjsf/core` removed the passing of `formContext` as props as well as replaced getting `formContext` from props with getting it from the registry
- In `@rjsf/daisyui` removed the passing of `formContext` as props in the mocks
- In `@rjsf/mui` removed the getting of `formContext` from the props
- In `playground` replaced a few `IdSchema` uses with `FieldPathId`
- In `@rjsf/primereact` removed the getting of `formContext` from the props
- In `@rjsf/shadcn` removed the passing of `formContext` as props in the mocks and added missing `globalFormOptions` in the registry mock

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
