### PR TITLE
updated docs for allowClearTextInputs

### DIFF
--- a/packages/docs/docs/api-reference/uiSchema.md
+++ b/packages/docs/docs/api-reference/uiSchema.md
@@ -603,6 +603,18 @@ const uiSchema: UiSchema = {
 };
 ```
 
+## allowClearTextInputs
+
+The`ui:allowClearTextInputs`uiSchema directive enables a clear/reset button for text-based input widgets. When set to true, a clear button will be displayed when the input field has a value and is not readonly or disabled. This flag is optional. When omitted, no clear button will be displayed for text input fields.
+
+```tsx
+import { RJSFSchema, UiSchema } from '@rjsf/utils';
+const schema: RJSFSchema = { type: 'string' };
+const uiSchema: UiSchema = {
+  'ui:allowClearTextInputs': true,
+};
+```
+
 ## `duplicateKeySuffixSeparator` option
 
 When using `additionalProperties`, key collision is prevented by appending a unique integer suffix to the duplicate key.


### PR DESCRIPTION
### Reasons for making this change

Added `ui:allowClearTextInputs` flag in docs

### Checklist

- [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npx nx run-many --target=build --exclude=@rjsf/docs && npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
