### PR TITLE
Fix: Reworked the additional properties remove code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Fixed duplicate label and description rendering in `CheckboxWidget` by conditionally rendering them based on widget type
     - Updated `CheckboxWidget` to handle label and description rendering consistently
     - Modified `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+- Updated `ObjectField` to change the removal of an additional property to defer the work to the `processPendingChange()` handler in `Form`, fixing [#4850](https://github.com/rjsf-team/react-jsonschema-form/issues/4850)
 
 ## @rjsf/fluentui-rc
 
@@ -65,6 +66,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/utils
 
 - Updated `getDefaultFormState()` to not save an undefined field value into an object when the type is `null` and `excludeObjectChildren` is provided, fixing [#4821](https://github.com/rjsf-team/react-jsonschema-form/issues/4821)
+- Added new `ADDITIONAL_PROPERTY_KEY_REMOVE` constant
 
 ## Dev / docs / playground
 

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -1,5 +1,6 @@
 import { Component, ElementType, FormEvent, ReactNode, Ref, RefObject, createRef } from 'react';
 import {
+  ADDITIONAL_PROPERTY_KEY_REMOVE,
   createSchemaUtils,
   CustomValidator,
   deepEquals,
@@ -51,6 +52,7 @@ import _isEmpty from 'lodash/isEmpty';
 import _pick from 'lodash/pick';
 import _set from 'lodash/set';
 import _toPath from 'lodash/toPath';
+import _unset from 'lodash/unset';
 
 import getDefaultRegistry from '../getDefaultRegistry';
 
@@ -875,7 +877,10 @@ export default class Form<
     let retrievedSchema = this.state.retrievedSchema;
     let formData = isRootPath ? newValue : _cloneDeep(oldFormData);
     if (isObject(formData) || Array.isArray(formData)) {
-      if (!isRootPath) {
+      if (newValue === ADDITIONAL_PROPERTY_KEY_REMOVE) {
+        // For additional properties, we were given the special remove this key value, so unset it
+        _unset(formData, path);
+      } else if (!isRootPath) {
         // If the newValue is not on the root path, then set it into the form data
         _set(formData, path, newValue);
       }

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -4,6 +4,7 @@
  * utility.
  */
 export const ADDITIONAL_PROPERTY_FLAG = '__additional_property';
+export const ADDITIONAL_PROPERTY_KEY_REMOVE = Symbol('remove-this-key');
 export const ADDITIONAL_PROPERTIES_KEY = 'additionalProperties';
 export const ALL_OF_KEY = 'allOf';
 export const ANY_OF_KEY = 'anyOf';


### PR DESCRIPTION
### Reasons for making this change

Fixes: #4850 by moving the deleting of an additional property from `ObjectField` to `Form`
- In `@rjsf/utils` added a special `ADDITIONAL_PROPERTY_KEY_REMOVE` symbol to `constants.ts`
- In `@rjsf/core`:
  - Updated `ObjectField`'s `handleRemoveProperty()` to call `onChange()` with `ADDITIONAL_PROPERTY_KEY_REMOVE` and the `fieldPathId.path` + `key`
    - Made the `key` for the `ObjectFieldProperty` render stable
  - Updated `Form`'s `processPendingChange()` to detect when the `newValue` is `ADDITIONAL_PROPERTY_KEY_REMOVE` and remove the data instead.
- Updated the `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
