### PR TITLE
fix(mantine): early return if no help defined

### DIFF
--- a/packages/mantine/src/templates/FieldHelpTemplate.tsx
+++ b/packages/mantine/src/templates/FieldHelpTemplate.tsx
@@ -12,9 +12,13 @@ export default function FieldHelpTemplate<
 >(props: FieldHelpProps<T, S, F>) {
   const { fieldPathId, help } = props;
 
+  if (!help) {
+    return null;
+  }
+
   const id = helpId(fieldPathId);
 
-  return !help ? null : (
+  return (
     <Text id={id} size='sm' my='xs' c='dimmed'>
       {help}
     </Text>


### PR DESCRIPTION
When `fieldPathId` is undefined, `helpId` will throw an undefined value error.

The other `FieldHelpTemplate.tsx` files guard against this with an early return.

### Reasons for making this change

Found this while trying the Mantine theme with a quickstart/simple string schema and it would not load the form because of this.

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
