### PR TITLE
Chore restore lost playground option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38752,10 +38752,10 @@
       },
       "devDependencies": {
         "@ant-design/icons": "^6.1.0",
-        "@rjsf/core": "6.x",
-        "@rjsf/snapshot-tests": "6.x",
-        "@rjsf/utils": "6.x",
-        "@rjsf/validator-ajv8": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/snapshot-tests": "^6.x",
+        "@rjsf/utils": "^6.x",
+        "@rjsf/validator-ajv8": "^6.x",
         "@rollup/plugin-replace": "^6.0.3",
         "antd": "^5.27.6",
         "atob": "^2.1.2",
@@ -38767,8 +38767,8 @@
       },
       "peerDependencies": {
         "@ant-design/icons": "^6.0.0",
-        "@rjsf/core": "6.x",
-        "@rjsf/utils": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/utils": "^6.x",
         "antd": "^5.8.5",
         "dayjs": "^1.8.0",
         "react": ">=18"
@@ -38789,10 +38789,10 @@
         "@emotion/eslint-plugin": "^11.12.0",
         "@emotion/jest": "^11.13.0",
         "@emotion/react": "^11.14.0",
-        "@rjsf/core": "6.x",
-        "@rjsf/snapshot-tests": "6.x",
-        "@rjsf/utils": "6.x",
-        "@rjsf/validator-ajv8": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/snapshot-tests": "^6.x",
+        "@rjsf/utils": "^6.x",
+        "@rjsf/validator-ajv8": "^6.x",
         "chakra-react-select": "^6.1.0",
         "eslint": "^8.57.1"
       },
@@ -38801,8 +38801,8 @@
       },
       "peerDependencies": {
         "@chakra-ui/react": ">=3.16.1",
-        "@rjsf/core": "6.x",
-        "@rjsf/utils": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/utils": "^6.x",
         "chakra-react-select": ">=6",
         "react": ">=18"
       }
@@ -38818,9 +38818,9 @@
         "prop-types": "^15.8.1"
       },
       "devDependencies": {
-        "@rjsf/snapshot-tests": "6.x",
-        "@rjsf/utils": "6.x",
-        "@rjsf/validator-ajv8": "6.x",
+        "@rjsf/snapshot-tests": "^6.x",
+        "@rjsf/utils": "^6.x",
+        "@rjsf/validator-ajv8": "^6.x",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -38838,7 +38838,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@rjsf/utils": "6.x",
+        "@rjsf/utils": "^6.x",
         "react": ">=18"
       }
     },
@@ -39052,10 +39052,10 @@
         "tailwindcss": "^4.1.12"
       },
       "devDependencies": {
-        "@rjsf/core": "6.x",
-        "@rjsf/snapshot-tests": "6.x",
-        "@rjsf/utils": "6.x",
-        "@rjsf/validator-ajv8": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/snapshot-tests": "^6.x",
+        "@rjsf/utils": "^6.x",
+        "@rjsf/validator-ajv8": "^6.x",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
@@ -39065,8 +39065,8 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@rjsf/core": "6.x",
-        "@rjsf/utils": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/utils": "^6.x",
         "daisyui": "^5.0.29",
         "react": ">=18"
       }
@@ -39097,10 +39097,10 @@
         "@fluentui/react-components": "^9.72.3",
         "@fluentui/react-icons": "^2.0.313",
         "@fluentui/react-migration-v0-v9": "^9.6.11",
-        "@rjsf/core": "6.x",
-        "@rjsf/snapshot-tests": "6.x",
-        "@rjsf/utils": "6.x",
-        "@rjsf/validator-ajv8": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/snapshot-tests": "^6.x",
+        "@rjsf/utils": "^6.x",
+        "@rjsf/validator-ajv8": "^6.x",
         "eslint": "^8.57.1"
       },
       "engines": {
@@ -39110,8 +39110,8 @@
         "@fluentui/react-components": "^9.63.0",
         "@fluentui/react-icons": "^2.0.298",
         "@fluentui/react-migration-v0-v9": "^9.3.10",
-        "@rjsf/core": "6.x",
-        "@rjsf/utils": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/utils": "^6.x",
         "react": ">=18"
       }
     },
