### PR TITLE
feat: added ui:enableMarkdownInHelp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,56 +15,72 @@ it according to semantic versioning. For example, if your PR adds a breaking cha
 should change the heading of the (upcoming) version to include a major version bump.
 
 -->
+
 # 6.0.2
 
 ## @rjsf/antd
 
 - Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
 - Updated `ArrayFieldTemplate` and `ObjectFieldTemplate` to remove the rendering of a duplicate description (since the `FieldTemplate` already does it), fixing [#3624](https://github.com/rjsf-team/react-jsonschema-form/issues/3624)
+- Added support for `ui:enableMarkdownInHelp` flag to enable markdown rendering in help text, fixing ([#4601](https://github.com/rjsf-team/react-jsonschema-form/issues/4601))
 
 ## @rjsf/chakra-ui
 
 - Modified `CheckboxesWidget` to render the Title, fixing ([#4840](https://github.com/rjsf-team/react-jsonschema-form/issues/4840))
 - Updated `CheckboxWidget` to handle label and description rendering consistently, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+- Updated `FieldHelpTemplate` to support `ui:enableMarkdownInHelp` flag for markdown rendering in help text, fixing ([#4601](https://github.com/rjsf-team/react-jsonschema-form/issues/4601))
 
 ## @rjsf/core
 
 - Fixed duplicate label and description rendering in `CheckboxWidget` by conditionally rendering them based on widget type
-    - Updated `CheckboxWidget` to handle label and description rendering consistently
-    - Modified `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+  - Updated `CheckboxWidget` to handle label and description rendering consistently
+  - Modified `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+- Added `RichHelp` component and updated `FieldHelpTemplate` to support `ui:enableMarkdownInHelp` flag for markdown rendering in help text, fixing ([#4601](https://github.com/rjsf-team/react-jsonschema-form/issues/4601))
+
+## @rjsf/daisyui
+
+- Updated `FieldHelpTemplate` to support `ui:enableMarkdownInHelp` flag for markdown rendering in help text, fixing ([#4601](https://github.com/rjsf-team/react-jsonschema-form/issues/4601))
 
 ## @rjsf/fluentui-rc
 
 - Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+- Updated `FieldHelpTemplate` to support `ui:enableMarkdownInHelp` flag for markdown rendering in help text, fixing ([#4601](https://github.com/rjsf-team/react-jsonschema-form/issues/4601))
 
 ## @rjsf/mantine
 
 - Updated `CheckboxWidget` to handle label and description rendering consistently, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+- Updated `FieldHelpTemplate` to support `ui:enableMarkdownInHelp` flag for markdown rendering in help text, fixing ([#4601](https://github.com/rjsf-team/react-jsonschema-form/issues/4601))
 
 ## @rjsf/mui
 
 - Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+- Updated `FieldHelpTemplate` to support `ui:enableMarkdownInHelp` flag for markdown rendering in help text, fixing ([#4601](https://github.com/rjsf-team/react-jsonschema-form/issues/4601))
 
 ## @rjsf/primereact
 
 - Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+- Updated `FieldHelpTemplate` to support `ui:enableMarkdownInHelp` flag for markdown rendering in help text, fixing ([#4601](https://github.com/rjsf-team/react-jsonschema-form/issues/4601))
 
 ## @rjsf/react-bootstrap
 
 - Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+- Updated `FieldHelpTemplate` to support `ui:enableMarkdownInHelp` flag for markdown rendering in help text, fixing ([#4601](https://github.com/rjsf-team/react-jsonschema-form/issues/4601))
 
 ## @rjsf/semantic-ui
 
 - Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+- Updated `FieldHelpTemplate` to support `ui:enableMarkdownInHelp` flag for markdown rendering in help text, fixing ([#4601](https://github.com/rjsf-team/react-jsonschema-form/issues/4601))
 
 ## @rjsf/shadcn
 
 - Updated `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
 - Updated the `Command` component to properly handle `forwardRef`
+- Updated `FieldHelpTemplate` to support `ui:enableMarkdownInHelp` flag for markdown rendering in help text, fixing ([#4601](https://github.com/rjsf-team/react-jsonschema-form/issues/4601))
 
 ## @rjsf/utils
 
 - Updated `getDefaultFormState()` to not save an undefined field value into an object when the type is `null` and `excludeObjectChildren` is provided, fixing [#4821](https://github.com/rjsf-team/react-jsonschema-form/issues/4821)
+- Added `enableMarkdownInHelp` flag to `GlobalUISchemaOptions` type to support markdown rendering in help text, fixing ([#4601](https://github.com/rjsf-team/react-jsonschema-form/issues/4601))
 
 ## Dev / docs / playground
 
@@ -90,7 +106,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 
 - Updated `SchemaField` to add a new optional property `childFieldPathId` to the `FieldComponent` render to prevent duplicate ids, fixing (#4819)[https://github.com/rjsf-team/react-jsonschema-form/issues/4819]
-    - Also updated `ObjectField` and `ArrayField` to make children use the `childFieldPathId` if present, falling back to the `fieldPathId` if not
+  - Also updated `ObjectField` and `ArrayField` to make children use the `childFieldPathId` if present, falling back to the `fieldPathId` if not
 
 ## Dev / docs / playground
 
@@ -117,7 +133,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated `Form` to support the new feature to do `onBlur` handling of `liveValidate` and `liveOmit`
 - Updated `FormProps` to add the new `initialFormData` prop
 - Updated `Form` so that is behaves as a "controlled" form when `formData` is passed and uncontrolled when `initialFormData` is passed, fixing [#391](https://github.com/rjsf-team/react-jsonschema-form/issues/391)
-    - Also fixed an issue where live validation was called on the initial form render, causing errors to show immediately, partially fixing [#512](https://github.com/rjsf-team/react-jsonschema-form/issues/512)
+  - Also fixed an issue where live validation was called on the initial form render, causing errors to show immediately, partially fixing [#512](https://github.com/rjsf-team/react-jsonschema-form/issues/512)
 - Updated `Form` to add a new programmatic function, `setFieldValue(fieldPath: string | FieldPathList, newValue?: T): void`, fixing [#2099](https://github.com/rjsf-team/react-jsonschema-form/issues/2099)
 - Added new `FallbackField` to add opt-in functionality to control form data that is of an unsupported or unknown type ([#4736](https://github.com/rjsf-team/react-jsonschema-form/issues/4736)).
 - Refactored much of the `FileWidget` implementation into a new `useFileWidgetProps()` hook, fixing [#3146](https://github.com/rjsf-team/react-jsonschema-form/issues/3146)
@@ -256,7 +272,7 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated the `customArray` sample to refactor out a `ArrayFieldItemButtonsTemplate`
 - Updated the `custom-templates.md` documentation to reflect the `additionalProperties`-based interface props replacement and `ArrayField` conversion changes
 - Updated the `utility-functions.md` documentation to add the new `useDeepCompareMemo()` hook
-- Updated the `v6.x upgrade guide.md` documentation to add the BREAKING CHANGES to the `ArrayFieldTemplateProps`, `ArrayFieldItemTemplateType`, `ArrayFieldItemButtonsTemplateType`,  `FieldTemplateProps`, `ObjectFieldTemplateProps` and `WrapIfAdditionalTemplateProps` interface props changes and the `useDeepCompareMemo()` hook
+- Updated the `v6.x upgrade guide.md` documentation to add the BREAKING CHANGES to the `ArrayFieldTemplateProps`, `ArrayFieldItemTemplateType`, `ArrayFieldItemButtonsTemplateType`, `FieldTemplateProps`, `ObjectFieldTemplateProps` and `WrapIfAdditionalTemplateProps` interface props changes and the `useDeepCompareMemo()` hook
 - Added documentation for the `nameGenerator` prop in `form-props.md` and v6.x upgrade guide
 - Updated `@rjsf/snapshot-tests` package to explicitly depend on `@rjsf/core` to build first, fixing an error with parallelized builds
 
@@ -283,11 +299,11 @@ should change the heading of the (upcoming) version to include a major version b
 - Updated `ArrayFieldTemplate`, `ObjectFieldTemplate`, `TitleField` to add support for the new `optionalDataControl` feature
   - Added the new `OptionalDataControlTemplate` to the theme, adding it to the `templates` list
 - Updated `Form` as follows to fix [#4796](https://github.com/rjsf-team/react-jsonschema-form/issues/4796)
-    - Refactored the `liveValidate()` and `mergeErrors()` functions out of `getStateFromProp()` and `processPendingChange()`
-    - Added new, optional `customErrors?: ErrorSchemaBuilder<T>` to the `FormState`, updating the `IChangeEvent` interface to remove all of the private variables
-    - Reworked the `newErrorSchema` handling in `processPendingChange()` to simplify the handling since `newErrorSchema` is now path-specific, adding `newErrorSchema` to `customErrors` when they don't match an existing validator-based validation
-        - This rework resulted in any custom errors passed from custom widgets/fields will now be remembered during the validation stage
-    - Removed the now unused `getPreviousCustomValidateErrors()` and `filterErrorsBasedOnSchema()` methods
+  - Refactored the `liveValidate()` and `mergeErrors()` functions out of `getStateFromProp()` and `processPendingChange()`
+  - Added new, optional `customErrors?: ErrorSchemaBuilder<T>` to the `FormState`, updating the `IChangeEvent` interface to remove all of the private variables
+  - Reworked the `newErrorSchema` handling in `processPendingChange()` to simplify the handling since `newErrorSchema` is now path-specific, adding `newErrorSchema` to `customErrors` when they don't match an existing validator-based validation
+    - This rework resulted in any custom errors passed from custom widgets/fields will now be remembered during the validation stage
+  - Removed the now unused `getPreviousCustomValidateErrors()` and `filterErrorsBasedOnSchema()` methods
 - Updated `LayoutGridField` to simplify `onFieldChange()` to just return the given `errorSchema` now that it is path-specific, fixing [#4796](https://github.com/rjsf-team/react-jsonschema-form/issues/4796)
 - Updated `NullField` to pass `fieldPathId.path` for the `onChange()` instead of `[name]`
 
@@ -348,7 +364,7 @@ should change the heading of the (upcoming) version to include a major version b
   - Updated `GlobalFormOptions` to add new `enableOptionalDataFieldForType?: ('object' | 'array')[]` prop
   - Updated `SchemaUtilsType`'s `retrieveSchema()` function to add an additional, property `resolveAnyOfOrOneOfRefs?: boolean`
 - Updated the `Templates` interface to add a new required template `OptionalDataControlsTemplate: ComponentType<OptionalDataControlsTemplateProps<T, S, F>>`
-- Updated `retrieveSchema()` to add an additional  property `resolveAnyOfOrOneOfRefs?: boolean` which causes `resolveAllSchemas()` to resolve `$ref`s inside of the options of `anyOf`/`oneOf` schemas
+- Updated `retrieveSchema()` to add an additional property `resolveAnyOfOrOneOfRefs?: boolean` which causes `resolveAllSchemas()` to resolve `$ref`s inside of the options of `anyOf`/`oneOf` schemas
 - Updated `getDefaultFormState` to fix an issue where optional array props had their default set to an empty array when they shouldn't be
 - Updated the `TranslatableString` enum to add three new strings in support of the new feature: `OptionalObjectAdd`, `OptionalObjectRemove` and `OptionalObjectEmptyMsg`
 - Added four new utility functions: `isFormDataAvailable()`, `isRootSchema()`, `optionalControlsId()`, and `shouldRenderOptionalField()`

--- a/packages/antd/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/antd/test/__snapshots__/Form.test.tsx.snap
@@ -8038,6 +8038,300 @@ exports[`single fields field with markdown description in uiSchema 1`] = `
 </form>
 `;
 
+exports[`single fields field with markdown help 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="ant-form-item css-dev-only-do-not-override-ac2jek ant-form-item-horizontal"
+    >
+      <div
+        className="ant-row ant-form-item-row css-dev-only-do-not-override-ac2jek"
+        style={
+          {
+            "rowGap": undefined,
+          }
+        }
+      >
+        <div
+          className="ant-col ant-col-24 ant-form-item-control css-dev-only-do-not-override-ac2jek"
+          style={{}}
+        >
+          <div
+            className="ant-form-item-control-input"
+          >
+            <div
+              className="ant-form-item-control-input-content"
+            >
+              <fieldset
+                id="root"
+              >
+                <div
+                  className="ant-row css-dev-only-do-not-override-ac2jek"
+                  style={
+                    {
+                      "marginLeft": -12,
+                      "marginRight": -12,
+                      "rowGap": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
+                    style={
+                      {
+                        "paddingLeft": 12,
+                        "paddingRight": 12,
+                      }
+                    }
+                  >
+                    <div
+                      className="rjsf-field rjsf-field-string"
+                    >
+                      <div
+                        className="ant-form-item css-dev-only-do-not-override-ac2jek ant-form-item-with-help ant-form-item-horizontal"
+                      >
+                        <div
+                          className="ant-row ant-form-item-row css-dev-only-do-not-override-ac2jek"
+                          style={
+                            {
+                              "rowGap": undefined,
+                            }
+                          }
+                        >
+                          <div
+                            className="ant-col ant-col-24 ant-form-item-label css-dev-only-do-not-override-ac2jek"
+                            style={{}}
+                          >
+                            <label
+                              className=""
+                              htmlFor="root_my-field"
+                              title="my-field"
+                            >
+                              my-field
+                            </label>
+                          </div>
+                          <div
+                            className="ant-col ant-col-24 ant-form-item-control css-dev-only-do-not-override-ac2jek"
+                            style={{}}
+                          >
+                            <div
+                              className="ant-form-item-control-input"
+                            >
+                              <div
+                                className="ant-form-item-control-input-content"
+                              >
+                                <span
+                                  className="ant-input-affix-wrapper css-dev-only-do-not-override-ac2jek ant-input-outlined"
+                                  onClick={[Function]}
+                                  style={
+                                    {
+                                      "width": "100%",
+                                    }
+                                  }
+                                >
+                                  <input
+                                    aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                                    className="ant-input css-dev-only-do-not-override-ac2jek"
+                                    disabled={false}
+                                    id="root_my-field"
+                                    name="root_my-field"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onCompositionEnd={[Function]}
+                                    onCompositionStart={[Function]}
+                                    onFocus={[Function]}
+                                    onKeyDown={[Function]}
+                                    onKeyUp={[Function]}
+                                    placeholder=""
+                                    type="text"
+                                    value=""
+                                  />
+                                  <span
+                                    className="ant-input-suffix"
+                                  />
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="ant-btn css-dev-only-do-not-override-ac2jek ant-btn-submit"
+    disabled={false}
+    onClick={[Function]}
+    style={{}}
+    type="submit"
+  >
+    <span>
+      Submit
+    </span>
+  </button>
+</form>
+`;
+
+exports[`single fields field with markdown help in uiSchema 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="ant-form-item css-dev-only-do-not-override-ac2jek ant-form-item-horizontal"
+    >
+      <div
+        className="ant-row ant-form-item-row css-dev-only-do-not-override-ac2jek"
+        style={
+          {
+            "rowGap": undefined,
+          }
+        }
+      >
+        <div
+          className="ant-col ant-col-24 ant-form-item-control css-dev-only-do-not-override-ac2jek"
+          style={{}}
+        >
+          <div
+            className="ant-form-item-control-input"
+          >
+            <div
+              className="ant-form-item-control-input-content"
+            >
+              <fieldset
+                id="root"
+              >
+                <div
+                  className="ant-row css-dev-only-do-not-override-ac2jek"
+                  style={
+                    {
+                      "marginLeft": -12,
+                      "marginRight": -12,
+                      "rowGap": undefined,
+                    }
+                  }
+                >
+                  <div
+                    className="ant-col ant-col-24 css-dev-only-do-not-override-ac2jek"
+                    style={
+                      {
+                        "paddingLeft": 12,
+                        "paddingRight": 12,
+                      }
+                    }
+                  >
+                    <div
+                      className="rjsf-field rjsf-field-string"
+                    >
+                      <div
+                        className="ant-form-item css-dev-only-do-not-override-ac2jek ant-form-item-with-help ant-form-item-horizontal"
+                      >
+                        <div
+                          className="ant-row ant-form-item-row css-dev-only-do-not-override-ac2jek"
+                          style={
+                            {
+                              "rowGap": undefined,
+                            }
+                          }
+                        >
+                          <div
+                            className="ant-col ant-col-24 ant-form-item-label css-dev-only-do-not-override-ac2jek"
+                            style={{}}
+                          >
+                            <label
+                              className=""
+                              htmlFor="root_my-field"
+                              title="my-field"
+                            >
+                              my-field
+                            </label>
+                          </div>
+                          <div
+                            className="ant-col ant-col-24 ant-form-item-control css-dev-only-do-not-override-ac2jek"
+                            style={{}}
+                          >
+                            <div
+                              className="ant-form-item-control-input"
+                            >
+                              <div
+                                className="ant-form-item-control-input-content"
+                              >
+                                <span
+                                  className="ant-input-affix-wrapper css-dev-only-do-not-override-ac2jek ant-input-outlined"
+                                  onClick={[Function]}
+                                  style={
+                                    {
+                                      "width": "100%",
+                                    }
+                                  }
+                                >
+                                  <input
+                                    aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                                    className="ant-input css-dev-only-do-not-override-ac2jek"
+                                    disabled={false}
+                                    id="root_my-field"
+                                    name="root_my-field"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onCompositionEnd={[Function]}
+                                    onCompositionStart={[Function]}
+                                    onFocus={[Function]}
+                                    onKeyDown={[Function]}
+                                    onKeyUp={[Function]}
+                                    placeholder=""
+                                    type="text"
+                                    value=""
+                                  />
+                                  <span
+                                    className="ant-input-suffix"
+                                  />
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="ant-btn css-dev-only-do-not-override-ac2jek ant-btn-submit"
+    disabled={false}
+    onClick={[Function]}
+    style={{}}
+    type="submit"
+  >
+    <span>
+      Submit
+    </span>
+  </button>
+</form>
+`;
+
 exports[`single fields format color 1`] = `
 <form
   className="rjsf"

--- a/packages/chakra-ui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/chakra-ui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,5 +1,6 @@
 import { Text } from '@chakra-ui/react';
 import { helpId, FieldHelpProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
+import { RichHelp } from '@rjsf/core';
 
 /** The `FieldHelpTemplate` component renders any help desired for a field
  *
@@ -10,10 +11,14 @@ export default function FieldHelpTemplate<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: FieldHelpProps<T, S, F>) {
-  const { fieldPathId, help } = props;
+  const { fieldPathId, help, registry, uiSchema } = props;
   if (!help) {
     return null;
   }
   const id = helpId(fieldPathId);
-  return <Text id={id}>{help}</Text>;
+  return (
+    <Text id={id}>
+      <RichHelp help={help} registry={registry} uiSchema={uiSchema} />
+    </Text>
+  );
 }

--- a/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/chakra-ui/test/__snapshots__/Form.test.tsx.snap
@@ -545,7 +545,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r8p:::legend"
+        aria-labelledby="fieldset:::r8v:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -562,7 +562,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                 className="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8q:::legend"
+                  aria-labelledby="fieldset:::r90:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -601,7 +601,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                 className="rjsf-field rjsf-field-object"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r8r:::legend"
+                                  aria-labelledby="fieldset:::r91:::legend"
                                   className="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -633,7 +633,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                           className="rjsf-field rjsf-field-string"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::r8s:::legend"
+                                            aria-labelledby="fieldset:::r92:::legend"
                                             className="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -646,15 +646,15 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                 className="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::r8t:"
+                                                id="field:::r93:"
                                                 role="group"
                                               >
                                                 <label
                                                   className="chakra-field__label emotion-20"
                                                   data-part="label"
                                                   data-scope="field"
-                                                  htmlFor=":r8t:"
-                                                  id="field:::r8t:::label"
+                                                  htmlFor=":r93:"
+                                                  id="field:::r93:::label"
                                                 >
                                                   title
                                                 </label>
@@ -686,7 +686,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                           className="rjsf-field rjsf-field-boolean"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::r8u:::legend"
+                                            aria-labelledby="fieldset:::r94:::legend"
                                             className="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -699,7 +699,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                 className="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::r8v:"
+                                                id="field:::r95:"
                                                 role="group"
                                               >
                                                 <label
@@ -709,7 +709,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                   data-scope="checkbox"
                                                   data-state="unchecked"
                                                   dir="ltr"
-                                                  htmlFor=":r8v:"
+                                                  htmlFor=":r95:"
                                                   id="checkbox:root_tasks_0_done"
                                                   onBlur={[Function]}
                                                   onClick={[Function]}
@@ -719,10 +719,10 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                 >
                                                   <input
                                                     aria-invalid={false}
-                                                    aria-labelledby="field:::r8v:::label"
+                                                    aria-labelledby="field:::r95:::label"
                                                     defaultChecked={false}
                                                     disabled={false}
-                                                    id=":r8v:"
+                                                    id=":r95:"
                                                     name="root[tasks][0][done]"
                                                     onBlur={[Function]}
                                                     onClick={[Function]}
@@ -766,7 +766,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                     data-scope="checkbox"
                                                     data-state="unchecked"
                                                     dir="ltr"
-                                                    id="field:::r8v:::label"
+                                                    id="field:::r95:::label"
                                                   >
                                                     <p>
                                                       done
@@ -893,7 +893,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                 className="rjsf-field rjsf-field-object"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r91:::legend"
+                                  aria-labelledby="fieldset:::r97:::legend"
                                   className="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -925,7 +925,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                           className="rjsf-field rjsf-field-string"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::r92:::legend"
+                                            aria-labelledby="fieldset:::r98:::legend"
                                             className="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -938,15 +938,15 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                 className="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::r93:"
+                                                id="field:::r99:"
                                                 role="group"
                                               >
                                                 <label
                                                   className="chakra-field__label emotion-20"
                                                   data-part="label"
                                                   data-scope="field"
-                                                  htmlFor=":r93:"
-                                                  id="field:::r93:::label"
+                                                  htmlFor=":r99:"
+                                                  id="field:::r99:::label"
                                                 >
                                                   title
                                                 </label>
@@ -978,7 +978,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                           className="rjsf-field rjsf-field-boolean"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::r94:::legend"
+                                            aria-labelledby="fieldset:::r9a:::legend"
                                             className="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -991,7 +991,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                 className="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::r95:"
+                                                id="field:::r9b:"
                                                 role="group"
                                               >
                                                 <label
@@ -1001,7 +1001,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                   data-scope="checkbox"
                                                   data-state="checked"
                                                   dir="ltr"
-                                                  htmlFor=":r95:"
+                                                  htmlFor=":r9b:"
                                                   id="checkbox:root_tasks_1_done"
                                                   onBlur={[Function]}
                                                   onClick={[Function]}
@@ -1011,10 +1011,10 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                 >
                                                   <input
                                                     aria-invalid={false}
-                                                    aria-labelledby="field:::r95:::label"
+                                                    aria-labelledby="field:::r9b:::label"
                                                     defaultChecked={true}
                                                     disabled={false}
-                                                    id=":r95:"
+                                                    id=":r9b:"
                                                     name="root[tasks][1][done]"
                                                     onBlur={[Function]}
                                                     onClick={[Function]}
@@ -1062,7 +1062,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                     data-scope="checkbox"
                                                     data-state="checked"
                                                     dir="ltr"
-                                                    id="field:::r95:::label"
+                                                    id="field:::r9b:::label"
                                                   >
                                                     <p>
                                                       done
@@ -1682,7 +1682,7 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r8j:::legend"
+        aria-labelledby="fieldset:::r8p:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -1699,7 +1699,7 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                 className="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r8k:::legend"
+                  aria-labelledby="fieldset:::r8q:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -1738,7 +1738,7 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                                 className="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r8l:::legend"
+                                  aria-labelledby="fieldset:::r8r:::legend"
                                   className="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -1751,7 +1751,7 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                                       className="chakra-field__root emotion-13"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::r8m:"
+                                      id="field:::r8s:"
                                       role="group"
                                     >
                                       <label
@@ -1759,8 +1759,8 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        htmlFor=":r8m:"
-                                        id="field:::r8m:::label"
+                                        htmlFor=":r8s:"
+                                        id="field:::r8s:::label"
                                       >
                                         tags-0
                                         <span
@@ -1904,7 +1904,7 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                                 className="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r8n:::legend"
+                                  aria-labelledby="fieldset:::r8t:::legend"
                                   className="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -1917,7 +1917,7 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                                       className="chakra-field__root emotion-13"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::r8o:"
+                                      id="field:::r8u:"
                                       role="group"
                                     >
                                       <label
@@ -1925,8 +1925,8 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        htmlFor=":r8o:"
-                                        id="field:::r8o:::label"
+                                        htmlFor=":r8u:"
+                                        id="field:::r8u:::label"
                                       >
                                         tags-1
                                         <span
@@ -2439,7 +2439,7 @@ exports[`nameGenerator bracketNameGenerator checkboxes field 1`] = `
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r9f:::legend"
+        aria-labelledby="fieldset:::r9l:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -2456,7 +2456,7 @@ exports[`nameGenerator bracketNameGenerator checkboxes field 1`] = `
                 className="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r9g:::legend"
+                  aria-labelledby="fieldset:::r9m:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -2466,7 +2466,7 @@ exports[`nameGenerator bracketNameGenerator checkboxes field 1`] = `
                     className="fieldset__content emotion-1"
                   >
                     <fieldset
-                      aria-labelledby="fieldset:::r9h:::legend"
+                      aria-labelledby="fieldset:::r9n:::legend"
                       className="fieldset__root emotion-5"
                       data-part="root"
                       data-scope="fieldset"
@@ -2476,7 +2476,7 @@ exports[`nameGenerator bracketNameGenerator checkboxes field 1`] = `
                         className="fieldset__legend emotion-6"
                         data-part="legend"
                         data-scope="fieldset"
-                        id="fieldset:::r9h:::legend"
+                        id="fieldset:::r9n:::legend"
                       >
                         choices
                       </legend>
@@ -2983,7 +2983,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r88:::legend"
+        aria-labelledby="fieldset:::r8e:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -3000,7 +3000,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                 className="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r89:::legend"
+                  aria-labelledby="fieldset:::r8f:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -3032,7 +3032,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                           className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r8a:::legend"
+                            aria-labelledby="fieldset:::r8g:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -3045,15 +3045,15 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                 className="chakra-field__root emotion-11"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r8b:"
+                                id="field:::r8h:"
                                 role="group"
                               >
                                 <label
                                   className="chakra-field__label emotion-12"
                                   data-part="label"
                                   data-scope="field"
-                                  htmlFor=":r8b:"
-                                  id="field:::r8b:::label"
+                                  htmlFor=":r8h:"
+                                  id="field:::r8h:::label"
                                 >
                                   firstName
                                 </label>
@@ -3085,7 +3085,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                           className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r8c:::legend"
+                            aria-labelledby="fieldset:::r8i:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -3098,15 +3098,15 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                 className="chakra-field__root emotion-11"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r8d:"
+                                id="field:::r8j:"
                                 role="group"
                               >
                                 <label
                                   className="chakra-field__label emotion-12"
                                   data-part="label"
                                   data-scope="field"
-                                  htmlFor=":r8d:"
-                                  id="field:::r8d:::label"
+                                  htmlFor=":r8j:"
+                                  id="field:::r8j:::label"
                                 >
                                   lastName
                                 </label>
@@ -3138,7 +3138,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                           className="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r8e:::legend"
+                            aria-labelledby="fieldset:::r8k:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -3170,7 +3170,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                     className="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r8f:::legend"
+                                      aria-labelledby="fieldset:::r8l:::legend"
                                       className="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -3183,15 +3183,15 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                           className="chakra-field__root emotion-11"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::r8g:"
+                                          id="field:::r8m:"
                                           role="group"
                                         >
                                           <label
                                             className="chakra-field__label emotion-12"
                                             data-part="label"
                                             data-scope="field"
-                                            htmlFor=":r8g:"
-                                            id="field:::r8g:::label"
+                                            htmlFor=":r8m:"
+                                            id="field:::r8m:::label"
                                           >
                                             street
                                           </label>
@@ -3223,7 +3223,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                     className="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r8h:::legend"
+                                      aria-labelledby="fieldset:::r8n:::legend"
                                       className="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -3236,15 +3236,15 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                           className="chakra-field__root emotion-11"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::r8i:"
+                                          id="field:::r8o:"
                                           role="group"
                                         >
                                           <label
                                             className="chakra-field__label emotion-12"
                                             data-part="label"
                                             data-scope="field"
-                                            htmlFor=":r8i:"
-                                            id="field:::r8i:::label"
+                                            htmlFor=":r8o:"
+                                            id="field:::r8o:::label"
                                           >
                                             city
                                           </label>
@@ -3600,7 +3600,7 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r9b:::legend"
+        aria-labelledby="fieldset:::r9h:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -3617,7 +3617,7 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                 className="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r9c:::legend"
+                  aria-labelledby="fieldset:::r9i:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -3630,28 +3630,28 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                       className="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r9d:"
+                      id="field:::r9j:"
                       role="group"
                     >
                       <label
                         className="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        htmlFor=":r9d:"
-                        id="field:::r9d:::label"
+                        htmlFor=":r9j:"
+                        id="field:::r9j:::label"
                       >
                         option
                       </label>
                       <div
                         aria-describedby="root_option__error root_option__description root_option__help"
-                        aria-labelledby="radio-group::r9e::label"
+                        aria-labelledby="radio-group::r9k::label"
                         aria-orientation="vertical"
                         className="chakra-radio-group__root"
                         data-orientation="vertical"
                         data-part="root"
                         data-scope="radio-group"
                         dir="ltr"
-                        id="radio-group::r9e:"
+                        id="radio-group::r9k:"
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
@@ -3673,7 +3673,7 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                             data-ssr=""
                             data-state="unchecked"
                             dir="ltr"
-                            htmlFor="radio-group::r9e::radio:input:0"
+                            htmlFor="radio-group::r9k::radio:input:0"
                             id="root_option-0"
                             onClick={[Function]}
                             onPointerDown={[Function]}
@@ -3682,9 +3682,9 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                             onPointerUp={[Function]}
                           >
                             <input
-                              data-ownedby="radio-group::r9e:"
+                              data-ownedby="radio-group::r9k:"
                               defaultChecked={false}
-                              id="radio-group::r9e::radio:input:0"
+                              id="radio-group::r9k::radio:input:0"
                               name="root[option]"
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -3717,7 +3717,7 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                               data-ssr=""
                               data-state="unchecked"
                               dir="ltr"
-                              id="radio-group::r9e::radio:control:0"
+                              id="radio-group::r9k::radio:control:0"
                             />
                             <span
                               className="chakra-radio-group__itemText"
@@ -3727,7 +3727,7 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                               data-ssr=""
                               data-state="unchecked"
                               dir="ltr"
-                              id="radio-group::r9e::radio:label:0"
+                              id="radio-group::r9k::radio:label:0"
                             >
                               foo
                             </span>
@@ -3740,7 +3740,7 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                             data-ssr=""
                             data-state="unchecked"
                             dir="ltr"
-                            htmlFor="radio-group::r9e::radio:input:1"
+                            htmlFor="radio-group::r9k::radio:input:1"
                             id="root_option-1"
                             onClick={[Function]}
                             onPointerDown={[Function]}
@@ -3749,9 +3749,9 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                             onPointerUp={[Function]}
                           >
                             <input
-                              data-ownedby="radio-group::r9e:"
+                              data-ownedby="radio-group::r9k:"
                               defaultChecked={false}
-                              id="radio-group::r9e::radio:input:1"
+                              id="radio-group::r9k::radio:input:1"
                               name="root[option]"
                               onBlur={[Function]}
                               onClick={[Function]}
@@ -3784,7 +3784,7 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                               data-ssr=""
                               data-state="unchecked"
                               dir="ltr"
-                              id="radio-group::r9e::radio:control:1"
+                              id="radio-group::r9k::radio:control:1"
                             />
                             <span
                               className="chakra-radio-group__itemText"
@@ -3794,7 +3794,7 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                               data-ssr=""
                               data-state="unchecked"
                               dir="ltr"
-                              id="radio-group::r9e::radio:label:1"
+                              id="radio-group::r9k::radio:label:1"
                             >
                               bar
                             </span>
@@ -4312,7 +4312,7 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r97:::legend"
+        aria-labelledby="fieldset:::r9d:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -4329,7 +4329,7 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                 className="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r98:::legend"
+                  aria-labelledby="fieldset:::r9e:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -4342,15 +4342,15 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                       className="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r99:"
+                      id="field:::r9f:"
                       role="group"
                     >
                       <label
                         className="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        htmlFor=":r99:"
-                        id="field:::r99:::label"
+                        htmlFor=":r9f:"
+                        id="field:::r9f:::label"
                       >
                         color
                       </label>
@@ -4367,9 +4367,9 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                       >
                         <select
                           aria-hidden={true}
-                          aria-labelledby="field:::r99:::label"
+                          aria-labelledby="field:::r9f:::label"
                           disabled={false}
-                          id=":r99:"
+                          id=":r9f:"
                           multiple={false}
                           name="root[color]"
                           onFocus={[Function]}
@@ -4433,7 +4433,7 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                               aria-expanded={false}
                               aria-haspopup="listbox"
                               aria-invalid={false}
-                              aria-labelledby="field:::r99:::label"
+                              aria-labelledby="field:::r9f:::label"
                               aria-required={false}
                               className="chakra-select__trigger emotion-10"
                               data-part="trigger"
@@ -4503,7 +4503,7 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                           }
                         >
                           <div
-                            aria-labelledby="field:::r99:::label"
+                            aria-labelledby="field:::r9f:::label"
                             className="chakra-select__content emotion-16"
                             data-part="content"
                             data-scope="select"
@@ -4991,7 +4991,7 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r80:::legend"
+        aria-labelledby="fieldset:::r86:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -5008,7 +5008,7 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                 className="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r81:::legend"
+                  aria-labelledby="fieldset:::r87:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -5021,15 +5021,15 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                       className="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r82:"
+                      id="field:::r88:"
                       role="group"
                     >
                       <label
                         className="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        htmlFor=":r82:"
-                        id="field:::r82:::label"
+                        htmlFor=":r88:"
+                        id="field:::r88:::label"
                       >
                         firstName
                       </label>
@@ -5061,7 +5061,7 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                 className="rjsf-field rjsf-field-number"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r83:::legend"
+                  aria-labelledby="fieldset:::r89:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -5074,15 +5074,15 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                       className="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r84:"
+                      id="field:::r8a:"
                       role="group"
                     >
                       <label
                         className="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        htmlFor=":r84:"
-                        id="field:::r84:::label"
+                        htmlFor=":r8a:"
+                        id="field:::r8a:::label"
                       >
                         age
                       </label>
@@ -5115,7 +5115,7 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                 className="rjsf-field rjsf-field-boolean"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r85:::legend"
+                  aria-labelledby="fieldset:::r8b:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -5128,7 +5128,7 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                       className="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r86:"
+                      id="field:::r8c:"
                       role="group"
                     >
                       <label
@@ -5138,7 +5138,7 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                         data-scope="checkbox"
                         data-state="unchecked"
                         dir="ltr"
-                        htmlFor=":r86:"
+                        htmlFor=":r8c:"
                         id="checkbox:root_active"
                         onBlur={[Function]}
                         onClick={[Function]}
@@ -5148,10 +5148,10 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                       >
                         <input
                           aria-invalid={false}
-                          aria-labelledby="field:::r86:::label"
+                          aria-labelledby="field:::r8c:::label"
                           defaultChecked={false}
                           disabled={false}
-                          id=":r86:"
+                          id=":r8c:"
                           name="root[active]"
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -5195,7 +5195,7 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                           data-scope="checkbox"
                           data-state="unchecked"
                           dir="ltr"
-                          id="field:::r86:::label"
+                          id="field:::r8c:::label"
                         >
                           <p>
                             active
@@ -5461,7 +5461,7 @@ exports[`nameGenerator bracketNameGenerator textarea field 1`] = `
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r9l:::legend"
+        aria-labelledby="fieldset:::r9r:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -5478,7 +5478,7 @@ exports[`nameGenerator bracketNameGenerator textarea field 1`] = `
                 className="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r9m:::legend"
+                  aria-labelledby="fieldset:::r9s:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -5491,15 +5491,15 @@ exports[`nameGenerator bracketNameGenerator textarea field 1`] = `
                       className="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r9n:"
+                      id="field:::r9t:"
                       role="group"
                     >
                       <label
                         className="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        htmlFor=":r9n:"
-                        id="field:::r9n:::label"
+                        htmlFor=":r9t:"
+                        id="field:::r9t:::label"
                       >
                         description
                       </label>
@@ -6097,7 +6097,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::rah:::legend"
+        aria-labelledby="fieldset:::ran:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -6114,7 +6114,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                 className="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::rai:::legend"
+                  aria-labelledby="fieldset:::rao:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -6153,7 +6153,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                 className="rjsf-field rjsf-field-object"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::raj:::legend"
+                                  aria-labelledby="fieldset:::rap:::legend"
                                   className="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -6185,7 +6185,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                           className="rjsf-field rjsf-field-string"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::rak:::legend"
+                                            aria-labelledby="fieldset:::raq:::legend"
                                             className="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -6198,15 +6198,15 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                 className="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::ral:"
+                                                id="field:::rar:"
                                                 role="group"
                                               >
                                                 <label
                                                   className="chakra-field__label emotion-20"
                                                   data-part="label"
                                                   data-scope="field"
-                                                  htmlFor=":ral:"
-                                                  id="field:::ral:::label"
+                                                  htmlFor=":rar:"
+                                                  id="field:::rar:::label"
                                                 >
                                                   title
                                                 </label>
@@ -6238,7 +6238,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                           className="rjsf-field rjsf-field-boolean"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::ram:::legend"
+                                            aria-labelledby="fieldset:::ras:::legend"
                                             className="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -6251,7 +6251,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                 className="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::ran:"
+                                                id="field:::rat:"
                                                 role="group"
                                               >
                                                 <label
@@ -6261,7 +6261,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                   data-scope="checkbox"
                                                   data-state="unchecked"
                                                   dir="ltr"
-                                                  htmlFor=":ran:"
+                                                  htmlFor=":rat:"
                                                   id="checkbox:root_tasks_0_done"
                                                   onBlur={[Function]}
                                                   onClick={[Function]}
@@ -6271,10 +6271,10 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                 >
                                                   <input
                                                     aria-invalid={false}
-                                                    aria-labelledby="field:::ran:::label"
+                                                    aria-labelledby="field:::rat:::label"
                                                     defaultChecked={false}
                                                     disabled={false}
-                                                    id=":ran:"
+                                                    id=":rat:"
                                                     name="root.tasks.0.done"
                                                     onBlur={[Function]}
                                                     onClick={[Function]}
@@ -6318,7 +6318,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                     data-scope="checkbox"
                                                     data-state="unchecked"
                                                     dir="ltr"
-                                                    id="field:::ran:::label"
+                                                    id="field:::rat:::label"
                                                   >
                                                     <p>
                                                       done
@@ -6445,7 +6445,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                 className="rjsf-field rjsf-field-object"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::rap:::legend"
+                                  aria-labelledby="fieldset:::rav:::legend"
                                   className="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -6477,7 +6477,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                           className="rjsf-field rjsf-field-string"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::raq:::legend"
+                                            aria-labelledby="fieldset:::rb0:::legend"
                                             className="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -6490,15 +6490,15 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                 className="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::rar:"
+                                                id="field:::rb1:"
                                                 role="group"
                                               >
                                                 <label
                                                   className="chakra-field__label emotion-20"
                                                   data-part="label"
                                                   data-scope="field"
-                                                  htmlFor=":rar:"
-                                                  id="field:::rar:::label"
+                                                  htmlFor=":rb1:"
+                                                  id="field:::rb1:::label"
                                                 >
                                                   title
                                                 </label>
@@ -6530,7 +6530,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                           className="rjsf-field rjsf-field-boolean"
                                         >
                                           <fieldset
-                                            aria-labelledby="fieldset:::ras:::legend"
+                                            aria-labelledby="fieldset:::rb2:::legend"
                                             className="fieldset__root emotion-0"
                                             data-part="root"
                                             data-scope="fieldset"
@@ -6543,7 +6543,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                 className="chakra-field__root emotion-19"
                                                 data-part="root"
                                                 data-scope="field"
-                                                id="field:::rat:"
+                                                id="field:::rb3:"
                                                 role="group"
                                               >
                                                 <label
@@ -6553,7 +6553,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                   data-scope="checkbox"
                                                   data-state="checked"
                                                   dir="ltr"
-                                                  htmlFor=":rat:"
+                                                  htmlFor=":rb3:"
                                                   id="checkbox:root_tasks_1_done"
                                                   onBlur={[Function]}
                                                   onClick={[Function]}
@@ -6563,10 +6563,10 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                 >
                                                   <input
                                                     aria-invalid={false}
-                                                    aria-labelledby="field:::rat:::label"
+                                                    aria-labelledby="field:::rb3:::label"
                                                     defaultChecked={true}
                                                     disabled={false}
-                                                    id=":rat:"
+                                                    id=":rb3:"
                                                     name="root.tasks.1.done"
                                                     onBlur={[Function]}
                                                     onClick={[Function]}
@@ -6614,7 +6614,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                     data-scope="checkbox"
                                                     data-state="checked"
                                                     dir="ltr"
-                                                    id="field:::rat:::label"
+                                                    id="field:::rb3:::label"
                                                   >
                                                     <p>
                                                       done
@@ -7234,7 +7234,7 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::rab:::legend"
+        aria-labelledby="fieldset:::rah:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -7251,7 +7251,7 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                 className="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::rac:::legend"
+                  aria-labelledby="fieldset:::rai:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -7290,7 +7290,7 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                                 className="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::rad:::legend"
+                                  aria-labelledby="fieldset:::raj:::legend"
                                   className="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -7303,7 +7303,7 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                                       className="chakra-field__root emotion-13"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::rae:"
+                                      id="field:::rak:"
                                       role="group"
                                     >
                                       <label
@@ -7311,8 +7311,8 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        htmlFor=":rae:"
-                                        id="field:::rae:::label"
+                                        htmlFor=":rak:"
+                                        id="field:::rak:::label"
                                       >
                                         tags-0
                                         <span
@@ -7456,7 +7456,7 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                                 className="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::raf:::legend"
+                                  aria-labelledby="fieldset:::ral:::legend"
                                   className="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -7469,7 +7469,7 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                                       className="chakra-field__root emotion-13"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::rag:"
+                                      id="field:::ram:"
                                       role="group"
                                     >
                                       <label
@@ -7477,8 +7477,8 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        htmlFor=":rag:"
-                                        id="field:::rag:::label"
+                                        htmlFor=":ram:"
+                                        id="field:::ram:::label"
                                       >
                                         tags-1
                                         <span
@@ -7934,7 +7934,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::ra0:::legend"
+        aria-labelledby="fieldset:::ra6:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -7951,7 +7951,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                 className="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::ra1:::legend"
+                  aria-labelledby="fieldset:::ra7:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -7983,7 +7983,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                           className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::ra2:::legend"
+                            aria-labelledby="fieldset:::ra8:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -7996,15 +7996,15 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                 className="chakra-field__root emotion-11"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::ra3:"
+                                id="field:::ra9:"
                                 role="group"
                               >
                                 <label
                                   className="chakra-field__label emotion-12"
                                   data-part="label"
                                   data-scope="field"
-                                  htmlFor=":ra3:"
-                                  id="field:::ra3:::label"
+                                  htmlFor=":ra9:"
+                                  id="field:::ra9:::label"
                                 >
                                   firstName
                                 </label>
@@ -8036,7 +8036,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                           className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::ra4:::legend"
+                            aria-labelledby="fieldset:::raa:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -8049,15 +8049,15 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                 className="chakra-field__root emotion-11"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::ra5:"
+                                id="field:::rab:"
                                 role="group"
                               >
                                 <label
                                   className="chakra-field__label emotion-12"
                                   data-part="label"
                                   data-scope="field"
-                                  htmlFor=":ra5:"
-                                  id="field:::ra5:::label"
+                                  htmlFor=":rab:"
+                                  id="field:::rab:::label"
                                 >
                                   lastName
                                 </label>
@@ -8089,7 +8089,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                           className="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::ra6:::legend"
+                            aria-labelledby="fieldset:::rac:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -8121,7 +8121,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                     className="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::ra7:::legend"
+                                      aria-labelledby="fieldset:::rad:::legend"
                                       className="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -8134,15 +8134,15 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                           className="chakra-field__root emotion-11"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::ra8:"
+                                          id="field:::rae:"
                                           role="group"
                                         >
                                           <label
                                             className="chakra-field__label emotion-12"
                                             data-part="label"
                                             data-scope="field"
-                                            htmlFor=":ra8:"
-                                            id="field:::ra8:::label"
+                                            htmlFor=":rae:"
+                                            id="field:::rae:::label"
                                           >
                                             street
                                           </label>
@@ -8174,7 +8174,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                     className="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::ra9:::legend"
+                                      aria-labelledby="fieldset:::raf:::legend"
                                       className="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -8187,15 +8187,15 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                           className="chakra-field__root emotion-11"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::raa:"
+                                          id="field:::rag:"
                                           role="group"
                                         >
                                           <label
                                             className="chakra-field__label emotion-12"
                                             data-part="label"
                                             data-scope="field"
-                                            htmlFor=":raa:"
-                                            id="field:::raa:::label"
+                                            htmlFor=":rag:"
+                                            id="field:::rag:::label"
                                           >
                                             city
                                           </label>
@@ -8738,7 +8738,7 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::rav:::legend"
+        aria-labelledby="fieldset:::rb5:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -8755,7 +8755,7 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                 className="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::rb0:::legend"
+                  aria-labelledby="fieldset:::rb6:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -8768,15 +8768,15 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                       className="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::rb1:"
+                      id="field:::rb7:"
                       role="group"
                     >
                       <label
                         className="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        htmlFor=":rb1:"
-                        id="field:::rb1:::label"
+                        htmlFor=":rb7:"
+                        id="field:::rb7:::label"
                       >
                         color
                       </label>
@@ -8793,9 +8793,9 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                       >
                         <select
                           aria-hidden={true}
-                          aria-labelledby="field:::rb1:::label"
+                          aria-labelledby="field:::rb7:::label"
                           disabled={false}
-                          id=":rb1:"
+                          id=":rb7:"
                           multiple={false}
                           name="root.color"
                           onFocus={[Function]}
@@ -8859,7 +8859,7 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                               aria-expanded={false}
                               aria-haspopup="listbox"
                               aria-invalid={false}
-                              aria-labelledby="field:::rb1:::label"
+                              aria-labelledby="field:::rb7:::label"
                               aria-required={false}
                               className="chakra-select__trigger emotion-10"
                               data-part="trigger"
@@ -8929,7 +8929,7 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                           }
                         >
                           <div
-                            aria-labelledby="field:::rb1:::label"
+                            aria-labelledby="field:::rb7:::label"
                             className="chakra-select__content emotion-16"
                             data-part="content"
                             data-scope="select"
@@ -9417,7 +9417,7 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r9o:::legend"
+        aria-labelledby="fieldset:::r9u:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -9434,7 +9434,7 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                 className="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r9p:::legend"
+                  aria-labelledby="fieldset:::r9v:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -9447,15 +9447,15 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                       className="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r9q:"
+                      id="field:::ra0:"
                       role="group"
                     >
                       <label
                         className="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        htmlFor=":r9q:"
-                        id="field:::r9q:::label"
+                        htmlFor=":ra0:"
+                        id="field:::ra0:::label"
                       >
                         firstName
                       </label>
@@ -9487,7 +9487,7 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                 className="rjsf-field rjsf-field-number"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r9r:::legend"
+                  aria-labelledby="fieldset:::ra1:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -9500,15 +9500,15 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                       className="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r9s:"
+                      id="field:::ra2:"
                       role="group"
                     >
                       <label
                         className="chakra-field__label emotion-6"
                         data-part="label"
                         data-scope="field"
-                        htmlFor=":r9s:"
-                        id="field:::r9s:::label"
+                        htmlFor=":ra2:"
+                        id="field:::ra2:::label"
                       >
                         age
                       </label>
@@ -9541,7 +9541,7 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                 className="rjsf-field rjsf-field-boolean"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r9t:::legend"
+                  aria-labelledby="fieldset:::ra3:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -9554,7 +9554,7 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                       className="chakra-field__root emotion-5"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r9u:"
+                      id="field:::ra4:"
                       role="group"
                     >
                       <label
@@ -9564,7 +9564,7 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                         data-scope="checkbox"
                         data-state="unchecked"
                         dir="ltr"
-                        htmlFor=":r9u:"
+                        htmlFor=":ra4:"
                         id="checkbox:root_active"
                         onBlur={[Function]}
                         onClick={[Function]}
@@ -9574,10 +9574,10 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                       >
                         <input
                           aria-invalid={false}
-                          aria-labelledby="field:::r9u:::label"
+                          aria-labelledby="field:::ra4:::label"
                           defaultChecked={false}
                           disabled={false}
-                          id=":r9u:"
+                          id=":ra4:"
                           name="root.active"
                           onBlur={[Function]}
                           onClick={[Function]}
@@ -9621,7 +9621,7 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                           data-scope="checkbox"
                           data-state="unchecked"
                           dir="ltr"
-                          id="field:::r9u:::label"
+                          id="field:::ra4:::label"
                         >
                           <p>
                             active
@@ -14869,6 +14869,666 @@ exports[`single fields field with markdown description in uiSchema 1`] = `
 ]
 `;
 
+exports[`single fields field with markdown help 1`] = `
+[
+  @layer recipes {
+  .emotion-0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+  }
+
+  .emotion-0>:not(style, [hidden])~:not(style, [hidden]) {
+    --space-y-reverse: 0;
+    margin-top: calc(var(--chakra-spacing-4) * calc(1 - var(--space-y-reverse)));
+    margin-bottom: calc(var(--chakra-spacing-4) * var(--space-y-reverse));
+  }
+}
+
+@layer recipes {
+  .emotion-1 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+    gap: var(--chakra-spacing-4);
+  }
+}
+
+.emotion-2 {
+  display: grid;
+  gap: var(--chakra-spacing-4);
+  margin-bottom: var(--chakra-spacing-4);
+}
+
+.emotion-5 {
+  margin-bottom: var(--chakra-spacing-1);
+}
+
+@layer recipes {
+  .emotion-5 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    width: 100%;
+    position: relative;
+    gap: var(--chakra-spacing-1\\.5);
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    -webkit-align-items: flex-start;
+    -webkit-box-align: flex-start;
+    -ms-flex-align: flex-start;
+    align-items: flex-start;
+  }
+}
+
+@layer recipes {
+  .emotion-6 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    text-align: start;
+    font-size: var(--chakra-font-sizes-sm);
+    line-height: 1.25rem;
+    font-weight: var(--chakra-font-weights-medium);
+    gap: var(--chakra-spacing-1);
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+
+  .emotion-6:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+  }
+}
+
+@layer recipes {
+  .emotion-7 {
+    width: 100%;
+    min-width: var(--input-height);
+    outline: 0;
+    position: relative;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
+    text-align: start;
+    border-radius: var(--chakra-radii-l2);
+    height: var(--input-height);
+    --focus-color: var(--chakra-colors-color-palette-focus-ring);
+    --error-color: var(--chakra-colors-border-error);
+    font-size: var(--chakra-font-sizes-sm);
+    line-height: 1.25rem;
+    padding-inline: var(--chakra-spacing-3);
+    --input-height: var(--chakra-sizes-10);
+    background: var(--chakra-colors-transparent);
+    --bg-currentcolor: var(--chakra-colors-transparent);
+    border-width: 1px;
+    border-color: var(--chakra-colors-border);
+    --focus-ring-color: var(--focus-color);
+  }
+
+  .emotion-7:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-7:is([data-invalid], [aria-invalid=true], [data-state=invalid]) {
+    --focus-ring-color: var(--error-color);
+    border-color: var(--error-color);
+  }
+
+  .emotion-7:is(:focus-visible, [data-focus-visible]) {
+    outline-offset: 0px;
+    outline-width: var(--focus-ring-width, 1px);
+    outline-color: var(--focus-ring-color);
+    outline-style: var(--focus-ring-style, solid);
+    border-color: var(--focus-ring-color);
+  }
+}
+
+.emotion-8 {
+  margin-top: var(--chakra-spacing-3);
+}
+
+@layer recipes {
+  .emotion-9 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    position: relative;
+    border-radius: var(--chakra-radii-l2);
+    white-space: nowrap;
+    vertical-align: middle;
+    border-width: 1px;
+    border-color: var(--chakra-colors-transparent);
+    cursor: var(--chakra-cursor-button);
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    outline: 0;
+    line-height: 1.25rem;
+    isolation: isolate;
+    font-weight: var(--chakra-font-weights-medium);
+    transition-property: background-color,border-color,color,fill,stroke,opacity,box-shadow,translate,transform;
+    transition-duration: var(--chakra-durations-moderate);
+    --focus-ring-color: var(--chakra-colors-color-palette-focus-ring);
+    height: var(--chakra-sizes-10);
+    min-width: var(--chakra-sizes-10);
+    font-size: var(--chakra-font-sizes-sm);
+    padding-inline: var(--chakra-spacing-4);
+    gap: var(--chakra-spacing-2);
+    background: var(--chakra-colors-color-palette-solid);
+    --bg-currentcolor: var(--chakra-colors-color-palette-solid);
+    color: var(--chakra-colors-color-palette-contrast);
+  }
+
+  .emotion-9:is(:focus-visible, [data-focus-visible]) {
+    outline-width: var(--focus-ring-width, 2px);
+    outline-offset: var(--focus-ring-offset, 2px);
+    outline-style: var(--focus-ring-style, solid);
+    outline-color: var(--focus-ring-color);
+  }
+
+  .emotion-9:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-9 :where(svg) {
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    width: var(--chakra-sizes-5);
+    height: var(--chakra-sizes-5);
+  }
+
+  .emotion-9:is([aria-expanded=true], [data-expanded], [data-state=expanded]) {
+    --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+    background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+  }
+
+  @media (hover: hover) {
+    .emotion-9:is(:hover, [data-hover]):not(:disabled, [data-disabled]) {
+      --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+      background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+      --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    }
+  }
+}
+
+<form
+    className="rjsf"
+    noValidate={false}
+    onSubmit={[Function]}
+  >
+    <div
+      className="rjsf-field rjsf-field-object"
+    >
+      <fieldset
+        aria-labelledby="fieldset:::r3r:::legend"
+        className="fieldset__root emotion-0"
+        data-part="root"
+        data-scope="fieldset"
+        disabled={false}
+      >
+        <div
+          className="fieldset__content emotion-1"
+        >
+          <div
+            className="emotion-2"
+          >
+            <div>
+              <div
+                className="rjsf-field rjsf-field-string"
+              >
+                <fieldset
+                  aria-labelledby="fieldset:::r3s:::legend"
+                  className="fieldset__root emotion-0"
+                  data-part="root"
+                  data-scope="fieldset"
+                  disabled={false}
+                >
+                  <p
+                    id="root_my-field__help"
+                  >
+                    <span>
+                      some 
+                      <strong>
+                        Rich
+                      </strong>
+                       help text
+                    </span>
+                  </p>
+                  <div
+                    className="fieldset__content emotion-1"
+                  >
+                    <div
+                      className="chakra-field__root emotion-5"
+                      data-part="root"
+                      data-scope="field"
+                      id="field:::r3t:"
+                      role="group"
+                    >
+                      <label
+                        className="chakra-field__label emotion-6"
+                        data-part="label"
+                        data-scope="field"
+                        htmlFor=":r3t:"
+                        id="field:::r3t:::label"
+                      >
+                        my-field
+                      </label>
+                      <input
+                        aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                        autoFocus={false}
+                        className="chakra-input emotion-7"
+                        data-part="input"
+                        data-scope="field"
+                        disabled={false}
+                        id="root_my-field"
+                        name="root_my-field"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder=""
+                        readOnly={false}
+                        required={false}
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <div
+      className="emotion-8"
+    >
+      <button
+        className="chakra-button emotion-9"
+        disabled={false}
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>,
+  <span
+    hidden={true}
+  />,
+]
+`;
+
+exports[`single fields field with markdown help in uiSchema 1`] = `
+[
+  @layer recipes {
+  .emotion-0 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+  }
+
+  .emotion-0>:not(style, [hidden])~:not(style, [hidden]) {
+    --space-y-reverse: 0;
+    margin-top: calc(var(--chakra-spacing-4) * calc(1 - var(--space-y-reverse)));
+    margin-bottom: calc(var(--chakra-spacing-4) * var(--space-y-reverse));
+  }
+}
+
+@layer recipes {
+  .emotion-1 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    width: var(--chakra-sizes-full);
+    gap: var(--chakra-spacing-4);
+  }
+}
+
+.emotion-2 {
+  display: grid;
+  gap: var(--chakra-spacing-4);
+  margin-bottom: var(--chakra-spacing-4);
+}
+
+.emotion-5 {
+  margin-bottom: var(--chakra-spacing-1);
+}
+
+@layer recipes {
+  .emotion-5 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    width: 100%;
+    position: relative;
+    gap: var(--chakra-spacing-1\\.5);
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    -webkit-align-items: flex-start;
+    -webkit-box-align: flex-start;
+    -ms-flex-align: flex-start;
+    align-items: flex-start;
+  }
+}
+
+@layer recipes {
+  .emotion-6 {
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    text-align: start;
+    font-size: var(--chakra-font-sizes-sm);
+    line-height: 1.25rem;
+    font-weight: var(--chakra-font-weights-medium);
+    gap: var(--chakra-spacing-1);
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+
+  .emotion-6:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+  }
+}
+
+@layer recipes {
+  .emotion-7 {
+    width: 100%;
+    min-width: var(--input-height);
+    outline: 0;
+    position: relative;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
+    text-align: start;
+    border-radius: var(--chakra-radii-l2);
+    height: var(--input-height);
+    --focus-color: var(--chakra-colors-color-palette-focus-ring);
+    --error-color: var(--chakra-colors-border-error);
+    font-size: var(--chakra-font-sizes-sm);
+    line-height: 1.25rem;
+    padding-inline: var(--chakra-spacing-3);
+    --input-height: var(--chakra-sizes-10);
+    background: var(--chakra-colors-transparent);
+    --bg-currentcolor: var(--chakra-colors-transparent);
+    border-width: 1px;
+    border-color: var(--chakra-colors-border);
+    --focus-ring-color: var(--focus-color);
+  }
+
+  .emotion-7:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-7:is([data-invalid], [aria-invalid=true], [data-state=invalid]) {
+    --focus-ring-color: var(--error-color);
+    border-color: var(--error-color);
+  }
+
+  .emotion-7:is(:focus-visible, [data-focus-visible]) {
+    outline-offset: 0px;
+    outline-width: var(--focus-ring-width, 1px);
+    outline-color: var(--focus-ring-color);
+    outline-style: var(--focus-ring-style, solid);
+    border-color: var(--focus-ring-color);
+  }
+}
+
+.emotion-8 {
+  margin-top: var(--chakra-spacing-3);
+}
+
+@layer recipes {
+  .emotion-9 {
+    display: -webkit-inline-box;
+    display: -webkit-inline-flex;
+    display: -ms-inline-flexbox;
+    display: inline-flex;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
+    -webkit-align-items: center;
+    -webkit-box-align: center;
+    -ms-flex-align: center;
+    align-items: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    justify-content: center;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    position: relative;
+    border-radius: var(--chakra-radii-l2);
+    white-space: nowrap;
+    vertical-align: middle;
+    border-width: 1px;
+    border-color: var(--chakra-colors-transparent);
+    cursor: var(--chakra-cursor-button);
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    outline: 0;
+    line-height: 1.25rem;
+    isolation: isolate;
+    font-weight: var(--chakra-font-weights-medium);
+    transition-property: background-color,border-color,color,fill,stroke,opacity,box-shadow,translate,transform;
+    transition-duration: var(--chakra-durations-moderate);
+    --focus-ring-color: var(--chakra-colors-color-palette-focus-ring);
+    height: var(--chakra-sizes-10);
+    min-width: var(--chakra-sizes-10);
+    font-size: var(--chakra-font-sizes-sm);
+    padding-inline: var(--chakra-spacing-4);
+    gap: var(--chakra-spacing-2);
+    background: var(--chakra-colors-color-palette-solid);
+    --bg-currentcolor: var(--chakra-colors-color-palette-solid);
+    color: var(--chakra-colors-color-palette-contrast);
+  }
+
+  .emotion-9:is(:focus-visible, [data-focus-visible]) {
+    outline-width: var(--focus-ring-width, 2px);
+    outline-offset: var(--focus-ring-offset, 2px);
+    outline-style: var(--focus-ring-style, solid);
+    outline-color: var(--focus-ring-color);
+  }
+
+  .emotion-9:is(:disabled, [disabled], [data-disabled], [aria-disabled=true]) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .emotion-9 :where(svg) {
+    -webkit-flex-shrink: 0;
+    -ms-flex-negative: 0;
+    flex-shrink: 0;
+    width: var(--chakra-sizes-5);
+    height: var(--chakra-sizes-5);
+  }
+
+  .emotion-9:is([aria-expanded=true], [data-expanded], [data-state=expanded]) {
+    --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+    background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+  }
+
+  @media (hover: hover) {
+    .emotion-9:is(:hover, [data-hover]):not(:disabled, [data-disabled]) {
+      --mix-background: color-mix(in srgb, var(--chakra-colors-color-palette-solid) 90%, transparent);
+      background: var(--mix-background, var(--chakra-colors-color-palette-solid));
+      --bg-currentcolor: var(--mix-background, var(--chakra-colors-color-palette-solid));
+    }
+  }
+}
+
+<form
+    className="rjsf"
+    noValidate={false}
+    onSubmit={[Function]}
+  >
+    <div
+      className="rjsf-field rjsf-field-object"
+    >
+      <fieldset
+        aria-labelledby="fieldset:::r3u:::legend"
+        className="fieldset__root emotion-0"
+        data-part="root"
+        data-scope="fieldset"
+        disabled={false}
+      >
+        <div
+          className="fieldset__content emotion-1"
+        >
+          <div
+            className="emotion-2"
+          >
+            <div>
+              <div
+                className="rjsf-field rjsf-field-string"
+              >
+                <fieldset
+                  aria-labelledby="fieldset:::r3v:::legend"
+                  className="fieldset__root emotion-0"
+                  data-part="root"
+                  data-scope="fieldset"
+                  disabled={false}
+                >
+                  <p
+                    id="root_my-field__help"
+                  >
+                    <span>
+                      some 
+                      <strong>
+                        other
+                      </strong>
+                       help
+                    </span>
+                  </p>
+                  <div
+                    className="fieldset__content emotion-1"
+                  >
+                    <div
+                      className="chakra-field__root emotion-5"
+                      data-part="root"
+                      data-scope="field"
+                      id="field:::r40:"
+                      role="group"
+                    >
+                      <label
+                        className="chakra-field__label emotion-6"
+                        data-part="label"
+                        data-scope="field"
+                        htmlFor=":r40:"
+                        id="field:::r40:::label"
+                      >
+                        my-field
+                      </label>
+                      <input
+                        aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                        autoFocus={false}
+                        className="chakra-input emotion-7"
+                        data-part="input"
+                        data-scope="field"
+                        disabled={false}
+                        id="root_my-field"
+                        name="root_my-field"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onFocus={[Function]}
+                        placeholder=""
+                        readOnly={false}
+                        required={false}
+                        type="text"
+                        value=""
+                      />
+                    </div>
+                  </div>
+                </fieldset>
+              </div>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <div
+      className="emotion-8"
+    >
+      <button
+        className="chakra-button emotion-9"
+        disabled={false}
+        type="submit"
+      >
+        Submit
+      </button>
+    </div>
+  </form>,
+  <span
+    hidden={true}
+  />,
+]
+`;
+
 exports[`single fields format color 1`] = `
 [
   @layer recipes {
@@ -16299,7 +16959,7 @@ exports[`single fields help and error display 1`] = `
       className="rjsf-field rjsf-field-string rjsf-field-error"
     >
       <fieldset
-        aria-labelledby="fieldset:::r44:::legend"
+        aria-labelledby="fieldset:::r4a:::legend"
         className="fieldset__root emotion-8"
         data-invalid=""
         data-part="root"
@@ -16319,7 +16979,7 @@ exports[`single fields help and error display 1`] = `
             data-invalid=""
             data-part="root"
             data-scope="field"
-            id="field:::r45:"
+            id="field:::r4b:"
             role="group"
           >
             <input
@@ -16759,7 +17419,7 @@ exports[`single fields hidden label 1`] = `
       className="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3u:::legend"
+        aria-labelledby="fieldset:::r44:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -16772,7 +17432,7 @@ exports[`single fields hidden label 1`] = `
             className="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r3v:"
+            id="field:::r45:"
             role="group"
           >
             <input
@@ -18129,7 +18789,7 @@ exports[`single fields optional data controls does not show optional controls wh
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r46:::legend"
+        aria-labelledby="fieldset:::r4c:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -18161,7 +18821,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 className="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r47:::legend"
+                  aria-labelledby="fieldset:::r4d:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -18193,7 +18853,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r48:::legend"
+                            aria-labelledby="fieldset:::r4e:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -18206,15 +18866,15 @@ exports[`single fields optional data controls does not show optional controls wh
                                 className="chakra-field__root emotion-14"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r49:"
+                                id="field:::r4f:"
                                 role="group"
                               >
                                 <label
                                   className="chakra-field__label emotion-15"
                                   data-part="label"
                                   data-scope="field"
-                                  htmlFor=":r49:"
-                                  id="field:::r49:::label"
+                                  htmlFor=":r4f:"
+                                  id="field:::r4f:::label"
                                 >
                                   test
                                 </label>
@@ -18246,7 +18906,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r4a:::legend"
+                            aria-labelledby="fieldset:::r4g:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -18278,7 +18938,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     className="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r4b:::legend"
+                                      aria-labelledby="fieldset:::r4h:::legend"
                                       className="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -18291,15 +18951,15 @@ exports[`single fields optional data controls does not show optional controls wh
                                           className="chakra-field__root emotion-14"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::r4c:"
+                                          id="field:::r4i:"
                                           role="group"
                                         >
                                           <label
                                             className="chakra-field__label emotion-15"
                                             data-part="label"
                                             data-scope="field"
-                                            htmlFor=":r4c:"
-                                            id="field:::r4c:::label"
+                                            htmlFor=":r4i:"
+                                            id="field:::r4i:::label"
                                           >
                                             deepTest
                                           </label>
@@ -18336,7 +18996,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r4d:::legend"
+                            aria-labelledby="fieldset:::r4j:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -18368,7 +19028,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     className="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r4e:::legend"
+                                      aria-labelledby="fieldset:::r4k:::legend"
                                       className="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -18381,15 +19041,15 @@ exports[`single fields optional data controls does not show optional controls wh
                                           className="chakra-field__root emotion-14"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::r4f:"
+                                          id="field:::r4l:"
                                           role="group"
                                         >
                                           <label
                                             className="chakra-field__label emotion-15"
                                             data-part="label"
                                             data-scope="field"
-                                            htmlFor=":r4f:"
-                                            id="field:::r4f:::label"
+                                            htmlFor=":r4l:"
+                                            id="field:::r4l:::label"
                                           >
                                             deepTest
                                           </label>
@@ -18426,7 +19086,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r4g:::legend"
+                            aria-labelledby="fieldset:::r4m:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -18503,7 +19163,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r4h:::legend"
+                            aria-labelledby="fieldset:::r4n:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -18580,7 +19240,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r4i:::legend"
+                            aria-labelledby="fieldset:::r4o:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -18662,7 +19322,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 className="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r4j:::legend"
+                  aria-labelledby="fieldset:::r4p:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -18739,7 +19399,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 className="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r4k:::legend"
+                  aria-labelledby="fieldset:::r4q:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -18771,7 +19431,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r4l:::legend"
+                            aria-labelledby="fieldset:::r4r:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -18784,15 +19444,15 @@ exports[`single fields optional data controls does not show optional controls wh
                                 className="chakra-field__root emotion-14"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r4m:"
+                                id="field:::r4s:"
                                 role="group"
                               >
                                 <label
                                   className="chakra-field__label emotion-15"
                                   data-part="label"
                                   data-scope="field"
-                                  htmlFor=":r4m:"
-                                  id="field:::r4m:::label"
+                                  htmlFor=":r4s:"
+                                  id="field:::r4s:::label"
                                 >
                                   test
                                 </label>
@@ -18829,7 +19489,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 className="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r4n:::legend"
+                  aria-labelledby="fieldset:::r4t:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -18906,7 +19566,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 className="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r4o:::legend"
+                  aria-labelledby="fieldset:::r4u:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -18928,15 +19588,15 @@ exports[`single fields optional data controls does not show optional controls wh
                             className="chakra-field__root emotion-100"
                             data-part="root"
                             data-scope="field"
-                            id="field:::r4p:"
+                            id="field:::r4v:"
                             role="group"
                           >
                             <label
                               className="chakra-field__label emotion-15"
                               data-part="label"
                               data-scope="field"
-                              htmlFor=":r4p:"
-                              id="field:::r4p:::label"
+                              htmlFor=":r4v:"
+                              id="field:::r4v:::label"
                             >
                               optionalObjectWithOneofs
                             </label>
@@ -18952,10 +19612,10 @@ exports[`single fields optional data controls does not show optional controls wh
                             >
                               <select
                                 aria-hidden={true}
-                                aria-labelledby="field:::r4p:::label"
+                                aria-labelledby="field:::r4v:::label"
                                 defaultValue="0"
                                 disabled={false}
-                                id=":r4p:"
+                                id=":r4v:"
                                 multiple={false}
                                 name="root_optionalObjectWithOneofs__oneof_select"
                                 onFocus={[Function]}
@@ -19016,7 +19676,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     aria-expanded={false}
                                     aria-haspopup="listbox"
                                     aria-invalid={false}
-                                    aria-labelledby="field:::r4p:::label"
+                                    aria-labelledby="field:::r4v:::label"
                                     aria-required={false}
                                     className="chakra-select__trigger emotion-105"
                                     data-part="trigger"
@@ -19087,7 +19747,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 }
                               >
                                 <div
-                                  aria-labelledby="field:::r4p:::label"
+                                  aria-labelledby="field:::r4v:::label"
                                   className="chakra-select__content emotion-111"
                                   data-part="content"
                                   data-scope="select"
@@ -19207,7 +19867,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r4r:::legend"
+                            aria-labelledby="fieldset:::r51:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -19239,7 +19899,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     className="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r4s:::legend"
+                                      aria-labelledby="fieldset:::r52:::legend"
                                       className="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -19254,7 +19914,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                           data-part="root"
                                           data-readonly=""
                                           data-scope="field"
-                                          id="field:::r4t:"
+                                          id="field:::r53:"
                                           role="group"
                                         >
                                           <label
@@ -19263,8 +19923,8 @@ exports[`single fields optional data controls does not show optional controls wh
                                             data-part="label"
                                             data-readonly=""
                                             data-scope="field"
-                                            htmlFor=":r4t:"
-                                            id="field:::r4t:::label"
+                                            htmlFor=":r53:"
+                                            id="field:::r53:::label"
                                           >
                                             name
                                           </label>
@@ -19307,7 +19967,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 className="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r4u:::legend"
+                  aria-labelledby="fieldset:::r54:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -19329,15 +19989,15 @@ exports[`single fields optional data controls does not show optional controls wh
                             className="chakra-field__root emotion-100"
                             data-part="root"
                             data-scope="field"
-                            id="field:::r4v:"
+                            id="field:::r55:"
                             role="group"
                           >
                             <label
                               className="chakra-field__label emotion-15"
                               data-part="label"
                               data-scope="field"
-                              htmlFor=":r4v:"
-                              id="field:::r4v:::label"
+                              htmlFor=":r55:"
+                              id="field:::r55:::label"
                             >
                               optionalArrayWithAnyofs
                             </label>
@@ -19353,10 +20013,10 @@ exports[`single fields optional data controls does not show optional controls wh
                             >
                               <select
                                 aria-hidden={true}
-                                aria-labelledby="field:::r4v:::label"
+                                aria-labelledby="field:::r55:::label"
                                 defaultValue="0"
                                 disabled={false}
-                                id=":r4v:"
+                                id=":r55:"
                                 multiple={false}
                                 name="root_optionalArrayWithAnyofs__anyof_select"
                                 onFocus={[Function]}
@@ -19417,7 +20077,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     aria-expanded={false}
                                     aria-haspopup="listbox"
                                     aria-invalid={false}
-                                    aria-labelledby="field:::r4v:::label"
+                                    aria-labelledby="field:::r55:::label"
                                     aria-required={false}
                                     className="chakra-select__trigger emotion-105"
                                     data-part="trigger"
@@ -19488,7 +20148,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 }
                               >
                                 <div
-                                  aria-labelledby="field:::r4v:::label"
+                                  aria-labelledby="field:::r55:::label"
                                   className="chakra-select__content emotion-111"
                                   data-part="content"
                                   data-scope="select"
@@ -19608,7 +20268,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r51:::legend"
+                            aria-labelledby="fieldset:::r57:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -20346,7 +21006,7 @@ exports[`single fields optional data controls does not show optional controls wh
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r63:::legend"
+        aria-labelledby="fieldset:::r69:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -20379,7 +21039,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 className="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r64:::legend"
+                  aria-labelledby="fieldset:::r6a:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -20412,7 +21072,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r65:::legend"
+                            aria-labelledby="fieldset:::r6b:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -20427,7 +21087,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 data-part="root"
                                 data-readonly=""
                                 data-scope="field"
-                                id="field:::r66:"
+                                id="field:::r6c:"
                                 role="group"
                               >
                                 <label
@@ -20436,8 +21096,8 @@ exports[`single fields optional data controls does not show optional controls wh
                                   data-part="label"
                                   data-readonly=""
                                   data-scope="field"
-                                  htmlFor=":r66:"
-                                  id="field:::r66:::label"
+                                  htmlFor=":r6c:"
+                                  id="field:::r6c:::label"
                                 >
                                   test
                                 </label>
@@ -20470,7 +21130,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r67:::legend"
+                            aria-labelledby="fieldset:::r6d:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -20503,7 +21163,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     className="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r68:::legend"
+                                      aria-labelledby="fieldset:::r6e:::legend"
                                       className="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -20518,7 +21178,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                           data-part="root"
                                           data-readonly=""
                                           data-scope="field"
-                                          id="field:::r69:"
+                                          id="field:::r6f:"
                                           role="group"
                                         >
                                           <label
@@ -20527,8 +21187,8 @@ exports[`single fields optional data controls does not show optional controls wh
                                             data-part="label"
                                             data-readonly=""
                                             data-scope="field"
-                                            htmlFor=":r69:"
-                                            id="field:::r69:::label"
+                                            htmlFor=":r6f:"
+                                            id="field:::r6f:::label"
                                           >
                                             deepTest
                                           </label>
@@ -20566,7 +21226,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6a:::legend"
+                            aria-labelledby="fieldset:::r6g:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -20599,7 +21259,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     className="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r6b:::legend"
+                                      aria-labelledby="fieldset:::r6h:::legend"
                                       className="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -20614,7 +21274,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                           data-part="root"
                                           data-readonly=""
                                           data-scope="field"
-                                          id="field:::r6c:"
+                                          id="field:::r6i:"
                                           role="group"
                                         >
                                           <label
@@ -20623,8 +21283,8 @@ exports[`single fields optional data controls does not show optional controls wh
                                             data-part="label"
                                             data-readonly=""
                                             data-scope="field"
-                                            htmlFor=":r6c:"
-                                            id="field:::r6c:::label"
+                                            htmlFor=":r6i:"
+                                            id="field:::r6i:::label"
                                           >
                                             deepTest
                                           </label>
@@ -20662,7 +21322,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6d:::legend"
+                            aria-labelledby="fieldset:::r6j:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -20739,7 +21399,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6e:::legend"
+                            aria-labelledby="fieldset:::r6k:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -20816,7 +21476,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6f:::legend"
+                            aria-labelledby="fieldset:::r6l:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -20898,7 +21558,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 className="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6g:::legend"
+                  aria-labelledby="fieldset:::r6m:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -20975,7 +21635,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 className="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6h:::legend"
+                  aria-labelledby="fieldset:::r6n:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -21008,7 +21668,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6i:::legend"
+                            aria-labelledby="fieldset:::r6o:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21023,7 +21683,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 data-part="root"
                                 data-readonly=""
                                 data-scope="field"
-                                id="field:::r6j:"
+                                id="field:::r6p:"
                                 role="group"
                               >
                                 <label
@@ -21032,8 +21692,8 @@ exports[`single fields optional data controls does not show optional controls wh
                                   data-part="label"
                                   data-readonly=""
                                   data-scope="field"
-                                  htmlFor=":r6j:"
-                                  id="field:::r6j:::label"
+                                  htmlFor=":r6p:"
+                                  id="field:::r6p:::label"
                                 >
                                   test
                                 </label>
@@ -21071,7 +21731,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 className="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6k:::legend"
+                  aria-labelledby="fieldset:::r6q:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -21148,7 +21808,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 className="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6l:::legend"
+                  aria-labelledby="fieldset:::r6r:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -21172,7 +21832,7 @@ exports[`single fields optional data controls does not show optional controls wh
                             data-part="root"
                             data-readonly=""
                             data-scope="field"
-                            id="field:::r6m:"
+                            id="field:::r6s:"
                             role="group"
                           >
                             <label
@@ -21181,8 +21841,8 @@ exports[`single fields optional data controls does not show optional controls wh
                               data-part="label"
                               data-readonly=""
                               data-scope="field"
-                              htmlFor=":r6m:"
-                              id="field:::r6m:::label"
+                              htmlFor=":r6s:"
+                              id="field:::r6s:::label"
                             >
                               optionalObjectWithOneofs
                             </label>
@@ -21199,10 +21859,10 @@ exports[`single fields optional data controls does not show optional controls wh
                             >
                               <select
                                 aria-hidden={true}
-                                aria-labelledby="field:::r6m:::label"
+                                aria-labelledby="field:::r6s:::label"
                                 defaultValue="0"
                                 disabled={true}
-                                id=":r6m:"
+                                id=":r6s:"
                                 multiple={false}
                                 name="root_optionalObjectWithOneofs__oneof_select"
                                 onFocus={[Function]}
@@ -21265,7 +21925,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     aria-expanded={false}
                                     aria-haspopup="listbox"
                                     aria-invalid={false}
-                                    aria-labelledby="field:::r6m:::label"
+                                    aria-labelledby="field:::r6s:::label"
                                     aria-required={false}
                                     className="chakra-select__trigger emotion-105"
                                     data-disabled=""
@@ -21341,7 +22001,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 }
                               >
                                 <div
-                                  aria-labelledby="field:::r6m:::label"
+                                  aria-labelledby="field:::r6s:::label"
                                   className="chakra-select__content emotion-111"
                                   data-part="content"
                                   data-scope="select"
@@ -21467,7 +22127,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6o:::legend"
+                            aria-labelledby="fieldset:::r6u:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -21500,7 +22160,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     className="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r6p:::legend"
+                                      aria-labelledby="fieldset:::r6v:::legend"
                                       className="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -21515,7 +22175,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                           data-part="root"
                                           data-readonly=""
                                           data-scope="field"
-                                          id="field:::r6q:"
+                                          id="field:::r70:"
                                           role="group"
                                         >
                                           <label
@@ -21524,8 +22184,8 @@ exports[`single fields optional data controls does not show optional controls wh
                                             data-part="label"
                                             data-readonly=""
                                             data-scope="field"
-                                            htmlFor=":r6q:"
-                                            id="field:::r6q:::label"
+                                            htmlFor=":r70:"
+                                            id="field:::r70:::label"
                                           >
                                             name
                                           </label>
@@ -21568,7 +22228,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 className="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r6r:::legend"
+                  aria-labelledby="fieldset:::r71:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -21592,7 +22252,7 @@ exports[`single fields optional data controls does not show optional controls wh
                             data-part="root"
                             data-readonly=""
                             data-scope="field"
-                            id="field:::r6s:"
+                            id="field:::r72:"
                             role="group"
                           >
                             <label
@@ -21601,8 +22261,8 @@ exports[`single fields optional data controls does not show optional controls wh
                               data-part="label"
                               data-readonly=""
                               data-scope="field"
-                              htmlFor=":r6s:"
-                              id="field:::r6s:::label"
+                              htmlFor=":r72:"
+                              id="field:::r72:::label"
                             >
                               optionalArrayWithAnyofs
                             </label>
@@ -21619,10 +22279,10 @@ exports[`single fields optional data controls does not show optional controls wh
                             >
                               <select
                                 aria-hidden={true}
-                                aria-labelledby="field:::r6s:::label"
+                                aria-labelledby="field:::r72:::label"
                                 defaultValue="0"
                                 disabled={true}
-                                id=":r6s:"
+                                id=":r72:"
                                 multiple={false}
                                 name="root_optionalArrayWithAnyofs__anyof_select"
                                 onFocus={[Function]}
@@ -21685,7 +22345,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                     aria-expanded={false}
                                     aria-haspopup="listbox"
                                     aria-invalid={false}
-                                    aria-labelledby="field:::r6s:::label"
+                                    aria-labelledby="field:::r72:::label"
                                     aria-required={false}
                                     className="chakra-select__trigger emotion-105"
                                     data-disabled=""
@@ -21761,7 +22421,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 }
                               >
                                 <div
-                                  aria-labelledby="field:::r6s:::label"
+                                  aria-labelledby="field:::r72:::label"
                                   className="chakra-select__content emotion-111"
                                   data-part="content"
                                   data-scope="select"
@@ -21887,7 +22547,7 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r6u:::legend"
+                            aria-labelledby="fieldset:::r74:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22584,7 +23244,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r5d:::legend"
+        aria-labelledby="fieldset:::r5j:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -22616,7 +23276,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 className="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5e:::legend"
+                  aria-labelledby="fieldset:::r5k:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -22687,7 +23347,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5f:::legend"
+                            aria-labelledby="fieldset:::r5l:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22700,15 +23360,15 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 className="chakra-field__root emotion-17"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r5g:"
+                                id="field:::r5m:"
                                 role="group"
                               >
                                 <label
                                   className="chakra-field__label emotion-18"
                                   data-part="label"
                                   data-scope="field"
-                                  htmlFor=":r5g:"
-                                  id="field:::r5g:::label"
+                                  htmlFor=":r5m:"
+                                  id="field:::r5m:::label"
                                 >
                                   test
                                 </label>
@@ -22740,7 +23400,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5h:::legend"
+                            aria-labelledby="fieldset:::r5n:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22812,7 +23472,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5i:::legend"
+                            aria-labelledby="fieldset:::r5o:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22844,7 +23504,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                     className="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r5j:::legend"
+                                      aria-labelledby="fieldset:::r5p:::legend"
                                       className="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -22857,15 +23517,15 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                           className="chakra-field__root emotion-17"
                                           data-part="root"
                                           data-scope="field"
-                                          id="field:::r5k:"
+                                          id="field:::r5q:"
                                           role="group"
                                         >
                                           <label
                                             className="chakra-field__label emotion-18"
                                             data-part="label"
                                             data-scope="field"
-                                            htmlFor=":r5k:"
-                                            id="field:::r5k:::label"
+                                            htmlFor=":r5q:"
+                                            id="field:::r5q:::label"
                                           >
                                             deepTest
                                           </label>
@@ -22902,7 +23562,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5l:::legend"
+                            aria-labelledby="fieldset:::r5r:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -22979,7 +23639,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5m:::legend"
+                            aria-labelledby="fieldset:::r5s:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23055,7 +23715,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5n:::legend"
+                            aria-labelledby="fieldset:::r5t:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23137,7 +23797,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 className="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5o:::legend"
+                  aria-labelledby="fieldset:::r5u:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23215,7 +23875,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 className="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r5p:::legend"
+                                  aria-labelledby="fieldset:::r5v:::legend"
                                   className="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -23228,7 +23888,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                       className="chakra-field__root emotion-17"
                                       data-part="root"
                                       data-scope="field"
-                                      id="field:::r5q:"
+                                      id="field:::r60:"
                                       role="group"
                                     >
                                       <label
@@ -23236,8 +23896,8 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                         data-part="label"
                                         data-required=""
                                         data-scope="field"
-                                        htmlFor=":r5q:"
-                                        id="field:::r5q:::label"
+                                        htmlFor=":r60:"
+                                        id="field:::r60:::label"
                                       >
                                         nestedArrayOptional-0
                                         <span
@@ -23360,7 +24020,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 className="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5r:::legend"
+                  aria-labelledby="fieldset:::r61:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23392,7 +24052,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5s:::legend"
+                            aria-labelledby="fieldset:::r62:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23405,15 +24065,15 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 className="chakra-field__root emotion-17"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r5t:"
+                                id="field:::r63:"
                                 role="group"
                               >
                                 <label
                                   className="chakra-field__label emotion-18"
                                   data-part="label"
                                   data-scope="field"
-                                  htmlFor=":r5t:"
-                                  id="field:::r5t:::label"
+                                  htmlFor=":r63:"
+                                  id="field:::r63:::label"
                                 >
                                   test
                                 </label>
@@ -23450,7 +24110,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 className="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5u:::legend"
+                  aria-labelledby="fieldset:::r64:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23527,7 +24187,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 className="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5v:::legend"
+                  aria-labelledby="fieldset:::r65:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23549,7 +24209,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r60:::legend"
+                            aria-labelledby="fieldset:::r66:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -23626,7 +24286,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 className="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r61:::legend"
+                  aria-labelledby="fieldset:::r67:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -23648,7 +24308,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r62:::legend"
+                            aria-labelledby="fieldset:::r68:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24234,7 +24894,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r7a:::legend"
+        aria-labelledby="fieldset:::r7g:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -24267,7 +24927,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 className="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7b:::legend"
+                  aria-labelledby="fieldset:::r7h:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24300,7 +24960,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7c:::legend"
+                            aria-labelledby="fieldset:::r7i:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24315,7 +24975,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 data-part="root"
                                 data-readonly=""
                                 data-scope="field"
-                                id="field:::r7d:"
+                                id="field:::r7j:"
                                 role="group"
                               >
                                 <label
@@ -24324,8 +24984,8 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                   data-part="label"
                                   data-readonly=""
                                   data-scope="field"
-                                  htmlFor=":r7d:"
-                                  id="field:::r7d:::label"
+                                  htmlFor=":r7j:"
+                                  id="field:::r7j:::label"
                                 >
                                   test
                                 </label>
@@ -24358,7 +25018,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7e:::legend"
+                            aria-labelledby="fieldset:::r7k:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24402,7 +25062,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7f:::legend"
+                            aria-labelledby="fieldset:::r7l:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24435,7 +25095,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                     className="rjsf-field rjsf-field-string"
                                   >
                                     <fieldset
-                                      aria-labelledby="fieldset:::r7g:::legend"
+                                      aria-labelledby="fieldset:::r7m:::legend"
                                       className="fieldset__root emotion-0"
                                       data-part="root"
                                       data-scope="fieldset"
@@ -24450,7 +25110,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                           data-part="root"
                                           data-readonly=""
                                           data-scope="field"
-                                          id="field:::r7h:"
+                                          id="field:::r7n:"
                                           role="group"
                                         >
                                           <label
@@ -24459,8 +25119,8 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                             data-part="label"
                                             data-readonly=""
                                             data-scope="field"
-                                            htmlFor=":r7h:"
-                                            id="field:::r7h:::label"
+                                            htmlFor=":r7n:"
+                                            id="field:::r7n:::label"
                                           >
                                             deepTest
                                           </label>
@@ -24498,7 +25158,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7i:::legend"
+                            aria-labelledby="fieldset:::r7o:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24575,7 +25235,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7j:::legend"
+                            aria-labelledby="fieldset:::r7p:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24621,7 +25281,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7k:::legend"
+                            aria-labelledby="fieldset:::r7q:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24703,7 +25363,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 className="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7l:::legend"
+                  aria-labelledby="fieldset:::r7r:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24742,7 +25402,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 className="rjsf-field rjsf-field-string"
                               >
                                 <fieldset
-                                  aria-labelledby="fieldset:::r7m:::legend"
+                                  aria-labelledby="fieldset:::r7s:::legend"
                                   className="fieldset__root emotion-0"
                                   data-part="root"
                                   data-scope="fieldset"
@@ -24757,7 +25417,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                       data-part="root"
                                       data-readonly=""
                                       data-scope="field"
-                                      id="field:::r7n:"
+                                      id="field:::r7t:"
                                       role="group"
                                     >
                                       <label
@@ -24767,8 +25427,8 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                         data-readonly=""
                                         data-required=""
                                         data-scope="field"
-                                        htmlFor=":r7n:"
-                                        id="field:::r7n:::label"
+                                        htmlFor=":r7t:"
+                                        id="field:::r7t:::label"
                                       >
                                         nestedArrayOptional-0
                                         <span
@@ -24892,7 +25552,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 className="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7o:::legend"
+                  aria-labelledby="fieldset:::r7u:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -24925,7 +25585,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7p:::legend"
+                            aria-labelledby="fieldset:::r7v:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -24940,7 +25600,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 data-part="root"
                                 data-readonly=""
                                 data-scope="field"
-                                id="field:::r7q:"
+                                id="field:::r80:"
                                 role="group"
                               >
                                 <label
@@ -24949,8 +25609,8 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                   data-part="label"
                                   data-readonly=""
                                   data-scope="field"
-                                  htmlFor=":r7q:"
-                                  id="field:::r7q:::label"
+                                  htmlFor=":r80:"
+                                  id="field:::r80:::label"
                                 >
                                   test
                                 </label>
@@ -24988,7 +25648,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 className="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7r:::legend"
+                  aria-labelledby="fieldset:::r81:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -25065,7 +25725,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 className="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7s:::legend"
+                  aria-labelledby="fieldset:::r82:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -25087,7 +25747,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7t:::legend"
+                            aria-labelledby="fieldset:::r83:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -25136,7 +25796,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 className="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r7u:::legend"
+                  aria-labelledby="fieldset:::r84:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -25158,7 +25818,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r7v:::legend"
+                            aria-labelledby="fieldset:::r85:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -25655,7 +26315,7 @@ exports[`single fields optional data controls shows "add" optional controls when
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r52:::legend"
+        aria-labelledby="fieldset:::r58:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -25687,7 +26347,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 className="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r53:::legend"
+                  aria-labelledby="fieldset:::r59:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -25759,7 +26419,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 className="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r54:::legend"
+                  aria-labelledby="fieldset:::r5a:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -25835,7 +26495,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 className="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r55:::legend"
+                  aria-labelledby="fieldset:::r5b:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -25867,7 +26527,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                           className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r56:::legend"
+                            aria-labelledby="fieldset:::r5c:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -25880,15 +26540,15 @@ exports[`single fields optional data controls shows "add" optional controls when
                                 className="chakra-field__root emotion-32"
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r57:"
+                                id="field:::r5d:"
                                 role="group"
                               >
                                 <label
                                   className="chakra-field__label emotion-33"
                                   data-part="label"
                                   data-scope="field"
-                                  htmlFor=":r57:"
-                                  id="field:::r57:::label"
+                                  htmlFor=":r5d:"
+                                  id="field:::r5d:::label"
                                 >
                                   test
                                 </label>
@@ -25925,7 +26585,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 className="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r58:::legend"
+                  aria-labelledby="fieldset:::r5e:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -26002,7 +26662,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 className="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r59:::legend"
+                  aria-labelledby="fieldset:::r5f:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -26024,7 +26684,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                           className="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5a:::legend"
+                            aria-labelledby="fieldset:::r5g:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -26101,7 +26761,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 className="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r5b:::legend"
+                  aria-labelledby="fieldset:::r5h:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -26123,7 +26783,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                           className="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r5c:::legend"
+                            aria-labelledby="fieldset:::r5i:::legend"
                             className="fieldset__root emotion-0"
                             data-part="root"
                             data-scope="fieldset"
@@ -26540,7 +27200,7 @@ exports[`single fields optional data controls shows "add" optional controls when
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r6v:::legend"
+        aria-labelledby="fieldset:::r75:::legend"
         className="fieldset__root emotion-0"
         data-disabled=""
         data-part="root"
@@ -26574,7 +27234,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 className="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r70:::legend"
+                  aria-labelledby="fieldset:::r76:::legend"
                   className="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -26619,7 +27279,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 className="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r71:::legend"
+                  aria-labelledby="fieldset:::r77:::legend"
                   className="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -26666,7 +27326,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 className="rjsf-field rjsf-field-object"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r72:::legend"
+                  aria-labelledby="fieldset:::r78:::legend"
                   className="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -26700,7 +27360,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                           className="rjsf-field rjsf-field-string"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r73:::legend"
+                            aria-labelledby="fieldset:::r79:::legend"
                             className="fieldset__root emotion-0"
                             data-disabled=""
                             data-part="root"
@@ -26715,7 +27375,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                 data-disabled=""
                                 data-part="root"
                                 data-scope="field"
-                                id="field:::r74:"
+                                id="field:::r7a:"
                                 role="group"
                               >
                                 <label
@@ -26723,8 +27383,8 @@ exports[`single fields optional data controls shows "add" optional controls when
                                   data-disabled=""
                                   data-part="label"
                                   data-scope="field"
-                                  htmlFor=":r74:"
-                                  id="field:::r74:::label"
+                                  htmlFor=":r7a:"
+                                  id="field:::r7a:::label"
                                 >
                                   test
                                 </label>
@@ -26761,7 +27421,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 className="rjsf-field rjsf-field-array"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r75:::legend"
+                  aria-labelledby="fieldset:::r7b:::legend"
                   className="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -26839,7 +27499,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 className="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r76:::legend"
+                  aria-labelledby="fieldset:::r7c:::legend"
                   className="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -26862,7 +27522,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                           className="rjsf-field rjsf-field-object"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r77:::legend"
+                            aria-labelledby="fieldset:::r7d:::legend"
                             className="fieldset__root emotion-0"
                             data-disabled=""
                             data-part="root"
@@ -26912,7 +27572,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 className="rjsf-field rjsf-field-undefined"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r78:::legend"
+                  aria-labelledby="fieldset:::r7e:::legend"
                   className="fieldset__root emotion-0"
                   data-disabled=""
                   data-part="root"
@@ -26935,7 +27595,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                           className="rjsf-field rjsf-field-array"
                         >
                           <fieldset
-                            aria-labelledby="fieldset:::r79:::legend"
+                            aria-labelledby="fieldset:::r7f:::legend"
                             className="fieldset__root emotion-0"
                             data-disabled=""
                             data-part="root"
@@ -28453,7 +29113,7 @@ exports[`single fields schema examples 1`] = `
       className="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r42:::legend"
+        aria-labelledby="fieldset:::r48:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -28466,7 +29126,7 @@ exports[`single fields schema examples 1`] = `
             className="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r43:"
+            id="field:::r49:"
             role="group"
           >
             <input
@@ -38857,7 +39517,7 @@ exports[`single fields title field 1`] = `
       className="rjsf-field rjsf-field-object"
     >
       <fieldset
-        aria-labelledby="fieldset:::r3r:::legend"
+        aria-labelledby="fieldset:::r41:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -38889,7 +39549,7 @@ exports[`single fields title field 1`] = `
                 className="rjsf-field rjsf-field-string"
               >
                 <fieldset
-                  aria-labelledby="fieldset:::r3s:::legend"
+                  aria-labelledby="fieldset:::r42:::legend"
                   className="fieldset__root emotion-0"
                   data-part="root"
                   data-scope="fieldset"
@@ -38902,15 +39562,15 @@ exports[`single fields title field 1`] = `
                       className="chakra-field__root emotion-8"
                       data-part="root"
                       data-scope="field"
-                      id="field:::r3t:"
+                      id="field:::r43:"
                       role="group"
                     >
                       <label
                         className="chakra-field__label emotion-9"
                         data-part="label"
                         data-scope="field"
-                        htmlFor=":r3t:"
-                        id="field:::r3t:::label"
+                        htmlFor=":r43:"
+                        id="field:::r43:::label"
                       >
                         Titre 2
                       </label>
@@ -39822,7 +40482,7 @@ exports[`single fields using custom tagName 1`] = `
       className="rjsf-field rjsf-field-string"
     >
       <fieldset
-        aria-labelledby="fieldset:::r40:::legend"
+        aria-labelledby="fieldset:::r46:::legend"
         className="fieldset__root emotion-0"
         data-part="root"
         data-scope="fieldset"
@@ -39835,7 +40495,7 @@ exports[`single fields using custom tagName 1`] = `
             className="chakra-field__root emotion-2"
             data-part="root"
             data-scope="field"
-            id="field:::r41:"
+            id="field:::r47:"
             role="group"
           >
             <input

--- a/packages/core/src/components/RichHelp.tsx
+++ b/packages/core/src/components/RichHelp.tsx
@@ -1,0 +1,46 @@
+import { ReactElement } from 'react';
+import {
+  FormContextType,
+  Registry,
+  RJSFSchema,
+  StrictRJSFSchema,
+  UiSchema,
+  getTestIds,
+  getUiOptions,
+} from '@rjsf/utils';
+import Markdown from 'markdown-to-jsx';
+
+const TEST_IDS = getTestIds();
+
+export interface RichHelpProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any> {
+  /** The help text for a field, potentially containing markdown */
+  help: string | ReactElement;
+  /** The uiSchema object for this base component */
+  uiSchema?: UiSchema<T, S, F>;
+  /** The `registry` object */
+  registry: Registry<T, S, F>;
+}
+
+/** Renders the given `help` in the props as markdown if enabled
+ *
+ * @param props - The `RichHelpProps` for this component
+ */
+export default function RichHelp<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any>({
+  help,
+  registry,
+  uiSchema = {},
+}: RichHelpProps<T, S, F>) {
+  const { globalUiOptions } = registry;
+  const uiOptions = getUiOptions<T, S, F>(uiSchema, globalUiOptions);
+
+  if (uiOptions.enableMarkdownInHelp && typeof help === 'string') {
+    return (
+      <Markdown options={{ disableParsingRawHTML: true }} data-testid={TEST_IDS.markdown}>
+        {help}
+      </Markdown>
+    );
+  }
+  return help;
+}
+
+RichHelp.TEST_IDS = TEST_IDS;

--- a/packages/core/src/components/templates/FieldHelpTemplate.tsx
+++ b/packages/core/src/components/templates/FieldHelpTemplate.tsx
@@ -1,4 +1,5 @@
 import { helpId, FieldHelpProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
+import RichHelp from '../RichHelp';
 
 /** The `FieldHelpTemplate` component renders any help desired for a field
  *
@@ -9,21 +10,22 @@ export default function FieldHelpTemplate<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: FieldHelpProps<T, S, F>) {
-  const { fieldPathId, help } = props;
+  const { fieldPathId, help, registry, uiSchema } = props;
   if (!help) {
     return null;
   }
   const id = helpId(fieldPathId);
+  const helpContent = <RichHelp help={help} registry={registry} uiSchema={uiSchema} />;
   if (typeof help === 'string') {
     return (
       <p id={id} className='help-block'>
-        {help}
+        {helpContent}
       </p>
     );
   }
   return (
     <div id={id} className='help-block'>
-      {help}
+      {helpContent}
     </div>
   );
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,10 +1,11 @@
 import Form, { FormProps, FormState, IChangeEvent } from './components/Form';
 import RichDescription, { RichDescriptionProps } from './components/RichDescription';
+import RichHelp, { RichHelpProps } from './components/RichHelp';
 import withTheme, { ThemeProps } from './withTheme';
 import getDefaultRegistry from './getDefaultRegistry';
 import getTestRegistry from './getTestRegistry';
 
-export type { FormProps, FormState, IChangeEvent, ThemeProps, RichDescriptionProps };
+export type { FormProps, FormState, IChangeEvent, ThemeProps, RichDescriptionProps, RichHelpProps };
 
-export { withTheme, getDefaultRegistry, getTestRegistry, RichDescription };
+export { withTheme, getDefaultRegistry, getTestRegistry, RichDescription, RichHelp };
 export default Form;

--- a/packages/core/test/RichHelp.test.tsx
+++ b/packages/core/test/RichHelp.test.tsx
@@ -1,0 +1,61 @@
+import { render, within } from '@testing-library/react';
+import { Registry } from '@rjsf/utils';
+
+import RichHelp, { RichHelpProps } from '../src/components/RichHelp';
+
+const TEST_ID = 'test-id';
+
+describe('RichHelp', () => {
+  function getProps(overrides: Partial<RichHelpProps> = {}) {
+    const { help = '', uiSchema = {}, registry = {} as Registry } = overrides;
+    return { help, uiSchema, registry };
+  }
+
+  test('simple text help', () => {
+    const text = 'text help';
+    const props = getProps({ help: text });
+    const { container } = render(<RichHelp {...props} />);
+    expect(container).toHaveTextContent(text);
+  });
+  test('react element help', () => {
+    const text = 'Text In P';
+    const props = getProps({ help: <p data-testid={TEST_ID}>{text}</p> });
+    const { container } = render(<RichHelp {...props} />);
+    expect(container).toBeInTheDocument();
+    const paragraph = within(container).getByTestId(TEST_ID);
+    expect(paragraph).toHaveTextContent(text);
+  });
+  test('react rich text help, not enabled', () => {
+    const text = '**Rich** Text';
+    const props = getProps({ help: text });
+    const { container } = render(<RichHelp {...props} />);
+    expect(container).toHaveTextContent(text);
+    const markdown = within(container).queryByTestId(RichHelp.TEST_IDS.markdown);
+    expect(markdown).not.toBeInTheDocument();
+  });
+  test('react element help, enabled enableMarkdownInHelp', () => {
+    const text = '**Text** In P';
+    const props = getProps({
+      help: <p data-testid={TEST_ID}>{text}</p>,
+      uiSchema: { 'ui:enableMarkdownInHelp': true },
+    });
+    const { container } = render(<RichHelp {...props} />);
+    expect(container).toBeInTheDocument();
+    const paragraph = within(container).getByTestId(TEST_ID);
+    expect(paragraph).toHaveTextContent(text);
+    const markdown = within(container).queryByTestId(RichHelp.TEST_IDS.markdown);
+    expect(markdown).not.toBeInTheDocument();
+  });
+  test('react rich text help, enabled enableMarkdownInHelp', () => {
+    const expectedBold = 'Rich';
+    const text = `**${expectedBold}** Text`;
+    const expected = `${expectedBold} Text`;
+    const props = getProps({ help: text, uiSchema: { 'ui:enableMarkdownInHelp': true } });
+    const { container } = render(<RichHelp {...props} />);
+    expect(container).toHaveTextContent(expected);
+    const markdown = within(container).getByTestId(RichHelp.TEST_IDS.markdown);
+    expect(markdown).toBeInTheDocument();
+    const bold = markdown.querySelector('strong');
+    expect(bold).toHaveTextContent(expectedBold);
+  });
+});

--- a/packages/core/test/__snapshots__/FormSnap.test.tsx.snap
+++ b/packages/core/test/__snapshots__/FormSnap.test.tsx.snap
@@ -2901,6 +2901,136 @@ exports[`single fields field with markdown description in uiSchema 1`] = `
 </form>
 `;
 
+exports[`single fields field with markdown help 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group rjsf-field rjsf-field-object"
+  >
+    <fieldset
+      id="root"
+    >
+      <div
+        className="form-group rjsf-field rjsf-field-string"
+      >
+        <label
+          className="control-label"
+          htmlFor="root_my-field"
+        >
+          my-field
+        </label>
+        <input
+          aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root_my-field"
+          label="my-field"
+          name="root_my-field"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          required={false}
+          type="text"
+          value=""
+        />
+        <p
+          className="help-block"
+          id="root_my-field__help"
+        >
+          <span>
+            some 
+            <strong>
+              Rich
+            </strong>
+             help text
+          </span>
+        </p>
+      </div>
+    </fieldset>
+  </div>
+  <div>
+    <button
+      className="btn btn-info "
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown help in uiSchema 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="form-group rjsf-field rjsf-field-object"
+  >
+    <fieldset
+      id="root"
+    >
+      <div
+        className="form-group rjsf-field rjsf-field-string"
+      >
+        <label
+          className="control-label"
+          htmlFor="root_my-field"
+        >
+          my-field
+        </label>
+        <input
+          aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+          autoFocus={false}
+          className="form-control"
+          disabled={false}
+          id="root_my-field"
+          label="my-field"
+          name="root_my-field"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          placeholder=""
+          readOnly={false}
+          required={false}
+          type="text"
+          value=""
+        />
+        <p
+          className="help-block"
+          id="root_my-field__help"
+        >
+          <span>
+            some 
+            <strong>
+              other
+            </strong>
+             help
+          </span>
+        </p>
+      </div>
+    </fieldset>
+  </div>
+  <div>
+    <button
+      className="btn btn-info "
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields format color 1`] = `
 <form
   className="rjsf"

--- a/packages/daisyui/src/templates/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/daisyui/src/templates/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,4 +1,5 @@
 import { FieldHelpProps, StrictRJSFSchema, RJSFSchema, FormContextType } from '@rjsf/utils';
+import { RichHelp } from '@rjsf/core';
 
 /** The `FieldHelpTemplate` component renders help text for a specific form field
  * with DaisyUI styling. It displays the help text in a subtle gray color and smaller size
@@ -14,10 +15,15 @@ export default function FieldHelpTemplate<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: FieldHelpProps<T, S, F>) {
-  const { help } = props;
+  const { help, registry, uiSchema } = props;
+  if (!help) {
+    return null;
+  }
   return (
     <div className='rjsf-field-help-template text-gray-500 text-sm'>
-      <div>{help}</div>
+      <div>
+        <RichHelp help={help} registry={registry} uiSchema={uiSchema} />
+      </div>
     </div>
   );
 }

--- a/packages/daisyui/test/__snapshots__/Array.test.tsx.snap
+++ b/packages/daisyui/test/__snapshots__/Array.test.tsx.snap
@@ -72,11 +72,6 @@ exports[`array fields array 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -175,11 +170,6 @@ exports[`array fields array icons 1`] = `
                     <ul
                       className="list-disc list-inside"
                     />
-                  </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
                   </div>
                 </div>
               </div>
@@ -347,11 +337,6 @@ exports[`array fields array icons 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
               <div
@@ -500,11 +485,6 @@ exports[`array fields array icons 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -640,11 +620,6 @@ exports[`array fields checkboxes 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -739,11 +714,6 @@ exports[`array fields empty errors array 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -755,11 +725,6 @@ exports[`array fields empty errors array 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -860,11 +825,6 @@ exports[`array fields fixed array 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
             </fieldset>
@@ -932,11 +892,6 @@ exports[`array fields fixed array 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
             </fieldset>
@@ -949,11 +904,6 @@ exports[`array fields fixed array 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -1064,11 +1014,6 @@ exports[`array fields has errors 1`] = `
                     </li>
                   </ul>
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -1080,11 +1025,6 @@ exports[`array fields has errors 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -1180,11 +1120,6 @@ exports[`array fields no errors 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -1196,11 +1131,6 @@ exports[`array fields no errors 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -1315,11 +1245,6 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                 className="list-disc list-inside"
                               />
                             </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
-                            </div>
                           </div>
                         </div>
                       </div>
@@ -1385,11 +1310,6 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                 className="list-disc list-inside"
                               />
                             </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
-                            </div>
                           </div>
                         </div>
                       </div>
@@ -1401,11 +1321,6 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                     <ul
                       className="list-disc list-inside"
                     />
-                  </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
                   </div>
                 </div>
               </div>
@@ -1564,11 +1479,6 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                 className="list-disc list-inside"
                               />
                             </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
-                            </div>
                           </div>
                         </div>
                       </div>
@@ -1634,11 +1544,6 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                 className="list-disc list-inside"
                               />
                             </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
-                            </div>
                           </div>
                         </div>
                       </div>
@@ -1650,11 +1555,6 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                     <ul
                       className="list-disc list-inside"
                     />
-                  </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
                   </div>
                 </div>
               </div>
@@ -1781,11 +1681,6 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -1884,11 +1779,6 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                     <ul
                       className="list-disc list-inside"
                     />
-                  </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
                   </div>
                 </div>
               </div>
@@ -2033,11 +1923,6 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
               <div
@@ -2162,11 +2047,6 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -2303,11 +2183,6 @@ exports[`nameGenerator bracketNameGenerator checkboxes with nameGenerator 1`] = 
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -2407,11 +2282,6 @@ exports[`nameGenerator bracketNameGenerator fixed array 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
             </fieldset>
@@ -2479,11 +2349,6 @@ exports[`nameGenerator bracketNameGenerator fixed array 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
             </fieldset>
@@ -2520,11 +2385,6 @@ exports[`nameGenerator bracketNameGenerator fixed array 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
             </fieldset>
@@ -2537,11 +2397,6 @@ exports[`nameGenerator bracketNameGenerator fixed array 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -2660,11 +2515,6 @@ exports[`nameGenerator bracketNameGenerator nested arrays 1`] = `
                                 <ul
                                   className="list-disc list-inside"
                                 />
-                              </div>
-                              <div
-                                className="rjsf-field-help-template text-gray-500 text-sm"
-                              >
-                                <div />
                               </div>
                             </div>
                           </div>
@@ -2809,11 +2659,6 @@ exports[`nameGenerator bracketNameGenerator nested arrays 1`] = `
                                   className="list-disc list-inside"
                                 />
                               </div>
-                              <div
-                                className="rjsf-field-help-template text-gray-500 text-sm"
-                              >
-                                <div />
-                              </div>
                             </div>
                           </div>
                           <div
@@ -2938,11 +2783,6 @@ exports[`nameGenerator bracketNameGenerator nested arrays 1`] = `
                     <ul
                       className="list-disc list-inside"
                     />
-                  </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
                   </div>
                 </div>
               </div>
@@ -3106,11 +2946,6 @@ exports[`nameGenerator bracketNameGenerator nested arrays 1`] = `
                                   className="list-disc list-inside"
                                 />
                               </div>
-                              <div
-                                className="rjsf-field-help-template text-gray-500 text-sm"
-                              >
-                                <div />
-                              </div>
                             </div>
                           </div>
                           <div
@@ -3254,11 +3089,6 @@ exports[`nameGenerator bracketNameGenerator nested arrays 1`] = `
                                   className="list-disc list-inside"
                                 />
                               </div>
-                              <div
-                                className="rjsf-field-help-template text-gray-500 text-sm"
-                              >
-                                <div />
-                              </div>
                             </div>
                           </div>
                           <div
@@ -3383,11 +3213,6 @@ exports[`nameGenerator bracketNameGenerator nested arrays 1`] = `
                     <ul
                       className="list-disc list-inside"
                     />
-                  </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
                   </div>
                 </div>
               </div>
@@ -3514,11 +3339,6 @@ exports[`nameGenerator bracketNameGenerator nested arrays 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -3632,11 +3452,6 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                 className="list-disc list-inside"
                               />
                             </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
-                            </div>
                           </div>
                         </div>
                       </div>
@@ -3702,11 +3517,6 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                 className="list-disc list-inside"
                               />
                             </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
-                            </div>
                           </div>
                         </div>
                       </div>
@@ -3718,11 +3528,6 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                     <ul
                       className="list-disc list-inside"
                     />
-                  </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
                   </div>
                 </div>
               </div>
@@ -3881,11 +3686,6 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                 className="list-disc list-inside"
                               />
                             </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
-                            </div>
                           </div>
                         </div>
                       </div>
@@ -3951,11 +3751,6 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                 className="list-disc list-inside"
                               />
                             </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
-                            </div>
                           </div>
                         </div>
                       </div>
@@ -3967,11 +3762,6 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                     <ul
                       className="list-disc list-inside"
                     />
-                  </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
                   </div>
                 </div>
               </div>
@@ -4098,11 +3888,6 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -4201,11 +3986,6 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                     <ul
                       className="list-disc list-inside"
                     />
-                  </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
                   </div>
                 </div>
               </div>
@@ -4350,11 +4130,6 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
               <div
@@ -4480,11 +4255,6 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -4593,11 +4363,6 @@ exports[`with title and description array 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -4723,11 +4488,6 @@ exports[`with title and description array icons 1`] = `
                     <ul
                       className="list-disc list-inside"
                     />
-                  </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
                   </div>
                 </div>
               </div>
@@ -4898,11 +4658,6 @@ exports[`with title and description array icons 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
               <div
@@ -5050,11 +4805,6 @@ exports[`with title and description array icons 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -5193,11 +4943,6 @@ exports[`with title and description checkboxes 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -5323,11 +5068,6 @@ exports[`with title and description fixed array 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
             </fieldset>
@@ -5398,11 +5138,6 @@ exports[`with title and description fixed array 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
             </fieldset>
@@ -5415,11 +5150,6 @@ exports[`with title and description fixed array 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -5529,11 +5259,6 @@ exports[`with title and description from both array 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -5659,11 +5384,6 @@ exports[`with title and description from both array icons 1`] = `
                     <ul
                       className="list-disc list-inside"
                     />
-                  </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
                   </div>
                 </div>
               </div>
@@ -5834,11 +5554,6 @@ exports[`with title and description from both array icons 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
               <div
@@ -5986,11 +5701,6 @@ exports[`with title and description from both array icons 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -6129,11 +5839,6 @@ exports[`with title and description from both checkboxes 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -6259,11 +5964,6 @@ exports[`with title and description from both fixed array 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
             </fieldset>
@@ -6334,11 +6034,6 @@ exports[`with title and description from both fixed array 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
             </fieldset>
@@ -6351,11 +6046,6 @@ exports[`with title and description from both fixed array 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -6465,11 +6155,6 @@ exports[`with title and description from uiSchema array 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -6595,11 +6280,6 @@ exports[`with title and description from uiSchema array icons 1`] = `
                     <ul
                       className="list-disc list-inside"
                     />
-                  </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
                   </div>
                 </div>
               </div>
@@ -6770,11 +6450,6 @@ exports[`with title and description from uiSchema array icons 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
               <div
@@ -6922,11 +6597,6 @@ exports[`with title and description from uiSchema array icons 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -7065,11 +6735,6 @@ exports[`with title and description from uiSchema checkboxes 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -7195,11 +6860,6 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
             </fieldset>
@@ -7270,11 +6930,6 @@ exports[`with title and description from uiSchema fixed array 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
             </fieldset>
@@ -7287,11 +6942,6 @@ exports[`with title and description from uiSchema fixed array 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -7379,11 +7029,6 @@ exports[`with title and description with global label off array 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -7470,11 +7115,6 @@ exports[`with title and description with global label off array icons 1`] = `
                     <ul
                       className="list-disc list-inside"
                     />
-                  </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
                   </div>
                 </div>
               </div>
@@ -7630,11 +7270,6 @@ exports[`with title and description with global label off array icons 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
               <div
@@ -7783,11 +7418,6 @@ exports[`with title and description with global label off array icons 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -7925,11 +7555,6 @@ exports[`with title and description with global label off checkboxes 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -8017,11 +7642,6 @@ exports[`with title and description with global label off fixed array 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
             </fieldset>
@@ -8077,11 +7697,6 @@ exports[`with title and description with global label off fixed array 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
             </fieldset>
@@ -8094,11 +7709,6 @@ exports[`with title and description with global label off fixed array 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>

--- a/packages/daisyui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/daisyui/test/__snapshots__/Form.test.tsx.snap
@@ -141,11 +141,6 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                           className="list-disc list-inside"
                                         />
                                       </div>
-                                      <div
-                                        className="rjsf-field-help-template text-gray-500 text-sm"
-                                      >
-                                        <div />
-                                      </div>
                                     </div>
                                   </div>
                                 </div>
@@ -195,11 +190,6 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                           className="list-disc list-inside"
                                         />
                                       </div>
-                                      <div
-                                        className="rjsf-field-help-template text-gray-500 text-sm"
-                                      >
-                                        <div />
-                                      </div>
                                     </div>
                                   </div>
                                 </div>
@@ -211,11 +201,6 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                               <ul
                                 className="list-disc list-inside"
                               />
-                            </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
                             </div>
                           </div>
                         </div>
@@ -387,11 +372,6 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                           className="list-disc list-inside"
                                         />
                                       </div>
-                                      <div
-                                        className="rjsf-field-help-template text-gray-500 text-sm"
-                                      >
-                                        <div />
-                                      </div>
                                     </div>
                                   </div>
                                 </div>
@@ -441,11 +421,6 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                           className="list-disc list-inside"
                                         />
                                       </div>
-                                      <div
-                                        className="rjsf-field-help-template text-gray-500 text-sm"
-                                      >
-                                        <div />
-                                      </div>
                                     </div>
                                   </div>
                                 </div>
@@ -457,11 +432,6 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                               <ul
                                 className="list-disc list-inside"
                               />
-                            </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
                             </div>
                           </div>
                         </div>
@@ -588,11 +558,6 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -604,11 +569,6 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -740,11 +700,6 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                               <ul
                                 className="list-disc list-inside"
                               />
-                            </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
                             </div>
                           </div>
                         </div>
@@ -892,11 +847,6 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                                 className="list-disc list-inside"
                               />
                             </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
-                            </div>
                           </div>
                         </div>
                         <div
@@ -1022,11 +972,6 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -1038,11 +983,6 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -1178,11 +1118,6 @@ exports[`nameGenerator bracketNameGenerator checkboxes field 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -1194,11 +1129,6 @@ exports[`nameGenerator bracketNameGenerator checkboxes field 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -1323,11 +1253,6 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -1391,11 +1316,6 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                             <ul
                               className="list-disc list-inside"
                             />
-                          </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
                           </div>
                         </div>
                       </div>
@@ -1490,11 +1410,6 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                         className="list-disc list-inside"
                                       />
                                     </div>
-                                    <div
-                                      className="rjsf-field-help-template text-gray-500 text-sm"
-                                    >
-                                      <div />
-                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -1559,11 +1474,6 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                         className="list-disc list-inside"
                                       />
                                     </div>
-                                    <div
-                                      className="rjsf-field-help-template text-gray-500 text-sm"
-                                    >
-                                      <div />
-                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -1575,11 +1485,6 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                             <ul
                               className="list-disc list-inside"
                             />
-                          </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
                           </div>
                         </div>
                       </div>
@@ -1593,11 +1498,6 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -1609,11 +1509,6 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -1729,11 +1624,6 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -1745,11 +1635,6 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -1884,11 +1769,6 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -1900,11 +1780,6 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -2000,11 +1875,6 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -2070,11 +1940,6 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -2123,11 +1988,6 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -2139,11 +1999,6 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -2222,11 +2077,6 @@ exports[`nameGenerator bracketNameGenerator textarea field 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -2238,11 +2088,6 @@ exports[`nameGenerator bracketNameGenerator textarea field 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -2399,11 +2244,6 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                           className="list-disc list-inside"
                                         />
                                       </div>
-                                      <div
-                                        className="rjsf-field-help-template text-gray-500 text-sm"
-                                      >
-                                        <div />
-                                      </div>
                                     </div>
                                   </div>
                                 </div>
@@ -2453,11 +2293,6 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                           className="list-disc list-inside"
                                         />
                                       </div>
-                                      <div
-                                        className="rjsf-field-help-template text-gray-500 text-sm"
-                                      >
-                                        <div />
-                                      </div>
                                     </div>
                                   </div>
                                 </div>
@@ -2469,11 +2304,6 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                               <ul
                                 className="list-disc list-inside"
                               />
-                            </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
                             </div>
                           </div>
                         </div>
@@ -2645,11 +2475,6 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                           className="list-disc list-inside"
                                         />
                                       </div>
-                                      <div
-                                        className="rjsf-field-help-template text-gray-500 text-sm"
-                                      >
-                                        <div />
-                                      </div>
                                     </div>
                                   </div>
                                 </div>
@@ -2699,11 +2524,6 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                           className="list-disc list-inside"
                                         />
                                       </div>
-                                      <div
-                                        className="rjsf-field-help-template text-gray-500 text-sm"
-                                      >
-                                        <div />
-                                      </div>
                                     </div>
                                   </div>
                                 </div>
@@ -2715,11 +2535,6 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                               <ul
                                 className="list-disc list-inside"
                               />
-                            </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
                             </div>
                           </div>
                         </div>
@@ -2846,11 +2661,6 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -2862,11 +2672,6 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -2998,11 +2803,6 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                               <ul
                                 className="list-disc list-inside"
                               />
-                            </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
                             </div>
                           </div>
                         </div>
@@ -3150,11 +2950,6 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                                 className="list-disc list-inside"
                               />
                             </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
-                            </div>
                           </div>
                         </div>
                         <div
@@ -3280,11 +3075,6 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -3296,11 +3086,6 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -3425,11 +3210,6 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -3493,11 +3273,6 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                             <ul
                               className="list-disc list-inside"
                             />
-                          </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
                           </div>
                         </div>
                       </div>
@@ -3592,11 +3367,6 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                         className="list-disc list-inside"
                                       />
                                     </div>
-                                    <div
-                                      className="rjsf-field-help-template text-gray-500 text-sm"
-                                    >
-                                      <div />
-                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -3661,11 +3431,6 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                         className="list-disc list-inside"
                                       />
                                     </div>
-                                    <div
-                                      className="rjsf-field-help-template text-gray-500 text-sm"
-                                    >
-                                      <div />
-                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -3677,11 +3442,6 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                             <ul
                               className="list-disc list-inside"
                             />
-                          </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
                           </div>
                         </div>
                       </div>
@@ -3695,11 +3455,6 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -3711,11 +3466,6 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -3850,11 +3600,6 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -3866,11 +3611,6 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -3966,11 +3706,6 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -4036,11 +3771,6 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -4089,11 +3819,6 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -4105,11 +3830,6 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -4158,11 +3878,6 @@ exports[`single fields checkbox field 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -4235,11 +3950,6 @@ exports[`single fields checkbox field with description in schema and FieldTempla
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -4300,11 +4010,6 @@ exports[`single fields checkbox field with label 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -4376,11 +4081,6 @@ exports[`single fields checkbox field with label and description 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -4460,11 +4160,6 @@ exports[`single fields checkbox field with label and rich text description 1`] =
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -4605,11 +4300,6 @@ exports[`single fields checkboxes field 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -4854,11 +4544,6 @@ exports[`single fields checkboxes widget with required field 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -4953,11 +4638,6 @@ exports[`single fields field with description 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -4969,11 +4649,6 @@ exports[`single fields field with description 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -5069,11 +4744,6 @@ exports[`single fields field with description in uiSchema 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -5085,11 +4755,6 @@ exports[`single fields field with description in uiSchema 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -5185,11 +4850,6 @@ exports[`single fields field with markdown description 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -5201,11 +4861,6 @@ exports[`single fields field with markdown description 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -5301,10 +4956,124 @@ exports[`single fields field with markdown description in uiSchema 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="rjsf-field-error-template text-red-600"
+      >
+        <ul
+          className="list-disc list-inside"
+        />
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-primary btn-primary-content "
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown help 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="field-template mb-3 rjsf-field rjsf-field-object"
+      disabled={false}
+    >
+      <div
+        className="form-control bg-base-100 p-6 rounded-xl shadow-lg"
+      >
+        <div
+          className="grid grid-cols-1 gap-4 "
+        >
+          <div
+            className=""
+          >
+            <div
+              className="rjsf-field rjsf-field-string"
+            >
+              <div
+                className="field-template mb-3 rjsf-field rjsf-field-string"
+                disabled={false}
+              >
+                <label
+                  className="label"
+                  htmlFor="root_my-field"
+                >
+                  <span
+                    className="label-text font-medium"
+                  >
+                    my-field
+                  </span>
+                </label>
+                <div
+                  className="form-control"
+                >
+                  <label
+                    className="label hidden"
+                    htmlFor="root_my-field"
+                    style={
+                      {
+                        "display": "none",
+                      }
+                    }
+                  >
+                    <span
+                      className="label-text"
+                    >
+                      my-field
+                    </span>
+                  </label>
+                  <input
+                    aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                    autoFocus={false}
+                    className="input input-bordered"
+                    disabled={false}
+                    id="root_my-field"
+                    name="root_my-field"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <div
+                  className="rjsf-field-error-template text-red-600"
+                >
+                  <ul
+                    className="list-disc list-inside"
+                  />
+                </div>
                 <div
                   className="rjsf-field-help-template text-gray-500 text-sm"
                 >
-                  <div />
+                  <div>
+                    <span>
+                      some 
+                      <strong>
+                        Rich
+                      </strong>
+                       help text
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -5318,10 +5087,124 @@ exports[`single fields field with markdown description in uiSchema 1`] = `
           className="list-disc list-inside"
         />
       </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-primary btn-primary-content "
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown help in uiSchema 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="field-template mb-3 rjsf-field rjsf-field-object"
+      disabled={false}
+    >
       <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
+        className="form-control bg-base-100 p-6 rounded-xl shadow-lg"
       >
-        <div />
+        <div
+          className="grid grid-cols-1 gap-4 "
+        >
+          <div
+            className=""
+          >
+            <div
+              className="rjsf-field rjsf-field-string"
+            >
+              <div
+                className="field-template mb-3 rjsf-field rjsf-field-string"
+                disabled={false}
+              >
+                <label
+                  className="label"
+                  htmlFor="root_my-field"
+                >
+                  <span
+                    className="label-text font-medium"
+                  >
+                    my-field
+                  </span>
+                </label>
+                <div
+                  className="form-control"
+                >
+                  <label
+                    className="label hidden"
+                    htmlFor="root_my-field"
+                    style={
+                      {
+                        "display": "none",
+                      }
+                    }
+                  >
+                    <span
+                      className="label-text"
+                    >
+                      my-field
+                    </span>
+                  </label>
+                  <input
+                    aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                    autoFocus={false}
+                    className="input input-bordered"
+                    disabled={false}
+                    id="root_my-field"
+                    name="root_my-field"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <div
+                  className="rjsf-field-error-template text-red-600"
+                >
+                  <ul
+                    className="list-disc list-inside"
+                  />
+                </div>
+                <div
+                  className="rjsf-field-help-template text-gray-500 text-sm"
+                >
+                  <div>
+                    <span>
+                      some 
+                      <strong>
+                        other
+                      </strong>
+                       help
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="rjsf-field-error-template text-red-600"
+      >
+        <ul
+          className="list-disc list-inside"
+        />
       </div>
     </div>
   </div>
@@ -5395,11 +5278,6 @@ exports[`single fields format color 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -5481,11 +5359,6 @@ exports[`single fields format date 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -5566,11 +5439,6 @@ exports[`single fields format datetime 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -5627,11 +5495,6 @@ exports[`single fields format time 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -5791,11 +5654,6 @@ exports[`single fields hidden field 1`] = `
                   className="list-disc list-inside"
                 />
               </div>
-              <div
-                className="rjsf-field-help-template text-gray-500 text-sm"
-              >
-                <div />
-              </div>
             </div>
           </div>
         </div>
@@ -5806,11 +5664,6 @@ exports[`single fields hidden field 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -5877,11 +5730,6 @@ exports[`single fields hidden label 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -5923,11 +5771,6 @@ exports[`single fields null field 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -6003,11 +5846,6 @@ exports[`single fields number field 0 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -6081,11 +5919,6 @@ exports[`single fields number field 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -6223,11 +6056,6 @@ exports[`single fields optional data controls does not show optional controls wh
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -6321,11 +6149,6 @@ exports[`single fields optional data controls does not show optional controls wh
                                         className="list-disc list-inside"
                                       />
                                     </div>
-                                    <div
-                                      className="rjsf-field-help-template text-gray-500 text-sm"
-                                    >
-                                      <div />
-                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -6337,11 +6160,6 @@ exports[`single fields optional data controls does not show optional controls wh
                             <ul
                               className="list-disc list-inside"
                             />
-                          </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
                           </div>
                         </div>
                       </div>
@@ -6436,11 +6254,6 @@ exports[`single fields optional data controls does not show optional controls wh
                                         className="list-disc list-inside"
                                       />
                                     </div>
-                                    <div
-                                      className="rjsf-field-help-template text-gray-500 text-sm"
-                                    >
-                                      <div />
-                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -6452,11 +6265,6 @@ exports[`single fields optional data controls does not show optional controls wh
                             <ul
                               className="list-disc list-inside"
                             />
-                          </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
                           </div>
                         </div>
                       </div>
@@ -6543,11 +6351,6 @@ exports[`single fields optional data controls does not show optional controls wh
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -6632,11 +6435,6 @@ exports[`single fields optional data controls does not show optional controls wh
                             <ul
                               className="list-disc list-inside"
                             />
-                          </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
                           </div>
                         </div>
                       </div>
@@ -6723,11 +6521,6 @@ exports[`single fields optional data controls does not show optional controls wh
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -6739,11 +6532,6 @@ exports[`single fields optional data controls does not show optional controls wh
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -6829,11 +6617,6 @@ exports[`single fields optional data controls does not show optional controls wh
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -6928,11 +6711,6 @@ exports[`single fields optional data controls does not show optional controls wh
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -6944,11 +6722,6 @@ exports[`single fields optional data controls does not show optional controls wh
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -7034,11 +6807,6 @@ exports[`single fields optional data controls does not show optional controls wh
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -7232,11 +7000,6 @@ exports[`single fields optional data controls does not show optional controls wh
                                     className="list-disc list-inside"
                                   />
                                 </div>
-                                <div
-                                  className="rjsf-field-help-template text-gray-500 text-sm"
-                                >
-                                  <div />
-                                </div>
                               </div>
                             </div>
                           </div>
@@ -7249,18 +7012,8 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="list-disc list-inside"
                         />
                       </div>
-                      <div
-                        className="rjsf-field-help-template text-gray-500 text-sm"
-                      >
-                        <div />
-                      </div>
                     </div>
                   </div>
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -7446,18 +7199,8 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="list-disc list-inside"
                         />
                       </div>
-                      <div
-                        className="rjsf-field-help-template text-gray-500 text-sm"
-                      >
-                        <div />
-                      </div>
                     </div>
                   </div>
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -7470,11 +7213,6 @@ exports[`single fields optional data controls does not show optional controls wh
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -7612,11 +7350,6 @@ exports[`single fields optional data controls does not show optional controls wh
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -7710,11 +7443,6 @@ exports[`single fields optional data controls does not show optional controls wh
                                         className="list-disc list-inside"
                                       />
                                     </div>
-                                    <div
-                                      className="rjsf-field-help-template text-gray-500 text-sm"
-                                    >
-                                      <div />
-                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -7726,11 +7454,6 @@ exports[`single fields optional data controls does not show optional controls wh
                             <ul
                               className="list-disc list-inside"
                             />
-                          </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
                           </div>
                         </div>
                       </div>
@@ -7825,11 +7548,6 @@ exports[`single fields optional data controls does not show optional controls wh
                                         className="list-disc list-inside"
                                       />
                                     </div>
-                                    <div
-                                      className="rjsf-field-help-template text-gray-500 text-sm"
-                                    >
-                                      <div />
-                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -7841,11 +7559,6 @@ exports[`single fields optional data controls does not show optional controls wh
                             <ul
                               className="list-disc list-inside"
                             />
-                          </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
                           </div>
                         </div>
                       </div>
@@ -7932,11 +7645,6 @@ exports[`single fields optional data controls does not show optional controls wh
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -8021,11 +7729,6 @@ exports[`single fields optional data controls does not show optional controls wh
                             <ul
                               className="list-disc list-inside"
                             />
-                          </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
                           </div>
                         </div>
                       </div>
@@ -8112,11 +7815,6 @@ exports[`single fields optional data controls does not show optional controls wh
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -8128,11 +7826,6 @@ exports[`single fields optional data controls does not show optional controls wh
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -8218,11 +7911,6 @@ exports[`single fields optional data controls does not show optional controls wh
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -8317,11 +8005,6 @@ exports[`single fields optional data controls does not show optional controls wh
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -8333,11 +8016,6 @@ exports[`single fields optional data controls does not show optional controls wh
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -8423,11 +8101,6 @@ exports[`single fields optional data controls does not show optional controls wh
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -8621,11 +8294,6 @@ exports[`single fields optional data controls does not show optional controls wh
                                     className="list-disc list-inside"
                                   />
                                 </div>
-                                <div
-                                  className="rjsf-field-help-template text-gray-500 text-sm"
-                                >
-                                  <div />
-                                </div>
                               </div>
                             </div>
                           </div>
@@ -8638,18 +8306,8 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="list-disc list-inside"
                         />
                       </div>
-                      <div
-                        className="rjsf-field-help-template text-gray-500 text-sm"
-                      >
-                        <div />
-                      </div>
                     </div>
                   </div>
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -8835,18 +8493,8 @@ exports[`single fields optional data controls does not show optional controls wh
                           className="list-disc list-inside"
                         />
                       </div>
-                      <div
-                        className="rjsf-field-help-template text-gray-500 text-sm"
-                      >
-                        <div />
-                      </div>
                     </div>
                   </div>
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -8859,11 +8507,6 @@ exports[`single fields optional data controls does not show optional controls wh
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -9035,11 +8678,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -9113,11 +8751,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                             <ul
                               className="list-disc list-inside"
                             />
-                          </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
                           </div>
                         </div>
                       </div>
@@ -9212,11 +8845,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                         className="list-disc list-inside"
                                       />
                                     </div>
-                                    <div
-                                      className="rjsf-field-help-template text-gray-500 text-sm"
-                                    >
-                                      <div />
-                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -9228,11 +8856,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                             <ul
                               className="list-disc list-inside"
                             />
-                          </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
                           </div>
                         </div>
                       </div>
@@ -9319,11 +8942,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -9401,11 +9019,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                             <ul
                               className="list-disc list-inside"
                             />
-                          </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
                           </div>
                         </div>
                       </div>
@@ -9492,11 +9105,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -9508,11 +9116,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -9649,11 +9252,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 className="list-disc list-inside"
                               />
                             </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
-                            </div>
                           </div>
                         </div>
                         <div
@@ -9728,11 +9326,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -9827,11 +9420,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -9843,11 +9431,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -9933,11 +9516,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -10026,18 +9604,8 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="list-disc list-inside"
                         />
                       </div>
-                      <div
-                        className="rjsf-field-help-template text-gray-500 text-sm"
-                      >
-                        <div />
-                      </div>
                     </div>
                   </div>
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -10130,18 +9698,8 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="list-disc list-inside"
                         />
                       </div>
-                      <div
-                        className="rjsf-field-help-template text-gray-500 text-sm"
-                      >
-                        <div />
-                      </div>
                     </div>
                   </div>
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -10154,11 +9712,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -10296,11 +9849,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -10346,11 +9894,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                             <ul
                               className="list-disc list-inside"
                             />
-                          </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
                           </div>
                         </div>
                       </div>
@@ -10445,11 +9988,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                         className="list-disc list-inside"
                                       />
                                     </div>
-                                    <div
-                                      className="rjsf-field-help-template text-gray-500 text-sm"
-                                    >
-                                      <div />
-                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -10461,11 +9999,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                             <ul
                               className="list-disc list-inside"
                             />
-                          </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
                           </div>
                         </div>
                       </div>
@@ -10552,11 +10085,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -10605,11 +10133,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                             <ul
                               className="list-disc list-inside"
                             />
-                          </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
                           </div>
                         </div>
                       </div>
@@ -10696,11 +10219,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -10712,11 +10230,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -10819,11 +10332,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 className="list-disc list-inside"
                               />
                             </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
-                            </div>
                           </div>
                         </div>
                         <div
@@ -10898,11 +10406,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -10997,11 +10500,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -11013,11 +10511,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -11104,11 +10597,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -11168,18 +10656,8 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="list-disc list-inside"
                         />
                       </div>
-                      <div
-                        className="rjsf-field-help-template text-gray-500 text-sm"
-                      >
-                        <div />
-                      </div>
                     </div>
                   </div>
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -11243,18 +10721,8 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                           className="list-disc list-inside"
                         />
                       </div>
-                      <div
-                        className="rjsf-field-help-template text-gray-500 text-sm"
-                      >
-                        <div />
-                      </div>
                     </div>
                   </div>
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -11267,11 +10735,6 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -11390,11 +10853,6 @@ exports[`single fields optional data controls shows "add" optional controls when
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -11472,11 +10930,6 @@ exports[`single fields optional data controls shows "add" optional controls when
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -11571,11 +11024,6 @@ exports[`single fields optional data controls shows "add" optional controls when
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -11587,11 +11035,6 @@ exports[`single fields optional data controls shows "add" optional controls when
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -11677,11 +11120,6 @@ exports[`single fields optional data controls shows "add" optional controls when
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -11770,18 +11208,8 @@ exports[`single fields optional data controls shows "add" optional controls when
                           className="list-disc list-inside"
                         />
                       </div>
-                      <div
-                        className="rjsf-field-help-template text-gray-500 text-sm"
-                      >
-                        <div />
-                      </div>
                     </div>
                   </div>
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -11874,18 +11302,8 @@ exports[`single fields optional data controls shows "add" optional controls when
                           className="list-disc list-inside"
                         />
                       </div>
-                      <div
-                        className="rjsf-field-help-template text-gray-500 text-sm"
-                      >
-                        <div />
-                      </div>
                     </div>
                   </div>
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -11898,11 +11316,6 @@ exports[`single fields optional data controls shows "add" optional controls when
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -11993,11 +11406,6 @@ exports[`single fields optional data controls shows "add" optional controls when
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -12046,11 +11454,6 @@ exports[`single fields optional data controls shows "add" optional controls when
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -12145,11 +11548,6 @@ exports[`single fields optional data controls shows "add" optional controls when
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -12161,11 +11559,6 @@ exports[`single fields optional data controls shows "add" optional controls when
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -12252,11 +11645,6 @@ exports[`single fields optional data controls shows "add" optional controls when
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -12316,18 +11704,8 @@ exports[`single fields optional data controls shows "add" optional controls when
                           className="list-disc list-inside"
                         />
                       </div>
-                      <div
-                        className="rjsf-field-help-template text-gray-500 text-sm"
-                      >
-                        <div />
-                      </div>
                     </div>
                   </div>
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -12391,18 +11769,8 @@ exports[`single fields optional data controls shows "add" optional controls when
                           className="list-disc list-inside"
                         />
                       </div>
-                      <div
-                        className="rjsf-field-help-template text-gray-500 text-sm"
-                      >
-                        <div />
-                      </div>
                     </div>
                   </div>
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -12415,11 +11783,6 @@ exports[`single fields optional data controls shows "add" optional controls when
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -12493,11 +11856,6 @@ exports[`single fields password field 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -12585,11 +11943,6 @@ exports[`single fields radio field 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -12675,11 +12028,6 @@ exports[`single fields radio widget with description in schema and FieldTemplate
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -12773,11 +12121,6 @@ exports[`single fields schema examples 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -12878,11 +12221,6 @@ exports[`single fields select field 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -13040,11 +12378,6 @@ exports[`single fields select field multiple choice 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -13201,11 +12534,6 @@ exports[`single fields select field multiple choice enumDisabled 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -13343,11 +12671,6 @@ exports[`single fields select field multiple choice enumDisabled using checkboxe
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -13505,11 +12828,6 @@ exports[`single fields select field multiple choice formData 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -13645,11 +12963,6 @@ exports[`single fields select field multiple choice with labels 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -13750,11 +13063,6 @@ exports[`single fields select field single choice enumDisabled 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -13849,11 +13157,6 @@ exports[`single fields select field single choice enumDisabled using radio widge
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -13947,11 +13250,6 @@ exports[`single fields select field single choice form disabled using radio widg
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -14055,11 +13353,6 @@ exports[`single fields select field single choice formData 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -14154,11 +13447,6 @@ exports[`single fields select field single choice uiSchema disabled using radio 
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -14251,11 +13539,6 @@ exports[`single fields select widget with description in schema and FieldTemplat
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -14323,11 +13606,6 @@ exports[`single fields slider field 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -14405,11 +13683,6 @@ exports[`single fields string field format data-url 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -14482,11 +13755,6 @@ exports[`single fields string field format email 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -14561,11 +13829,6 @@ exports[`single fields string field format uri 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -14638,11 +13901,6 @@ exports[`single fields string field regular 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -14717,11 +13975,6 @@ exports[`single fields string field with placeholder 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -14779,11 +14032,6 @@ exports[`single fields textarea field 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -14892,11 +14140,6 @@ exports[`single fields title field 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -14908,11 +14151,6 @@ exports[`single fields title field 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -14975,11 +14213,6 @@ exports[`single fields unsupported field 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -15054,11 +14287,6 @@ exports[`single fields up/down field 1`] = `
           className="list-disc list-inside"
         />
       </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
-      </div>
     </div>
   </div>
   <div>
@@ -15131,11 +14359,6 @@ exports[`single fields using custom tagName 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>

--- a/packages/daisyui/test/__snapshots__/Object.test.tsx.snap
+++ b/packages/daisyui/test/__snapshots__/Object.test.tsx.snap
@@ -109,11 +109,6 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -207,11 +202,6 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                         className="list-disc list-inside"
                                       />
                                     </div>
-                                    <div
-                                      className="rjsf-field-help-template text-gray-500 text-sm"
-                                    >
-                                      <div />
-                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -275,11 +265,6 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                       <ul
                                         className="list-disc list-inside"
                                       />
-                                    </div>
-                                    <div
-                                      className="rjsf-field-help-template text-gray-500 text-sm"
-                                    >
-                                      <div />
                                     </div>
                                   </div>
                                 </div>
@@ -345,11 +330,6 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                         className="list-disc list-inside"
                                       />
                                     </div>
-                                    <div
-                                      className="rjsf-field-help-template text-gray-500 text-sm"
-                                    >
-                                      <div />
-                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -361,11 +341,6 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                             <ul
                               className="list-disc list-inside"
                             />
-                          </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
                           </div>
                         </div>
                       </div>
@@ -379,11 +354,6 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -395,11 +365,6 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -495,11 +460,6 @@ exports[`nameGenerator bracketNameGenerator object with additionalProperties 1`]
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -592,11 +552,6 @@ exports[`nameGenerator bracketNameGenerator object with additionalProperties 1`]
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
                 <div
                   className="flex self-center"
@@ -671,11 +626,6 @@ exports[`nameGenerator bracketNameGenerator object with additionalProperties 1`]
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -771,11 +721,6 @@ exports[`nameGenerator bracketNameGenerator object with mixed types 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -841,11 +786,6 @@ exports[`nameGenerator bracketNameGenerator object with mixed types 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -894,11 +834,6 @@ exports[`nameGenerator bracketNameGenerator object with mixed types 1`] = `
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -1000,11 +935,6 @@ exports[`nameGenerator bracketNameGenerator object with mixed types 1`] = `
                               <ul
                                 className="list-disc list-inside"
                               />
-                            </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
                             </div>
                           </div>
                         </div>
@@ -1152,11 +1082,6 @@ exports[`nameGenerator bracketNameGenerator object with mixed types 1`] = `
                                 className="list-disc list-inside"
                               />
                             </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
-                            </div>
                           </div>
                         </div>
                         <div
@@ -1282,11 +1207,6 @@ exports[`nameGenerator bracketNameGenerator object with mixed types 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -1298,11 +1218,6 @@ exports[`nameGenerator bracketNameGenerator object with mixed types 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -1398,11 +1313,6 @@ exports[`nameGenerator bracketNameGenerator simple object 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -1466,11 +1376,6 @@ exports[`nameGenerator bracketNameGenerator simple object 1`] = `
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -1537,11 +1442,6 @@ exports[`nameGenerator bracketNameGenerator simple object 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -1553,11 +1453,6 @@ exports[`nameGenerator bracketNameGenerator simple object 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -1682,11 +1577,6 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                               className="list-disc list-inside"
                             />
                           </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
-                          </div>
                         </div>
                       </div>
                     </div>
@@ -1780,11 +1670,6 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                         className="list-disc list-inside"
                                       />
                                     </div>
-                                    <div
-                                      className="rjsf-field-help-template text-gray-500 text-sm"
-                                    >
-                                      <div />
-                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -1849,11 +1734,6 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                         className="list-disc list-inside"
                                       />
                                     </div>
-                                    <div
-                                      className="rjsf-field-help-template text-gray-500 text-sm"
-                                    >
-                                      <div />
-                                    </div>
                                   </div>
                                 </div>
                               </div>
@@ -1865,11 +1745,6 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                             <ul
                               className="list-disc list-inside"
                             />
-                          </div>
-                          <div
-                            className="rjsf-field-help-template text-gray-500 text-sm"
-                          >
-                            <div />
                           </div>
                         </div>
                       </div>
@@ -1883,11 +1758,6 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -1899,11 +1769,6 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -1999,11 +1864,6 @@ exports[`nameGenerator dotNotationNameGenerator object with mixed types 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -2068,11 +1928,6 @@ exports[`nameGenerator dotNotationNameGenerator object with mixed types 1`] = `
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -2174,11 +2029,6 @@ exports[`nameGenerator dotNotationNameGenerator object with mixed types 1`] = `
                               <ul
                                 className="list-disc list-inside"
                               />
-                            </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
                             </div>
                           </div>
                         </div>
@@ -2326,11 +2176,6 @@ exports[`nameGenerator dotNotationNameGenerator object with mixed types 1`] = `
                                 className="list-disc list-inside"
                               />
                             </div>
-                            <div
-                              className="rjsf-field-help-template text-gray-500 text-sm"
-                            >
-                              <div />
-                            </div>
                           </div>
                         </div>
                         <div
@@ -2456,11 +2301,6 @@ exports[`nameGenerator dotNotationNameGenerator object with mixed types 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -2472,11 +2312,6 @@ exports[`nameGenerator dotNotationNameGenerator object with mixed types 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -2572,11 +2407,6 @@ exports[`nameGenerator dotNotationNameGenerator simple object 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -2640,11 +2470,6 @@ exports[`nameGenerator dotNotationNameGenerator simple object 1`] = `
                   <ul
                     className="list-disc list-inside"
                   />
-                </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
                 </div>
               </div>
             </div>
@@ -2711,11 +2536,6 @@ exports[`nameGenerator dotNotationNameGenerator simple object 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -2727,11 +2547,6 @@ exports[`nameGenerator dotNotationNameGenerator simple object 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -2855,11 +2670,6 @@ exports[`object fields additionalProperties 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
                 <div
                   className="flex self-center"
@@ -2934,11 +2744,6 @@ exports[`object fields additionalProperties 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -3034,11 +2839,6 @@ exports[`object fields object 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -3104,11 +2904,6 @@ exports[`object fields object 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -3120,11 +2915,6 @@ exports[`object fields object 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -3248,11 +3038,6 @@ exports[`object fields show add button and fields if additionalProperties is tru
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
                 <div
                   className="flex self-center"
@@ -3327,11 +3112,6 @@ exports[`object fields show add button and fields if additionalProperties is tru
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -3478,11 +3258,6 @@ exports[`object fields with title and description additionalProperties 1`] = `
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
                 <div
                   className="flex self-center"
@@ -3557,11 +3332,6 @@ exports[`object fields with title and description additionalProperties 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -3708,11 +3478,6 @@ exports[`object fields with title and description from both additionalProperties
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
                 <div
                   className="flex self-center"
@@ -3787,11 +3552,6 @@ exports[`object fields with title and description from both additionalProperties
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -3910,11 +3670,6 @@ exports[`object fields with title and description from both object 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -3980,11 +3735,6 @@ exports[`object fields with title and description from both object 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -3996,11 +3746,6 @@ exports[`object fields with title and description from both object 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -4147,11 +3892,6 @@ exports[`object fields with title and description from uiSchema additionalProper
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
                 <div
                   className="flex self-center"
@@ -4226,11 +3966,6 @@ exports[`object fields with title and description from uiSchema additionalProper
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -4349,11 +4084,6 @@ exports[`object fields with title and description from uiSchema object 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -4419,11 +4149,6 @@ exports[`object fields with title and description from uiSchema object 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -4435,11 +4160,6 @@ exports[`object fields with title and description from uiSchema object 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -4586,11 +4306,6 @@ exports[`object fields with title and description from uiSchema show add button 
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
                 <div
                   className="flex self-center"
@@ -4665,11 +4380,6 @@ exports[`object fields with title and description from uiSchema show add button 
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -4788,11 +4498,6 @@ exports[`object fields with title and description object 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -4858,11 +4563,6 @@ exports[`object fields with title and description object 1`] = `
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -4874,11 +4574,6 @@ exports[`object fields with title and description object 1`] = `
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -5025,11 +4720,6 @@ exports[`object fields with title and description show add button and fields if 
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
                 <div
                   className="flex self-center"
@@ -5104,11 +4794,6 @@ exports[`object fields with title and description show add button and fields if 
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -5222,11 +4907,6 @@ exports[`object fields with title and description with global label off addition
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
                 <div
                   className="flex self-center"
@@ -5301,11 +4981,6 @@ exports[`object fields with title and description with global label off addition
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -5391,11 +5066,6 @@ exports[`object fields with title and description with global label off object 1
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -5451,11 +5121,6 @@ exports[`object fields with title and description with global label off object 1
                     className="list-disc list-inside"
                   />
                 </div>
-                <div
-                  className="rjsf-field-help-template text-gray-500 text-sm"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>
@@ -5467,11 +5132,6 @@ exports[`object fields with title and description with global label off object 1
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>
@@ -5585,11 +5245,6 @@ exports[`object fields with title and description with global label off show add
                       className="list-disc list-inside"
                     />
                   </div>
-                  <div
-                    className="rjsf-field-help-template text-gray-500 text-sm"
-                  >
-                    <div />
-                  </div>
                 </div>
                 <div
                   className="flex self-center"
@@ -5664,11 +5319,6 @@ exports[`object fields with title and description with global label off show add
         <ul
           className="list-disc list-inside"
         />
-      </div>
-      <div
-        className="rjsf-field-help-template text-gray-500 text-sm"
-      >
-        <div />
       </div>
     </div>
   </div>

--- a/packages/fluentui-rc/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/fluentui-rc/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,5 +1,6 @@
 import { Caption1 } from '@fluentui/react-components';
 import { helpId, FieldHelpProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
+import { RichHelp } from '@rjsf/core';
 
 /** The `FieldHelpTemplate` component renders any help desired for a field
  *
@@ -10,10 +11,15 @@ export default function FieldHelpTemplate<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: FieldHelpProps<T, S, F>) {
-  const { fieldPathId, help } = props;
+  const { fieldPathId, help, registry, uiSchema } = props;
   if (!help) {
     return null;
   }
   const id = helpId(fieldPathId);
-  return <Caption1 id={id}>{help}</Caption1>;
+  return (
+    <Caption1 id={id}>
+      {' '}
+      <RichHelp help={help} registry={registry} uiSchema={uiSchema} />
+    </Caption1>
+  );
 }

--- a/packages/fluentui-rc/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/fluentui-rc/test/__snapshots__/Form.test.tsx.snap
@@ -1505,8 +1505,8 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
               >
                 <label
                   className="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-                  htmlFor="field-r9g__control"
-                  id="field-r9g__label"
+                  htmlFor="field-r9k__control"
+                  id="field-r9k__label"
                 >
                   color
                 </label>
@@ -1516,7 +1516,7 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                   <button
                     aria-describedby="root_color__error root_color__description root_color__help"
                     aria-expanded={false}
-                    aria-labelledby="field-r9g__label"
+                    aria-labelledby="field-r9k__label"
                     autoFocus={false}
                     className="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                     disabled={false}
@@ -3082,8 +3082,8 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
               >
                 <label
                   className="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-                  htmlFor="field-rb0__control"
-                  id="field-rb0__label"
+                  htmlFor="field-rb4__control"
+                  id="field-rb4__label"
                 >
                   color
                 </label>
@@ -3093,7 +3093,7 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                   <button
                     aria-describedby="root_color__error root_color__description root_color__help"
                     aria-expanded={false}
-                    aria-labelledby="field-rb0__label"
+                    aria-labelledby="field-rb4__label"
                     autoFocus={false}
                     className="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                     disabled={false}
@@ -3928,6 +3928,7 @@ exports[`single fields checkboxes widget with custom options and labels 1`] = `
         className="fui-Caption1 fui-Text ___13vod6f_1082073 fk6fouc fy9rknc fwrc4pm figsok6 fpgzoln f1w7gpdv f6juhto f1gl81tg f2jf649"
         id="root__help"
       >
+         
         Select all that apply
       </span>
     </div>
@@ -4455,6 +4456,182 @@ exports[`single fields field with markdown description in uiSchema 1`] = `
 </form>
 `;
 
+exports[`single fields field with markdown help 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
+    >
+      <div
+        className="fui-Flex ___2axmsj0_qpg1ts0 f22iagw f1vx9l62 fly5x3f f1l02sjl f16r77es"
+      >
+        <div
+          className="fui-Flex ___13jx0ny_nlbnai0 f22iagw f1vx9l62 fly5x3f f1l02sjl"
+          style={
+            {
+              "marginBottom": "10px",
+            }
+          }
+        >
+          <div
+            className="rjsf-field rjsf-field-string"
+          >
+            <div
+              className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
+            >
+              <label
+                className="fui-Label ___zkh2gz0_1ef3qts fk6fouc f19n0e5 fkhj508 f1i3iumi fq1loh5 futqtb8 f14rdt9"
+                htmlFor="root_my-field"
+              >
+                my-field
+              </label>
+              <span
+                className="fui-Input r1oeeo9n ___1v9icnz_137yv9i fvcxoqz f1ub3y4t f1l4zc64 f1m52nbi f8vnjqi fz1etlk f1klwx88 f1hc16gm"
+              >
+                <input
+                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                  autoFocus={false}
+                  className="fui-Input__input r12stul0 ___cqaz2i0_9xw1o20 fly5x3f"
+                  disabled={false}
+                  id="root_my-field"
+                  name="root_my-field"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  required={false}
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                className="fui-Caption1 fui-Text ___13vod6f_1082073 fk6fouc fy9rknc fwrc4pm figsok6 fpgzoln f1w7gpdv f6juhto f1gl81tg f2jf649"
+                id="root_my-field__help"
+              >
+                 
+                <span>
+                  some 
+                  <strong>
+                    Rich
+                  </strong>
+                   help text
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="___fko12g0_0000000 f1wswflg"
+  >
+    <button
+      className="fui-Button r1alrhcs ___1akj6hk_ih97uj0 ffp7eso f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1phragk f15wkkf3 f1s2uweq fr80ssc f1ukrpxl fecsdlb f1rq72xc fnp9lpt f1h0usnq fs4ktlq f16h9ulv fx2bmrt f1d6v5y2 f1rirnrt f1uu00uk fkvaka8 f1ux7til f9a0qzu f1lkg8j3 fkc42ay fq7113v ff1wgvm fiob0tu f1j6scgf f1x4h75k f4xjyn1 fbgcvur f1ks1yx8 f1o6qegi fcnxywj fmxjhhp f9ddjv3 f17t0x8g f194v5ow f1qgg65p fk7jm04 fhgccpy f32wu9k fu5nqqq f13prjl2 f1czftr5 f1nl83rv f12k37oa fr96u23"
+      disabled={false}
+      onClick={[Function]}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown help in uiSchema 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
+    >
+      <div
+        className="fui-Flex ___2axmsj0_qpg1ts0 f22iagw f1vx9l62 fly5x3f f1l02sjl f16r77es"
+      >
+        <div
+          className="fui-Flex ___13jx0ny_nlbnai0 f22iagw f1vx9l62 fly5x3f f1l02sjl"
+          style={
+            {
+              "marginBottom": "10px",
+            }
+          }
+        >
+          <div
+            className="rjsf-field rjsf-field-string"
+          >
+            <div
+              className="fui-Field ___keyyzl0_1dbn5sh f13qh94s"
+            >
+              <label
+                className="fui-Label ___zkh2gz0_1ef3qts fk6fouc f19n0e5 fkhj508 f1i3iumi fq1loh5 futqtb8 f14rdt9"
+                htmlFor="root_my-field"
+              >
+                my-field
+              </label>
+              <span
+                className="fui-Input r1oeeo9n ___1v9icnz_137yv9i fvcxoqz f1ub3y4t f1l4zc64 f1m52nbi f8vnjqi fz1etlk f1klwx88 f1hc16gm"
+              >
+                <input
+                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                  autoFocus={false}
+                  className="fui-Input__input r12stul0 ___cqaz2i0_9xw1o20 fly5x3f"
+                  disabled={false}
+                  id="root_my-field"
+                  name="root_my-field"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  required={false}
+                  type="text"
+                  value=""
+                />
+              </span>
+              <span
+                className="fui-Caption1 fui-Text ___13vod6f_1082073 fk6fouc fy9rknc fwrc4pm figsok6 fpgzoln f1w7gpdv f6juhto f1gl81tg f2jf649"
+                id="root_my-field__help"
+              >
+                 
+                <span>
+                  some 
+                  <strong>
+                    other
+                  </strong>
+                   help
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="___fko12g0_0000000 f1wswflg"
+  >
+    <button
+      className="fui-Button r1alrhcs ___1akj6hk_ih97uj0 ffp7eso f1p3nwhy f11589ue f1q5o8ev f1pdflbu f1phragk f15wkkf3 f1s2uweq fr80ssc f1ukrpxl fecsdlb f1rq72xc fnp9lpt f1h0usnq fs4ktlq f16h9ulv fx2bmrt f1d6v5y2 f1rirnrt f1uu00uk fkvaka8 f1ux7til f9a0qzu f1lkg8j3 fkc42ay fq7113v ff1wgvm fiob0tu f1j6scgf f1x4h75k f4xjyn1 fbgcvur f1ks1yx8 f1o6qegi fcnxywj fmxjhhp f9ddjv3 f17t0x8g f194v5ow f1qgg65p fk7jm04 fhgccpy f32wu9k fu5nqqq f13prjl2 f1czftr5 f1nl83rv f12k37oa fr96u23"
+      disabled={false}
+      onClick={[Function]}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields format color 1`] = `
 <form
   className="rjsf"
@@ -4727,6 +4904,7 @@ exports[`single fields help and error display 1`] = `
         className="fui-Caption1 fui-Text ___13vod6f_1082073 fk6fouc fy9rknc fwrc4pm figsok6 fpgzoln f1w7gpdv f6juhto f1gl81tg f2jf649"
         id="root__help"
       >
+         
         help me!
       </span>
     </div>
@@ -5722,8 +5900,8 @@ exports[`single fields optional data controls does not show optional controls wh
                   >
                     <label
                       className="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-                      htmlFor="field-r43__control"
-                      id="field-r43__label"
+                      htmlFor="field-r47__control"
+                      id="field-r47__label"
                     >
                       optionalObjectWithOneofs
                     </label>
@@ -5733,7 +5911,7 @@ exports[`single fields optional data controls does not show optional controls wh
                       <button
                         aria-describedby="root_optionalObjectWithOneofs__oneof_select__error root_optionalObjectWithOneofs__oneof_select__description root_optionalObjectWithOneofs__oneof_select__help"
                         aria-expanded={false}
-                        aria-labelledby="field-r43__label"
+                        aria-labelledby="field-r47__label"
                         autoFocus={false}
                         className="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                         disabled={false}
@@ -5893,8 +6071,8 @@ exports[`single fields optional data controls does not show optional controls wh
                   >
                     <label
                       className="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-                      htmlFor="field-r49__control"
-                      id="field-r49__label"
+                      htmlFor="field-r4d__control"
+                      id="field-r4d__label"
                     >
                       optionalArrayWithAnyofs
                     </label>
@@ -5904,7 +6082,7 @@ exports[`single fields optional data controls does not show optional controls wh
                       <button
                         aria-describedby="root_optionalArrayWithAnyofs__anyof_select__error root_optionalArrayWithAnyofs__anyof_select__description root_optionalArrayWithAnyofs__anyof_select__help"
                         aria-expanded={false}
-                        aria-labelledby="field-r49__label"
+                        aria-labelledby="field-r4d__label"
                         autoFocus={false}
                         className="fui-Dropdown__button ___12pyx89_1vewwra f122n59 f1c21dwh f3bhgqh f1ewtqcl f19n0e5 f14mj54c f1k6fduh f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                         disabled={false}
@@ -6798,8 +6976,8 @@ exports[`single fields optional data controls does not show optional controls wh
                   >
                     <label
                       className="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-                      htmlFor="field-r6l__control"
-                      id="field-r6l__label"
+                      htmlFor="field-r6p__control"
+                      id="field-r6p__label"
                     >
                       optionalObjectWithOneofs
                     </label>
@@ -6809,7 +6987,7 @@ exports[`single fields optional data controls does not show optional controls wh
                       <button
                         aria-describedby="root_optionalObjectWithOneofs__oneof_select__error root_optionalObjectWithOneofs__oneof_select__description root_optionalObjectWithOneofs__oneof_select__help"
                         aria-expanded={false}
-                        aria-labelledby="field-r6l__label"
+                        aria-labelledby="field-r6p__label"
                         autoFocus={false}
                         className="fui-Dropdown__button ___b67tb00_4t2umz0 f122n59 f1c21dwh f3bhgqh f1ewtqcl f1s2aq7o f14mj54c fdrzuqr f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                         disabled={true}
@@ -6968,8 +7146,8 @@ exports[`single fields optional data controls does not show optional controls wh
                   >
                     <label
                       className="fui-Label fui-Field__label ___1r7nw7g_2qzl200 fk6fouc f19n0e5 fkhj508 f1i3iumi fclwglc fywfov9 fyacil5"
-                      htmlFor="field-r6r__control"
-                      id="field-r6r__label"
+                      htmlFor="field-r6v__control"
+                      id="field-r6v__label"
                     >
                       optionalArrayWithAnyofs
                     </label>
@@ -6979,7 +7157,7 @@ exports[`single fields optional data controls does not show optional controls wh
                       <button
                         aria-describedby="root_optionalArrayWithAnyofs__anyof_select__error root_optionalArrayWithAnyofs__anyof_select__description root_optionalArrayWithAnyofs__anyof_select__help"
                         aria-expanded={false}
-                        aria-labelledby="field-r6r__label"
+                        aria-labelledby="field-r6v__label"
                         autoFocus={false}
                         className="fui-Dropdown__button ___b67tb00_4t2umz0 f122n59 f1c21dwh f3bhgqh f1ewtqcl f1s2aq7o f14mj54c fdrzuqr f13qh94s fk6fouc f12nh0o2 f1869bpl f1o700av fly5x3f ftqa4ok fkhj508 figsok6 f1i3iumi f14ev680"
                         disabled={true}

--- a/packages/mantine/src/templates/FieldHelpTemplate.tsx
+++ b/packages/mantine/src/templates/FieldHelpTemplate.tsx
@@ -1,5 +1,6 @@
 import { helpId, FieldHelpProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
 import { Text } from '@mantine/core';
+import { RichHelp } from '@rjsf/core';
 
 /** The `FieldHelpTemplate` component renders any help desired for a field
  *
@@ -10,7 +11,7 @@ export default function FieldHelpTemplate<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: FieldHelpProps<T, S, F>) {
-  const { fieldPathId, help } = props;
+  const { fieldPathId, help, registry, uiSchema } = props;
 
   if (!help) {
     return null;
@@ -20,7 +21,7 @@ export default function FieldHelpTemplate<
 
   return (
     <Text id={id} size='sm' my='xs' c='dimmed'>
-      {help}
+      <RichHelp help={help} registry={registry} uiSchema={uiSchema} />
     </Text>
   );
 }

--- a/packages/mantine/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mantine/test/__snapshots__/Form.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-r1bb{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-r1c3{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -116,7 +116,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                         "children": null,
                                                         "props": {
                                                           "dangerouslySetInnerHTML": {
-                                                            "__html": ".__m__-r1bn{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                                            "__html": ".__m__-r1cf{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                                           },
                                                           "data-mantine-styles": "inline",
                                                           "nonce": undefined,
@@ -369,7 +369,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                           },
                                                         ],
                                                         "props": {
-                                                          "className": "m_2415a157 __m__-r1bn",
+                                                          "className": "m_2415a157 __m__-r1cf",
                                                           "data-size": undefined,
                                                           "data-variant": undefined,
                                                           "size": undefined,
@@ -675,7 +675,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_8bffd616 __m__-r1bi",
+                                          "className": "m_8bffd616 __m__-r1ca",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -736,7 +736,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                         "children": null,
                                                         "props": {
                                                           "dangerouslySetInnerHTML": {
-                                                            "__html": ".__m__-r1cj{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                                            "__html": ".__m__-r1db{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                                           },
                                                           "data-mantine-styles": "inline",
                                                           "nonce": undefined,
@@ -989,7 +989,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                                           },
                                                         ],
                                                         "props": {
-                                                          "className": "m_2415a157 __m__-r1cj",
+                                                          "className": "m_2415a157 __m__-r1db",
                                                           "data-size": undefined,
                                                           "data-variant": undefined,
                                                           "size": undefined,
@@ -1295,7 +1295,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_8bffd616 __m__-r1ce",
+                                          "className": "m_8bffd616 __m__-r1d6",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -1467,7 +1467,7 @@ exports[`nameGenerator bracketNameGenerator array of objects 1`] = `
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-r1bb",
+                  "className": "m_2415a157 __m__-r1c3",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -1597,7 +1597,7 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-r19v{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-r1an{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -2020,7 +2020,7 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_8bffd616 __m__-r1a6",
+                                          "className": "m_8bffd616 __m__-r1au",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -2420,7 +2420,7 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_8bffd616 __m__-r1am",
+                                          "className": "m_8bffd616 __m__-r1be",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -2592,7 +2592,7 @@ exports[`nameGenerator bracketNameGenerator array of strings 1`] = `
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-r19v",
+                  "className": "m_2415a157 __m__-r1an",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -2722,7 +2722,7 @@ exports[`nameGenerator bracketNameGenerator checkboxes field 1`] = `
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-r1f3{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-r1fr{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -3124,7 +3124,7 @@ exports[`nameGenerator bracketNameGenerator checkboxes field 1`] = `
                                       },
                                     ],
                                     "props": {
-                                      "className": "m_8bffd616 __m__-r1f9",
+                                      "className": "m_8bffd616 __m__-r1g1",
                                       "data-size": undefined,
                                       "data-variant": undefined,
                                       "size": undefined,
@@ -3180,7 +3180,7 @@ exports[`nameGenerator bracketNameGenerator checkboxes field 1`] = `
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-r1f3",
+                  "className": "m_2415a157 __m__-r1fr",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -3310,7 +3310,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-r18o{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-r19g{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -3351,7 +3351,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                 "children": null,
                                 "props": {
                                   "dangerouslySetInnerHTML": {
-                                    "__html": ".__m__-r18t{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                    "__html": ".__m__-r19l{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                   },
                                   "data-mantine-styles": "inline",
                                   "nonce": undefined,
@@ -3582,7 +3582,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                                 "children": null,
                                                 "props": {
                                                   "dangerouslySetInnerHTML": {
-                                                    "__html": ".__m__-r19e{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                                    "__html": ".__m__-r1a6{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                                   },
                                                   "data-mantine-styles": "inline",
                                                   "nonce": undefined,
@@ -3784,7 +3784,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                                   },
                                                 ],
                                                 "props": {
-                                                  "className": "m_2415a157 __m__-r19e",
+                                                  "className": "m_2415a157 __m__-r1a6",
                                                   "data-size": undefined,
                                                   "data-variant": undefined,
                                                   "size": undefined,
@@ -3831,7 +3831,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                                   },
                                 ],
                                 "props": {
-                                  "className": "m_2415a157 __m__-r18t",
+                                  "className": "m_2415a157 __m__-r19l",
                                   "data-size": undefined,
                                   "data-variant": undefined,
                                   "size": undefined,
@@ -3878,7 +3878,7 @@ exports[`nameGenerator bracketNameGenerator nested object 1`] = `
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-r18o",
+                  "className": "m_2415a157 __m__-r19g",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -4008,7 +4008,7 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-r1eb{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-r1f3{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -4295,7 +4295,7 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                                       },
                                     ],
                                     "props": {
-                                      "className": "m_8bffd616 __m__-r1ei",
+                                      "className": "m_8bffd616 __m__-r1fa",
                                       "data-size": undefined,
                                       "data-variant": undefined,
                                       "size": undefined,
@@ -4351,7 +4351,7 @@ exports[`nameGenerator bracketNameGenerator radio field 1`] = `
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-r1eb",
+                  "className": "m_2415a157 __m__-r1f3",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -4481,7 +4481,7 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-r1df{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-r1e7{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -4643,7 +4643,7 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                                                           "data-combobox-option": true,
                                                           "data-size": undefined,
                                                           "data-variant": undefined,
-                                                          "id": ":r1e2:",
+                                                          "id": ":r1eq:",
                                                           "onClick": [Function],
                                                           "onMouseDown": [Function],
                                                           "onMouseOver": [Function],
@@ -4672,7 +4672,7 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                                                           "data-combobox-option": true,
                                                           "data-size": undefined,
                                                           "data-variant": undefined,
-                                                          "id": ":r1e4:",
+                                                          "id": ":r1es:",
                                                           "onClick": [Function],
                                                           "onMouseDown": [Function],
                                                           "onMouseOver": [Function],
@@ -4701,7 +4701,7 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                                                           "data-combobox-option": true,
                                                           "data-size": undefined,
                                                           "data-variant": undefined,
-                                                          "id": ":r1e6:",
+                                                          "id": ":r1eu:",
                                                           "onClick": [Function],
                                                           "onMouseDown": [Function],
                                                           "onMouseOver": [Function],
@@ -4912,7 +4912,7 @@ exports[`nameGenerator bracketNameGenerator select field with enum 1`] = `
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-r1df",
+                  "className": "m_2415a157 __m__-r1e7",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -5042,7 +5042,7 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-r17u{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-r18m{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -5515,7 +5515,7 @@ exports[`nameGenerator bracketNameGenerator simple fields 1`] = `
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-r17u",
+                  "className": "m_2415a157 __m__-r18m",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -5645,7 +5645,7 @@ exports[`nameGenerator bracketNameGenerator textarea field 1`] = `
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-r1g0{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-r1go{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -5755,7 +5755,7 @@ exports[`nameGenerator bracketNameGenerator textarea field 1`] = `
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-r1g0",
+                  "className": "m_2415a157 __m__-r1go",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -5885,7 +5885,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-r1jo{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-r1kg{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -5969,7 +5969,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                         "children": null,
                                                         "props": {
                                                           "dangerouslySetInnerHTML": {
-                                                            "__html": ".__m__-r1k4{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                                            "__html": ".__m__-r1ks{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                                           },
                                                           "data-mantine-styles": "inline",
                                                           "nonce": undefined,
@@ -6222,7 +6222,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                           },
                                                         ],
                                                         "props": {
-                                                          "className": "m_2415a157 __m__-r1k4",
+                                                          "className": "m_2415a157 __m__-r1ks",
                                                           "data-size": undefined,
                                                           "data-variant": undefined,
                                                           "size": undefined,
@@ -6528,7 +6528,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_8bffd616 __m__-r1jv",
+                                          "className": "m_8bffd616 __m__-r1kn",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -6589,7 +6589,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                         "children": null,
                                                         "props": {
                                                           "dangerouslySetInnerHTML": {
-                                                            "__html": ".__m__-r1l0{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                                            "__html": ".__m__-r1lo{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                                           },
                                                           "data-mantine-styles": "inline",
                                                           "nonce": undefined,
@@ -6842,7 +6842,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                                           },
                                                         ],
                                                         "props": {
-                                                          "className": "m_2415a157 __m__-r1l0",
+                                                          "className": "m_2415a157 __m__-r1lo",
                                                           "data-size": undefined,
                                                           "data-variant": undefined,
                                                           "size": undefined,
@@ -7148,7 +7148,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_8bffd616 __m__-r1kr",
+                                          "className": "m_8bffd616 __m__-r1lj",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -7320,7 +7320,7 @@ exports[`nameGenerator dotNotationNameGenerator array of objects 1`] = `
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-r1jo",
+                  "className": "m_2415a157 __m__-r1kg",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -7450,7 +7450,7 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-r1ic{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-r1j4{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -7873,7 +7873,7 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_8bffd616 __m__-r1ij",
+                                          "className": "m_8bffd616 __m__-r1jb",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -8273,7 +8273,7 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_8bffd616 __m__-r1j3",
+                                          "className": "m_8bffd616 __m__-r1jr",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -8445,7 +8445,7 @@ exports[`nameGenerator dotNotationNameGenerator array of strings 1`] = `
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-r1ic",
+                  "className": "m_2415a157 __m__-r1j4",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -8575,7 +8575,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-r1h5{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-r1ht{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -8616,7 +8616,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                 "children": null,
                                 "props": {
                                   "dangerouslySetInnerHTML": {
-                                    "__html": ".__m__-r1ha{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                    "__html": ".__m__-r1i2{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                   },
                                   "data-mantine-styles": "inline",
                                   "nonce": undefined,
@@ -8847,7 +8847,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                                 "children": null,
                                                 "props": {
                                                   "dangerouslySetInnerHTML": {
-                                                    "__html": ".__m__-r1hr{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                                    "__html": ".__m__-r1ij{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                                   },
                                                   "data-mantine-styles": "inline",
                                                   "nonce": undefined,
@@ -9049,7 +9049,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                                   },
                                                 ],
                                                 "props": {
-                                                  "className": "m_2415a157 __m__-r1hr",
+                                                  "className": "m_2415a157 __m__-r1ij",
                                                   "data-size": undefined,
                                                   "data-variant": undefined,
                                                   "size": undefined,
@@ -9096,7 +9096,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                                   },
                                 ],
                                 "props": {
-                                  "className": "m_2415a157 __m__-r1ha",
+                                  "className": "m_2415a157 __m__-r1i2",
                                   "data-size": undefined,
                                   "data-variant": undefined,
                                   "size": undefined,
@@ -9143,7 +9143,7 @@ exports[`nameGenerator dotNotationNameGenerator nested object 1`] = `
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-r1h5",
+                  "className": "m_2415a157 __m__-r1ht",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -9273,7 +9273,7 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-r1ls{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-r1mk{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -9435,7 +9435,7 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                                                           "data-combobox-option": true,
                                                           "data-size": undefined,
                                                           "data-variant": undefined,
-                                                          "id": ":r1mf:",
+                                                          "id": ":r1n7:",
                                                           "onClick": [Function],
                                                           "onMouseDown": [Function],
                                                           "onMouseOver": [Function],
@@ -9464,7 +9464,7 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                                                           "data-combobox-option": true,
                                                           "data-size": undefined,
                                                           "data-variant": undefined,
-                                                          "id": ":r1mh:",
+                                                          "id": ":r1n9:",
                                                           "onClick": [Function],
                                                           "onMouseDown": [Function],
                                                           "onMouseOver": [Function],
@@ -9493,7 +9493,7 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                                                           "data-combobox-option": true,
                                                           "data-size": undefined,
                                                           "data-variant": undefined,
-                                                          "id": ":r1mj:",
+                                                          "id": ":r1nb:",
                                                           "onClick": [Function],
                                                           "onMouseDown": [Function],
                                                           "onMouseOver": [Function],
@@ -9704,7 +9704,7 @@ exports[`nameGenerator dotNotationNameGenerator select field with enum 1`] = `
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-r1ls",
+                  "className": "m_2415a157 __m__-r1mk",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -9834,7 +9834,7 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-r1gb{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-r1h3{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -10307,7 +10307,7 @@ exports[`nameGenerator dotNotationNameGenerator simple fields 1`] = `
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-r1gb",
+                  "className": "m_2415a157 __m__-r1h3",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -14254,6 +14254,562 @@ exports[`single fields field with markdown description in uiSchema 1`] = `
 ]
 `;
 
+exports[`single fields field with markdown help 1`] = `
+[
+  <style
+    dangerouslySetInnerHTML={
+      {
+        "__html": "
+
+
+
+",
+      }
+    }
+    data-mantine-styles={true}
+  />,
+  <style
+    dangerouslySetInnerHTML={
+      {
+        "__html": "@media (max-width: 35.99375em) {.mantine-visible-from-xs {display: none !important;}}@media (min-width: 36em) {.mantine-hidden-from-xs {display: none !important;}}@media (max-width: 47.99375em) {.mantine-visible-from-sm {display: none !important;}}@media (min-width: 48em) {.mantine-hidden-from-sm {display: none !important;}}@media (max-width: 61.99375em) {.mantine-visible-from-md {display: none !important;}}@media (min-width: 62em) {.mantine-hidden-from-md {display: none !important;}}@media (max-width: 74.99375em) {.mantine-visible-from-lg {display: none !important;}}@media (min-width: 75em) {.mantine-hidden-from-lg {display: none !important;}}@media (max-width: 87.99375em) {.mantine-visible-from-xl {display: none !important;}}@media (min-width: 88em) {.mantine-hidden-from-xl {display: none !important;}}",
+      }
+    }
+    data-mantine-styles="classes"
+  />,
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "children": null,
+                "props": {
+                  "dangerouslySetInnerHTML": {
+                    "__html": ".__m__-rj0{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                  },
+                  "data-mantine-styles": "inline",
+                  "nonce": undefined,
+                },
+                "type": "style",
+                Symbol(cleaned): true,
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "children": [
+                                  "my-field",
+                                ],
+                                "props": {
+                                  "className": "m_8fdc1311",
+                                  "data-size": "sm",
+                                  "data-variant": undefined,
+                                  "htmlFor": "root_my-field",
+                                  "id": "root_my-field-label",
+                                  "onMouseDown": [Function],
+                                  "size": undefined,
+                                  "style": {
+                                    "--input-label-size": "var(--mantine-font-size-sm)",
+                                  },
+                                },
+                                "type": "label",
+                                Symbol(cleaned): true,
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "children": null,
+                                    "props": {
+                                      "aria-describedby": undefined,
+                                      "aria-invalid": false,
+                                      "autoFocus": false,
+                                      "className": "m_8fb7ebe7",
+                                      "data-size": undefined,
+                                      "data-variant": "default",
+                                      "disabled": false,
+                                      "enableMarkdownInHelp": true,
+                                      "id": "root_my-field",
+                                      "name": "root_my-field",
+                                      "onBlur": [Function],
+                                      "onChange": [Function],
+                                      "onFocus": [Function],
+                                      "placeholder": "",
+                                      "required": false,
+                                      "size": undefined,
+                                      "style": {},
+                                      "type": "text",
+                                    },
+                                    "type": "input",
+                                    Symbol(cleaned): true,
+                                  },
+                                ],
+                                "props": {
+                                  "className": "m_6c018570",
+                                  "data-size": "sm",
+                                  "data-variant": "default",
+                                  "size": undefined,
+                                  "style": {
+                                    "--input-fz": "var(--mantine-font-size-sm)",
+                                    "--input-height": "var(--input-height-sm)",
+                                  },
+                                },
+                                "type": "div",
+                                Symbol(cleaned): true,
+                              },
+                            ],
+                            "props": {
+                              "className": "m_46b77525",
+                              "data-size": "sm",
+                              "data-variant": undefined,
+                              "size": undefined,
+                              "style": {},
+                            },
+                            "type": "div",
+                            Symbol(cleaned): true,
+                          },
+                          {
+                            "children": [
+                              {
+                                "children": [
+                                  "some ",
+                                  {
+                                    "children": [
+                                      "Rich",
+                                    ],
+                                    "props": {
+                                      "className": undefined,
+                                    },
+                                    "type": "strong",
+                                    Symbol(cleaned): true,
+                                  },
+                                  " help text",
+                                ],
+                                "props": {
+                                  "data-testid": undefined,
+                                },
+                                "type": "span",
+                                Symbol(cleaned): true,
+                              },
+                            ],
+                            "props": {
+                              "className": "m_b6d8b162",
+                              "data-size": "sm",
+                              "data-variant": undefined,
+                              "id": "root_my-field__help",
+                              "size": undefined,
+                              "style": {
+                                "--text-fz": "var(--mantine-font-size-sm)",
+                                "--text-lh": "var(--mantine-line-height-sm)",
+                                "color": "var(--mantine-color-dimmed)",
+                                "marginBlock": "var(--mantine-spacing-xs)",
+                              },
+                            },
+                            "type": "p",
+                            Symbol(cleaned): true,
+                          },
+                        ],
+                        "props": {
+                          "className": "rjsf-field rjsf-field-string",
+                          "style": undefined,
+                        },
+                        "type": "div",
+                        Symbol(cleaned): true,
+                      },
+                    ],
+                    "props": {
+                      "className": "",
+                      "data-size": undefined,
+                      "data-variant": undefined,
+                      "size": undefined,
+                      "style": {},
+                    },
+                    "type": "div",
+                    Symbol(cleaned): true,
+                  },
+                ],
+                "props": {
+                  "className": "m_2415a157 __m__-rj0",
+                  "data-size": undefined,
+                  "data-variant": undefined,
+                  "size": undefined,
+                  "style": {
+                    "marginBottom": "var(--mantine-spacing-sm)",
+                  },
+                },
+                "type": "div",
+                Symbol(cleaned): true,
+              },
+            ],
+            "props": {
+              "className": "m_7485cace",
+              "data-size": undefined,
+              "data-strategy": "block",
+              "data-variant": undefined,
+              "id": "root",
+              "size": undefined,
+              "style": {
+                "padding": "0rem",
+              },
+            },
+            "type": "div",
+            Symbol(cleaned): true,
+          },
+        ],
+        "props": {
+          "className": "rjsf-field rjsf-field-object",
+          "style": undefined,
+        },
+        "type": "div",
+        Symbol(cleaned): true,
+      },
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "children": [
+                  "Submit",
+                ],
+                "props": {
+                  "className": "m_811560b9",
+                  "data-size": undefined,
+                  "data-variant": undefined,
+                  "size": undefined,
+                  "style": {},
+                },
+                "type": "span",
+                Symbol(cleaned): true,
+              },
+            ],
+            "props": {
+              "className": "m_80f1301b",
+              "style": {},
+            },
+            "type": "span",
+            Symbol(cleaned): true,
+          },
+        ],
+        "props": {
+          "className": "m_77c9d27d m_87cf2631",
+          "data-size": undefined,
+          "data-variant": "filled",
+          "size": undefined,
+          "style": {
+            "--button-bd": "calc(0.0625rem * var(--mantine-scale)) solid transparent",
+            "--button-bg": "var(--mantine-color-blue-filled)",
+            "--button-color": "var(--mantine-color-white)",
+            "--button-hover": "var(--mantine-color-blue-filled-hover)",
+          },
+          "type": "submit",
+        },
+        "type": "button",
+        Symbol(cleaned): true,
+      },
+    ],
+    "props": {
+      "acceptCharset": undefined,
+      "action": undefined,
+      "as": undefined,
+      "autoComplete": undefined,
+      "className": "rjsf",
+      "encType": undefined,
+      "id": undefined,
+      "method": undefined,
+      "name": undefined,
+      "noValidate": false,
+      "onSubmit": [Function],
+      "target": undefined,
+    },
+    "type": "form",
+    Symbol(cleaned): true,
+  },
+]
+`;
+
+exports[`single fields field with markdown help in uiSchema 1`] = `
+[
+  <style
+    dangerouslySetInnerHTML={
+      {
+        "__html": "
+
+
+
+",
+      }
+    }
+    data-mantine-styles={true}
+  />,
+  <style
+    dangerouslySetInnerHTML={
+      {
+        "__html": "@media (max-width: 35.99375em) {.mantine-visible-from-xs {display: none !important;}}@media (min-width: 36em) {.mantine-hidden-from-xs {display: none !important;}}@media (max-width: 47.99375em) {.mantine-visible-from-sm {display: none !important;}}@media (min-width: 48em) {.mantine-hidden-from-sm {display: none !important;}}@media (max-width: 61.99375em) {.mantine-visible-from-md {display: none !important;}}@media (min-width: 62em) {.mantine-hidden-from-md {display: none !important;}}@media (max-width: 74.99375em) {.mantine-visible-from-lg {display: none !important;}}@media (min-width: 75em) {.mantine-hidden-from-lg {display: none !important;}}@media (max-width: 87.99375em) {.mantine-visible-from-xl {display: none !important;}}@media (min-width: 88em) {.mantine-hidden-from-xl {display: none !important;}}",
+      }
+    }
+    data-mantine-styles="classes"
+  />,
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "children": null,
+                "props": {
+                  "dangerouslySetInnerHTML": {
+                    "__html": ".__m__-rjc{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                  },
+                  "data-mantine-styles": "inline",
+                  "nonce": undefined,
+                },
+                "type": "style",
+                Symbol(cleaned): true,
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "children": [
+                          {
+                            "children": [
+                              {
+                                "children": [
+                                  "my-field",
+                                ],
+                                "props": {
+                                  "className": "m_8fdc1311",
+                                  "data-size": "sm",
+                                  "data-variant": undefined,
+                                  "htmlFor": "root_my-field",
+                                  "id": "root_my-field-label",
+                                  "onMouseDown": [Function],
+                                  "size": undefined,
+                                  "style": {
+                                    "--input-label-size": "var(--mantine-font-size-sm)",
+                                  },
+                                },
+                                "type": "label",
+                                Symbol(cleaned): true,
+                              },
+                              {
+                                "children": [
+                                  {
+                                    "children": null,
+                                    "props": {
+                                      "aria-describedby": undefined,
+                                      "aria-invalid": false,
+                                      "autoFocus": false,
+                                      "className": "m_8fb7ebe7",
+                                      "data-size": undefined,
+                                      "data-variant": "default",
+                                      "disabled": false,
+                                      "enableMarkdownInHelp": true,
+                                      "id": "root_my-field",
+                                      "name": "root_my-field",
+                                      "onBlur": [Function],
+                                      "onChange": [Function],
+                                      "onFocus": [Function],
+                                      "placeholder": "",
+                                      "required": false,
+                                      "size": undefined,
+                                      "style": {},
+                                      "type": "text",
+                                    },
+                                    "type": "input",
+                                    Symbol(cleaned): true,
+                                  },
+                                ],
+                                "props": {
+                                  "className": "m_6c018570",
+                                  "data-size": "sm",
+                                  "data-variant": "default",
+                                  "size": undefined,
+                                  "style": {
+                                    "--input-fz": "var(--mantine-font-size-sm)",
+                                    "--input-height": "var(--input-height-sm)",
+                                  },
+                                },
+                                "type": "div",
+                                Symbol(cleaned): true,
+                              },
+                            ],
+                            "props": {
+                              "className": "m_46b77525",
+                              "data-size": "sm",
+                              "data-variant": undefined,
+                              "size": undefined,
+                              "style": {},
+                            },
+                            "type": "div",
+                            Symbol(cleaned): true,
+                          },
+                          {
+                            "children": [
+                              {
+                                "children": [
+                                  "some ",
+                                  {
+                                    "children": [
+                                      "other",
+                                    ],
+                                    "props": {
+                                      "className": undefined,
+                                    },
+                                    "type": "strong",
+                                    Symbol(cleaned): true,
+                                  },
+                                  " help",
+                                ],
+                                "props": {
+                                  "data-testid": undefined,
+                                },
+                                "type": "span",
+                                Symbol(cleaned): true,
+                              },
+                            ],
+                            "props": {
+                              "className": "m_b6d8b162",
+                              "data-size": "sm",
+                              "data-variant": undefined,
+                              "id": "root_my-field__help",
+                              "size": undefined,
+                              "style": {
+                                "--text-fz": "var(--mantine-font-size-sm)",
+                                "--text-lh": "var(--mantine-line-height-sm)",
+                                "color": "var(--mantine-color-dimmed)",
+                                "marginBlock": "var(--mantine-spacing-xs)",
+                              },
+                            },
+                            "type": "p",
+                            Symbol(cleaned): true,
+                          },
+                        ],
+                        "props": {
+                          "className": "rjsf-field rjsf-field-string",
+                          "style": undefined,
+                        },
+                        "type": "div",
+                        Symbol(cleaned): true,
+                      },
+                    ],
+                    "props": {
+                      "className": "",
+                      "data-size": undefined,
+                      "data-variant": undefined,
+                      "size": undefined,
+                      "style": {},
+                    },
+                    "type": "div",
+                    Symbol(cleaned): true,
+                  },
+                ],
+                "props": {
+                  "className": "m_2415a157 __m__-rjc",
+                  "data-size": undefined,
+                  "data-variant": undefined,
+                  "size": undefined,
+                  "style": {
+                    "marginBottom": "var(--mantine-spacing-sm)",
+                  },
+                },
+                "type": "div",
+                Symbol(cleaned): true,
+              },
+            ],
+            "props": {
+              "className": "m_7485cace",
+              "data-size": undefined,
+              "data-strategy": "block",
+              "data-variant": undefined,
+              "id": "root",
+              "size": undefined,
+              "style": {
+                "padding": "0rem",
+              },
+            },
+            "type": "div",
+            Symbol(cleaned): true,
+          },
+        ],
+        "props": {
+          "className": "rjsf-field rjsf-field-object",
+          "style": undefined,
+        },
+        "type": "div",
+        Symbol(cleaned): true,
+      },
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "children": [
+                  "Submit",
+                ],
+                "props": {
+                  "className": "m_811560b9",
+                  "data-size": undefined,
+                  "data-variant": undefined,
+                  "size": undefined,
+                  "style": {},
+                },
+                "type": "span",
+                Symbol(cleaned): true,
+              },
+            ],
+            "props": {
+              "className": "m_80f1301b",
+              "style": {},
+            },
+            "type": "span",
+            Symbol(cleaned): true,
+          },
+        ],
+        "props": {
+          "className": "m_77c9d27d m_87cf2631",
+          "data-size": undefined,
+          "data-variant": "filled",
+          "size": undefined,
+          "style": {
+            "--button-bd": "calc(0.0625rem * var(--mantine-scale)) solid transparent",
+            "--button-bg": "var(--mantine-color-blue-filled)",
+            "--button-color": "var(--mantine-color-white)",
+            "--button-hover": "var(--mantine-color-blue-filled-hover)",
+          },
+          "type": "submit",
+        },
+        "type": "button",
+        Symbol(cleaned): true,
+      },
+    ],
+    "props": {
+      "acceptCharset": undefined,
+      "action": undefined,
+      "as": undefined,
+      "autoComplete": undefined,
+      "className": "rjsf",
+      "encType": undefined,
+      "id": undefined,
+      "method": undefined,
+      "name": undefined,
+      "noValidate": false,
+      "onSubmit": [Function],
+      "target": undefined,
+    },
+    "type": "form",
+    Symbol(cleaned): true,
+  },
+]
+`;
+
 exports[`single fields format color 1`] = `
 [
   <style
@@ -16405,7 +16961,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-rkf{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-rl7{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -16446,7 +17002,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 "children": null,
                                 "props": {
                                   "dangerouslySetInnerHTML": {
-                                    "__html": ".__m__-rkk{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                    "__html": ".__m__-rlc{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                   },
                                   "data-mantine-styles": "inline",
                                   "nonce": undefined,
@@ -16582,7 +17138,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                 "children": null,
                                                 "props": {
                                                   "dangerouslySetInnerHTML": {
-                                                    "__html": ".__m__-rkv{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                                    "__html": ".__m__-rln{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                                   },
                                                   "data-mantine-styles": "inline",
                                                   "nonce": undefined,
@@ -16689,7 +17245,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                   },
                                                 ],
                                                 "props": {
-                                                  "className": "m_2415a157 __m__-rkv",
+                                                  "className": "m_2415a157 __m__-rln",
                                                   "data-size": undefined,
                                                   "data-variant": undefined,
                                                   "size": undefined,
@@ -16765,7 +17321,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                 "children": null,
                                                 "props": {
                                                   "dangerouslySetInnerHTML": {
-                                                    "__html": ".__m__-rla{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                                    "__html": ".__m__-rm2{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                                   },
                                                   "data-mantine-styles": "inline",
                                                   "nonce": undefined,
@@ -16872,7 +17428,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                   },
                                                 ],
                                                 "props": {
-                                                  "className": "m_2415a157 __m__-rla",
+                                                  "className": "m_2415a157 __m__-rm2",
                                                   "data-size": undefined,
                                                   "data-variant": undefined,
                                                   "size": undefined,
@@ -17465,7 +18021,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                   },
                                 ],
                                 "props": {
-                                  "className": "m_2415a157 __m__-rkk",
+                                  "className": "m_2415a157 __m__-rlc",
                                   "data-size": undefined,
                                   "data-variant": undefined,
                                   "size": undefined,
@@ -17723,7 +18279,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 "children": null,
                                 "props": {
                                   "dangerouslySetInnerHTML": {
-                                    "__html": ".__m__-rmh{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                    "__html": ".__m__-rn9{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                   },
                                   "data-mantine-styles": "inline",
                                   "nonce": undefined,
@@ -17830,7 +18386,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                   },
                                 ],
                                 "props": {
-                                  "className": "m_2415a157 __m__-rmh",
+                                  "className": "m_2415a157 __m__-rn9",
                                   "data-size": undefined,
                                   "data-variant": undefined,
                                   "size": undefined,
@@ -18236,7 +18792,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                               "data-combobox-option": true,
                                                               "data-size": undefined,
                                                               "data-variant": undefined,
-                                                              "id": ":rni:",
+                                                              "id": ":roa:",
                                                               "onClick": [Function],
                                                               "onMouseDown": [Function],
                                                               "onMouseOver": [Function],
@@ -18265,7 +18821,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                               "data-combobox-option": true,
                                                               "data-size": undefined,
                                                               "data-variant": undefined,
-                                                              "id": ":rnk:",
+                                                              "id": ":roc:",
                                                               "onClick": [Function],
                                                               "onMouseDown": [Function],
                                                               "onMouseOver": [Function],
@@ -18294,7 +18850,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                               "data-combobox-option": true,
                                                               "data-size": undefined,
                                                               "data-variant": undefined,
-                                                              "id": ":rnm:",
+                                                              "id": ":roe:",
                                                               "onClick": [Function],
                                                               "onMouseDown": [Function],
                                                               "onMouseOver": [Function],
@@ -18513,7 +19069,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                         "children": null,
                                         "props": {
                                           "dangerouslySetInnerHTML": {
-                                            "__html": ".__m__-rnq{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                            "__html": ".__m__-roi{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                           },
                                           "data-mantine-styles": "inline",
                                           "nonce": undefined,
@@ -18619,7 +19175,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_2415a157 __m__-rnq",
+                                          "className": "m_2415a157 __m__-roi",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -18867,7 +19423,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                               "data-combobox-option": true,
                                                               "data-size": undefined,
                                                               "data-variant": undefined,
-                                                              "id": ":rok:",
+                                                              "id": ":rpc:",
                                                               "onClick": [Function],
                                                               "onMouseDown": [Function],
                                                               "onMouseOver": [Function],
@@ -18896,7 +19452,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                               "data-combobox-option": true,
                                                               "data-size": undefined,
                                                               "data-variant": undefined,
-                                                              "id": ":rom:",
+                                                              "id": ":rpe:",
                                                               "onClick": [Function],
                                                               "onMouseDown": [Function],
                                                               "onMouseOver": [Function],
@@ -18925,7 +19481,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                               "data-combobox-option": true,
                                                               "data-size": undefined,
                                                               "data-variant": undefined,
-                                                              "id": ":roo:",
+                                                              "id": ":rpg:",
                                                               "onClick": [Function],
                                                               "onMouseDown": [Function],
                                                               "onMouseOver": [Function],
@@ -19321,7 +19877,7 @@ exports[`single fields optional data controls does not show optional controls wh
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-rkf",
+                  "className": "m_2415a157 __m__-rl7",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -19472,7 +20028,7 @@ exports[`single fields optional data controls does not show optional controls wh
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-rur{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-rvj{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -19513,7 +20069,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 "children": null,
                                 "props": {
                                   "dangerouslySetInnerHTML": {
-                                    "__html": ".__m__-rv0{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                    "__html": ".__m__-rvo{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                   },
                                   "data-mantine-styles": "inline",
                                   "nonce": undefined,
@@ -19648,7 +20204,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                 "children": null,
                                                 "props": {
                                                   "dangerouslySetInnerHTML": {
-                                                    "__html": ".__m__-rvb{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                                    "__html": ".__m__-r103{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                                   },
                                                   "data-mantine-styles": "inline",
                                                   "nonce": undefined,
@@ -19754,7 +20310,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                   },
                                                 ],
                                                 "props": {
-                                                  "className": "m_2415a157 __m__-rvb",
+                                                  "className": "m_2415a157 __m__-r103",
                                                   "data-size": undefined,
                                                   "data-variant": undefined,
                                                   "size": undefined,
@@ -19830,7 +20386,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                 "children": null,
                                                 "props": {
                                                   "dangerouslySetInnerHTML": {
-                                                    "__html": ".__m__-rvm{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                                    "__html": ".__m__-r10e{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                                   },
                                                   "data-mantine-styles": "inline",
                                                   "nonce": undefined,
@@ -19936,7 +20492,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                   },
                                                 ],
                                                 "props": {
-                                                  "className": "m_2415a157 __m__-rvm",
+                                                  "className": "m_2415a157 __m__-r10e",
                                                   "data-size": undefined,
                                                   "data-variant": undefined,
                                                   "size": undefined,
@@ -20535,7 +21091,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                   },
                                 ],
                                 "props": {
-                                  "className": "m_2415a157 __m__-rv0",
+                                  "className": "m_2415a157 __m__-rvo",
                                   "data-size": undefined,
                                   "data-variant": undefined,
                                   "size": undefined,
@@ -20795,7 +21351,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                 "children": null,
                                 "props": {
                                   "dangerouslySetInnerHTML": {
-                                    "__html": ".__m__-r10t{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                    "__html": ".__m__-r11l{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                   },
                                   "data-mantine-styles": "inline",
                                   "nonce": undefined,
@@ -20901,7 +21457,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                   },
                                 ],
                                 "props": {
-                                  "className": "m_2415a157 __m__-r10t",
+                                  "className": "m_2415a157 __m__-r11l",
                                   "data-size": undefined,
                                   "data-variant": undefined,
                                   "size": undefined,
@@ -21311,7 +21867,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                               "data-combobox-option": true,
                                                               "data-size": undefined,
                                                               "data-variant": undefined,
-                                                              "id": ":r11u:",
+                                                              "id": ":r12m:",
                                                               "onClick": [Function],
                                                               "onMouseDown": [Function],
                                                               "onMouseOver": [Function],
@@ -21340,7 +21896,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                               "data-combobox-option": true,
                                                               "data-size": undefined,
                                                               "data-variant": undefined,
-                                                              "id": ":r120:",
+                                                              "id": ":r12o:",
                                                               "onClick": [Function],
                                                               "onMouseDown": [Function],
                                                               "onMouseOver": [Function],
@@ -21369,7 +21925,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                               "data-combobox-option": true,
                                                               "data-size": undefined,
                                                               "data-variant": undefined,
-                                                              "id": ":r122:",
+                                                              "id": ":r12q:",
                                                               "onClick": [Function],
                                                               "onMouseDown": [Function],
                                                               "onMouseOver": [Function],
@@ -21589,7 +22145,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                         "children": null,
                                         "props": {
                                           "dangerouslySetInnerHTML": {
-                                            "__html": ".__m__-r126{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                            "__html": ".__m__-r12u{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                           },
                                           "data-mantine-styles": "inline",
                                           "nonce": undefined,
@@ -21695,7 +22251,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_2415a157 __m__-r126",
+                                          "className": "m_2415a157 __m__-r12u",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -21945,7 +22501,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                               "data-combobox-option": true,
                                                               "data-size": undefined,
                                                               "data-variant": undefined,
-                                                              "id": ":r130:",
+                                                              "id": ":r13o:",
                                                               "onClick": [Function],
                                                               "onMouseDown": [Function],
                                                               "onMouseOver": [Function],
@@ -21974,7 +22530,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                               "data-combobox-option": true,
                                                               "data-size": undefined,
                                                               "data-variant": undefined,
-                                                              "id": ":r132:",
+                                                              "id": ":r13q:",
                                                               "onClick": [Function],
                                                               "onMouseDown": [Function],
                                                               "onMouseOver": [Function],
@@ -22003,7 +22559,7 @@ exports[`single fields optional data controls does not show optional controls wh
                                                               "data-combobox-option": true,
                                                               "data-size": undefined,
                                                               "data-variant": undefined,
-                                                              "id": ":r134:",
+                                                              "id": ":r13s:",
                                                               "onClick": [Function],
                                                               "onMouseDown": [Function],
                                                               "onMouseOver": [Function],
@@ -22402,7 +22958,7 @@ exports[`single fields optional data controls does not show optional controls wh
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-rur",
+                  "className": "m_2415a157 __m__-rvj",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -22553,7 +23109,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-rr0{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-rro{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -22573,7 +23129,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 "children": null,
                                 "props": {
                                   "dangerouslySetInnerHTML": {
-                                    "__html": ".__m__-rr4{--grid-gutter:var(--mantine-spacing-md);}",
+                                    "__html": ".__m__-rrs{--grid-gutter:var(--mantine-spacing-md);}",
                                   },
                                   "data-mantine-styles": "inline",
                                   "nonce": undefined,
@@ -22589,7 +23145,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                         "children": null,
                                         "props": {
                                           "dangerouslySetInnerHTML": {
-                                            "__html": ".__m__-rr6{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}",
+                                            "__html": ".__m__-rru{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}",
                                           },
                                           "data-mantine-styles": "inline",
                                           "nonce": undefined,
@@ -22622,7 +23178,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_96bdd299 __m__-rr6",
+                                          "className": "m_96bdd299 __m__-rru",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -22635,7 +23191,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                         "children": null,
                                         "props": {
                                           "dangerouslySetInnerHTML": {
-                                            "__html": ".__m__-rr9{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}",
+                                            "__html": ".__m__-rs1{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}",
                                           },
                                           "data-mantine-styles": "inline",
                                           "nonce": undefined,
@@ -22731,7 +23287,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_96bdd299 __m__-rr9",
+                                          "className": "m_96bdd299 __m__-rs1",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -22750,7 +23306,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                   },
                                 ],
                                 "props": {
-                                  "className": "m_410352e9 __m__-rr4",
+                                  "className": "m_410352e9 __m__-rrs",
                                   "data-size": undefined,
                                   "data-variant": undefined,
                                   "size": undefined,
@@ -22763,7 +23319,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 "children": null,
                                 "props": {
                                   "dangerouslySetInnerHTML": {
-                                    "__html": ".__m__-rrd{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                    "__html": ".__m__-rs5{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                   },
                                   "data-mantine-styles": "inline",
                                   "nonce": undefined,
@@ -22879,7 +23435,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                                 "children": null,
                                                 "props": {
                                                   "dangerouslySetInnerHTML": {
-                                                    "__html": ".__m__-rrn{--grid-gutter:var(--mantine-spacing-md);}",
+                                                    "__html": ".__m__-rsf{--grid-gutter:var(--mantine-spacing-md);}",
                                                   },
                                                   "data-mantine-styles": "inline",
                                                   "nonce": undefined,
@@ -22895,7 +23451,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                                         "children": null,
                                                         "props": {
                                                           "dangerouslySetInnerHTML": {
-                                                            "__html": ".__m__-rrp{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}",
+                                                            "__html": ".__m__-rsh{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}",
                                                           },
                                                           "data-mantine-styles": "inline",
                                                           "nonce": undefined,
@@ -22928,7 +23484,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                                           },
                                                         ],
                                                         "props": {
-                                                          "className": "m_96bdd299 __m__-rrp",
+                                                          "className": "m_96bdd299 __m__-rsh",
                                                           "data-size": undefined,
                                                           "data-variant": undefined,
                                                           "size": undefined,
@@ -22941,7 +23497,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                                         "children": null,
                                                         "props": {
                                                           "dangerouslySetInnerHTML": {
-                                                            "__html": ".__m__-rrs{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}",
+                                                            "__html": ".__m__-rsk{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}",
                                                           },
                                                           "data-mantine-styles": "inline",
                                                           "nonce": undefined,
@@ -23037,7 +23593,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                                           },
                                                         ],
                                                         "props": {
-                                                          "className": "m_96bdd299 __m__-rrs",
+                                                          "className": "m_96bdd299 __m__-rsk",
                                                           "data-size": undefined,
                                                           "data-variant": undefined,
                                                           "size": undefined,
@@ -23056,7 +23612,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                                   },
                                                 ],
                                                 "props": {
-                                                  "className": "m_410352e9 __m__-rrn",
+                                                  "className": "m_410352e9 __m__-rsf",
                                                   "data-size": undefined,
                                                   "data-variant": undefined,
                                                   "size": undefined,
@@ -23069,7 +23625,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                                 "children": null,
                                                 "props": {
                                                   "dangerouslySetInnerHTML": {
-                                                    "__html": ".__m__-rs0{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                                    "__html": ".__m__-rso{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                                   },
                                                   "data-mantine-styles": "inline",
                                                   "nonce": undefined,
@@ -23080,7 +23636,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                               {
                                                 "children": null,
                                                 "props": {
-                                                  "className": "m_2415a157 __m__-rs0",
+                                                  "className": "m_2415a157 __m__-rso",
                                                   "data-size": undefined,
                                                   "data-variant": undefined,
                                                   "size": undefined,
@@ -23156,7 +23712,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                                 "children": null,
                                                 "props": {
                                                   "dangerouslySetInnerHTML": {
-                                                    "__html": ".__m__-rs5{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                                    "__html": ".__m__-rst{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                                   },
                                                   "data-mantine-styles": "inline",
                                                   "nonce": undefined,
@@ -23263,7 +23819,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                                   },
                                                 ],
                                                 "props": {
-                                                  "className": "m_2415a157 __m__-rs5",
+                                                  "className": "m_2415a157 __m__-rst",
                                                   "data-size": undefined,
                                                   "data-variant": undefined,
                                                   "size": undefined,
@@ -23754,7 +24310,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                   },
                                 ],
                                 "props": {
-                                  "className": "m_2415a157 __m__-rrd",
+                                  "className": "m_2415a157 __m__-rs5",
                                   "data-size": undefined,
                                   "data-variant": undefined,
                                   "size": undefined,
@@ -24058,7 +24614,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_8bffd616 __m__-rt4",
+                                          "className": "m_8bffd616 __m__-rts",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -24259,7 +24815,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 "children": null,
                                 "props": {
                                   "dangerouslySetInnerHTML": {
-                                    "__html": ".__m__-rtl{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                    "__html": ".__m__-rud{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                   },
                                   "data-mantine-styles": "inline",
                                   "nonce": undefined,
@@ -24366,7 +24922,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                   },
                                 ],
                                 "props": {
-                                  "className": "m_2415a157 __m__-rtl",
+                                  "className": "m_2415a157 __m__-rud",
                                   "data-size": undefined,
                                   "data-variant": undefined,
                                   "size": undefined,
@@ -24607,7 +25163,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                         "children": null,
                                         "props": {
                                           "dangerouslySetInnerHTML": {
-                                            "__html": ".__m__-ru7{--grid-gutter:var(--mantine-spacing-md);}",
+                                            "__html": ".__m__-ruv{--grid-gutter:var(--mantine-spacing-md);}",
                                           },
                                           "data-mantine-styles": "inline",
                                           "nonce": undefined,
@@ -24623,7 +25179,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                                 "children": null,
                                                 "props": {
                                                   "dangerouslySetInnerHTML": {
-                                                    "__html": ".__m__-ru9{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}",
+                                                    "__html": ".__m__-rv1{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}",
                                                   },
                                                   "data-mantine-styles": "inline",
                                                   "nonce": undefined,
@@ -24656,7 +25212,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                                   },
                                                 ],
                                                 "props": {
-                                                  "className": "m_96bdd299 __m__-ru9",
+                                                  "className": "m_96bdd299 __m__-rv1",
                                                   "data-size": undefined,
                                                   "data-variant": undefined,
                                                   "size": undefined,
@@ -24669,7 +25225,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                                 "children": null,
                                                 "props": {
                                                   "dangerouslySetInnerHTML": {
-                                                    "__html": ".__m__-ruc{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}",
+                                                    "__html": ".__m__-rv4{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}",
                                                   },
                                                   "data-mantine-styles": "inline",
                                                   "nonce": undefined,
@@ -24765,7 +25321,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                                   },
                                                 ],
                                                 "props": {
-                                                  "className": "m_96bdd299 __m__-ruc",
+                                                  "className": "m_96bdd299 __m__-rv4",
                                                   "data-size": undefined,
                                                   "data-variant": undefined,
                                                   "size": undefined,
@@ -24784,7 +25340,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_410352e9 __m__-ru7",
+                                          "className": "m_410352e9 __m__-ruv",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -24797,7 +25353,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                         "children": null,
                                         "props": {
                                           "dangerouslySetInnerHTML": {
-                                            "__html": ".__m__-rug{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                            "__html": ".__m__-rv8{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                           },
                                           "data-mantine-styles": "inline",
                                           "nonce": undefined,
@@ -24808,7 +25364,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                       {
                                         "children": null,
                                         "props": {
-                                          "className": "m_2415a157 __m__-rug",
+                                          "className": "m_2415a157 __m__-rv8",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -24987,7 +25543,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-rr0",
+                  "className": "m_2415a157 __m__-rro",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -25138,7 +25694,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-r14s{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-r15k{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -25179,7 +25735,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 "children": null,
                                 "props": {
                                   "dangerouslySetInnerHTML": {
-                                    "__html": ".__m__-r151{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                    "__html": ".__m__-r15p{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                   },
                                   "data-mantine-styles": "inline",
                                   "nonce": undefined,
@@ -25315,7 +25871,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                                 "children": null,
                                                 "props": {
                                                   "dangerouslySetInnerHTML": {
-                                                    "__html": ".__m__-r15c{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                                    "__html": ".__m__-r164{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                                   },
                                                   "data-mantine-styles": "inline",
                                                   "nonce": undefined,
@@ -25337,7 +25893,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                                   },
                                                 ],
                                                 "props": {
-                                                  "className": "m_2415a157 __m__-r15c",
+                                                  "className": "m_2415a157 __m__-r164",
                                                   "data-size": undefined,
                                                   "data-variant": undefined,
                                                   "size": undefined,
@@ -25413,7 +25969,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                                 "children": null,
                                                 "props": {
                                                   "dangerouslySetInnerHTML": {
-                                                    "__html": ".__m__-r15h{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                                    "__html": ".__m__-r169{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                                   },
                                                   "data-mantine-styles": "inline",
                                                   "nonce": undefined,
@@ -25519,7 +26075,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                                   },
                                                 ],
                                                 "props": {
-                                                  "className": "m_2415a157 __m__-r15h",
+                                                  "className": "m_2415a157 __m__-r169",
                                                   "data-size": undefined,
                                                   "data-variant": undefined,
                                                   "size": undefined,
@@ -26025,7 +26581,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                   },
                                 ],
                                 "props": {
-                                  "className": "m_2415a157 __m__-r151",
+                                  "className": "m_2415a157 __m__-r15p",
                                   "data-size": undefined,
                                   "data-variant": undefined,
                                   "size": undefined,
@@ -26330,7 +26886,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_8bffd616 __m__-r16g",
+                                          "className": "m_8bffd616 __m__-r178",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -26533,7 +27089,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                 "children": null,
                                 "props": {
                                   "dangerouslySetInnerHTML": {
-                                    "__html": ".__m__-r171{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                    "__html": ".__m__-r17p{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                   },
                                   "data-mantine-styles": "inline",
                                   "nonce": undefined,
@@ -26639,7 +27195,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                   },
                                 ],
                                 "props": {
-                                  "className": "m_2415a157 __m__-r171",
+                                  "className": "m_2415a157 __m__-r17p",
                                   "data-size": undefined,
                                   "data-variant": undefined,
                                   "size": undefined,
@@ -26903,7 +27459,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                         "children": null,
                                         "props": {
                                           "dangerouslySetInnerHTML": {
-                                            "__html": ".__m__-r17k{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                            "__html": ".__m__-r18c{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                           },
                                           "data-mantine-styles": "inline",
                                           "nonce": undefined,
@@ -26925,7 +27481,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_2415a157 __m__-r17k",
+                                          "className": "m_2415a157 __m__-r18c",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -27115,7 +27671,7 @@ exports[`single fields optional data controls shows "add" and "remove" optional 
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-r14s",
+                  "className": "m_2415a157 __m__-r15k",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -27266,7 +27822,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-rp4{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-rps{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -27286,7 +27842,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                 "children": null,
                                 "props": {
                                   "dangerouslySetInnerHTML": {
-                                    "__html": ".__m__-rp8{--grid-gutter:var(--mantine-spacing-md);}",
+                                    "__html": ".__m__-rq0{--grid-gutter:var(--mantine-spacing-md);}",
                                   },
                                   "data-mantine-styles": "inline",
                                   "nonce": undefined,
@@ -27302,7 +27858,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                         "children": null,
                                         "props": {
                                           "dangerouslySetInnerHTML": {
-                                            "__html": ".__m__-rpa{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}",
+                                            "__html": ".__m__-rq2{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}",
                                           },
                                           "data-mantine-styles": "inline",
                                           "nonce": undefined,
@@ -27335,7 +27891,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_96bdd299 __m__-rpa",
+                                          "className": "m_96bdd299 __m__-rq2",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -27348,7 +27904,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                         "children": null,
                                         "props": {
                                           "dangerouslySetInnerHTML": {
-                                            "__html": ".__m__-rpd{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}",
+                                            "__html": ".__m__-rq5{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}",
                                           },
                                           "data-mantine-styles": "inline",
                                           "nonce": undefined,
@@ -27444,7 +28000,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_96bdd299 __m__-rpd",
+                                          "className": "m_96bdd299 __m__-rq5",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -27463,7 +28019,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                   },
                                 ],
                                 "props": {
-                                  "className": "m_410352e9 __m__-rp8",
+                                  "className": "m_410352e9 __m__-rq0",
                                   "data-size": undefined,
                                   "data-variant": undefined,
                                   "size": undefined,
@@ -27476,7 +28032,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                 "children": null,
                                 "props": {
                                   "dangerouslySetInnerHTML": {
-                                    "__html": ".__m__-rph{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                    "__html": ".__m__-rq9{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                   },
                                   "data-mantine-styles": "inline",
                                   "nonce": undefined,
@@ -27487,7 +28043,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                               {
                                 "children": null,
                                 "props": {
-                                  "className": "m_2415a157 __m__-rph",
+                                  "className": "m_2415a157 __m__-rq9",
                                   "data-size": undefined,
                                   "data-variant": undefined,
                                   "size": undefined,
@@ -27643,7 +28199,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                 "children": null,
                                 "props": {
                                   "dangerouslySetInnerHTML": {
-                                    "__html": ".__m__-rpq{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                    "__html": ".__m__-rqi{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                   },
                                   "data-mantine-styles": "inline",
                                   "nonce": undefined,
@@ -27750,7 +28306,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                   },
                                 ],
                                 "props": {
-                                  "className": "m_2415a157 __m__-rpq",
+                                  "className": "m_2415a157 __m__-rqi",
                                   "data-size": undefined,
                                   "data-variant": undefined,
                                   "size": undefined,
@@ -27991,7 +28547,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                         "children": null,
                                         "props": {
                                           "dangerouslySetInnerHTML": {
-                                            "__html": ".__m__-rqc{--grid-gutter:var(--mantine-spacing-md);}",
+                                            "__html": ".__m__-rr4{--grid-gutter:var(--mantine-spacing-md);}",
                                           },
                                           "data-mantine-styles": "inline",
                                           "nonce": undefined,
@@ -28007,7 +28563,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                                 "children": null,
                                                 "props": {
                                                   "dangerouslySetInnerHTML": {
-                                                    "__html": ".__m__-rqe{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}",
+                                                    "__html": ".__m__-rr6{--col-flex-grow:1;--col-flex-basis:0rem;--col-max-width:100%;}",
                                                   },
                                                   "data-mantine-styles": "inline",
                                                   "nonce": undefined,
@@ -28040,7 +28596,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                                   },
                                                 ],
                                                 "props": {
-                                                  "className": "m_96bdd299 __m__-rqe",
+                                                  "className": "m_96bdd299 __m__-rr6",
                                                   "data-size": undefined,
                                                   "data-variant": undefined,
                                                   "size": undefined,
@@ -28053,7 +28609,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                                 "children": null,
                                                 "props": {
                                                   "dangerouslySetInnerHTML": {
-                                                    "__html": ".__m__-rqh{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}",
+                                                    "__html": ".__m__-rr9{--col-flex-grow:auto;--col-flex-basis:auto;--col-width:auto;--col-max-width:unset;}",
                                                   },
                                                   "data-mantine-styles": "inline",
                                                   "nonce": undefined,
@@ -28149,7 +28705,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                                   },
                                                 ],
                                                 "props": {
-                                                  "className": "m_96bdd299 __m__-rqh",
+                                                  "className": "m_96bdd299 __m__-rr9",
                                                   "data-size": undefined,
                                                   "data-variant": undefined,
                                                   "size": undefined,
@@ -28168,7 +28724,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_410352e9 __m__-rqc",
+                                          "className": "m_410352e9 __m__-rr4",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -28181,7 +28737,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                         "children": null,
                                         "props": {
                                           "dangerouslySetInnerHTML": {
-                                            "__html": ".__m__-rql{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                            "__html": ".__m__-rrd{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                           },
                                           "data-mantine-styles": "inline",
                                           "nonce": undefined,
@@ -28192,7 +28748,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                       {
                                         "children": null,
                                         "props": {
-                                          "className": "m_2415a157 __m__-rql",
+                                          "className": "m_2415a157 __m__-rrd",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -28371,7 +28927,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-rp4",
+                  "className": "m_2415a157 __m__-rps",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -28522,7 +29078,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-r13g{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-r148{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -28563,7 +29119,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                 "children": null,
                                 "props": {
                                   "dangerouslySetInnerHTML": {
-                                    "__html": ".__m__-r13l{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                    "__html": ".__m__-r14d{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                   },
                                   "data-mantine-styles": "inline",
                                   "nonce": undefined,
@@ -28585,7 +29141,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                   },
                                 ],
                                 "props": {
-                                  "className": "m_2415a157 __m__-r13l",
+                                  "className": "m_2415a157 __m__-r14d",
                                   "data-size": undefined,
                                   "data-variant": undefined,
                                   "size": undefined,
@@ -28752,7 +29308,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                 "children": null,
                                 "props": {
                                   "dangerouslySetInnerHTML": {
-                                    "__html": ".__m__-r13u{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                    "__html": ".__m__-r14m{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                   },
                                   "data-mantine-styles": "inline",
                                   "nonce": undefined,
@@ -28861,7 +29417,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                   },
                                 ],
                                 "props": {
-                                  "className": "m_2415a157 __m__-r13u",
+                                  "className": "m_2415a157 __m__-r14m",
                                   "data-size": undefined,
                                   "data-variant": undefined,
                                   "size": undefined,
@@ -29125,7 +29681,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                         "children": null,
                                         "props": {
                                           "dangerouslySetInnerHTML": {
-                                            "__html": ".__m__-r14h{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                                            "__html": ".__m__-r159{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                                           },
                                           "data-mantine-styles": "inline",
                                           "nonce": undefined,
@@ -29147,7 +29703,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                                           },
                                         ],
                                         "props": {
-                                          "className": "m_2415a157 __m__-r14h",
+                                          "className": "m_2415a157 __m__-r159",
                                           "data-size": undefined,
                                           "data-variant": undefined,
                                           "size": undefined,
@@ -29337,7 +29893,7 @@ exports[`single fields optional data controls shows "add" optional controls when
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-r13g",
+                  "className": "m_2415a157 __m__-r148",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,
@@ -37810,7 +38366,7 @@ exports[`single fields title field 1`] = `
                 "children": null,
                 "props": {
                   "dangerouslySetInnerHTML": {
-                    "__html": ".__m__-rj1{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
+                    "__html": ".__m__-rjp{--sg-spacing-x:var(--mantine-spacing-md);--sg-spacing-y:var(--mantine-spacing-md);--sg-cols:1;}",
                   },
                   "data-mantine-styles": "inline",
                   "nonce": undefined,
@@ -37917,7 +38473,7 @@ exports[`single fields title field 1`] = `
                   },
                 ],
                 "props": {
-                  "className": "m_2415a157 __m__-rj1",
+                  "className": "m_2415a157 __m__-rjp",
                   "data-size": undefined,
                   "data-variant": undefined,
                   "size": undefined,

--- a/packages/mui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/mui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,5 +1,6 @@
 import FormHelperText from '@mui/material/FormHelperText';
 import { helpId, FieldHelpProps, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
+import { RichHelp } from '@rjsf/core';
 
 /** The `FieldHelpTemplate` component renders any help desired for a field
  *
@@ -10,14 +11,14 @@ export default function FieldHelpTemplate<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: FieldHelpProps<T, S, F>) {
-  const { fieldPathId, help } = props;
+  const { fieldPathId, help, registry, uiSchema } = props;
   if (!help) {
     return null;
   }
   const id = helpId(fieldPathId);
   return (
     <FormHelperText component='div' id={id}>
-      {help}
+      <RichHelp help={help} registry={registry} uiSchema={uiSchema} />
     </FormHelperText>
   );
 }

--- a/packages/mui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/mui/test/__snapshots__/Form.test.tsx.snap
@@ -18582,6 +18582,1172 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-p
 </form>
 `;
 
+exports[`single fields field with markdown help 1`] = `
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
+.emotion-1 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
+}
+
+.emotion-1>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-1>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-1>* {
+  --Grid-parent-rowSpacing: 16px;
+}
+
+.emotion-2 {
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
+  min-width: 0;
+  box-sizing: border-box;
+}
+
+.emotion-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+}
+
+.emotion-5 {
+  color: rgba(0, 0, 0, 0.6);
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  padding: 0;
+  position: relative;
+  display: block;
+  transform-origin: top left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+  -webkit-transform: translate(0, 20px) scale(1);
+  -moz-transform: translate(0, 20px) scale(1);
+  -ms-transform: translate(0, 20px) scale(1);
+  transform: translate(0, 20px) scale(1);
+  -webkit-transition: color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,-webkit-transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,max-width 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,max-width 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  z-index: 1;
+  pointer-events: none;
+  -webkit-transform: translate(14px, 16px) scale(1);
+  -moz-transform: translate(14px, 16px) scale(1);
+  -ms-transform: translate(14px, 16px) scale(1);
+  transform: translate(14px, 16px) scale(1);
+  max-width: calc(100% - 24px);
+}
+
+.emotion-5.Mui-focused {
+  color: #1976d2;
+}
+
+.emotion-5.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-5.Mui-error {
+  color: #d32f2f;
+}
+
+.emotion-6 {
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  color: rgba(0, 0, 0, 0.87);
+  box-sizing: border-box;
+  position: relative;
+  cursor: text;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border-radius: 4px;
+}
+
+.emotion-6.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+  cursor: default;
+}
+
+.emotion-6:hover .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.87);
+}
+
+@media (hover: none) {
+  .emotion-6:hover .MuiOutlinedInput-notchedOutline {
+    border-color: rgba(0, 0, 0, 0.23);
+  }
+}
+
+.emotion-6.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-width: 2px;
+}
+
+.emotion-6.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-color: #1976d2;
+}
+
+.emotion-6.Mui-error .MuiOutlinedInput-notchedOutline {
+  border-color: #d32f2f;
+}
+
+.emotion-6.Mui-disabled .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-7 {
+  font: inherit;
+  letter-spacing: inherit;
+  color: currentColor;
+  padding: 4px 0 5px;
+  border: 0;
+  box-sizing: content-box;
+  background: none;
+  height: 1.4375em;
+  margin: 0;
+  -webkit-tap-highlight-color: transparent;
+  display: block;
+  min-width: 0;
+  width: 100%;
+  -webkit-animation-name: mui-auto-fill-cancel;
+  animation-name: mui-auto-fill-cancel;
+  -webkit-animation-duration: 10ms;
+  animation-duration: 10ms;
+  padding: 16.5px 14px;
+}
+
+.emotion-7::-webkit-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-7::-moz-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-7::-ms-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-7:focus {
+  outline: 0;
+}
+
+.emotion-7:invalid {
+  box-shadow: none;
+}
+
+.emotion-7::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7::-webkit-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7::-moz-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7::-ms-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-webkit-input-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-moz-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-placeholder {
+  opacity: 0.42;
+}
+
+.emotion-7.Mui-disabled {
+  opacity: 1;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-7:-webkit-autofill {
+  -webkit-animation-duration: 5000s;
+  animation-duration: 5000s;
+  -webkit-animation-name: mui-auto-fill;
+  animation-name: mui-auto-fill;
+}
+
+.emotion-7:-webkit-autofill {
+  border-radius: inherit;
+}
+
+.emotion-8 {
+  text-align: left;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  top: -5px;
+  left: 0;
+  margin: 0;
+  padding: 0 8px;
+  pointer-events: none;
+  border-radius: inherit;
+  border-style: solid;
+  border-width: 1px;
+  overflow: hidden;
+  min-width: 0%;
+  border-color: rgba(0, 0, 0, 0.23);
+}
+
+.emotion-9 {
+  float: unset;
+  width: auto;
+  overflow: hidden;
+  display: block;
+  padding: 0;
+  height: 11px;
+  font-size: 0.75em;
+  visibility: hidden;
+  max-width: 0.01px;
+  -webkit-transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  white-space: nowrap;
+}
+
+.emotion-9>span {
+  padding-left: 5px;
+  padding-right: 5px;
+  display: inline-block;
+  opacity: 0;
+  visibility: visible;
+}
+
+.emotion-10 {
+  color: rgba(0, 0, 0, 0.6);
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 0.75rem;
+  line-height: 1.66;
+  letter-spacing: 0.03333em;
+  text-align: left;
+  margin-top: 3px;
+  margin-right: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  margin-left: 14px;
+  margin-right: 14px;
+}
+
+.emotion-10.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-10.Mui-error {
+  color: #d32f2f;
+}
+
+.emotion-11 {
+  margin-top: 24px;
+}
+
+.emotion-12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  letter-spacing: 0.02857em;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 6px 16px;
+  border: 0;
+  border-radius: 4px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  color: var(--variant-containedColor);
+  background-color: var(--variant-containedBg);
+  box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  --variant-textColor: #1976d2;
+  --variant-outlinedColor: #1976d2;
+  --variant-outlinedBorder: rgba(25, 118, 210, 0.5);
+  --variant-containedColor: #fff;
+  --variant-containedBg: #1976d2;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-12::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-12.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-12 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-12:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-12.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-12:hover {
+  box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+}
+
+@media (hover: none) {
+  .emotion-12:hover {
+    box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  }
+}
+
+.emotion-12:active {
+  box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+}
+
+.emotion-12.Mui-focusVisible {
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+}
+
+.emotion-12.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+@media (hover: hover) {
+  .emotion-12:hover {
+    --variant-containedBg: #1565c0;
+    --variant-textBg: rgba(25, 118, 210, 0.04);
+    --variant-outlinedBorder: #1976d2;
+    --variant-outlinedBg: rgba(25, 118, 210, 0.04);
+  }
+}
+
+.emotion-12.MuiButton-loading {
+  color: transparent;
+}
+
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    >
+      <div
+        className="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row MuiGrid-spacing-xs-2 emotion-1"
+        style={
+          {
+            "marginTop": "10px",
+          }
+        }
+      >
+        <div
+          className="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 emotion-2"
+          style={
+            {
+              "marginBottom": "10px",
+            }
+          }
+        >
+          <div
+            className="rjsf-field rjsf-field-string"
+          >
+            <div
+              className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+            >
+              <div
+                aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                className="MuiFormControl-root MuiTextField-root emotion-4"
+              >
+                <label
+                  className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined emotion-5"
+                  data-shrink={false}
+                  htmlFor="root_my-field"
+                  id="root_my-field-label"
+                >
+                  my-field
+                </label>
+                <div
+                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-6"
+                  onClick={[Function]}
+                >
+                  <input
+                    aria-invalid={false}
+                    autoFocus={false}
+                    className="MuiInputBase-input MuiOutlinedInput-input emotion-7"
+                    disabled={false}
+                    id="root_my-field"
+                    name="root_my-field"
+                    onAnimationStart={[Function]}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                  <fieldset
+                    aria-hidden={true}
+                    className="MuiOutlinedInput-notchedOutline emotion-8"
+                  >
+                    <legend
+                      className="emotion-9"
+                    >
+                      <span>
+                        my-field
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+              <div
+                className="MuiFormHelperText-root MuiFormHelperText-sizeMedium MuiFormHelperText-contained emotion-10"
+                id="root_my-field__help"
+              >
+                <span>
+                  some 
+                  <strong>
+                    Rich
+                  </strong>
+                   help text
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="MuiBox-root emotion-11"
+  >
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary emotion-12"
+      disabled={null}
+      onBlur={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown help in uiSchema 1`] = `
+.emotion-0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
+.emotion-1 {
+  --Grid-columns: 12;
+  --Grid-columnSpacing: 16px;
+  --Grid-rowSpacing: 16px;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  min-width: 0;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  gap: var(--Grid-rowSpacing) var(--Grid-columnSpacing);
+}
+
+.emotion-1>* {
+  --Grid-parent-columns: 12;
+}
+
+.emotion-1>* {
+  --Grid-parent-columnSpacing: 16px;
+}
+
+.emotion-1>* {
+  --Grid-parent-rowSpacing: 16px;
+}
+
+.emotion-2 {
+  -webkit-box-flex: 0;
+  -webkit-flex-grow: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -webkit-flex-basis: auto;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+  width: calc(100% * 12 / var(--Grid-parent-columns) - (var(--Grid-parent-columns) - 12) * (var(--Grid-parent-columnSpacing) / var(--Grid-parent-columns)));
+  min-width: 0;
+  box-sizing: border-box;
+}
+
+.emotion-4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  position: relative;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  vertical-align: top;
+}
+
+.emotion-5 {
+  color: rgba(0, 0, 0, 0.6);
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  padding: 0;
+  position: relative;
+  display: block;
+  transform-origin: top left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+  -webkit-transform: translate(0, 20px) scale(1);
+  -moz-transform: translate(0, 20px) scale(1);
+  -ms-transform: translate(0, 20px) scale(1);
+  transform: translate(0, 20px) scale(1);
+  -webkit-transition: color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,-webkit-transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,max-width 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: color 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,max-width 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  z-index: 1;
+  pointer-events: none;
+  -webkit-transform: translate(14px, 16px) scale(1);
+  -moz-transform: translate(14px, 16px) scale(1);
+  -ms-transform: translate(14px, 16px) scale(1);
+  transform: translate(14px, 16px) scale(1);
+  max-width: calc(100% - 24px);
+}
+
+.emotion-5.Mui-focused {
+  color: #1976d2;
+}
+
+.emotion-5.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-5.Mui-error {
+  color: #d32f2f;
+}
+
+.emotion-6 {
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
+  line-height: 1.4375em;
+  letter-spacing: 0.00938em;
+  color: rgba(0, 0, 0, 0.87);
+  box-sizing: border-box;
+  position: relative;
+  cursor: text;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: relative;
+  border-radius: 4px;
+}
+
+.emotion-6.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+  cursor: default;
+}
+
+.emotion-6:hover .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.87);
+}
+
+@media (hover: none) {
+  .emotion-6:hover .MuiOutlinedInput-notchedOutline {
+    border-color: rgba(0, 0, 0, 0.23);
+  }
+}
+
+.emotion-6.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-width: 2px;
+}
+
+.emotion-6.Mui-focused .MuiOutlinedInput-notchedOutline {
+  border-color: #1976d2;
+}
+
+.emotion-6.Mui-error .MuiOutlinedInput-notchedOutline {
+  border-color: #d32f2f;
+}
+
+.emotion-6.Mui-disabled .MuiOutlinedInput-notchedOutline {
+  border-color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-7 {
+  font: inherit;
+  letter-spacing: inherit;
+  color: currentColor;
+  padding: 4px 0 5px;
+  border: 0;
+  box-sizing: content-box;
+  background: none;
+  height: 1.4375em;
+  margin: 0;
+  -webkit-tap-highlight-color: transparent;
+  display: block;
+  min-width: 0;
+  width: 100%;
+  -webkit-animation-name: mui-auto-fill-cancel;
+  animation-name: mui-auto-fill-cancel;
+  -webkit-animation-duration: 10ms;
+  animation-duration: 10ms;
+  padding: 16.5px 14px;
+}
+
+.emotion-7::-webkit-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-7::-moz-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-7::-ms-input-placeholder {
+  color: currentColor;
+  opacity: 0.42;
+  -webkit-transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-7:focus {
+  outline: 0;
+}
+
+.emotion-7:invalid {
+  box-shadow: none;
+}
+
+.emotion-7::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7::-webkit-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7::-moz-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7::-ms-input-placeholder {
+  opacity: 0!important;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-webkit-input-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-moz-placeholder {
+  opacity: 0.42;
+}
+
+label[data-shrink=false]+.MuiInputBase-formControl .emotion-7:focus::-ms-input-placeholder {
+  opacity: 0.42;
+}
+
+.emotion-7.Mui-disabled {
+  opacity: 1;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-7:-webkit-autofill {
+  -webkit-animation-duration: 5000s;
+  animation-duration: 5000s;
+  -webkit-animation-name: mui-auto-fill;
+  animation-name: mui-auto-fill;
+}
+
+.emotion-7:-webkit-autofill {
+  border-radius: inherit;
+}
+
+.emotion-8 {
+  text-align: left;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  top: -5px;
+  left: 0;
+  margin: 0;
+  padding: 0 8px;
+  pointer-events: none;
+  border-radius: inherit;
+  border-style: solid;
+  border-width: 1px;
+  overflow: hidden;
+  min-width: 0%;
+  border-color: rgba(0, 0, 0, 0.23);
+}
+
+.emotion-9 {
+  float: unset;
+  width: auto;
+  overflow: hidden;
+  display: block;
+  padding: 0;
+  height: 11px;
+  font-size: 0.75em;
+  visibility: hidden;
+  max-width: 0.01px;
+  -webkit-transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  transition: max-width 50ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;
+  white-space: nowrap;
+}
+
+.emotion-9>span {
+  padding-left: 5px;
+  padding-right: 5px;
+  display: inline-block;
+  opacity: 0;
+  visibility: visible;
+}
+
+.emotion-10 {
+  color: rgba(0, 0, 0, 0.6);
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 400;
+  font-size: 0.75rem;
+  line-height: 1.66;
+  letter-spacing: 0.03333em;
+  text-align: left;
+  margin-top: 3px;
+  margin-right: 0;
+  margin-bottom: 0;
+  margin-left: 0;
+  margin-left: 14px;
+  margin-right: 14px;
+}
+
+.emotion-10.Mui-disabled {
+  color: rgba(0, 0, 0, 0.38);
+}
+
+.emotion-10.Mui-error {
+  color: #d32f2f;
+}
+
+.emotion-11 {
+  margin-top: 24px;
+}
+
+.emotion-12 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+  background-color: transparent;
+  outline: 0;
+  border: 0;
+  margin: 0;
+  border-radius: 0;
+  padding: 0;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  vertical-align: middle;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: inherit;
+  font-family: "Roboto","Helvetica","Arial",sans-serif;
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.75;
+  letter-spacing: 0.02857em;
+  text-transform: uppercase;
+  min-width: 64px;
+  padding: 6px 16px;
+  border: 0;
+  border-radius: 4px;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  color: var(--variant-containedColor);
+  background-color: var(--variant-containedBg);
+  box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  --variant-textColor: #1976d2;
+  --variant-outlinedColor: #1976d2;
+  --variant-outlinedBorder: rgba(25, 118, 210, 0.5);
+  --variant-containedColor: #fff;
+  --variant-containedBg: #1976d2;
+  -webkit-transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,box-shadow 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,border-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+}
+
+.emotion-12::-moz-focus-inner {
+  border-style: none;
+}
+
+.emotion-12.Mui-disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+@media print {
+  .emotion-12 {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+  }
+}
+
+.emotion-12:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.emotion-12.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+}
+
+.emotion-12:hover {
+  box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+}
+
+@media (hover: none) {
+  .emotion-12:hover {
+    box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+  }
+}
+
+.emotion-12:active {
+  box-shadow: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+}
+
+.emotion-12.Mui-focusVisible {
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+}
+
+.emotion-12.Mui-disabled {
+  color: rgba(0, 0, 0, 0.26);
+  box-shadow: none;
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+@media (hover: hover) {
+  .emotion-12:hover {
+    --variant-containedBg: #1565c0;
+    --variant-textBg: rgba(25, 118, 210, 0.04);
+    --variant-outlinedBorder: #1976d2;
+    --variant-outlinedBg: rgba(25, 118, 210, 0.04);
+  }
+}
+
+.emotion-12.MuiButton-loading {
+  color: transparent;
+}
+
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+    >
+      <div
+        className="MuiGrid-root MuiGrid-container MuiGrid-direction-xs-row MuiGrid-spacing-xs-2 emotion-1"
+        style={
+          {
+            "marginTop": "10px",
+          }
+        }
+      >
+        <div
+          className="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-12 emotion-2"
+          style={
+            {
+              "marginBottom": "10px",
+            }
+          }
+        >
+          <div
+            className="rjsf-field rjsf-field-string"
+          >
+            <div
+              className="MuiFormControl-root MuiFormControl-fullWidth emotion-0"
+            >
+              <div
+                aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                className="MuiFormControl-root MuiTextField-root emotion-4"
+              >
+                <label
+                  className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-outlined emotion-5"
+                  data-shrink={false}
+                  htmlFor="root_my-field"
+                  id="root_my-field-label"
+                >
+                  my-field
+                </label>
+                <div
+                  className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl emotion-6"
+                  onClick={[Function]}
+                >
+                  <input
+                    aria-invalid={false}
+                    autoFocus={false}
+                    className="MuiInputBase-input MuiOutlinedInput-input emotion-7"
+                    disabled={false}
+                    id="root_my-field"
+                    name="root_my-field"
+                    onAnimationStart={[Function]}
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                  <fieldset
+                    aria-hidden={true}
+                    className="MuiOutlinedInput-notchedOutline emotion-8"
+                  >
+                    <legend
+                      className="emotion-9"
+                    >
+                      <span>
+                        my-field
+                      </span>
+                    </legend>
+                  </fieldset>
+                </div>
+              </div>
+              <div
+                className="MuiFormHelperText-root MuiFormHelperText-sizeMedium MuiFormHelperText-contained emotion-10"
+                id="root_my-field__help"
+              >
+                <span>
+                  some 
+                  <strong>
+                    other
+                  </strong>
+                   help
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="MuiBox-root emotion-11"
+  >
+    <button
+      className="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary emotion-12"
+      disabled={null}
+      onBlur={[Function]}
+      onContextMenu={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields format color 1`] = `
 .emotion-0 {
   display: -webkit-inline-box;

--- a/packages/primereact/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/primereact/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,4 +1,5 @@
 import { FieldHelpProps, FormContextType, RJSFSchema, StrictRJSFSchema, helpId } from '@rjsf/utils';
+import { RichHelp } from '@rjsf/core';
 
 /** The `FieldHelpTemplate` component renders any help desired for a field
  *
@@ -9,10 +10,14 @@ export default function FieldHelpTemplate<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: FieldHelpProps<T, S, F>) {
-  const { fieldPathId, help } = props;
-  if (help) {
-    const id = helpId(fieldPathId);
-    return <small id={id}>{help}</small>;
+  const { fieldPathId, help, registry, uiSchema } = props;
+  if (!help) {
+    return null;
   }
-  return null;
+  const id = helpId(fieldPathId);
+  return (
+    <small id={id}>
+      <RichHelp help={help} registry={registry} uiSchema={uiSchema} />
+    </small>
+  );
 }

--- a/packages/primereact/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/primereact/test/__snapshots__/Form.test.tsx.snap
@@ -5431,6 +5431,190 @@ exports[`single fields field with markdown description in uiSchema 1`] = `
 </form>
 `;
 
+exports[`single fields field with markdown help 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      style={
+        {
+          "display": "flex",
+          "flexDirection": "column",
+          "gap": "0.5rem",
+          "marginBottom": "1rem",
+        }
+      }
+    >
+      <div
+        className="rjsf-field rjsf-field-string"
+      >
+        <div
+          style={
+            {
+              "display": "flex",
+              "flexDirection": "column",
+              "gap": "0.5rem",
+              "marginBottom": "1rem",
+            }
+          }
+        >
+          <label
+            htmlFor="root_my-field"
+          >
+            my-field
+             
+          </label>
+          <input
+            aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+            autoFocus={false}
+            className="p-inputtext p-component"
+            data-pc-name="inputtext"
+            data-pc-section="root"
+            disabled={false}
+            id="root_my-field"
+            name="root_my-field"
+            onBeforeInput={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            onKeyDown={[Function]}
+            onPaste={[Function]}
+            placeholder=""
+            required={false}
+            type="text"
+            value=""
+          />
+          <small
+            id="root_my-field__help"
+          >
+            <span>
+              some 
+              <strong>
+                Rich
+              </strong>
+               help text
+            </span>
+          </small>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    aria-label="Submit"
+    className="p-button p-component"
+    data-pc-name="button"
+    data-pc-section="root"
+    disabled={false}
+    type="submit"
+  >
+    <span
+      className="p-button-label p-c"
+      data-pc-section="label"
+    >
+      Submit
+    </span>
+  </button>
+</form>
+`;
+
+exports[`single fields field with markdown help in uiSchema 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      style={
+        {
+          "display": "flex",
+          "flexDirection": "column",
+          "gap": "0.5rem",
+          "marginBottom": "1rem",
+        }
+      }
+    >
+      <div
+        className="rjsf-field rjsf-field-string"
+      >
+        <div
+          style={
+            {
+              "display": "flex",
+              "flexDirection": "column",
+              "gap": "0.5rem",
+              "marginBottom": "1rem",
+            }
+          }
+        >
+          <label
+            htmlFor="root_my-field"
+          >
+            my-field
+             
+          </label>
+          <input
+            aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+            autoFocus={false}
+            className="p-inputtext p-component"
+            data-pc-name="inputtext"
+            data-pc-section="root"
+            disabled={false}
+            id="root_my-field"
+            name="root_my-field"
+            onBeforeInput={[Function]}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            onKeyDown={[Function]}
+            onPaste={[Function]}
+            placeholder=""
+            required={false}
+            type="text"
+            value=""
+          />
+          <small
+            id="root_my-field__help"
+          >
+            <span>
+              some 
+              <strong>
+                other
+              </strong>
+               help
+            </span>
+          </small>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    aria-label="Submit"
+    className="p-button p-component"
+    data-pc-name="button"
+    data-pc-section="root"
+    disabled={false}
+    type="submit"
+  >
+    <span
+      className="p-button-label p-c"
+      data-pc-section="label"
+    >
+      Submit
+    </span>
+  </button>
+</form>
+`;
+
 exports[`single fields format color 1`] = `
 <form
   className="rjsf"

--- a/packages/react-bootstrap/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/react-bootstrap/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,5 +1,6 @@
 import { FieldHelpProps, FormContextType, RJSFSchema, StrictRJSFSchema, helpId } from '@rjsf/utils';
 import Form from 'react-bootstrap/Form';
+import { RichHelp } from '@rjsf/core';
 
 /** The `FieldHelpTemplate` component renders any help desired for a field
  *
@@ -10,14 +11,14 @@ export default function FieldHelpTemplate<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: FieldHelpProps<T, S, F>) {
-  const { fieldPathId, help, hasErrors } = props;
+  const { fieldPathId, help, hasErrors, registry, uiSchema } = props;
   if (!help) {
     return null;
   }
   const id = helpId(fieldPathId);
   return (
     <Form.Text className={hasErrors ? 'text-danger' : 'text-muted'} id={id}>
-      {help}
+      <RichHelp help={help} registry={registry} uiSchema={uiSchema} />
     </Form.Text>
   );
 }

--- a/packages/react-bootstrap/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/react-bootstrap/test/__snapshots__/Form.test.tsx.snap
@@ -4278,6 +4278,170 @@ exports[`single fields field with markdown description in uiSchema 1`] = `
 </form>
 `;
 
+exports[`single fields field with markdown help 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div>
+      <div
+        className="p-0 container-fluid"
+      >
+        <div
+          className="row"
+          style={
+            {
+              "marginBottom": "10px",
+            }
+          }
+        >
+          <div
+            className="col-12"
+          >
+             
+            <div
+              className="rjsf-field rjsf-field-string"
+            >
+              <div>
+                <label
+                  className="form-label"
+                  htmlFor="root_my-field"
+                >
+                  my-field
+                </label>
+                <input
+                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                  autoFocus={false}
+                  className="form-control"
+                  disabled={false}
+                  id="root_my-field"
+                  name="root_my-field"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
+                <small
+                  className="text-muted form-text"
+                  id="root_my-field__help"
+                >
+                  <span>
+                    some 
+                    <strong>
+                      Rich
+                    </strong>
+                     help text
+                  </span>
+                </small>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown help in uiSchema 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div>
+      <div
+        className="p-0 container-fluid"
+      >
+        <div
+          className="row"
+          style={
+            {
+              "marginBottom": "10px",
+            }
+          }
+        >
+          <div
+            className="col-12"
+          >
+             
+            <div
+              className="rjsf-field rjsf-field-string"
+            >
+              <div>
+                <label
+                  className="form-label"
+                  htmlFor="root_my-field"
+                >
+                  my-field
+                </label>
+                <input
+                  aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                  autoFocus={false}
+                  className="form-control"
+                  disabled={false}
+                  id="root_my-field"
+                  name="root_my-field"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  placeholder=""
+                  readOnly={false}
+                  required={false}
+                  type="text"
+                  value=""
+                />
+                <small
+                  className="text-muted form-text"
+                  id="root_my-field__help"
+                >
+                  <span>
+                    some 
+                    <strong>
+                      other
+                    </strong>
+                     help
+                  </span>
+                </small>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="btn btn-primary"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields format color 1`] = `
 <form
   className="rjsf"

--- a/packages/semantic-ui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/semantic-ui/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,5 +1,6 @@
 import { Message } from 'semantic-ui-react';
 import { FieldHelpProps, FormContextType, RJSFSchema, StrictRJSFSchema, helpId } from '@rjsf/utils';
+import { RichHelp } from '@rjsf/core';
 
 /** The `FieldHelpTemplate` component renders any help desired for a field
  *
@@ -10,10 +11,12 @@ export default function FieldHelpTemplate<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: FieldHelpProps<T, S, F>) {
-  const { fieldPathId, help } = props;
+  const { fieldPathId, help, registry, uiSchema } = props;
   if (help) {
     const id = helpId(fieldPathId);
-    return <Message size='mini' info id={id} content={help} />;
+    return (
+      <Message size='mini' info id={id} content={<RichHelp help={help} registry={registry} uiSchema={uiSchema} />} />
+    );
   }
   return null;
 }

--- a/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/semantic-ui/test/__snapshots__/Form.test.tsx.snap
@@ -3298,9 +3298,7 @@ exports[`single fields checkboxes widget with custom options and labels 1`] = `
         <div
           className="content"
         >
-          <p>
-            Select all that apply
-          </p>
+          Select all that apply
         </div>
       </div>
     </div>
@@ -3721,6 +3719,156 @@ exports[`single fields field with markdown description in uiSchema 1`] = `
 </form>
 `;
 
+exports[`single fields field with markdown help 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      <div
+        className="rjsf-field rjsf-field-string"
+      >
+        <div
+          className="grouped equal width fields"
+        >
+          <div
+            className="field"
+          >
+            <label
+              htmlFor="root_my-field"
+            >
+              my-field
+            </label>
+            <div
+              className="ui fluid input"
+            >
+              <input
+                aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                autoFocus={false}
+                disabled={false}
+                id="root_my-field"
+                name="root_my-field"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                placeholder=""
+                required={false}
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            className="ui mini info message"
+            id="root_my-field__help"
+          >
+            <div
+              className="content"
+            >
+              <span>
+                some 
+                <strong>
+                  Rich
+                </strong>
+                 help text
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
+exports[`single fields field with markdown help in uiSchema 1`] = `
+<form
+  className="ui form rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="grouped equal width fields"
+    >
+      <div
+        className="rjsf-field rjsf-field-string"
+      >
+        <div
+          className="grouped equal width fields"
+        >
+          <div
+            className="field"
+          >
+            <label
+              htmlFor="root_my-field"
+            >
+              my-field
+            </label>
+            <div
+              className="ui fluid input"
+            >
+              <input
+                aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                autoFocus={false}
+                disabled={false}
+                id="root_my-field"
+                name="root_my-field"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                placeholder=""
+                required={false}
+                type="text"
+                value=""
+              />
+            </div>
+          </div>
+          <div
+            className="ui mini info message"
+            id="root_my-field__help"
+          >
+            <div
+              className="content"
+            >
+              <span>
+                some 
+                <strong>
+                  other
+                </strong>
+                 help
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <button
+    className="ui primary button"
+    onClick={[Function]}
+    type="submit"
+  >
+    Submit
+  </button>
+</form>
+`;
+
 exports[`single fields format color 1`] = `
 <form
   className="ui form rjsf"
@@ -3960,9 +4108,7 @@ exports[`single fields help and error display 1`] = `
         <div
           className="content"
         >
-          <p>
-            help me!
-          </p>
+          help me!
         </div>
       </div>
       <div

--- a/packages/shadcn/src/FieldHelpTemplate/FieldHelpTemplate.tsx
+++ b/packages/shadcn/src/FieldHelpTemplate/FieldHelpTemplate.tsx
@@ -1,6 +1,7 @@
 import { FieldHelpProps, FormContextType, RJSFSchema, StrictRJSFSchema, helpId } from '@rjsf/utils';
 
 import { cn } from '../lib/utils';
+import { RichHelp } from '@rjsf/core';
 
 /** The `FieldHelpTemplate` component renders any help desired for a field
  *
@@ -11,14 +12,14 @@ export default function FieldHelpTemplate<
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = any,
 >(props: FieldHelpProps<T, S, F>) {
-  const { fieldPathId, help, hasErrors } = props;
+  const { fieldPathId, help, hasErrors, registry, uiSchema } = props;
   if (!help) {
     return null;
   }
   const id = helpId(fieldPathId);
   return (
     <span className={cn('text-xs font-medium text-muted-foreground', { ' text-destructive': hasErrors })} id={id}>
-      {help}
+      <RichHelp help={help} registry={registry} uiSchema={uiSchema} />
     </span>
   );
 }

--- a/packages/shadcn/test/__snapshots__/Form.test.tsx.snap
+++ b/packages/shadcn/test/__snapshots__/Form.test.tsx.snap
@@ -5225,6 +5225,178 @@ exports[`single fields field with markdown description in uiSchema 1`] = `
 </form>
 `;
 
+exports[`single fields field with markdown help 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="flex flex-col gap-2"
+    >
+      <div
+        className="flex flex-col gap-2"
+      >
+        <div
+          className=" flex"
+        >
+          <div
+            className="w-full"
+          >
+            <div
+              className="rjsf-field rjsf-field-string"
+            >
+              <div
+                className="flex flex-col gap-2"
+              >
+                <label
+                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                  htmlFor="root_my-field"
+                >
+                  my-field
+                </label>
+                <div
+                  className="p-0.5"
+                >
+                  <input
+                    aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                    autoFocus={false}
+                    className="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive"
+                    data-slot="input"
+                    disabled={false}
+                    id="root_my-field"
+                    name="root_my-field"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    readOnly={false}
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <span
+                  className="text-xs font-medium text-muted-foreground"
+                  id="root_my-field__help"
+                >
+                  <span>
+                    some 
+                    <strong>
+                      Rich
+                    </strong>
+                     help text
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground shadow-xs hover:bg-primary/90 h-9 px-4 py-2 has-[>svg]:px-3 my-2"
+      data-slot="button"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
+exports[`single fields field with markdown help in uiSchema 1`] = `
+<form
+  className="rjsf"
+  noValidate={false}
+  onSubmit={[Function]}
+>
+  <div
+    className="rjsf-field rjsf-field-object"
+  >
+    <div
+      className="flex flex-col gap-2"
+    >
+      <div
+        className="flex flex-col gap-2"
+      >
+        <div
+          className=" flex"
+        >
+          <div
+            className="w-full"
+          >
+            <div
+              className="rjsf-field rjsf-field-string"
+            >
+              <div
+                className="flex flex-col gap-2"
+              >
+                <label
+                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                  htmlFor="root_my-field"
+                >
+                  my-field
+                </label>
+                <div
+                  className="p-0.5"
+                >
+                  <input
+                    aria-describedby="root_my-field__error root_my-field__description root_my-field__help"
+                    autoFocus={false}
+                    className="file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive"
+                    data-slot="input"
+                    disabled={false}
+                    id="root_my-field"
+                    name="root_my-field"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    placeholder=""
+                    readOnly={false}
+                    required={false}
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <span
+                  className="text-xs font-medium text-muted-foreground"
+                  id="root_my-field__help"
+                >
+                  <span>
+                    some 
+                    <strong>
+                      other
+                    </strong>
+                     help
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div>
+    <button
+      className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground shadow-xs hover:bg-primary/90 h-9 px-4 py-2 has-[>svg]:px-3 my-2"
+      data-slot="button"
+      disabled={false}
+      type="submit"
+    >
+      Submit
+    </button>
+  </div>
+</form>
+`;
+
 exports[`single fields format color 1`] = `
 <form
   className="rjsf"

--- a/packages/snapshot-tests/src/formTests.tsx
+++ b/packages/snapshot-tests/src/formTests.tsx
@@ -567,6 +567,42 @@ export function formTests(Form: ComponentType<FormProps>, customOptions: FormRen
       const tree = renderer.create(<Form schema={schema} validator={validator} uiSchema={uiSchema} />).toJSON();
       expect(tree).toMatchSnapshot();
     });
+    test('field with markdown help', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          'my-field': {
+            type: 'string',
+          },
+        },
+      };
+      const uiSchema = {
+        'my-field': {
+          'ui:help': 'some **Rich** help text',
+          'ui:enableMarkdownInHelp': true,
+        },
+      };
+      const tree = renderer.create(<Form schema={schema} uiSchema={uiSchema} validator={validator} />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+    test('field with markdown help in uiSchema', () => {
+      const schema: RJSFSchema = {
+        type: 'object',
+        properties: {
+          'my-field': {
+            type: 'string',
+          },
+        },
+      };
+      const uiSchema = {
+        'my-field': {
+          'ui:help': 'some **other** help',
+          'ui:enableMarkdownInHelp': true,
+        },
+      };
+      const tree = renderer.create(<Form schema={schema} validator={validator} uiSchema={uiSchema} />).toJSON();
+      expect(tree).toMatchSnapshot();
+    });
     test('title field', () => {
       const schema: RJSFSchema = {
         type: 'object',


### PR DESCRIPTION
### Reasons for making this change

This PR implements the ability to render markdown in help text fields across all themes by introducing a new `ui:enableMarkdownInHelp` flag, similar to the existing `ui:enableMarkdownInDescription` functionality.

Key changes:
- Updated all theme packages to support markdown in help text
- Added comprehensive tests 

Fixes #4601

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
