### PR TITLE
Fix 3624 by removing duplicate description render in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,38 +17,10 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # 6.0.2
 
-## @rjsf/shadcn
-
-- Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
-
-## @rjsf/semantic-ui
-
-- Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
-
-## @rjsf/react-bootstrap
-
-- Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
-
-## @rjsf/primereact
-
-- Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
-
-## @rjsf/mui
-
-- Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
-
-## @rjsf/mantine
-
-- Updated `CheckboxWidget` to handle label and description rendering consistently, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
-
-## @rjsf/fluentui-rc
-
-- Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
-
 ## @rjsf/antd
 
 - Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
-
+- Updated `ArrayFieldTemplate` and `ObjectFieldTemplate` to remove the rendering of a duplicate description (since the `FieldTemplate` already does it), fixing [#3624](https://github.com/rjsf-team/react-jsonschema-form/issues/3624)
 
 ## @rjsf/chakra-ui
 
@@ -57,8 +29,40 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 
 - Fixed duplicate label and description rendering in `CheckboxWidget` by conditionally rendering them based on widget type
-  - Updated `CheckboxWidget` to handle label and description rendering consistently
-  - Modified `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+    - Updated `CheckboxWidget` to handle label and description rendering consistently
+    - Modified `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+
+## @rjsf/fluentui-rc
+
+- Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+
+## @rjsf/mantine
+
+- Updated `CheckboxWidget` to handle label and description rendering consistently, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+
+## @rjsf/mui
+
+- Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+
+## @rjsf/primereact
+
+- Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+
+## @rjsf/react-bootstrap
+
+- Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+
+## @rjsf/semantic-ui
+
+- Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+
+## @rjsf/shadcn
+
+- Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+
+## Dev / docs / playground
+
+- Updated the `OptionsDrawer` of the playground to add `idPrefix` and `idSeparator` fields
 
 # 6.0.1
 

--- a/packages/antd/src/templates/ArrayFieldTemplate/index.tsx
+++ b/packages/antd/src/templates/ArrayFieldTemplate/index.tsx
@@ -12,10 +12,6 @@ import classNames from 'classnames';
 import { Col, Row, ConfigProvider } from 'antd';
 import { useContext } from 'react';
 
-const DESCRIPTION_COL_STYLE = {
-  paddingBottom: '8px',
-};
-
 /** The `ArrayFieldTemplate` component is the template used to render all items in an array.
  *
  * @param props - The `ArrayFieldTemplateProps` props for the component
@@ -41,11 +37,6 @@ export default function ArrayFieldTemplate<
     uiSchema,
   } = props;
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
-  const ArrayFieldDescriptionTemplate = getTemplate<'ArrayFieldDescriptionTemplate', T, S, F>(
-    'ArrayFieldDescriptionTemplate',
-    registry,
-    uiOptions,
-  );
   const ArrayFieldTitleTemplate = getTemplate<'ArrayFieldTitleTemplate', T, S, F>(
     'ArrayFieldTitleTemplate',
     registry,
@@ -81,17 +72,6 @@ export default function ArrayFieldTemplate<
               uiSchema={uiSchema}
               registry={registry}
               optionalDataControl={showOptionalDataControlInTitle ? optionalDataControl : undefined}
-            />
-          </Col>
-        )}
-        {(uiOptions.description || schema.description) && (
-          <Col span={24} style={DESCRIPTION_COL_STYLE}>
-            <ArrayFieldDescriptionTemplate
-              description={uiOptions.description || schema.description}
-              fieldPathId={fieldPathId}
-              schema={schema}
-              uiSchema={uiSchema}
-              registry={registry}
             />
           </Col>
         )}

--- a/packages/antd/src/templates/ObjectFieldTemplate/index.tsx
+++ b/packages/antd/src/templates/ObjectFieldTemplate/index.tsx
@@ -11,7 +11,6 @@ import {
   StrictRJSFSchema,
   UiSchema,
   canExpand,
-  descriptionId,
   getTemplate,
   getUiOptions,
   titleId,
@@ -19,10 +18,6 @@ import {
 } from '@rjsf/utils';
 import { Col, Row, ConfigProvider } from 'antd';
 import { useContext } from 'react';
-
-const DESCRIPTION_COL_STYLE = {
-  paddingBottom: '8px',
-};
 
 /** The `ObjectFieldTemplate` is the template to use to render all the inner properties of an object along with the
  * title and description if available. If the object is expandable, then an `AddButton` is also rendered after all
@@ -36,7 +31,6 @@ export default function ObjectFieldTemplate<
   F extends FormContextType = any,
 >(props: ObjectFieldTemplateProps<T, S, F>) {
   const {
-    description,
     disabled,
     formData,
     fieldPathId,
@@ -52,11 +46,6 @@ export default function ObjectFieldTemplate<
   } = props;
   const uiOptions = getUiOptions<T, S, F>(uiSchema);
   const TitleFieldTemplate = getTemplate<'TitleFieldTemplate', T, S, F>('TitleFieldTemplate', registry, uiOptions);
-  const DescriptionFieldTemplate = getTemplate<'DescriptionFieldTemplate', T, S, F>(
-    'DescriptionFieldTemplate',
-    registry,
-    uiOptions,
-  );
   const { formContext } = registry;
   const showOptionalDataControlInTitle = !readonly && !disabled;
   // Button templates are not overridden in the uiSchema
@@ -129,17 +118,6 @@ export default function ObjectFieldTemplate<
               uiSchema={uiSchema}
               registry={registry}
               optionalDataControl={showOptionalDataControlInTitle ? optionalDataControl : undefined}
-            />
-          </Col>
-        )}
-        {description && (
-          <Col span={24} style={DESCRIPTION_COL_STYLE}>
-            <DescriptionFieldTemplate
-              id={descriptionId(fieldPathId)}
-              description={description}
-              schema={schema}
-              uiSchema={uiSchema}
-              registry={registry}
             />
           </Col>
         )}

--- a/packages/antd/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Array.test.tsx.snap
@@ -7307,22 +7307,6 @@ exports[`with title and description array 1`] = `
                     />
                   </div>
                   <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
-                        "paddingBottom": "8px",
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  >
-                    <span
-                      id="root__description"
-                    >
-                      a test description
-                    </span>
-                  </div>
-                  <div
                     className="ant-col ant-col-24 row array-item-list css-dev-only-do-not-override-ac2jek"
                     style={
                       {
@@ -7510,22 +7494,6 @@ exports[`with title and description array icons 1`] = `
                         }
                       }
                     />
-                  </div>
-                  <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
-                        "paddingBottom": "8px",
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  >
-                    <span
-                      id="root__description"
-                    >
-                      a test description
-                    </span>
                   </div>
                   <div
                     className="ant-col ant-col-24 row array-item-list css-dev-only-do-not-override-ac2jek"
@@ -8480,22 +8448,6 @@ exports[`with title and description fixed array 1`] = `
                     />
                   </div>
                   <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
-                        "paddingBottom": "8px",
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  >
-                    <span
-                      id="root__description"
-                    >
-                      a test description
-                    </span>
-                  </div>
-                  <div
                     className="ant-col ant-col-24 row array-item-list css-dev-only-do-not-override-ac2jek"
                     style={
                       {
@@ -8908,22 +8860,6 @@ exports[`with title and description from both array 1`] = `
                     />
                   </div>
                   <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
-                        "paddingBottom": "8px",
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  >
-                    <span
-                      id="root__description"
-                    >
-                      a fancier description
-                    </span>
-                  </div>
-                  <div
                     className="ant-col ant-col-24 row array-item-list css-dev-only-do-not-override-ac2jek"
                     style={
                       {
@@ -9111,22 +9047,6 @@ exports[`with title and description from both array icons 1`] = `
                         }
                       }
                     />
-                  </div>
-                  <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
-                        "paddingBottom": "8px",
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  >
-                    <span
-                      id="root__description"
-                    >
-                      a fancier description
-                    </span>
                   </div>
                   <div
                     className="ant-col ant-col-24 row array-item-list css-dev-only-do-not-override-ac2jek"
@@ -10081,22 +10001,6 @@ exports[`with title and description from both fixed array 1`] = `
                     />
                   </div>
                   <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
-                        "paddingBottom": "8px",
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  >
-                    <span
-                      id="root__description"
-                    >
-                      a fancier description
-                    </span>
-                  </div>
-                  <div
                     className="ant-col ant-col-24 row array-item-list css-dev-only-do-not-override-ac2jek"
                     style={
                       {
@@ -10509,22 +10413,6 @@ exports[`with title and description from uiSchema array 1`] = `
                     />
                   </div>
                   <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
-                        "paddingBottom": "8px",
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  >
-                    <span
-                      id="root__description"
-                    >
-                      a fancier description
-                    </span>
-                  </div>
-                  <div
                     className="ant-col ant-col-24 row array-item-list css-dev-only-do-not-override-ac2jek"
                     style={
                       {
@@ -10712,22 +10600,6 @@ exports[`with title and description from uiSchema array icons 1`] = `
                         }
                       }
                     />
-                  </div>
-                  <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
-                        "paddingBottom": "8px",
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  >
-                    <span
-                      id="root__description"
-                    >
-                      a fancier description
-                    </span>
                   </div>
                   <div
                     className="ant-col ant-col-24 row array-item-list css-dev-only-do-not-override-ac2jek"
@@ -11682,22 +11554,6 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                     />
                   </div>
                   <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
-                        "paddingBottom": "8px",
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  >
-                    <span
-                      id="root__description"
-                    >
-                      a fancier description
-                    </span>
-                  </div>
-                  <div
                     className="ant-col ant-col-24 row array-item-list css-dev-only-do-not-override-ac2jek"
                     style={
                       {
@@ -12092,16 +11948,6 @@ exports[`with title and description with global label off array 1`] = `
                     }
                   />
                   <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
-                        "paddingBottom": "8px",
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  />
-                  <div
                     className="ant-col ant-col-24 row array-item-list css-dev-only-do-not-override-ac2jek"
                     style={
                       {
@@ -12267,16 +12113,6 @@ exports[`with title and description with global label off array icons 1`] = `
                     className="ant-col ant-col-24 ant-form-item-label css-dev-only-do-not-override-ac2jek"
                     style={
                       {
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  />
-                  <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
-                        "paddingBottom": "8px",
                         "paddingLeft": 12,
                         "paddingRight": 12,
                       }
@@ -13187,16 +13023,6 @@ exports[`with title and description with global label off fixed array 1`] = `
                     className="ant-col ant-col-24 ant-form-item-label css-dev-only-do-not-override-ac2jek"
                     style={
                       {
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  />
-                  <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
-                        "paddingBottom": "8px",
                         "paddingLeft": 12,
                         "paddingRight": 12,
                       }

--- a/packages/antd/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Object.test.tsx.snap
@@ -5309,22 +5309,6 @@ exports[`object fields with title and description additionalProperties 1`] = `
                     className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
                     style={
                       {
-                        "paddingBottom": "8px",
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  >
-                    <span
-                      id="root__description"
-                    >
-                      a test description
-                    </span>
-                  </div>
-                  <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
                         "paddingLeft": 12,
                         "paddingRight": 12,
                       }
@@ -5728,22 +5712,6 @@ exports[`object fields with title and description from both additionalProperties
                         }
                       }
                     />
-                  </div>
-                  <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
-                        "paddingBottom": "8px",
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  >
-                    <span
-                      id="root__description"
-                    >
-                      a fancier description
-                    </span>
                   </div>
                   <div
                     className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
@@ -6157,22 +6125,6 @@ exports[`object fields with title and description from both object 1`] = `
                     className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
                     style={
                       {
-                        "paddingBottom": "8px",
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  >
-                    <span
-                      id="root__description"
-                    >
-                      a fancier description
-                    </span>
-                  </div>
-                  <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
                         "paddingLeft": 12,
                         "paddingRight": 12,
                       }
@@ -6545,22 +6497,6 @@ exports[`object fields with title and description from uiSchema additionalProper
                         }
                       }
                     />
-                  </div>
-                  <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
-                        "paddingBottom": "8px",
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  >
-                    <span
-                      id="root__description"
-                    >
-                      a fancier description
-                    </span>
                   </div>
                   <div
                     className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
@@ -6974,22 +6910,6 @@ exports[`object fields with title and description from uiSchema object 1`] = `
                     className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
                     style={
                       {
-                        "paddingBottom": "8px",
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  >
-                    <span
-                      id="root__description"
-                    >
-                      a fancier description
-                    </span>
-                  </div>
-                  <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
                         "paddingLeft": 12,
                         "paddingRight": 12,
                       }
@@ -7362,22 +7282,6 @@ exports[`object fields with title and description from uiSchema show add button 
                         }
                       }
                     />
-                  </div>
-                  <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
-                        "paddingBottom": "8px",
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  >
-                    <span
-                      id="root__description"
-                    >
-                      a fancier description
-                    </span>
                   </div>
                   <div
                     className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
@@ -7791,22 +7695,6 @@ exports[`object fields with title and description object 1`] = `
                     className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
                     style={
                       {
-                        "paddingBottom": "8px",
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  >
-                    <span
-                      id="root__description"
-                    >
-                      a test description
-                    </span>
-                  </div>
-                  <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
                         "paddingLeft": 12,
                         "paddingRight": 12,
                       }
@@ -8179,22 +8067,6 @@ exports[`object fields with title and description show add button and fields if 
                         }
                       }
                     />
-                  </div>
-                  <div
-                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
-                    style={
-                      {
-                        "paddingBottom": "8px",
-                        "paddingLeft": 12,
-                        "paddingRight": 12,
-                      }
-                    }
-                  >
-                    <span
-                      id="root__description"
-                    >
-                      a test description
-                    </span>
                   </div>
                   <div
                     className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"

--- a/packages/playground/src/components/OptionsDrawer.tsx
+++ b/packages/playground/src/components/OptionsDrawer.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react';
 import Drawer from '@mui/material/Drawer';
 import Form, { IChangeEvent } from '@rjsf/core';
-import { RJSFSchema, UiSchema, ValidatorType } from '@rjsf/utils';
+import { RJSFSchema, UiSchema, ValidatorType, DEFAULT_ID_PREFIX, DEFAULT_ID_SEPARATOR } from '@rjsf/utils';
 import localValidator from '@rjsf/validator-ajv8';
 
 import base64 from '../utils/base64';
@@ -208,6 +208,8 @@ const liveSettingsBooleanSchema: RJSFSchema = {
         },
       },
     },
+    idPrefix: { type: 'string', title: 'ID prefix', default: DEFAULT_ID_PREFIX },
+    idSeparator: { type: 'string', title: 'ID separator', default: DEFAULT_ID_SEPARATOR, maximum: 2 },
   },
 };
 
@@ -238,6 +240,16 @@ const liveSettingsBooleanUiSchema: UiSchema = {
       'ui:options': {
         label: false,
       },
+    },
+  },
+  idPrefix: {
+    'ui:options': {
+      emptyValue: DEFAULT_ID_PREFIX,
+    },
+  },
+  idSeparator: {
+    'ui:options': {
+      emptyValue: DEFAULT_ID_SEPARATOR,
     },
   },
 };


### PR DESCRIPTION
### Reasons for making this change

Fixes #3624 by removing the duplicate render of the `description` in the `ObjectFieldTemplate` and `ArrayFieldTemplate`
- In `@rjsf/antd` - Removed render of `description` in the object and array field templates because it is already done in `FieldTemplate` in this theme
  - Updated the snapshots accordingly
- Updated `OptionsDrawer` in the playground to allow users to change the `idPrefix` and `idSeparator`
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