@@ -39125,10 +39125,10 @@
         "@mantine/hooks": "^8.3.6",
         "@restart/hooks": "^0.6.2",
         "@restart/ui": "^1.9.4",
-        "@rjsf/core": "6.x",
-        "@rjsf/snapshot-tests": "6.x",
-        "@rjsf/utils": "6.x",
-        "@rjsf/validator-ajv8": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/snapshot-tests": "^6.x",
+        "@rjsf/utils": "^6.x",
+        "@rjsf/validator-ajv8": "^6.x",
         "eslint": "^8.57.1",
         "uncontrollable": "^9.0.0"
       },
@@ -39139,8 +39139,8 @@
         "@mantine/core": ">=8",
         "@mantine/dates": ">=8",
         "@mantine/hooks": ">=8",
-        "@rjsf/core": "6.x",
-        "@rjsf/utils": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/utils": "^6.x",
         "react": ">=18"
       }
     },
@@ -39154,10 +39154,10 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^7.3.4",
         "@mui/material": "^7.3.4",
-        "@rjsf/core": "6.x",
-        "@rjsf/snapshot-tests": "6.x",
-        "@rjsf/utils": "6.x",
-        "@rjsf/validator-ajv8": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/snapshot-tests": "^6.x",
+        "@rjsf/utils": "^6.x",
+        "@rjsf/validator-ajv8": "^6.x",
         "eslint": "^8.57.1"
       },
       "engines": {
@@ -39168,8 +39168,8 @@
         "@emotion/styled": "^11.6.0",
         "@mui/icons-material": "^7.0.0",
         "@mui/material": "^7.0.0",
-        "@rjsf/core": "6.x",
-        "@rjsf/utils": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/utils": "^6.x",
         "react": ">=18"
       }
     },
@@ -39186,16 +39186,16 @@
         "@mantine/dates": "^8.3.6",
         "@mantine/hooks": "^8.3.6",
         "@mui/material": "^7.3.4",
-        "@rjsf/antd": "6.x",
-        "@rjsf/chakra-ui": "6.x",
-        "@rjsf/core": "6.x",
-        "@rjsf/fluentui-rc": "6.x",
-        "@rjsf/mui": "6.x",
-        "@rjsf/primereact": "6.x",
-        "@rjsf/react-bootstrap": "6.x",
-        "@rjsf/semantic-ui": "6.x",
-        "@rjsf/utils": "6.x",
-        "@rjsf/validator-ajv8": "6.x",
+        "@rjsf/antd": "^6.x",
+        "@rjsf/chakra-ui": "^6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/fluentui-rc": "^6.x",
+        "@rjsf/mui": "^6.x",
+        "@rjsf/primereact": "^6.x",
+        "@rjsf/react-bootstrap": "^6.x",
+        "@rjsf/semantic-ui": "^6.x",
+        "@rjsf/utils": "^6.x",
+        "@rjsf/validator-ajv8": "^6.x",
         "ajv": "^8.17.1",
         "ajv-i18n": "^4.2.0",
         "antd": "^5.27.6",
@@ -39260,10 +39260,10 @@
       "version": "6.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@rjsf/core": "6.x",
-        "@rjsf/snapshot-tests": "6.x",
-        "@rjsf/utils": "6.x",
-        "@rjsf/validator-ajv8": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/snapshot-tests": "^6.x",
+        "@rjsf/utils": "^6.x",
+        "@rjsf/validator-ajv8": "^6.x",
         "@rollup/plugin-replace": "^6.0.3",
         "eslint": "^8.57.1",
         "primeflex": "^4.0.0",
@@ -39274,8 +39274,8 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@rjsf/core": "6.x",
-        "@rjsf/utils": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/utils": "^6.x",
         "primeicons": ">=6.0.0",
         "primereact": ">=8.0.0",
         "react": ">=18"
@@ -39289,10 +39289,10 @@
         "@react-icons/all-files": "^4.1.0"
       },
       "devDependencies": {
-        "@rjsf/core": "6.x",
-        "@rjsf/snapshot-tests": "6.x",
-        "@rjsf/utils": "6.x",
-        "@rjsf/validator-ajv8": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/snapshot-tests": "^6.x",
+        "@rjsf/utils": "^6.x",
+        "@rjsf/validator-ajv8": "^6.x",
         "eslint": "^8.57.1",
         "react-bootstrap": "^2.10.10"
       },
