### PR TITLE
Fix 3846 - add brackets around name when getting data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ should change the heading of the (upcoming) version to include a major version b
 -->
 # 6.1.1
 
+## @rjsf/core
+
+- Updated `ObjectField` to get errors and formData by wrapping `name` in brackets to prevent names that have dots in them incorrectly getting data from a lower level, fixing [#3846](https://github.com/rjsf-team/react-jsonschema-form/issues/3846)
+
 ## @rjsf/shadcn
 
 - Updated `package.json` to copy css files to new `resources` directory

--- a/packages/core/src/components/fields/ObjectField.tsx
+++ b/packages/core/src/components/fields/ObjectField.tsx
@@ -367,9 +367,9 @@ export default function ObjectField<T = any, S extends StrictRJSFSchema = RJSFSc
           required={isRequired<S>(schema, name)}
           schema={get(schema, [PROPERTIES_KEY, name], {}) as S}
           uiSchema={fieldUiSchema}
-          errorSchema={get(errorSchema, name)}
+          errorSchema={get(errorSchema, [name])}
           fieldPathId={childFieldPathId}
-          formData={get(formData, name)}
+          formData={get(formData, [name])}
           handleKeyRename={handleKeyRename}
           handleRemoveProperty={handleRemoveProperty}
           addedByAdditionalProperties={addedByAdditionalProperties}

--- a/packages/core/test/ObjectField.test.jsx
+++ b/packages/core/test/ObjectField.test.jsx
@@ -468,6 +468,41 @@ describe('ObjectField', () => {
       errorMessages = node.querySelectorAll('#root_foo__error');
       expect(errorMessages).to.have.length(0);
     });
+
+    it('should not copy errors when name has dotted-path similar to real property', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          'Foo.Bar': {
+            type: 'string',
+            minLength: 5,
+          },
+          Foo: {
+            type: 'object',
+            properties: {
+              Bar: {
+                type: 'string',
+                minLength: 2,
+              },
+            },
+          },
+        },
+      };
+      const formData = {
+        'Foo.Bar': 'FooBar',
+        Foo: {
+          Bar: 'B',
+        },
+      };
+      const { node } = createFormComponent({ schema, formData });
+      // click submit
+      submitForm(node);
+      console.log(node.innerHTML);
+      const fooDotBarErrors = node.querySelectorAll('#root_Foo.Bar__error');
+      expect(fooDotBarErrors).to.have.length(0);
+      const fooBarErrors = node.querySelectorAll('#root_Foo_Bar__error');
+      expect(fooBarErrors).to.have.length(1);
+    });
   });
 
   describe('fields ordering', () => {


### PR DESCRIPTION
### Reasons for making this change

Fixed #3846 by wrapping the `name` in brackets to avoid lodash `get()` treating properties with dots in them as dotted paths
- Updated `ObjectField` to wrap `name` in brackets when calling lodash `get()`
- Updated the `CHANGELOG.md` accordingly


### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
