### PR TITLE
Switch to trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  id-token: write
+
 jobs:
   release_to_npm:
     name: Release to npm


### PR DESCRIPTION
### Reasons for making this change

Publishing now uses OIDC connect, so we don't need npm tokens anymore.