@@ -39300,8 +39300,8 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@rjsf/core": "6.x",
-        "@rjsf/utils": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/utils": "^6.x",
         "react": ">=18",
         "react-bootstrap": "^2.x"
       }
@@ -39314,10 +39314,10 @@
         "semantic-ui-css": "^2.5.0"
       },
       "devDependencies": {
-        "@rjsf/core": "6.x",
-        "@rjsf/snapshot-tests": "6.x",
-        "@rjsf/utils": "6.x",
-        "@rjsf/validator-ajv8": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/snapshot-tests": "^6.x",
+        "@rjsf/utils": "^6.x",
+        "@rjsf/validator-ajv8": "^6.x",
         "atob": "^2.1.2",
         "eslint": "^8.57.1",
         "semantic-ui-react": "^2.1.5"
@@ -39326,8 +39326,8 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@rjsf/core": "6.x",
-        "@rjsf/utils": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/utils": "^6.x",
         "react": ">=18",
         "semantic-ui-react": "^2.1.3"
       }
@@ -39359,10 +39359,10 @@
         "uuid": "^13.0.0"
       },
       "devDependencies": {
-        "@rjsf/core": "6.x",
-        "@rjsf/snapshot-tests": "6.x",
-        "@rjsf/utils": "6.x",
-        "@rjsf/validator-ajv8": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/snapshot-tests": "^6.x",
+        "@rjsf/utils": "^6.x",
+        "@rjsf/validator-ajv8": "^6.x",
         "@tailwindcss/cli": "^4.1.16",
         "eslint": "^8.57.1",
         "jsdom": "^27.0.1",
@@ -39372,8 +39372,8 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@rjsf/core": "6.x",
-        "@rjsf/utils": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/utils": "^6.x",
         "react": ">=18"
       }
     },
@@ -39579,16 +39579,16 @@
       "version": "6.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@rjsf/core": "6.x",
-        "@rjsf/utils": "6.x",
-        "@rjsf/validator-ajv8": "6.x"
+        "@rjsf/core": "^6.x",
+        "@rjsf/utils": "^6.x",
+        "@rjsf/validator-ajv8": "^6.x"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@rjsf/core": "6.x",
-        "@rjsf/utils": "6.x",
+        "@rjsf/core": "^6.x",
+        "@rjsf/utils": "^6.x",
         "react": ">=18",
         "react-test-renderer": "^18.2.0"
       }
@@ -39640,7 +39640,7 @@
         "lodash-es": "^4.17.21"
       },
       "devDependencies": {
-        "@rjsf/utils": "6.x",
+        "@rjsf/utils": "^6.x",
         "@types/json-schema": "^7.0.15",
         "ajv-i18n": "^4.2.0",
         "eslint": "^8.57.1"
@@ -39649,7 +39649,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@rjsf/utils": "6.x"
+        "@rjsf/utils": "^6.x"
       }
     }
   }

--- a/packages/playground/src/components/OptionsDrawer.tsx
+++ b/packages/playground/src/components/OptionsDrawer.tsx
@@ -75,6 +75,7 @@ const liveSettingsBooleanSchema: RJSFSchema = {
     noValidate: { type: 'boolean', title: 'Disable validation' },
     noHtml5Validate: { type: 'boolean', title: 'Disable HTML 5 validation' },
     focusOnFirstError: { type: 'boolean', title: 'Focus on 1st Error' },
+    useFallbackUiForUnsupportedType: { type: 'boolean', title: 'Use Fallback UI', default: false },
     omitExtraData: { type: 'boolean', title: 'Omit extra data' },
     liveOmit: { type: 'string', title: 'Live omit', default: false, enum: [false, 'onChange', 'onBlur'] },
     liveValidate: { type: 'string', title: 'Live validation', default: false, enum: [false, 'onChange', 'onBlur'] },


### PR DESCRIPTION

### Reasons for making this change

`useFallbackUiForUnsupportedType` got lost in a rebase, restoring

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
