### PR TITLE
Fix: utils issue with next 15 server building

### DIFF
--- a/packages/utils/src/useAltDateWidgetProps.tsx
+++ b/packages/utils/src/useAltDateWidgetProps.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { MouseEvent, useCallback, useEffect, useMemo, useState } from 'react';
 
 import dateRangeOptions from './dateRangeOptions';

--- a/packages/utils/src/useDeepCompareMemo.ts
+++ b/packages/utils/src/useDeepCompareMemo.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useRef } from 'react';
 import isEqual from 'lodash/isEqual';
 

--- a/packages/utils/src/useFileWidgetProps.ts
+++ b/packages/utils/src/useFileWidgetProps.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback, useMemo } from 'react';
 
 import dataURItoBlob from './dataURItoBlob';


### PR DESCRIPTION
### Reasons for making this change

Fixed issue where the new hooks were failing next 15 server builds when importing `@rjsf/utils`
- Updated the new v6 hooks to add `use client` to them so that NextJS 15 doesn't fail on server-side builds

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
