### PR TITLE
Feature: expanded FallbackField for object and array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,10 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/core
 
 - Fixed duplicate label and description rendering in `CheckboxWidget` by conditionally rendering them based on widget type
-    - Updated `CheckboxWidget` to handle label and description rendering consistently
-    - Modified `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
+  - Updated `CheckboxWidget` to handle label and description rendering consistently
+  - Modified `FieldTemplate` to skip label and description rendering for checkbox widgets, fixing ([#4742](https://github.com/rjsf-team/react-jsonschema-form/issues/4742))
 - Updated `ObjectField` to change the removal of an additional property to defer the work to the `processPendingChange()` handler in `Form`, fixing [#4850](https://github.com/rjsf-team/react-jsonschema-form/issues/4850)
+- Updated `FallbackField` to support `object` and `array` types, and improved `ArrayField` so that it handles missing items properly with the fallback field
 
 ## @rjsf/fluentui-rc
 
@@ -66,7 +67,6 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/utils
 
 - Updated `getDefaultFormState()` to not save an undefined field value into an object when the type is `null` and `excludeObjectChildren` is provided, fixing [#4821](https://github.com/rjsf-team/react-jsonschema-form/issues/4821)
-- Added new `ADDITIONAL_PROPERTY_KEY_REMOVE` constant
 
 ## Dev / docs / playground
 

--- a/packages/core/src/components/Form.tsx
+++ b/packages/core/src/components/Form.tsx
@@ -1,6 +1,5 @@
 import { Component, ElementType, FormEvent, ReactNode, Ref, RefObject, createRef } from 'react';
 import {
-  ADDITIONAL_PROPERTY_KEY_REMOVE,
   createSchemaUtils,
   CustomValidator,
   deepEquals,
@@ -55,9 +54,7 @@ import _toPath from 'lodash/toPath';
 import _unset from 'lodash/unset';
 
 import getDefaultRegistry from '../getDefaultRegistry';
-
-/** Internal only symbol used by the `reset()` function to indicate that a reset operation is happening */
-const IS_RESET = Symbol('reset');
+import { ADDITIONAL_PROPERTY_KEY_REMOVE, IS_RESET } from './constants';
 
 /** The properties that are passed to the `Form` */
 export interface FormProps<T = any, S extends StrictRJSFSchema = RJSFSchema, F extends FormContextType = any> {

--- a/packages/core/src/components/constants.ts
+++ b/packages/core/src/components/constants.ts
@@ -1,0 +1,5 @@
+/** Internal only symbol used by `Form` & `ObjectField` to mark an additional property element to be removed */
+export const ADDITIONAL_PROPERTY_KEY_REMOVE = Symbol('remove-this-key');
+
+/** Internal only symbol used by the `reset()` function to indicate that a reset operation is happening */
+export const IS_RESET = Symbol('reset');

--- a/packages/core/src/components/fields/ObjectField.tsx
+++ b/packages/core/src/components/fields/ObjectField.tsx
@@ -1,6 +1,5 @@
 import { FocusEvent, useCallback, useState } from 'react';
 import {
-  ADDITIONAL_PROPERTY_KEY_REMOVE,
   ADDITIONAL_PROPERTY_FLAG,
   ANY_OF_KEY,
   getTemplate,
@@ -29,6 +28,8 @@ import get from 'lodash/get';
 import has from 'lodash/has';
 import isObject from 'lodash/isObject';
 import set from 'lodash/set';
+
+import { ADDITIONAL_PROPERTY_KEY_REMOVE } from '../constants';
 
 /** Returns a flag indicating whether the `name` field is required in the object schema
  *

--- a/packages/core/test/Form.test.jsx
+++ b/packages/core/test/Form.test.jsx
@@ -145,6 +145,69 @@ describeRepeated('Form common', (createFormComponent) => {
         },
         'root_unknownProperty',
       );
+
+      // Change the fallback type to 'boolean'
+      fireEvent.change(node.querySelector('select'), { target: { value: 2 } });
+      optionValue = node.querySelector('select').value;
+      optionText = node.querySelector(`select option[value="${optionValue}"]`).textContent;
+      expect(optionText).to.equal('boolean');
+      expect(node.querySelector('input[type=checkbox]')).to.exist;
+      expect(node.querySelector('input[type=checkbox]').checked).to.equal(true);
+      // Verify formData was casted to number
+      sinon.assert.calledWithMatch(
+        onChange.lastCall,
+        {
+          formData: {
+            unknownProperty: true,
+          },
+          schema,
+        },
+        'root_unknownProperty',
+      );
+
+      // Change the fallback type to 'object'
+      fireEvent.change(node.querySelector('select'), { target: { value: 3 } });
+      optionValue = node.querySelector('select').value;
+      optionText = node.querySelector(`select option[value="${optionValue}"]`).textContent;
+      expect(optionText).to.equal('object');
+      let addButton = node.querySelector('.rjsf-object-property-expand button');
+      expect(addButton).to.exist;
+      // click the add button
+      act(() => addButton.click());
+
+      // Verify formData was casted to number
+      sinon.assert.calledWithMatch(
+        onChange.lastCall,
+        {
+          formData: {
+            unknownProperty: { newKey: 'New Value' },
+          },
+          schema,
+        },
+        'root_unknownProperty',
+      );
+
+      // Change the fallback type to 'array'
+      fireEvent.change(node.querySelector('select'), { target: { value: 4 } });
+      optionValue = node.querySelector('select').value;
+      optionText = node.querySelector(`select option[value="${optionValue}"]`).textContent;
+      expect(optionText).to.equal('array');
+      addButton = node.querySelector('.rjsf-array-item-add button');
+      expect(addButton).to.exist;
+      // click the add button
+      act(() => addButton.click());
+
+      // Verify formData was casted to number
+      sinon.assert.calledWithMatch(
+        onChange.lastCall,
+        {
+          formData: {
+            unknownProperty: [undefined],
+          },
+          schema,
+        },
+        'root_unknownProperty',
+      );
     });
   });
 

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -4,7 +4,6 @@
  * utility.
  */
 export const ADDITIONAL_PROPERTY_FLAG = '__additional_property';
-export const ADDITIONAL_PROPERTY_KEY_REMOVE = Symbol('remove-this-key');
 export const ADDITIONAL_PROPERTIES_KEY = 'additionalProperties';
 export const ALL_OF_KEY = 'allOf';
 export const ANY_OF_KEY = 'anyOf';


### PR DESCRIPTION
### Reasons for making this change

Feature improvement for `FallbackField` to support object and array types
- In `@rjsf/utils` removed `ADDITIONAL_PROPERTY_KEY_REMOVE` in favor of moving it to a local `core` `constants.ts` file
- In `@rjsf/core` added `src/components/constants.ts` and refactored `ADDITIONAL_PROPERTY_KEY_REMOVE` and `IS_RESET` into it
  - Updated `Form` to get `ADDITIONAL_PROPERTY_KEY_REMOVE` and `IS_RESET` from the constants file
  - Updated `ObjectField` to get `ADDITIONAL_PROPERTY_KEY_REMOVE` from the constants file
  - Updated `FallbackField` to add `object` support (via additional properties) and `array` support
  - Updated `ArrayField` to handle missing `items` differently when the fallback field feature is on so that clicking the add button presents the fallback field UI
- Updated the `CHANGELOG.md` accordingly
### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [x] **I'm adding or updating code**
  - [x] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [x] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature


https://github.com/user-attachments/assets/d056ae99-79a5-40e2-98b7-b1bb97ab9ef9


