### PR TITLE
Chore document antd BaseInputTemplate as to why step='1' is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ should change the heading of the (upcoming) version to include a major version b
 ## @rjsf/antd
 
 - Updated `SelectWidget` to add a static `getPopupContainerCallback` to the `SelectWidget` component, partially fixing [#3609](https://github.com/rjsf-team/react-jsonschema-form/issues/3609)
+  - Also, added the explicit `open` state to the `Select` in conjunction with providing the `setOpen` as the `onOpenChange` prop 
 
 ## @rjsf/mantine
 

--- a/packages/antd/src/templates/BaseInputTemplate/index.tsx
+++ b/packages/antd/src/templates/BaseInputTemplate/index.tsx
@@ -43,6 +43,8 @@ export default function BaseInputTemplate<
     type,
   } = props;
   const { formContext } = registry;
+  // InputNumber doesn't use a native <input type="number"> directly - it wraps it and controls the stepping behavior
+  // through its own props. The step prop in Ant Design expects a number, not the string "any"
   const inputProps = getInputProps<T, S, F>(schema, type, options, false);
   const { readonlyAsDisabled = true } = formContext as GenericObjectType;
 

--- a/packages/antd/src/widgets/SelectWidget/index.tsx
+++ b/packages/antd/src/widgets/SelectWidget/index.tsx
@@ -107,9 +107,7 @@ export default function SelectWidget<
       value={selectedIndexes}
       {...extraProps}
       // When the open change is called, set the open state, needed so that the select opens properly in the playground
-      onOpenChange={(open) => {
-        setOpen(open);
-      }}
+      onOpenChange={setOpen}
       filterOption={filterOption}
       aria-describedby={ariaDescribedByIds(id)}
       options={selectOptions}


### PR DESCRIPTION
### Reasons for making this change

Closing #4022 by documenting why the `step='1'` is used instead of `step='any'`
- In `@rjsf/antd` added documentation comment to `BaseInputTemplate`
  - Also simplified the `SelectWidget`'s use of `onOpenChange`
- Updated `CHANGELOG.md` accordingly

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
