### PR TITLE
Fix issue with omitted extension for antd icons

### DIFF
--- a/packages/antd/README.md
+++ b/packages/antd/README.md
@@ -61,7 +61,7 @@ Ant Design theme, fields and widgets for `react-jsonschema-form`.
 ### Prerequisites
 
 - `antd >= 5`
-- `@ant-design/icons >= 5`
+- `@ant-design/icons >= 6`
 - `dayjs >= 1.8.0`
 - `@rjsf/core >= 6`
 - `@rjsf/utils >= 6`

--- a/packages/antd/src/templates/ErrorList/index.tsx
+++ b/packages/antd/src/templates/ErrorList/index.tsx
@@ -1,5 +1,5 @@
 import { Alert, List, Space } from 'antd';
-import ExclamationCircleOutlined from '@ant-design/icons/ExclamationCircleOutlined';
+import { ExclamationCircleOutlined } from '@ant-design/icons';
 import { ErrorListProps, FormContextType, RJSFSchema, StrictRJSFSchema, TranslatableString } from '@rjsf/utils';
 
 /** The `ErrorList` component is the template that renders the all the errors associated with the fields in the `Form`

--- a/packages/antd/src/templates/IconButton/index.tsx
+++ b/packages/antd/src/templates/IconButton/index.tsx
@@ -1,9 +1,11 @@
 import { Button, ButtonProps } from 'antd';
-import ArrowDownOutlined from '@ant-design/icons/ArrowDownOutlined';
-import ArrowUpOutlined from '@ant-design/icons/ArrowUpOutlined';
-import CopyOutlined from '@ant-design/icons/CopyOutlined';
-import DeleteOutlined from '@ant-design/icons/DeleteOutlined';
-import PlusCircleOutlined from '@ant-design/icons/PlusCircleOutlined';
+import {
+  ArrowDownOutlined,
+  ArrowUpOutlined,
+  CopyOutlined,
+  DeleteOutlined,
+  PlusCircleOutlined,
+} from '@ant-design/icons';
 import {
   getUiOptions,
   FormContextType,


### PR DESCRIPTION
### Reasons for making this change

With `"type": "module"` in package.json most bundlers (e.g. webpack 5 and vite) expect an extension for referencing files directly inside `node_modules`. I guess the safest way is to just import them directly from the package.

For us e.g. Webpack 5 fails with:

```
BREAKING CHANGE: The request '@ant-design/icons/PlusCircleOutlined' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```

And vite fails with:

```
Error: Cannot find module '/home/stefan/workspace/stracciatella-toolset/node_modules/@ant-design/icons/ExclamationCircleOutlined' imported from /home/stefan/workspace/stracciatella-toolset/node_modules/@rjsf/antd/lib/templates/ErrorList/index.js
Did you mean to import "@ant-design/icons/ExclamationCircleOutlined.js"?
```

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
